### PR TITLE
[Frost DK] Move Remorseless Winter ahead of Frostscythe

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -6619,9 +6619,9 @@ void death_knight_t::default_apl_frost()
   // Core rotation
   core -> add_talent( this, "Glacial Advance" );
   core -> add_action( this, "Frost Strike", "if=buff.obliteration.up&!buff.killing_machine.react" );
+  core -> add_action( this, "Remorseless Winter", "if=spell_targets.remorseless_winter>=2" );
   core -> add_talent( this, "Frostscythe", "if=!talent.breath_of_sindragosa.enabled&(buff.killing_machine.react|spell_targets.frostscythe>=4)" );
   core -> add_action( this, "Obliterate", "if=buff.killing_machine.react" );
-  core -> add_action( this, "Remorseless Winter", "if=spell_targets.remorseless_winter>=2" );
   core -> add_action( this, "Obliterate" );
 
   // Empty out runes if Frozen Pulse is used

--- a/profiles/Tier19P/Death_Knight_Frost_T19P.simc
+++ b/profiles/Tier19P/Death_Knight_Frost_T19P.simc
@@ -4,7 +4,7 @@ race=blood_elf
 role=attack
 position=back
 talents=3330021
-artifact=12:0:0:0:0:108:3:109:3:110:6:113:3:119:1:120:1:122:1:123:1:1090:3:1332:1
+artifact=12:137308:133684:137308:0:108:3:109:3:110:6:113:3:119:1:120:1:122:1:123:1:1090:3:1332:1
 spec=frost
 
 # This default action priority list is automatically created based on your character.

--- a/profiles/Tier19P/Death_Knight_Frost_T19P.simc
+++ b/profiles/Tier19P/Death_Knight_Frost_T19P.simc
@@ -4,7 +4,7 @@ race=blood_elf
 role=attack
 position=back
 talents=3330021
-artifact=12:0:0:0:0:108:3:110:6:113:3:114:3:119:1:120:1:122:1:123:1:1090:3:1332:1
+artifact=12:0:0:0:0:108:3:109:3:110:6:113:3:119:1:120:1:122:1:123:1:1090:3:1332:1
 spec=frost
 
 # This default action priority list is automatically created based on your character.

--- a/profiles/Tier19P/Death_Knight_Frost_T19P.simc
+++ b/profiles/Tier19P/Death_Knight_Frost_T19P.simc
@@ -59,9 +59,9 @@ actions.generic+=/hungering_rune_weapon,if=!talent.breath_of_sindragosa.enabled
 
 actions.core=glacial_advance
 actions.core+=/frost_strike,if=buff.obliteration.up&!buff.killing_machine.react
+actions.core+=/remorseless_winter,if=spell_targets.remorseless_winter>=2
 actions.core+=/frostscythe,if=!talent.breath_of_sindragosa.enabled&(buff.killing_machine.react|spell_targets.frostscythe>=4)
 actions.core+=/obliterate,if=buff.killing_machine.react
-actions.core+=/remorseless_winter,if=spell_targets.remorseless_winter>=2
 actions.core+=/obliterate
 actions.core+=/frostscythe,if=talent.frozen_pulse.enabled
 actions.core+=/howling_blast,if=talent.frozen_pulse.enabled

--- a/profiles/Tier19P/generate_Death_Knight_T19P.simc
+++ b/profiles/Tier19P/generate_Death_Knight_T19P.simc
@@ -5,7 +5,7 @@ spec=frost
 role=attack
 position=back
 talents=3330021
-artifact=12:0:0:0:0:108:3:110:6:113:3:114:3:119:1:120:1:122:1:123:1:1090:3:1332:1
+artifact=12:137308:133684:137308:0:108:3:109:3:110:6:113:3:119:1:120:1:122:1:123:1:1090:3:1332:1
 head=,id=137526,bonus_id=1727
 neck=,id=134499,bonus_id=1727,enchant=mark_of_the_claw
 shoulder=,id=134518,bonus_id=1727


### PR DESCRIPTION
In situations where Frostscythe will be used, Remorseless Winter will never be called due to the catch-all manner of the Frostscythe line.
