### PR TITLE
[Mage] Add Potion Flag

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -244,6 +244,7 @@ public:
          incanters_flow_stack_mult,
          iv_haste;
   bool blessing_of_wisdom;
+  std::string mage_potion_choice;
 
   // Benefits
   struct benefits_t
@@ -7195,6 +7196,7 @@ mage_t::mage_t( sim_t* sim, const std::string& name, race_e r ) :
   last_summoned( temporal_hero_e::INVALID ),
   distance_from_rune( 0.0 ),
   global_cinder_count( 0 ),
+  mage_potion_choice ("deadly_grace"),
   incanters_flow_stack_mult( find_spell( 116267 ) -> effectN( 1 ).percent() ),
   iv_haste( 1.0 ),
   blessing_of_wisdom( false ),
@@ -7363,6 +7365,7 @@ void mage_t::create_options()
 {
   add_option( opt_float( "global_cinder_count", global_cinder_count ) );
   add_option( opt_bool( "blessing_of_wisdom", blessing_of_wisdom ) );
+  add_option(opt_string("mage_potion_choice", mage_potion_choice ) );
   player_t::create_options();
 }
 // mage_t::create_pets ========================================================
@@ -8141,7 +8144,13 @@ std::string mage_t::get_potion_action()
   }
   else
   {
-    potion_action += "deadly_grace";
+    if (mage_potion_choice == "prolonged_power")
+    {
+      potion_action += "prolonged_power";
+    }
+    else {
+      potion_action += "deadly_grace";
+    }
   }
 
   return potion_action;


### PR DESCRIPTION
Because the choice between PP and DG seems to fluctuate frequently with gear/artifact/talents we constantly have users on altered-time/Hall of the Guardians asking how to swap potions. In order to alleviate the difficulty of editing the APL for inexperienced users (or even finding it in the case of using addon imports or similar  which only show it in the output/save=) add a simple text flag to control which is used.

Syntax/Info:
-Player-scope flag, mage only
-defaults to deadly_grace at 110 (Or if invalid/no value given)
-Has no impact prior to 110 (though could easily be expanded)

Flag Name:
mage_potion_choice
Expected Values:
"prolonged_power"
(Additional keywords could easily be added)