### PR TITLE
[Death Knight] Frozen Pulse triggers from main-hand and off-hand auto…

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -3007,7 +3007,7 @@ struct melee_t : public death_knight_melee_attack_t
         p() -> buffs.killing_machine -> trigger();
       }
 
-      if ( weapon && weapon -> slot == SLOT_MAIN_HAND && p() -> buffs.frozen_pulse -> up() )
+      if ( p() -> buffs.frozen_pulse -> up() )
       {
         frozen_pulse -> target = s -> target;
         frozen_pulse -> schedule_execute();


### PR DESCRIPTION
…attacks

More detailed analysis showed that Recount was wrong and FP triggers from mh and oh autoattacks.
