### PR TITLE
[Rogue] Make Agonizing Poison proc Kingsbane

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -1513,7 +1513,7 @@ struct leeching_poison_t : public rogue_poison_t
   }
 };
 
-// Numbing poison =========================================================
+// Agonizing Poison =========================================================
 
 struct agonizing_poison_t : public rogue_poison_t
 {
@@ -1547,6 +1547,11 @@ struct agonizing_poison_t : public rogue_poison_t
 
     proc -> target = state -> target;
     proc -> execute();
+
+    if ( td( state -> target ) -> dots.kingsbane -> is_ticking() )
+    {
+      td( state -> target ) -> debuffs.kingsbane -> trigger();
+    }
   }
 };
 


### PR DESCRIPTION
Not yet tested ingame, though it should be the case: http://us.battle.net/wow/en/forum/topic/20743504316?page=15#282
Tooltip was recently changed from Wound/Deadly Poison to "Lethal Poison".
