### PR TITLE
[Rogue] Sub APL Improvements

### DIFF
--- a/profiles/Tier19M_NH/Rogue_Subtlety_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Rogue_Subtlety_T19M_NH.simc
@@ -25,7 +25,7 @@ actions.precombat+=/potion,name=old_war
 actions.precombat+=/marked_for_death,if=raid_event.adds.in>40
 # Defined variables that doesn't change during the fight
 actions.precombat+=/variable,name=ssw_refund,value=equipped.shadow_satyrs_walk*(4+ssw_refund_offset)
-actions.precombat+=/variable,name=stealth_threshold,value=(15+talent.vigor.enabled*35+talent.master_of_shadows.enabled*30+variable.ssw_refund)
+actions.precombat+=/variable,name=stealth_threshold,value=(15+talent.vigor.enabled*35+talent.master_of_shadows.enabled*25+variable.ssw_refund)
 actions.precombat+=/enveloping_shadows,if=combo_points>=5
 actions.precombat+=/symbols_of_death
 
@@ -33,8 +33,8 @@ actions.precombat+=/symbols_of_death
 actions=call_action_list,name=cds
 # Fully switch to the Stealthed Rotation (by doing so, it forces pooling if nothing is available)
 actions+=/run_action_list,name=stealthed,if=stealthed.all
+actions+=/call_action_list,name=stealth_als,if=combo_points.deficit>=2+talent.premeditation.enabled+buff.shadow_blades.up
 actions+=/call_action_list,name=finish,if=combo_points>=5|(combo_points>=4&spell_targets.shuriken_storm>=3&spell_targets.shuriken_storm<=4)
-actions+=/call_action_list,name=stealth_als,if=combo_points.deficit>=2+talent.premeditation.enabled
 actions+=/call_action_list,name=build,if=energy.deficit<=variable.stealth_threshold
 
 # Builders
@@ -59,23 +59,24 @@ actions.finish+=/death_from_above
 actions.finish+=/eviscerate
 
 # Stealth Action List Starter
-actions.stealth_als=call_action_list,name=stealth_cds,if=energy.deficit<=variable.stealth_threshold&(!equipped.shadow_satyrs_walk|cooldown.shadow_dance.charges_fractional>=2.45|energy.deficit>=10)
+actions.stealth_als=call_action_list,name=stealth_cds,if=energy.deficit<=variable.stealth_threshold&(cooldown.shadow_dance.charges_fractional>=2.45|energy.deficit>=20)
 actions.stealth_als+=/call_action_list,name=stealth_cds,if=spell_targets.shuriken_storm>=5
-actions.stealth_als+=/call_action_list,name=stealth_cds,if=(cooldown.shadowmeld.up&!cooldown.vanish.up&cooldown.shadow_dance.charges<=1)
+#actions.stealth_als+=/call_action_list,name=stealth_cds,if=(cooldown.shadowmeld.up&!cooldown.vanish.up&cooldown.shadow_dance.charges<=1)
 actions.stealth_als+=/call_action_list,name=stealth_cds,if=target.time_to_die<12*cooldown.shadow_dance.charges_fractional*(1+equipped.shadow_satyrs_walk*0.5)
 
 # Stealth Cooldowns
 actions.stealth_cds=shadow_dance,if=charges_fractional>=2.45
 actions.stealth_cds+=/vanish
-actions.stealth_cds+=/shadow_dance,if=charges>=2&combo_points<=1
-actions.stealth_cds+=/pool_resource,for_next=1,extra_amount=40
+actions.stealth_cds+=/shadow_dance,if=charges>=2&combo_points.deficit>=5
+#actions.stealth_cds+=/pool_resource,for_next=1,extra_amount=40
 actions.stealth_cds+=/shadowmeld,if=energy>=40&energy.deficit>=10+variable.ssw_refund
-actions.stealth_cds+=/shadow_dance,if=combo_points<=1
+actions.stealth_cds+=/shadow_dance,if=combo_points.deficit>=5
 
 # Stealthed Rotation
 actions.stealthed=symbols_of_death,if=(buff.symbols_of_death.remains<target.time_to_die-4&buff.symbols_of_death.remains<=buff.symbols_of_death.duration*0.3)|equipped.shadow_satyrs_walk&energy.time_to_max<0.25
+actions.stealthed+=/shuriken_storm,if=combo_points.deficit>=1+buff.shadow_blades.up&buff.shadowmeld.down&((combo_points.deficit>=3&spell_targets.shuriken_storm>=2+talent.premeditation.enabled+equipped.shadow_satyrs_walk)|buff.the_dreadlords_deceit.stack>=29)
+actions.stealthed+=/shadowstrike,if=combo_points.deficit>=2+talent.premeditation.enabled+buff.shadow_blades.up
 actions.stealthed+=/call_action_list,name=finish,if=combo_points>=5
-actions.stealthed+=/shuriken_storm,if=buff.shadowmeld.down&((combo_points.deficit>=3&spell_targets.shuriken_storm>=2+talent.premeditation.enabled+equipped.shadow_satyrs_walk)|buff.the_dreadlords_deceit.stack>=29)
 actions.stealthed+=/shadowstrike
 
 head=doomblade_cowl,id=138332,bonus_id=3519


### PR DESCRIPTION
- Update energy pooling threshold for talent changes
- Activate stealth over finishing if sufficient point deficit
- Burn off energy excess before activating dance, even without boots
- Commented out lines do provide any gain for night elves, but actually hurt all other races
- Activate dance if sufficient deficit, rather than explicitly low points
- Prioritize generating CP if sufficient deficit over finishing