### PR TITLE
Mr/blood dk profile update

### DIFF
--- a/profiles/Tier18H/Death_Knight_Blood_T18H.simc
+++ b/profiles/Tier18H/Death_Knight_Blood_T18H.simc
@@ -1,0 +1,117 @@
+deathknight="Death_Knight_Blood_T17H"
+level=100
+race=tauren
+role=tank
+position=front
+talents=2013102
+spec=blood
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+
+actions.precombat=flask,type=greater_draenic_stamina_flask
+actions.precombat+=/food,type=whiptail_fillet
+actions.precombat+=/blood_presence
+actions.precombat+=/horn_of_winter
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/potion,name=draenic_armor
+actions.precombat+=/bone_shield
+actions.precombat+=/army_of_the_dead
+
+# Executed every time the actor is available.
+
+actions=auto_attack
+actions+=/potion,name=draenic_armor,if=buff.potion.down&buff.blood_shield.down&!unholy&!frost
+# if=time>10
+actions+=/blood_fury
+# if=time>10
+actions+=/berserking
+# if=time>10
+actions+=/arcane_torrent
+actions+=/antimagic_shell
+actions+=/conversion,if=!buff.conversion.up&runic_power>50&health.pct<90
+actions+=/lichborne,if=health.pct<90
+actions+=/death_strike,if=incoming_damage_5s>=health.max*0.65
+actions+=/army_of_the_dead,if=buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.vampiric_blood.down
+actions+=/bone_shield,if=buff.army_of_the_dead.down&buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.vampiric_blood.down
+actions+=/vampiric_blood,if=health.pct<50
+actions+=/icebound_fortitude,if=health.pct<30&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.vampiric_blood.down
+actions+=/rune_tap,if=health.pct<50&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.vampiric_blood.down&buff.icebound_fortitude.down
+actions+=/dancing_rune_weapon,if=health.pct<80&buff.army_of_the_dead.down&buff.icebound_fortitude.down&buff.bone_shield.down&buff.vampiric_blood.down
+actions+=/death_pact,if=health.pct<50
+actions+=/outbreak,if=(!talent.necrotic_plague.enabled&disease.min_remains<8)|!disease.ticking
+actions+=/death_coil,if=runic_power>90
+actions+=/plague_strike,if=(!talent.necrotic_plague.enabled&!dot.blood_plague.ticking)|(talent.necrotic_plague.enabled&!dot.necrotic_plague.ticking)
+actions+=/icy_touch,if=(!talent.necrotic_plague.enabled&!dot.frost_fever.ticking)|(talent.necrotic_plague.enabled&!dot.necrotic_plague.ticking)
+actions+=/defile
+actions+=/plague_leech,if=((!blood&!unholy)|(!blood&!frost)|(!unholy&!frost))&cooldown.outbreak.remains<=gcd
+actions+=/call_action_list,name=bt,if=talent.blood_tap.enabled
+actions+=/call_action_list,name=re,if=talent.runic_empowerment.enabled
+actions+=/call_action_list,name=rc,if=talent.runic_corruption.enabled
+actions+=/call_action_list,name=nrt,if=!talent.blood_tap.enabled&!talent.runic_empowerment.enabled&!talent.runic_corruption.enabled
+actions+=/defile,if=buff.crimson_scourge.react
+actions+=/death_and_decay,if=buff.crimson_scourge.react
+actions+=/blood_boil,if=buff.crimson_scourge.react
+actions+=/death_coil
+actions+=/empower_rune_weapon,if=!blood&!unholy&!frost
+
+actions.bt=death_strike,if=unholy=2|frost=2
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&!blood
+actions.bt+=/death_strike,if=buff.blood_charge.stack>=10&unholy&frost
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=10&!unholy&!frost
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&(!unholy|!frost)
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&blood.death&!unholy&!frost
+actions.bt+=/death_coil,if=runic_power>70
+actions.bt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&(blood=2|(blood&!blood.death))
+actions.bt+=/blood_boil,if=blood=2|(blood&!blood.death)
+
+actions.re=death_strike,if=unholy&frost
+actions.re+=/death_coil,if=runic_power>70
+actions.re+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood=2
+actions.re+=/blood_boil,if=blood=2
+
+actions.rc=death_strike,if=unholy=2|frost=2
+actions.rc+=/death_coil,if=runic_power>70
+actions.rc+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
+actions.rc+=/blood_boil,if=blood=2
+
+actions.nrt=death_strike,if=unholy=2|frost=2
+actions.nrt+=/death_coil,if=runic_power>70
+actions.nrt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
+actions.nrt+=/blood_boil,if=blood>=1
+
+head=ogreskull_boneplate_greathelm,id=115539,bonus_id=566
+neck=gluttons_kerchief,id=113882,bonus_id=566,enchant=gift_of_multistrike
+shoulders=unstable_slag_shoulderplates,id=113884,bonus_id=566
+back=gronnstitched_greatcloak,id=113873,bonus_id=566,enchant=gift_of_multistrike
+chest=ogreskull_boneplate_breastplate,id=115537,bonus_id=566
+wrists=bracers_of_visceral_force,id=119331,bonus_id=566
+hands=ogreskull_boneplate_gauntlets,id=115538,bonus_id=566
+waist=ironcrushers_collar,id=113950,bonus_id=566
+legs=ogreskull_boneplate_greaves,id=115535,bonus_id=566
+feet=sabatons_of_fractal_earth,id=113936,bonus_id=566
+finger1=spellbound_solium_band_of_sorcerous_invincibility,id=118303,enchant=gift_of_multistrike
+finger2=seal_of_unquenchable_flame,id=113922,bonus_id=566,enchant=gift_of_multistrike
+trinket1=pillar_of_the_earth,id=113650,bonus_id=566
+trinket2=petrified_flesheating_spore,id=113663,bonus_id=566
+main_hand=kagrazs_burning_blade,id=113913,bonus_id=566,enchant=rune_of_the_stoneskin_gargoyle
+
+# Gear Summary
+# gear_ilvl=683.33
+# gear_strength=2744
+# gear_stamina=5276
+# gear_crit_rating=326
+# gear_haste_rating=654
+# gear_mastery_rating=484
+# gear_multistrike_rating=1517
+# gear_versatility_rating=598
+# gear_armor=2181
+# gear_bonus_armor=596
+# set_bonus=tier17_2pc=1
+# set_bonus=tier17_4pc=1

--- a/profiles/Tier18H/Death_Knight_Blood_T18H.simc
+++ b/profiles/Tier18H/Death_Knight_Blood_T18H.simc
@@ -85,33 +85,3 @@ actions.nrt=death_strike,if=unholy=2|frost=2
 actions.nrt+=/death_coil,if=runic_power>70
 actions.nrt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
 actions.nrt+=/blood_boil,if=blood>=1
-
-head=ogreskull_boneplate_greathelm,id=115539,bonus_id=566
-neck=gluttons_kerchief,id=113882,bonus_id=566,enchant=gift_of_multistrike
-shoulders=unstable_slag_shoulderplates,id=113884,bonus_id=566
-back=gronnstitched_greatcloak,id=113873,bonus_id=566,enchant=gift_of_multistrike
-chest=ogreskull_boneplate_breastplate,id=115537,bonus_id=566
-wrists=bracers_of_visceral_force,id=119331,bonus_id=566
-hands=ogreskull_boneplate_gauntlets,id=115538,bonus_id=566
-waist=ironcrushers_collar,id=113950,bonus_id=566
-legs=ogreskull_boneplate_greaves,id=115535,bonus_id=566
-feet=sabatons_of_fractal_earth,id=113936,bonus_id=566
-finger1=spellbound_solium_band_of_sorcerous_invincibility,id=118303,enchant=gift_of_multistrike
-finger2=seal_of_unquenchable_flame,id=113922,bonus_id=566,enchant=gift_of_multistrike
-trinket1=pillar_of_the_earth,id=113650,bonus_id=566
-trinket2=petrified_flesheating_spore,id=113663,bonus_id=566
-main_hand=kagrazs_burning_blade,id=113913,bonus_id=566,enchant=rune_of_the_stoneskin_gargoyle
-
-# Gear Summary
-# gear_ilvl=683.33
-# gear_strength=2744
-# gear_stamina=5276
-# gear_crit_rating=326
-# gear_haste_rating=654
-# gear_mastery_rating=484
-# gear_multistrike_rating=1517
-# gear_versatility_rating=598
-# gear_armor=2181
-# gear_bonus_armor=596
-# set_bonus=tier17_2pc=1
-# set_bonus=tier17_4pc=1

--- a/profiles/Tier18M/Death_Knight_Blood_T18M.simc
+++ b/profiles/Tier18M/Death_Knight_Blood_T18M.simc
@@ -1,0 +1,117 @@
+deathknight="Death_Knight_Blood_T17M"
+level=100
+race=tauren
+role=tank
+position=front
+talents=2012102
+spec=blood
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+
+actions.precombat=flask,type=greater_draenic_stamina_flask
+actions.precombat+=/food,type=whiptail_fillet
+actions.precombat+=/blood_presence
+actions.precombat+=/horn_of_winter
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/potion,name=draenic_armor
+actions.precombat+=/bone_shield
+actions.precombat+=/army_of_the_dead
+
+# Executed every time the actor is available.
+
+actions=auto_attack
+actions+=/potion,name=draenic_armor,if=buff.potion.down&buff.blood_shield.down&!unholy&!frost
+# if=time>10
+actions+=/blood_fury
+# if=time>10
+actions+=/berserking
+# if=time>10
+actions+=/arcane_torrent
+actions+=/antimagic_shell
+actions+=/conversion,if=!buff.conversion.up&runic_power>50&health.pct<90
+actions+=/lichborne,if=health.pct<90
+actions+=/death_strike,if=incoming_damage_5s>=health.max*0.65
+actions+=/army_of_the_dead,if=buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.vampiric_blood.down
+actions+=/bone_shield,if=buff.army_of_the_dead.down&buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.vampiric_blood.down
+actions+=/vampiric_blood,if=health.pct<50
+actions+=/icebound_fortitude,if=health.pct<30&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.vampiric_blood.down
+actions+=/rune_tap,if=health.pct<50&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.vampiric_blood.down&buff.icebound_fortitude.down
+actions+=/dancing_rune_weapon,if=health.pct<80&buff.army_of_the_dead.down&buff.icebound_fortitude.down&buff.bone_shield.down&buff.vampiric_blood.down
+actions+=/death_pact,if=health.pct<50
+actions+=/outbreak,if=(!talent.necrotic_plague.enabled&disease.min_remains<8)|!disease.ticking
+actions+=/death_coil,if=runic_power>90
+actions+=/plague_strike,if=(!talent.necrotic_plague.enabled&!dot.blood_plague.ticking)|(talent.necrotic_plague.enabled&!dot.necrotic_plague.ticking)
+actions+=/icy_touch,if=(!talent.necrotic_plague.enabled&!dot.frost_fever.ticking)|(talent.necrotic_plague.enabled&!dot.necrotic_plague.ticking)
+actions+=/defile
+actions+=/plague_leech,if=((!blood&!unholy)|(!blood&!frost)|(!unholy&!frost))&cooldown.outbreak.remains<=gcd
+actions+=/call_action_list,name=bt,if=talent.blood_tap.enabled
+actions+=/call_action_list,name=re,if=talent.runic_empowerment.enabled
+actions+=/call_action_list,name=rc,if=talent.runic_corruption.enabled
+actions+=/call_action_list,name=nrt,if=!talent.blood_tap.enabled&!talent.runic_empowerment.enabled&!talent.runic_corruption.enabled
+actions+=/defile,if=buff.crimson_scourge.react
+actions+=/death_and_decay,if=buff.crimson_scourge.react
+actions+=/blood_boil,if=buff.crimson_scourge.react
+actions+=/death_coil
+actions+=/empower_rune_weapon,if=!blood&!unholy&!frost
+
+actions.bt=death_strike,if=unholy=2|frost=2
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&!blood
+actions.bt+=/death_strike,if=buff.blood_charge.stack>=10&unholy&frost
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=10&!unholy&!frost
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&(!unholy|!frost)
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&blood.death&!unholy&!frost
+actions.bt+=/death_coil,if=runic_power>70
+actions.bt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&(blood=2|(blood&!blood.death))
+actions.bt+=/blood_boil,if=blood=2|(blood&!blood.death)
+
+actions.re=death_strike,if=unholy&frost
+actions.re+=/death_coil,if=runic_power>70
+actions.re+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood=2
+actions.re+=/blood_boil,if=blood=2
+
+actions.rc=death_strike,if=unholy=2|frost=2
+actions.rc+=/death_coil,if=runic_power>70
+actions.rc+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
+actions.rc+=/blood_boil,if=blood=2
+
+actions.nrt=death_strike,if=unholy=2|frost=2
+actions.nrt+=/death_coil,if=runic_power>70
+actions.nrt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
+actions.nrt+=/blood_boil,if=blood>=1
+
+head=ogreskull_boneplate_greathelm,id=115539,bonus_id=567
+neck=gluttons_kerchief,id=113882,bonus_id=567,enchant=gift_of_multistrike
+shoulders=unstable_slag_shoulderplates,id=113884,bonus_id=567
+back=gronnstitched_greatcloak,id=113873,bonus_id=567,enchant=gift_of_multistrike
+chest=ogreskull_boneplate_breastplate,id=115537,bonus_id=567
+wrists=bracers_of_visceral_force,id=119331,bonus_id=567
+hands=ogreskull_boneplate_gauntlets,id=115538,bonus_id=567
+waist=ironcrushers_collar,id=113950,bonus_id=567
+legs=ogreskull_boneplate_greaves,id=115535,bonus_id=567
+feet=sabatons_of_fractal_earth,id=113936,bonus_id=567
+finger1=spellbound_runic_band_of_elemental_invincibility,id=118308,enchant=gift_of_multistrike
+finger2=seal_of_unquenchable_flame,id=113922,bonus_id=567,enchant=gift_of_multistrike
+trinket1=pillar_of_the_earth,id=113650,bonus_id=567
+trinket2=petrified_flesheating_spore,id=113663,bonus_id=567
+main_hand=kagrazs_burning_blade,id=113913,bonus_id=567,enchant=rune_of_the_stoneskin_gargoyle
+
+# Gear Summary
+# gear_ilvl=699.00
+# gear_strength=3175
+# gear_stamina=6100
+# gear_crit_rating=375
+# gear_haste_rating=753
+# gear_mastery_rating=557
+# gear_multistrike_rating=1703
+# gear_versatility_rating=698
+# gear_armor=2287
+# gear_bonus_armor=699
+# set_bonus=tier17_2pc=1
+# set_bonus=tier17_4pc=1

--- a/profiles/Tier18M/Death_Knight_Blood_T18M.simc
+++ b/profiles/Tier18M/Death_Knight_Blood_T18M.simc
@@ -14,8 +14,8 @@ spec=blood
 
 # Executed before combat begins. Accepts non-harmful actions only.
 
-actions.precombat=flask,type=greater_draenic_stamina_flask
-actions.precombat+=/food,type=whiptail_fillet
+actions.precombat=flask,type=greater_draenic_strength_flask
+actions.precombat+=/food,type=salty_squid_roll
 actions.precombat+=/blood_presence
 actions.precombat+=/horn_of_winter
 # Snapshot raid buffed stats before combat begins and pre-potting is done.
@@ -85,33 +85,3 @@ actions.nrt=death_strike,if=unholy=2|frost=2
 actions.nrt+=/death_coil,if=runic_power>70
 actions.nrt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
 actions.nrt+=/blood_boil,if=blood>=1
-
-head=ogreskull_boneplate_greathelm,id=115539,bonus_id=567
-neck=gluttons_kerchief,id=113882,bonus_id=567,enchant=gift_of_multistrike
-shoulders=unstable_slag_shoulderplates,id=113884,bonus_id=567
-back=gronnstitched_greatcloak,id=113873,bonus_id=567,enchant=gift_of_multistrike
-chest=ogreskull_boneplate_breastplate,id=115537,bonus_id=567
-wrists=bracers_of_visceral_force,id=119331,bonus_id=567
-hands=ogreskull_boneplate_gauntlets,id=115538,bonus_id=567
-waist=ironcrushers_collar,id=113950,bonus_id=567
-legs=ogreskull_boneplate_greaves,id=115535,bonus_id=567
-feet=sabatons_of_fractal_earth,id=113936,bonus_id=567
-finger1=spellbound_runic_band_of_elemental_invincibility,id=118308,enchant=gift_of_multistrike
-finger2=seal_of_unquenchable_flame,id=113922,bonus_id=567,enchant=gift_of_multistrike
-trinket1=pillar_of_the_earth,id=113650,bonus_id=567
-trinket2=petrified_flesheating_spore,id=113663,bonus_id=567
-main_hand=kagrazs_burning_blade,id=113913,bonus_id=567,enchant=rune_of_the_stoneskin_gargoyle
-
-# Gear Summary
-# gear_ilvl=699.00
-# gear_strength=3175
-# gear_stamina=6100
-# gear_crit_rating=375
-# gear_haste_rating=753
-# gear_mastery_rating=557
-# gear_multistrike_rating=1703
-# gear_versatility_rating=698
-# gear_armor=2287
-# gear_bonus_armor=699
-# set_bonus=tier17_2pc=1
-# set_bonus=tier17_4pc=1

--- a/profiles/Tier18M/Death_Knight_Blood_T18M_BoS.simc
+++ b/profiles/Tier18M/Death_Knight_Blood_T18M_BoS.simc
@@ -1,0 +1,148 @@
+deathknight="Death_Knight_Blood_T17M_BoS"
+level=100
+race=orc
+role=tank
+position=front
+talents=2111113
+glyphs=vampiric_blood/regenerative_magic
+spec=blood
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+
+actions.precombat=flask,type=greater_draenic_strength_flask
+actions.precombat+=/food,type=salty_squid_roll
+actions.precombat+=/blood_presence
+actions.precombat+=/horn_of_winter
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/potion,name=draenic_armor
+actions.precombat+=/bone_shield
+actions.precombat+=/army_of_the_dead
+
+# Executed every time the actor is available.
+
+actions=auto_attack
+actions+=/blood_fury,if=target.time_to_die>120|buff.draenic_armor_potion.remains<=buff.blood_fury.duration
+actions+=/berserking,if=buff.dancing_rune_weapon.up
+actions+=/dancing_rune_weapon,if=target.time_to_die>90|buff.draenic_armor_potion.remains<=buff.dancing_rune_weapon.duration
+actions+=/potion,name=draenic_armor,if=target.time_to_die<(buff.draenic_armor_potion.duration+13)
+actions+=/blood_fury,if=buff.blast_furnace.up
+actions+=/dancing_rune_weapon,if=target.time_to_die<90&buff.blast_furnace.up
+actions+=/potion,name=draenic_armor,if=buff.blast_furnace.up&dot.soul_reaper.ticking&target.time_to_die<120
+actions+=/use_item,name=vial_of_convulsive_shadows,if=target.time_to_die>120|buff.draenic_armor_potion.remains<21
+actions+=/bone_shield,if=buff.army_of_the_dead.down&buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.rune_tap.down
+actions+=/lichborne,if=health.pct<30
+actions+=/vampiric_blood,if=health.pct<40
+actions+=/icebound_fortitude,if=health.pct<30&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.rune_tap.down
+actions+=/death_pact,if=health.pct<30
+actions+=/run_action_list,name=last,if=target.time_to_die<8|target.time_to_die<13&cooldown.empower_rune_weapon.remains<4
+actions+=/run_action_list,name=bos,if=dot.breath_of_sindragosa.ticking
+actions+=/run_action_list,name=nbos,if=!dot.breath_of_sindragosa.ticking&cooldown.breath_of_sindragosa.remains<4
+actions+=/run_action_list,name=cdbos,if=!dot.breath_of_sindragosa.ticking&cooldown.breath_of_sindragosa.remains>=4
+
+actions.bos=blood_tap,if=buff.blood_charge.stack>=11
+actions.bos+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<35&runic_power>5
+actions.bos+=/blood_tap,if=buff.blood_charge.stack>=9&runic_power>80&(blood.frac>1.8|frost.frac>1.8|unholy.frac>1.8)
+actions.bos+=/death_coil,if=runic_power>80&(blood.frac>1.8|frost.frac>1.8|unholy.frac>1.8)
+actions.bos+=/blood_tap,if=buff.blood_charge.stack>=9&runic_power>85&(buff.convulsive_shadows.remains>5|buff.convulsive_shadows.remains>2&buff.bloodlust.up)
+actions.bos+=/death_coil,if=runic_power>85&(buff.convulsive_shadows.remains>5|buff.convulsive_shadows.remains>2&buff.bloodlust.up)
+actions.bos+=/outbreak,if=(!dot.blood_plague.ticking|!dot.frost_fever.ticking)&runic_power>21
+actions.bos+=/chains_of_ice,if=!dot.frost_fever.ticking&runic_power<90
+actions.bos+=/plague_strike,if=!dot.blood_plague.ticking&runic_power>5
+actions.bos+=/icy_touch,if=!dot.frost_fever.ticking&runic_power>5
+actions.bos+=/death_strike,if=runic_power<16
+actions.bos+=/blood_tap,if=runic_power<16
+actions.bos+=/blood_boil,if=runic_power<16&runic_power>5&buff.crimson_scourge.down&(blood>=1&blood.death=0|blood=2&blood.death<2)
+actions.bos+=/arcane_torrent,if=runic_power<16
+actions.bos+=/chains_of_ice,if=runic_power<16
+actions.bos+=/blood_boil,if=runic_power<16&buff.crimson_scourge.down&(blood>=1&blood.death=0|blood=2&blood.death<2)
+actions.bos+=/icy_touch,if=runic_power<16
+actions.bos+=/plague_strike,if=runic_power<16
+actions.bos+=/rune_tap,if=runic_power<16&blood>=1&blood.death=0&frost=0&unholy=0&buff.crimson_scourge.up
+actions.bos+=/empower_rune_weapon,if=runic_power<16&blood=0&frost=0&unholy=0
+actions.bos+=/death_strike,if=(blood.frac>1.8&blood.death>=1|frost.frac>1.8|unholy.frac>1.8|buff.blood_charge.stack>=11)
+actions.bos+=/blood_tap,if=(blood.frac>1.8&blood.death>=1|frost.frac>1.8|unholy.frac>1.8)
+actions.bos+=/blood_boil,if=(blood>=1&blood.death=0&target.health.pct-3*(target.health.pct%target.time_to_die)>35|blood=2&blood.death<2)&buff.crimson_scourge.down
+actions.bos+=/antimagic_shell,if=runic_power<65
+actions.bos+=/plague_leech,if=runic_power<65
+actions.bos+=/outbreak,if=!dot.blood_plague.ticking
+actions.bos+=/outbreak,if=pet.dancing_rune_weapon.active&!pet.dancing_rune_weapon.dot.blood_plague.ticking
+actions.bos+=/death_and_decay,if=buff.crimson_scourge.up
+actions.bos+=/blood_boil,if=buff.crimson_scourge.up
+
+actions.cdbos=soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35
+actions.cdbos+=/blood_tap,if=buff.blood_charge.stack>=10
+actions.cdbos+=/death_coil,if=runic_power>65
+actions.cdbos+=/plague_strike,if=!dot.blood_plague.ticking&unholy=2
+actions.cdbos+=/icy_touch,if=!dot.frost_fever.ticking&frost=2
+actions.cdbos+=/death_strike,if=unholy=2|frost=2|blood=2&blood.death>=1
+actions.cdbos+=/blood_boil,if=blood=2&blood.death<2
+actions.cdbos+=/outbreak,if=!dot.blood_plague.ticking
+actions.cdbos+=/plague_strike,if=!dot.blood_plague.ticking
+actions.cdbos+=/icy_touch,if=!dot.frost_fever.ticking
+actions.cdbos+=/outbreak,if=pet.dancing_rune_weapon.active&!pet.dancing_rune_weapon.dot.blood_plague.ticking
+actions.cdbos+=/blood_boil,if=((dot.frost_fever.remains<4&dot.frost_fever.ticking)|(dot.blood_plague.remains<4&dot.blood_plague.ticking))
+actions.cdbos+=/death_and_decay,if=buff.crimson_scourge.up
+actions.cdbos+=/blood_boil,if=buff.crimson_scourge.up
+actions.cdbos+=/death_coil,if=runic_power>45
+actions.cdbos+=/blood_tap
+actions.cdbos+=/death_strike
+actions.cdbos+=/blood_boil,if=blood>=1&blood.death=0
+actions.cdbos+=/death_coil
+
+actions.last=antimagic_shell,if=runic_power<90
+actions.last+=/blood_tap
+actions.last+=/soul_reaper,if=target.time_to_die>7
+actions.last+=/death_coil,if=runic_power>80
+actions.last+=/death_strike
+actions.last+=/blood_boil,if=blood=2|target.time_to_die<=7
+actions.last+=/death_coil,if=runic_power>75|target.time_to_die<4|!dot.breath_of_sindragosa.ticking
+actions.last+=/plague_strike,if=target.time_to_die<2|cooldown.empower_rune_weapon.remains<2
+actions.last+=/icy_touch,if=target.time_to_die<2|cooldown.empower_rune_weapon.remains<2
+actions.last+=/empower_rune_weapon,if=!blood&!unholy&!frost&runic_power<76|target.time_to_die<5
+actions.last+=/plague_leech
+
+actions.nbos=breath_of_sindragosa,if=runic_power>=80
+actions.nbos+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35
+actions.nbos+=/chains_of_ice,if=!dot.frost_fever.ticking
+actions.nbos+=/icy_touch,if=!dot.frost_fever.ticking
+actions.nbos+=/plague_strike,if=!dot.blood_plague.ticking
+actions.nbos+=/death_strike,if=(blood.frac>1.8&blood.death>=1|frost.frac>1.8|unholy.frac>1.8)&runic_power<80
+actions.nbos+=/death_and_decay,if=buff.crimson_scourge.up
+actions.nbos+=/blood_boil,if=buff.crimson_scourge.up|(blood=2&runic_power<80&blood.death<2)
+
+head=ogreskull_boneplate_greathelm,id=115539,bonus_id=567
+neck=gluttons_kerchief,id=113882,bonus_id=567,enchant=gift_of_multistrike
+shoulders=overdriven_spaulders,id=113990,bonus_id=567
+back=gronnstitched_greatcloak,id=113873,bonus_id=567,enchant=gift_of_multistrike
+chest=ogreskull_boneplate_breastplate,id=115537,bonus_id=567
+wrists=bracers_of_visceral_force,id=119331,bonus_id=567
+hands=ogreskull_boneplate_gauntlets,id=115538,bonus_id=567
+waist=ironcrushers_collar,id=113950,bonus_id=567
+legs=ogreskull_boneplate_greaves,id=115535,bonus_id=567
+feet=sabatons_of_fractal_earth,id=113936,bonus_id=567
+finger1=seal_of_unquenchable_flame,id=113922,bonus_id=567,enchant=gift_of_multistrike
+finger2=spellbound_runic_band_of_elemental_power,id=118305,enchant=gift_of_multistrike
+trinket1=blast_furnace_door,id=113893,bonus_id=567
+trinket2=vial_of_convulsive_shadows,id=113969,bonus_id=567
+main_hand=kagrazs_burning_blade,id=113913,bonus_id=567,enchant=rune_of_the_fallen_crusader
+
+# Gear Summary
+# gear_ilvl=701.00
+# gear_strength=3618
+# gear_stamina=4763
+# gear_crit_rating=521
+# gear_haste_rating=574
+# gear_mastery_rating=720
+# gear_multistrike_rating=1985
+# gear_versatility_rating=267
+# gear_armor=2287
+# gear_bonus_armor=875
+# set_bonus=tier17_2pc=1
+# set_bonus=tier17_4pc=1

--- a/profiles/Tier18M/Death_Knight_Blood_T18M_BoS.simc
+++ b/profiles/Tier18M/Death_Knight_Blood_T18M_BoS.simc
@@ -43,7 +43,7 @@ actions+=/icebound_fortitude,if=health.pct<30&buff.army_of_the_dead.down&buff.da
 actions+=/death_pact,if=health.pct<30
 actions+=/run_action_list,name=last,if=target.time_to_die<8|target.time_to_die<13&cooldown.empower_rune_weapon.remains<4
 actions+=/run_action_list,name=bos,if=dot.breath_of_sindragosa.ticking
-actions+=/run_action_list,name=nbos,if=!dot.breath_of_sindragosa.ticking&cooldown.breath_of_sindragosa.remains<4
+actions+=/run_action_list,name=near_bos,if=!dot.breath_of_sindragosa.ticking&cooldown.breath_of_sindragosa.remains<4
 actions+=/run_action_list,name=cdbos,if=!dot.breath_of_sindragosa.ticking&cooldown.breath_of_sindragosa.remains>=4
 
 actions.bos=blood_tap,if=buff.blood_charge.stack>=11
@@ -53,14 +53,12 @@ actions.bos+=/death_coil,if=runic_power>80&(blood.frac>1.8|frost.frac>1.8|unholy
 actions.bos+=/blood_tap,if=buff.blood_charge.stack>=9&runic_power>85&(buff.convulsive_shadows.remains>5|buff.convulsive_shadows.remains>2&buff.bloodlust.up)
 actions.bos+=/death_coil,if=runic_power>85&(buff.convulsive_shadows.remains>5|buff.convulsive_shadows.remains>2&buff.bloodlust.up)
 actions.bos+=/outbreak,if=(!dot.blood_plague.ticking|!dot.frost_fever.ticking)&runic_power>21
-actions.bos+=/chains_of_ice,if=!dot.frost_fever.ticking&runic_power<90
 actions.bos+=/plague_strike,if=!dot.blood_plague.ticking&runic_power>5
 actions.bos+=/icy_touch,if=!dot.frost_fever.ticking&runic_power>5
 actions.bos+=/death_strike,if=runic_power<16
 actions.bos+=/blood_tap,if=runic_power<16
 actions.bos+=/blood_boil,if=runic_power<16&runic_power>5&buff.crimson_scourge.down&(blood>=1&blood.death=0|blood=2&blood.death<2)
 actions.bos+=/arcane_torrent,if=runic_power<16
-actions.bos+=/chains_of_ice,if=runic_power<16
 actions.bos+=/blood_boil,if=runic_power<16&buff.crimson_scourge.down&(blood>=1&blood.death=0|blood=2&blood.death<2)
 actions.bos+=/icy_touch,if=runic_power<16
 actions.bos+=/plague_strike,if=runic_power<16
@@ -108,41 +106,10 @@ actions.last+=/icy_touch,if=target.time_to_die<2|cooldown.empower_rune_weapon.re
 actions.last+=/empower_rune_weapon,if=!blood&!unholy&!frost&runic_power<76|target.time_to_die<5
 actions.last+=/plague_leech
 
-actions.nbos=breath_of_sindragosa,if=runic_power>=80
-actions.nbos+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35
-actions.nbos+=/chains_of_ice,if=!dot.frost_fever.ticking
-actions.nbos+=/icy_touch,if=!dot.frost_fever.ticking
-actions.nbos+=/plague_strike,if=!dot.blood_plague.ticking
-actions.nbos+=/death_strike,if=(blood.frac>1.8&blood.death>=1|frost.frac>1.8|unholy.frac>1.8)&runic_power<80
-actions.nbos+=/death_and_decay,if=buff.crimson_scourge.up
-actions.nbos+=/blood_boil,if=buff.crimson_scourge.up|(blood=2&runic_power<80&blood.death<2)
-
-head=ogreskull_boneplate_greathelm,id=115539,bonus_id=567
-neck=gluttons_kerchief,id=113882,bonus_id=567,enchant=gift_of_multistrike
-shoulders=overdriven_spaulders,id=113990,bonus_id=567
-back=gronnstitched_greatcloak,id=113873,bonus_id=567,enchant=gift_of_multistrike
-chest=ogreskull_boneplate_breastplate,id=115537,bonus_id=567
-wrists=bracers_of_visceral_force,id=119331,bonus_id=567
-hands=ogreskull_boneplate_gauntlets,id=115538,bonus_id=567
-waist=ironcrushers_collar,id=113950,bonus_id=567
-legs=ogreskull_boneplate_greaves,id=115535,bonus_id=567
-feet=sabatons_of_fractal_earth,id=113936,bonus_id=567
-finger1=seal_of_unquenchable_flame,id=113922,bonus_id=567,enchant=gift_of_multistrike
-finger2=spellbound_runic_band_of_elemental_power,id=118305,enchant=gift_of_multistrike
-trinket1=blast_furnace_door,id=113893,bonus_id=567
-trinket2=vial_of_convulsive_shadows,id=113969,bonus_id=567
-main_hand=kagrazs_burning_blade,id=113913,bonus_id=567,enchant=rune_of_the_fallen_crusader
-
-# Gear Summary
-# gear_ilvl=701.00
-# gear_strength=3618
-# gear_stamina=4763
-# gear_crit_rating=521
-# gear_haste_rating=574
-# gear_mastery_rating=720
-# gear_multistrike_rating=1985
-# gear_versatility_rating=267
-# gear_armor=2287
-# gear_bonus_armor=875
-# set_bonus=tier17_2pc=1
-# set_bonus=tier17_4pc=1
+actions.near_bos=breath_of_sindragosa,if=runic_power>=80
+actions.near_bos+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35
+actions.near_bos+=/icy_touch,if=!dot.frost_fever.ticking
+actions.near_bos+=/plague_strike,if=!dot.blood_plague.ticking
+actions.near_bos+=/death_strike,if=(blood.frac>1.8&blood.death>=1|frost.frac>1.8|unholy.frac>1.8)&runic_power<80
+actions.near_bos+=/death_and_decay,if=buff.crimson_scourge.up
+actions.near_bos+=/blood_boil,if=buff.crimson_scourge.up|(blood=2&runic_power<80&blood.death<2)

--- a/profiles/Tier18N/Death_Knight_Blood_T18N.simc
+++ b/profiles/Tier18N/Death_Knight_Blood_T18N.simc
@@ -1,0 +1,117 @@
+deathknight="Death_Knight_Blood_T17N"
+level=100
+race=tauren
+role=tank
+position=front
+talents=2013102
+spec=blood
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+
+actions.precombat=flask,type=greater_draenic_stamina_flask
+actions.precombat+=/food,type=whiptail_fillet
+actions.precombat+=/blood_presence
+actions.precombat+=/horn_of_winter
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/potion,name=draenic_armor
+actions.precombat+=/bone_shield
+actions.precombat+=/army_of_the_dead
+
+# Executed every time the actor is available.
+
+actions=auto_attack
+actions+=/potion,name=draenic_armor,if=buff.potion.down&buff.blood_shield.down&!unholy&!frost
+# if=time>10
+actions+=/blood_fury
+# if=time>10
+actions+=/berserking
+# if=time>10
+actions+=/arcane_torrent
+actions+=/antimagic_shell
+actions+=/conversion,if=!buff.conversion.up&runic_power>50&health.pct<90
+actions+=/lichborne,if=health.pct<90
+actions+=/death_strike,if=incoming_damage_5s>=health.max*0.65
+actions+=/army_of_the_dead,if=buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.vampiric_blood.down
+actions+=/bone_shield,if=buff.army_of_the_dead.down&buff.bone_shield.down&buff.dancing_rune_weapon.down&buff.icebound_fortitude.down&buff.vampiric_blood.down
+actions+=/vampiric_blood,if=health.pct<50
+actions+=/icebound_fortitude,if=health.pct<30&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.vampiric_blood.down
+actions+=/rune_tap,if=health.pct<50&buff.army_of_the_dead.down&buff.dancing_rune_weapon.down&buff.bone_shield.down&buff.vampiric_blood.down&buff.icebound_fortitude.down
+actions+=/dancing_rune_weapon,if=health.pct<80&buff.army_of_the_dead.down&buff.icebound_fortitude.down&buff.bone_shield.down&buff.vampiric_blood.down
+actions+=/death_pact,if=health.pct<50
+actions+=/outbreak,if=(!talent.necrotic_plague.enabled&disease.min_remains<8)|!disease.ticking
+actions+=/death_coil,if=runic_power>90
+actions+=/plague_strike,if=(!talent.necrotic_plague.enabled&!dot.blood_plague.ticking)|(talent.necrotic_plague.enabled&!dot.necrotic_plague.ticking)
+actions+=/icy_touch,if=(!talent.necrotic_plague.enabled&!dot.frost_fever.ticking)|(talent.necrotic_plague.enabled&!dot.necrotic_plague.ticking)
+actions+=/defile
+actions+=/plague_leech,if=((!blood&!unholy)|(!blood&!frost)|(!unholy&!frost))&cooldown.outbreak.remains<=gcd
+actions+=/call_action_list,name=bt,if=talent.blood_tap.enabled
+actions+=/call_action_list,name=re,if=talent.runic_empowerment.enabled
+actions+=/call_action_list,name=rc,if=talent.runic_corruption.enabled
+actions+=/call_action_list,name=nrt,if=!talent.blood_tap.enabled&!talent.runic_empowerment.enabled&!talent.runic_corruption.enabled
+actions+=/defile,if=buff.crimson_scourge.react
+actions+=/death_and_decay,if=buff.crimson_scourge.react
+actions+=/blood_boil,if=buff.crimson_scourge.react
+actions+=/death_coil
+actions+=/empower_rune_weapon,if=!blood&!unholy&!frost
+
+actions.bt=death_strike,if=unholy=2|frost=2
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&!blood
+actions.bt+=/death_strike,if=buff.blood_charge.stack>=10&unholy&frost
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=10&!unholy&!frost
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&(!unholy|!frost)
+actions.bt+=/blood_tap,if=buff.blood_charge.stack>=5&blood.death&!unholy&!frost
+actions.bt+=/death_coil,if=runic_power>70
+actions.bt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&(blood=2|(blood&!blood.death))
+actions.bt+=/blood_boil,if=blood=2|(blood&!blood.death)
+
+actions.re=death_strike,if=unholy&frost
+actions.re+=/death_coil,if=runic_power>70
+actions.re+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood=2
+actions.re+=/blood_boil,if=blood=2
+
+actions.rc=death_strike,if=unholy=2|frost=2
+actions.rc+=/death_coil,if=runic_power>70
+actions.rc+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
+actions.rc+=/blood_boil,if=blood=2
+
+actions.nrt=death_strike,if=unholy=2|frost=2
+actions.nrt+=/death_coil,if=runic_power>70
+actions.nrt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
+actions.nrt+=/blood_boil,if=blood>=1
+
+head=ogreskull_boneplate_greathelm,id=115539
+neck=gluttons_kerchief,id=113882,enchant=gift_of_multistrike
+shoulders=unstable_slag_shoulderplates,id=113884
+back=gronnstitched_greatcloak,id=113873,enchant=gift_of_multistrike
+chest=ogreskull_boneplate_breastplate,id=115537
+wrists=bracers_of_visceral_force,id=119331
+hands=ogreskull_boneplate_gauntlets,id=115538
+waist=ironcrushers_collar,id=113950
+legs=ogreskull_boneplate_greaves,id=115535
+feet=sabatons_of_fractal_earth,id=113936
+finger1=timeless_solium_band_of_the_bulwark,id=118298,enchant=gift_of_multistrike
+finger2=seal_of_unquenchable_flame,id=113922,enchant=gift_of_multistrike
+trinket1=pillar_of_the_earth,id=113650
+trinket2=petrified_flesheating_spore,id=113663
+main_hand=kagrazs_burning_blade,id=113913,enchant=rune_of_the_stoneskin_gargoyle
+
+# Gear Summary
+# gear_ilvl=668.67
+# gear_strength=2390
+# gear_stamina=4600
+# gear_crit_rating=283
+# gear_haste_rating=568
+# gear_mastery_rating=421
+# gear_multistrike_rating=1353
+# gear_versatility_rating=523
+# gear_armor=2082
+# gear_bonus_armor=523
+# set_bonus=tier17_2pc=1
+# set_bonus=tier17_4pc=1

--- a/profiles/Tier18N/Death_Knight_Blood_T18N.simc
+++ b/profiles/Tier18N/Death_Knight_Blood_T18N.simc
@@ -85,33 +85,3 @@ actions.nrt=death_strike,if=unholy=2|frost=2
 actions.nrt+=/death_coil,if=runic_power>70
 actions.nrt+=/soul_reaper,if=target.health.pct-3*(target.health.pct%target.time_to_die)<=35&blood>=1
 actions.nrt+=/blood_boil,if=blood>=1
-
-head=ogreskull_boneplate_greathelm,id=115539
-neck=gluttons_kerchief,id=113882,enchant=gift_of_multistrike
-shoulders=unstable_slag_shoulderplates,id=113884
-back=gronnstitched_greatcloak,id=113873,enchant=gift_of_multistrike
-chest=ogreskull_boneplate_breastplate,id=115537
-wrists=bracers_of_visceral_force,id=119331
-hands=ogreskull_boneplate_gauntlets,id=115538
-waist=ironcrushers_collar,id=113950
-legs=ogreskull_boneplate_greaves,id=115535
-feet=sabatons_of_fractal_earth,id=113936
-finger1=timeless_solium_band_of_the_bulwark,id=118298,enchant=gift_of_multistrike
-finger2=seal_of_unquenchable_flame,id=113922,enchant=gift_of_multistrike
-trinket1=pillar_of_the_earth,id=113650
-trinket2=petrified_flesheating_spore,id=113663
-main_hand=kagrazs_burning_blade,id=113913,enchant=rune_of_the_stoneskin_gargoyle
-
-# Gear Summary
-# gear_ilvl=668.67
-# gear_strength=2390
-# gear_stamina=4600
-# gear_crit_rating=283
-# gear_haste_rating=568
-# gear_mastery_rating=421
-# gear_multistrike_rating=1353
-# gear_versatility_rating=523
-# gear_armor=2082
-# gear_bonus_armor=523
-# set_bonus=tier17_2pc=1
-# set_bonus=tier17_4pc=1


### PR DESCRIPTION
@mserrano - updates T18 profiles for blood dk.

I don't know if it's correct to strip out the default gear, or if it will break the sims. I was under the impression that importing your character sets all the gear anyways. I don't really want to go through and build the BIS lists for each difficulty.

Minor changes to the T18M_BoS APL, where chains of ice is removed from the "Active Breath of Sindragosa" priority list, as the glyph to generate RP from CoI has been removed in T18.