### PR TITLE
[DK] fixed Runic Power generation Bug

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -1772,7 +1772,7 @@ struct death_knight_action_t : public Base
     {
       this -> energize_type = ENERGIZE_ON_CAST;
       this -> energize_resource = RESOURCE_RUNIC_POWER;
-      this -> energize_amount += std::fabs( this -> base_costs[ RESOURCE_RUNIC_POWER ] );
+      this -> energize_amount = std::fabs( this -> base_costs[ RESOURCE_RUNIC_POWER ] );
       this -> base_costs[ RESOURCE_RUNIC_POWER ] = 0;
     }
   }


### PR DESCRIPTION
[Problem](http://puu.sh/pQnGW/d5599b5bb0.png)
[Full Report](http://files.jokre.eu/simc_report.html)

`this -> energize_amount += std::fabs( this -> base_costs[ RESOURCE_RUNIC_POWER ] );`

somehow sets `energize_amount` to a very large negative number while

`this -> energize_amount = std::fabs( this -> base_costs[ RESOURCE_RUNIC_POWER ] );`

doesn't.

[Expected Result](http://files.jokre.eu/simc_report_0.html) and also result with the change applied
