### PR TITLE
FrostDK - try to fix "Frozen Pulse"

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -2787,6 +2787,7 @@ struct frozen_pulse_t : public death_knight_spell_t
   {
     aoe = -1;
     background = true;
+    may_crit = false;
   }
 };
 


### PR DESCRIPTION
I'm not 100% sure, but I think this talent should not be allowed to crit? If yes, this should fix it.
