### PR TITLE
Envenom wrong cp usage

### DIFF
--- a/profiles/Tier19M_NH/Rogue_Assassination_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Rogue_Assassination_T19M_NH.simc
@@ -54,7 +54,7 @@ actions.cds+=/exsanguinate,if=prev_gcd.1.rupture&dot.rupture.remains>4+4*cp_max_
 
 # Finishers
 actions.finish=death_from_above,if=combo_points>=cp_max_spend
-actions.finish+=/envenom,if=combo_points>=5|(talent.elaborate_planning.enabled&combo_points>=3+!talent.exsanguinate.enabled&buff.elaborate_planning.remains<0.1)
+actions.finish+=/envenom,if=combo_points>=4|(talent.elaborate_planning.enabled&combo_points>=3+!talent.exsanguinate.enabled&buff.elaborate_planning.remains<0.1)
 
 # Maintain
 actions.maintain=rupture,if=(talent.nightstalker.enabled&stealthed.rogue)|(talent.exsanguinate.enabled&((combo_points>=cp_max_spend&cooldown.exsanguinate.remains<1)|(!ticking&(time>10|combo_points>=2+artifact.urge_to_kill.enabled))))


### PR DESCRIPTION
Hi, envenom should be using 4 or greater combo points instead of 5 or greater in the Finishers section of the Rogue APL.