### PR TITLE
[Mage] Add variables to action lists to track legendary items

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -8097,6 +8097,20 @@ void mage_t::apl_precombat()
     precombat -> add_action( this, "Pyroblast" );
   else if ( specialization() == MAGE_FROST )
     precombat -> add_action( this, "Frostbolt" );
+
+
+  if ( specialization() == MAGE_ARCANE ) {
+    precombat -> add_action( "variable,op=set,name=mystic_kilt_equipped,value=equipped.132451" );
+    precombat -> add_action( "variable,op=set,name=rhonins_bracers_equipped,value=equipped.132413" );
+  } else if ( specialization() == MAGE_FIRE ) {
+    precombat -> add_action( "variable,op=set,name=marquee_bracers_equipped,value=equipped.132406" );
+    precombat -> add_action( "variable,op=set,name=darcklis_helm_equipped,value=equipped.132863" );
+    precombat -> add_action( "variable,op=set,name=koralons_belt_equipped,value=equipped.132454" );
+  } else if ( specialization() == MAGE_FROST ) {
+    precombat -> add_action( "variable,op=set,name=zannesu_belt_equipped,value=equipped.133970" );
+  }
+
+  precombat -> add_action( "variable,op=set,name=shard_ring_equipped,value=equipped.132410" );
 }
 
 std::string mage_t::get_food_action()
@@ -8199,9 +8213,8 @@ void mage_t::apl_arcane()
   action_priority_list_t* burn                = get_action_priority_list( "burn"             );
   action_priority_list_t* init_burn           = get_action_priority_list( "init_burn"        );
 
-  default_list -> add_action( this, "Counterspell",
-                              "if=target.debuff.casting.react" );
-  default_list -> add_action( this, "Time Warp", "if=(buff.bloodlust.down)&((time=0)|(equipped.132410&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))" );
+  default_list -> add_action( this, "Counterspell", "if=target.debuff.casting.react" );
+  default_list -> add_action( this, "Time Warp", "if=(buff.bloodlust.down)&((time=0)|(variable.shard_ring_equipped&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))" );
   default_list -> add_talent( this, "Mirror Image", "if=buff.arcane_power.down" );
   default_list -> add_action( "stop_burn_phase,if=prev_gcd.1.evocation&burn_phase_duration>gcd.max" );
   default_list -> add_action( this, "Mark of Aluneth", "if=cooldown.arcane_power.remains>20" );
@@ -8218,12 +8231,12 @@ void mage_t::apl_arcane()
   conserve     -> add_action( this, "Arcane Missiles", "if=buff.arcane_missiles.react=3" );
   conserve     -> add_action( this, "Arcane Blast", "if=mana.pct>99" );
   conserve     -> add_talent( this, "Nether Tempest", "if=(refreshable|!ticking)" );
-  conserve     -> add_action( this, "Arcane Blast", "if=buff.rhonins_assaulting_armwraps.up&equipped.132413" );
+  conserve     -> add_action( this, "Arcane Blast", "if=variable.rhonins_bracers_equipped&buff.rhonins_assaulting_armwraps.up" );
   conserve     -> add_action( this, "Arcane Missiles" );
   conserve     -> add_talent( this, "Supernova", "if=mana.pct<100" );
   //conserve     -> add_action( this, "Frost Nova", "if=equipped.132452" );
-  conserve     -> add_action( this, "Arcane Explosion", "if=mana.pct>=82&equipped.132451&active_enemies>1" );
-  conserve     -> add_action( this, "Arcane Blast", "if=mana.pct>=82&equipped.132451" );
+  conserve     -> add_action( this, "Arcane Explosion", "if=mana.pct>=82&variable.mystic_kilt_equipped&active_enemies>1" );
+  conserve     -> add_action( this, "Arcane Blast", "if=mana.pct>=82&variable.mystic_kilt_equipped" );
   conserve     -> add_action( this, "Arcane Barrage", "if=mana.pct<100&cooldown.arcane_power.remains>5" );
   conserve     -> add_action( this, "Arcane Explosion", "if=active_enemies>1" );
   conserve     -> add_action( this, "Arcane Blast" );
@@ -8268,7 +8281,7 @@ void mage_t::apl_arcane()
   init_burn -> add_action( "start_burn_phase,if=((cooldown.evocation.remains-(2*burn_phase_duration))%2<burn_phase_duration)|cooldown.arcane_power.remains=0|target.time_to_die<55" );
 
   burn      -> add_action( "call_action_list,name=cooldowns" );
-  burn      -> add_talent( this, "Charged Up", "if=(equipped.132451&buff.arcane_charge.stack<=1)" );
+  burn      -> add_talent( this, "Charged Up", "if=(variable.mystic_kilt_equipped&buff.arcane_charge.stack<=1)" );
   burn      -> add_action( this, "Arcane Missiles", "if=buff.arcane_missiles.react=3" );
   burn      -> add_talent( this, "Nether Tempest", "if=dot.nether_tempest.remains<=2|!ticking" );
   burn      -> add_action( this, "Arcane Blast", "if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die" );
@@ -8280,7 +8293,7 @@ void mage_t::apl_arcane()
   burn      -> add_talent( this, "Supernova", "if=mana.pct<100" );
   burn      -> add_action( this, "Arcane Missiles", "if=mana.pct>10&(talent.overpowered.enabled|buff.arcane_power.down)" );
   burn      -> add_action( this, "Arcane Explosion", "if=active_enemies>1" );
-  burn      -> add_action( this, "Arcane Barrage", "if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))" );
+  burn      -> add_action( this, "Arcane Barrage", "if=talent.charged_up.enabled&(variable.mystic_kilt_equipped&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))" );
   burn      -> add_action( this, "Arcane Blast" );
   burn      -> add_action( this, "Evocation", "interrupt_if=mana.pct>99" );
 
@@ -8301,7 +8314,7 @@ void mage_t::apl_fire()
   action_priority_list_t* standard            = get_action_priority_list( "standard_rotation" );
 
   default_list -> add_action( this, "Counterspell", "if=target.debuff.casting.react" );
-  default_list -> add_action( this, "Time Warp", "if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.combustion.remains<1|target.time_to_die.remains<50))" );
+  default_list -> add_action( this, "Time Warp", "if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.combustion.remains<1|target.time_to_die.remains<50))" );
   default_list -> add_talent( this, "Mirror Image", "if=buff.combustion.down" );
   default_list -> add_talent( this, "Rune of Power", "if=cooldown.combustion.remains>40&buff.combustion.down&!talent.kindling.enabled|target.time_to_die.remains<11|talent.kindling.enabled&(charges_fractional>1.8|time<40)&cooldown.combustion.remains>40" );
   default_list -> add_action( mage_t::get_special_use_items( "horn_of_valor", true ) );
@@ -8328,22 +8341,22 @@ void mage_t::apl_fire()
     combustion_phase -> add_action( non_special_item_actions[i] );
   }
   combustion_phase -> add_action( mage_t::get_special_use_items( "obelisk_of_the_void", false ) );
-  combustion_phase -> add_action( this, "Pyroblast", "if=buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time" );
+  combustion_phase -> add_action( this, "Pyroblast", "if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time" );
   combustion_phase -> add_action( this, "Pyroblast", "if=buff.hot_streak.up" );
   combustion_phase -> add_action( this, "Fire Blast", "if=buff.heating_up.up" );
   combustion_phase -> add_action( this, "Phoenix's Flames" );
   combustion_phase -> add_action( this, "Scorch", "if=buff.combustion.remains>cast_time" );
   combustion_phase -> add_action( this, "Dragon's Breath", "if=buff.hot_streak.down&action.fire_blast.charges<1&action.phoenixs_flames.charges<1" );
-  combustion_phase -> add_action( this, "Scorch", "if=target.health.pct<=30&equipped.132454");
+  combustion_phase -> add_action( this, "Scorch", "if=target.health.pct<=30&variable.koralons_belt_equipped");
 
   rop_phase        -> add_talent( this, "Rune of Power" );
   rop_phase        -> add_action( this, "Flamestrike", "if=((talent.flame_patch.enabled&active_enemies>1)|(active_enemies>3))&buff.hot_streak.up" );
   rop_phase        -> add_action( this, "Pyroblast", "if=buff.hot_streak.up" );
   rop_phase        -> add_action( "call_action_list,name=active_talents" );
-  rop_phase        -> add_action( this, "Pyroblast", "if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains" );
+  rop_phase        -> add_action( this, "Pyroblast", "if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains" );
   rop_phase        -> add_action( this, "Fire Blast", "if=!prev_off_gcd.fire_blast" );
   rop_phase        -> add_action( this, "Phoenix's Flames", "if=!prev_gcd.1.phoenixs_flames" );
-  rop_phase        -> add_action( this, "Scorch", "if=target.health.pct<=30&equipped.132454" );
+  rop_phase        -> add_action( this, "Scorch", "if=target.health.pct<=30&variable.koralons_belt_equipped" );
   rop_phase        -> add_action( this, "Dragon's Breath", "if=active_enemies>2" );
   rop_phase        -> add_action( this, "Flamestrike", "if=(talent.flame_patch.enabled&active_enemies>2)|active_enemies>5" );
   rop_phase        -> add_action( this, "Fireball" );
@@ -8351,22 +8364,22 @@ void mage_t::apl_fire()
   active_talents   -> add_talent( this, "Blast Wave", "if=(buff.combustion.down)|(buff.combustion.up&action.fire_blast.charges<1&action.phoenixs_flames.charges<1)" );
   active_talents   -> add_talent( this, "Meteor", "if=cooldown.combustion.remains>15|(cooldown.combustion.remains>target.time_to_die)|buff.rune_of_power.up" );
   active_talents   -> add_talent( this, "Cinderstorm", "if=cooldown.combustion.remains<cast_time&(buff.rune_of_power.up|!talent.rune_on_power.enabled)|cooldown.combustion.remains>10*spell_haste&!buff.combustion.up" );
-  active_talents   -> add_action( this, "Dragon's Breath", "if=equipped.132863|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)" );
+  active_talents   -> add_action( this, "Dragon's Breath", "if=variable.darcklis_helm_equipped|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)" );
   active_talents   -> add_talent( this, "Living Bomb", "if=active_enemies>1&buff.combustion.down" );
 
   standard    -> add_action( this, "Flamestrike", "if=((talent.flame_patch.enabled&active_enemies>1)|active_enemies>3)&buff.hot_streak.up" );
   standard    -> add_action( this, "Pyroblast", "if=buff.hot_streak.up&buff.hot_streak.remains<action.fireball.execute_time" );
   standard    -> add_action( this, "Phoenix's Flames", "if=charges_fractional>2.7&active_enemies>2" );
   standard    -> add_action( this, "Pyroblast", "if=buff.hot_streak.up&!prev_gcd.1.pyroblast" );
-  standard    -> add_action( this, "Pyroblast", "if=buff.hot_streak.react&target.health.pct<=30&equipped.132454" );
-  standard    -> add_action( this, "Pyroblast", "if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains" );
+  standard    -> add_action( this, "Pyroblast", "if=buff.hot_streak.react&target.health.pct<=30&variable.koralons_belt_equipped" );
+  standard    -> add_action( this, "Pyroblast", "if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains" );
   standard    -> add_action( "call_action_list,name=active_talents" );
   standard    -> add_action( this, "Fire Blast", "if=!talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.4|cooldown.combustion.remains<40)&(3-charges_fractional)*(12*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4" );
   standard    -> add_action( this, "Fire Blast", "if=talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.5|cooldown.combustion.remains<40)&(3-charges_fractional)*(18*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4" );
   standard    -> add_action( this, "Phoenix's Flames", "if=(buff.combustion.up|buff.rune_of_power.up|buff.incanters_flow.stack>3|talent.mirror_image.enabled)&artifact.phoenix_reborn.enabled&(4-charges_fractional)*13<cooldown.combustion.remains+5|target.time_to_die.remains<10" );
   standard    -> add_action( this, "Phoenix's Flames", "if=(buff.combustion.up|buff.rune_of_power.up)&(4-charges_fractional)*30<cooldown.combustion.remains+5" );
   standard    -> add_action( this, "Flamestrike", "if=(talent.flame_patch.enabled&active_enemies>1)|active_enemies>5" );
-  standard    -> add_action( this, "Scorch", "if=target.health.pct<=30&equipped.132454" );
+  standard    -> add_action( this, "Scorch", "if=target.health.pct<=30&variable.koralons_belt_equipped" );
   standard    -> add_action( this, "Fireball" );
 
 
@@ -8386,7 +8399,7 @@ void mage_t::apl_frost()
 
   default_list -> add_action( this, "Counterspell", "if=target.debuff.casting.react" );
   default_list -> add_action( this, "Ice Lance", "if=buff.fingers_of_frost.react=0&prev_gcd.1.flurry" );
-  default_list -> add_action( this, "Time Warp", "if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.icy_veins.remains<1|target.time_to_die<50))" );
+  default_list -> add_action( this, "Time Warp", "if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.icy_veins.remains<1|target.time_to_die<50))" );
   default_list -> add_action( mage_t::get_special_use_items( "horn_of_valor", false ) );
   default_list -> add_action( mage_t::get_special_use_items( "obelisk_of_the_void", false ) );
   default_list -> add_action( mage_t::get_special_use_items( "mrrgrias_favor", false ) );
@@ -8407,7 +8420,7 @@ void mage_t::apl_frost()
   single -> add_action( this, "Frozen Orb" );
   single -> add_talent( this, "Ice Nova" );
   single -> add_talent( this, "Comet Storm" );
-  single -> add_action( this, "Blizzard", "if=talent.arctic_gale.enabled|active_enemies>1|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)" );
+  single -> add_action( this, "Blizzard", "if=talent.arctic_gale.enabled|active_enemies>1|(variable.zannesu_belt_equipped&buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)" );
   single -> add_action( this, "Ebonbolt", "if=buff.brain_freeze.react=0" );
   single -> add_talent( this, "Glacial Spike" );
   single -> add_action( this, "Frostbolt" );

--- a/profiles/Tier19H/Mage_Arcane_T19H.simc
+++ b/profiles/Tier19H/Mage_Arcane_T19H.simc
@@ -22,10 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/arcane_blast
+actions.precombat+=/variable,op=set,name=mystic_kilt_equipped,value=equipped.132451
+actions.precombat+=/variable,op=set,name=rhonins_bracers_equipped,value=equipped.132413
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(equipped.132410&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
+actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(variable.shard_ring_equipped&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
 actions+=/mirror_image,if=buff.arcane_power.down
 actions+=/stop_burn_phase,if=prev_gcd.1.evocation&burn_phase_duration>gcd.max
 actions+=/mark_of_aluneth,if=cooldown.arcane_power.remains>20
@@ -42,7 +45,7 @@ actions.build+=/arcane_explosion,if=active_enemies>1
 actions.build+=/arcane_blast
 
 actions.burn=call_action_list,name=cooldowns
-actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
+actions.burn+=/charged_up,if=(variable.mystic_kilt_equipped&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
 actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
@@ -54,18 +57,18 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up|buff.arcane_power.remain
 actions.burn+=/supernova,if=mana.pct<100
 actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.arcane_power.down)
 actions.burn+=/arcane_explosion,if=active_enemies>1
-actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
+actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(variable.mystic_kilt_equipped&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3
 actions.conserve+=/arcane_blast,if=mana.pct>99
 actions.conserve+=/nether_tempest,if=(refreshable|!ticking)
-actions.conserve+=/arcane_blast,if=buff.rhonins_assaulting_armwraps.up&equipped.132413
+actions.conserve+=/arcane_blast,if=variable.rhonins_bracers_equipped&buff.rhonins_assaulting_armwraps.up
 actions.conserve+=/arcane_missiles
 actions.conserve+=/supernova,if=mana.pct<100
-actions.conserve+=/arcane_explosion,if=mana.pct>=82&equipped.132451&active_enemies>1
-actions.conserve+=/arcane_blast,if=mana.pct>=82&equipped.132451
+actions.conserve+=/arcane_explosion,if=mana.pct>=82&variable.mystic_kilt_equipped&active_enemies>1
+actions.conserve+=/arcane_blast,if=mana.pct>=82&variable.mystic_kilt_equipped
 actions.conserve+=/arcane_barrage,if=mana.pct<100&cooldown.arcane_power.remains>5
 actions.conserve+=/arcane_explosion,if=active_enemies>1
 actions.conserve+=/arcane_blast

--- a/profiles/Tier19H/Mage_Fire_T19H.simc
+++ b/profiles/Tier19H/Mage_Fire_T19H.simc
@@ -21,10 +21,14 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/pyroblast
+actions.precombat+=/variable,op=set,name=marquee_bracers_equipped,value=equipped.132406
+actions.precombat+=/variable,op=set,name=darcklis_helm_equipped,value=equipped.132863
+actions.precombat+=/variable,op=set,name=koralons_belt_equipped,value=equipped.132454
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
 actions+=/mirror_image,if=buff.combustion.down
 actions+=/rune_of_power,if=cooldown.combustion.remains>40&buff.combustion.down&!talent.kindling.enabled|target.time_to_die.remains<11|talent.kindling.enabled&(charges_fractional>1.8|time<40)&cooldown.combustion.remains>40
 actions+=/call_action_list,name=combustion_phase,if=cooldown.combustion.remains<=action.rune_of_power.cast_time+(!talent.kindling.enabled*gcd)|buff.combustion.up
@@ -34,7 +38,7 @@ actions+=/call_action_list,name=standard_rotation
 actions.active_talents=blast_wave,if=(buff.combustion.down)|(buff.combustion.up&action.fire_blast.charges<1&action.phoenixs_flames.charges<1)
 actions.active_talents+=/meteor,if=cooldown.combustion.remains>15|(cooldown.combustion.remains>target.time_to_die)|buff.rune_of_power.up
 actions.active_talents+=/cinderstorm,if=cooldown.combustion.remains<cast_time&(buff.rune_of_power.up|!talent.rune_on_power.enabled)|cooldown.combustion.remains>10*spell_haste&!buff.combustion.up
-actions.active_talents+=/dragons_breath,if=equipped.132863|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
+actions.active_talents+=/dragons_breath,if=variable.darcklis_helm_equipped|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
 actions.active_talents+=/living_bomb,if=active_enemies>1&buff.combustion.down
 
 actions.combustion_phase=rune_of_power,if=buff.combustion.down
@@ -46,22 +50,22 @@ actions.combustion_phase+=/berserking
 actions.combustion_phase+=/arcane_torrent
 actions.combustion_phase+=/use_item,slot=finger1
 actions.combustion_phase+=/use_item,slot=trinket2
-actions.combustion_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
+actions.combustion_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
 actions.combustion_phase+=/pyroblast,if=buff.hot_streak.up
 actions.combustion_phase+=/fire_blast,if=buff.heating_up.up
 actions.combustion_phase+=/phoenixs_flames
 actions.combustion_phase+=/scorch,if=buff.combustion.remains>cast_time
 actions.combustion_phase+=/dragons_breath,if=buff.hot_streak.down&action.fire_blast.charges<1&action.phoenixs_flames.charges<1
-actions.combustion_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.combustion_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 
 actions.rop_phase=rune_of_power
 actions.rop_phase+=/flamestrike,if=((talent.flame_patch.enabled&active_enemies>1)|(active_enemies>3))&buff.hot_streak.up
 actions.rop_phase+=/pyroblast,if=buff.hot_streak.up
 actions.rop_phase+=/call_action_list,name=active_talents
-actions.rop_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.rop_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.rop_phase+=/fire_blast,if=!prev_off_gcd.fire_blast
 actions.rop_phase+=/phoenixs_flames,if=!prev_gcd.1.phoenixs_flames
-actions.rop_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.rop_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.rop_phase+=/dragons_breath,if=active_enemies>2
 actions.rop_phase+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>2)|active_enemies>5
 actions.rop_phase+=/fireball
@@ -70,15 +74,15 @@ actions.standard_rotation=flamestrike,if=((talent.flame_patch.enabled&active_ene
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&buff.hot_streak.remains<action.fireball.execute_time
 actions.standard_rotation+=/phoenixs_flames,if=charges_fractional>2.7&active_enemies>2
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&!prev_gcd.1.pyroblast
-actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&equipped.132454
-actions.standard_rotation+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&variable.koralons_belt_equipped
+actions.standard_rotation+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.standard_rotation+=/call_action_list,name=active_talents
 actions.standard_rotation+=/fire_blast,if=!talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.4|cooldown.combustion.remains<40)&(3-charges_fractional)*(12*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/fire_blast,if=talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.5|cooldown.combustion.remains<40)&(3-charges_fractional)*(18*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up|buff.incanters_flow.stack>3|talent.mirror_image.enabled)&artifact.phoenix_reborn.enabled&(4-charges_fractional)*13<cooldown.combustion.remains+5|target.time_to_die.remains<10
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up)&(4-charges_fractional)*30<cooldown.combustion.remains+5
 actions.standard_rotation+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>1)|active_enemies>5
-actions.standard_rotation+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.standard_rotation+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.standard_rotation+=/fireball
 
 head=collar_of_enclosure,id=134424,bonus_id=1727/1517

--- a/profiles/Tier19H/Mage_Frost_T19H.simc
+++ b/profiles/Tier19H/Mage_Frost_T19H.simc
@@ -22,11 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/frostbolt
+actions.precombat+=/variable,op=set,name=zannesu_belt_equipped,value=equipped.133970
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
 actions+=/ice_lance,if=buff.fingers_of_frost.react=0&prev_gcd.1.flurry
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.icy_veins.remains<1|target.time_to_die<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.icy_veins.remains<1|target.time_to_die<50))
 actions+=/call_action_list,name=cooldowns
 actions+=/call_action_list,name=aoe,if=active_enemies>=4
 actions+=/call_action_list,name=single
@@ -63,7 +65,7 @@ actions.single+=/ice_lance,if=buff.fingers_of_frost.react>0&cooldown.icy_veins.r
 actions.single+=/frozen_orb
 actions.single+=/ice_nova
 actions.single+=/comet_storm
-actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
+actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(variable.zannesu_belt_equipped&buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
 actions.single+=/ebonbolt,if=buff.brain_freeze.react=0
 actions.single+=/glacial_spike
 actions.single+=/frostbolt

--- a/profiles/Tier19M/Mage_Arcane_T19M.simc
+++ b/profiles/Tier19M/Mage_Arcane_T19M.simc
@@ -22,10 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/arcane_blast
+actions.precombat+=/variable,op=set,name=mystic_kilt_equipped,value=equipped.132451
+actions.precombat+=/variable,op=set,name=rhonins_bracers_equipped,value=equipped.132413
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(equipped.132410&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
+actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(variable.shard_ring_equipped&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
 actions+=/mirror_image,if=buff.arcane_power.down
 actions+=/stop_burn_phase,if=prev_gcd.1.evocation&burn_phase_duration>gcd.max
 actions+=/mark_of_aluneth,if=cooldown.arcane_power.remains>20
@@ -42,7 +45,7 @@ actions.build+=/arcane_explosion,if=active_enemies>1
 actions.build+=/arcane_blast
 
 actions.burn=call_action_list,name=cooldowns
-actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
+actions.burn+=/charged_up,if=(variable.mystic_kilt_equipped&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
 actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
@@ -54,18 +57,18 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up|buff.arcane_power.remain
 actions.burn+=/supernova,if=mana.pct<100
 actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.arcane_power.down)
 actions.burn+=/arcane_explosion,if=active_enemies>1
-actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
+actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(variable.mystic_kilt_equipped&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3
 actions.conserve+=/arcane_blast,if=mana.pct>99
 actions.conserve+=/nether_tempest,if=(refreshable|!ticking)
-actions.conserve+=/arcane_blast,if=buff.rhonins_assaulting_armwraps.up&equipped.132413
+actions.conserve+=/arcane_blast,if=variable.rhonins_bracers_equipped&buff.rhonins_assaulting_armwraps.up
 actions.conserve+=/arcane_missiles
 actions.conserve+=/supernova,if=mana.pct<100
-actions.conserve+=/arcane_explosion,if=mana.pct>=82&equipped.132451&active_enemies>1
-actions.conserve+=/arcane_blast,if=mana.pct>=82&equipped.132451
+actions.conserve+=/arcane_explosion,if=mana.pct>=82&variable.mystic_kilt_equipped&active_enemies>1
+actions.conserve+=/arcane_blast,if=mana.pct>=82&variable.mystic_kilt_equipped
 actions.conserve+=/arcane_barrage,if=mana.pct<100&cooldown.arcane_power.remains>5
 actions.conserve+=/arcane_explosion,if=active_enemies>1
 actions.conserve+=/arcane_blast

--- a/profiles/Tier19M/Mage_Fire_T19M.simc
+++ b/profiles/Tier19M/Mage_Fire_T19M.simc
@@ -21,10 +21,14 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/pyroblast
+actions.precombat+=/variable,op=set,name=marquee_bracers_equipped,value=equipped.132406
+actions.precombat+=/variable,op=set,name=darcklis_helm_equipped,value=equipped.132863
+actions.precombat+=/variable,op=set,name=koralons_belt_equipped,value=equipped.132454
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
 actions+=/mirror_image,if=buff.combustion.down
 actions+=/rune_of_power,if=cooldown.combustion.remains>40&buff.combustion.down&!talent.kindling.enabled|target.time_to_die.remains<11|talent.kindling.enabled&(charges_fractional>1.8|time<40)&cooldown.combustion.remains>40
 actions+=/call_action_list,name=combustion_phase,if=cooldown.combustion.remains<=action.rune_of_power.cast_time+(!talent.kindling.enabled*gcd)|buff.combustion.up
@@ -34,7 +38,7 @@ actions+=/call_action_list,name=standard_rotation
 actions.active_talents=blast_wave,if=(buff.combustion.down)|(buff.combustion.up&action.fire_blast.charges<1&action.phoenixs_flames.charges<1)
 actions.active_talents+=/meteor,if=cooldown.combustion.remains>15|(cooldown.combustion.remains>target.time_to_die)|buff.rune_of_power.up
 actions.active_talents+=/cinderstorm,if=cooldown.combustion.remains<cast_time&(buff.rune_of_power.up|!talent.rune_on_power.enabled)|cooldown.combustion.remains>10*spell_haste&!buff.combustion.up
-actions.active_talents+=/dragons_breath,if=equipped.132863|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
+actions.active_talents+=/dragons_breath,if=variable.darcklis_helm_equipped|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
 actions.active_talents+=/living_bomb,if=active_enemies>1&buff.combustion.down
 
 actions.combustion_phase=rune_of_power,if=buff.combustion.down
@@ -45,22 +49,22 @@ actions.combustion_phase+=/blood_fury
 actions.combustion_phase+=/berserking
 actions.combustion_phase+=/arcane_torrent
 actions.combustion_phase+=/use_item,slot=neck
-actions.combustion_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
+actions.combustion_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
 actions.combustion_phase+=/pyroblast,if=buff.hot_streak.up
 actions.combustion_phase+=/fire_blast,if=buff.heating_up.up
 actions.combustion_phase+=/phoenixs_flames
 actions.combustion_phase+=/scorch,if=buff.combustion.remains>cast_time
 actions.combustion_phase+=/dragons_breath,if=buff.hot_streak.down&action.fire_blast.charges<1&action.phoenixs_flames.charges<1
-actions.combustion_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.combustion_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 
 actions.rop_phase=rune_of_power
 actions.rop_phase+=/flamestrike,if=((talent.flame_patch.enabled&active_enemies>1)|(active_enemies>3))&buff.hot_streak.up
 actions.rop_phase+=/pyroblast,if=buff.hot_streak.up
 actions.rop_phase+=/call_action_list,name=active_talents
-actions.rop_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.rop_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.rop_phase+=/fire_blast,if=!prev_off_gcd.fire_blast
 actions.rop_phase+=/phoenixs_flames,if=!prev_gcd.1.phoenixs_flames
-actions.rop_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.rop_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.rop_phase+=/dragons_breath,if=active_enemies>2
 actions.rop_phase+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>2)|active_enemies>5
 actions.rop_phase+=/fireball
@@ -69,15 +73,15 @@ actions.standard_rotation=flamestrike,if=((talent.flame_patch.enabled&active_ene
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&buff.hot_streak.remains<action.fireball.execute_time
 actions.standard_rotation+=/phoenixs_flames,if=charges_fractional>2.7&active_enemies>2
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&!prev_gcd.1.pyroblast
-actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&equipped.132454
-actions.standard_rotation+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&variable.koralons_belt_equipped
+actions.standard_rotation+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.standard_rotation+=/call_action_list,name=active_talents
 actions.standard_rotation+=/fire_blast,if=!talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.4|cooldown.combustion.remains<40)&(3-charges_fractional)*(12*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/fire_blast,if=talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.5|cooldown.combustion.remains<40)&(3-charges_fractional)*(18*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up|buff.incanters_flow.stack>3|talent.mirror_image.enabled)&artifact.phoenix_reborn.enabled&(4-charges_fractional)*13<cooldown.combustion.remains+5|target.time_to_die.remains<10
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up)&(4-charges_fractional)*30<cooldown.combustion.remains+5
 actions.standard_rotation+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>1)|active_enemies>5
-actions.standard_rotation+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.standard_rotation+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.standard_rotation+=/fireball
 
 head=collar_of_enclosure,id=134424,bonus_id=1727/1522

--- a/profiles/Tier19M/Mage_Frost_T19M.simc
+++ b/profiles/Tier19M/Mage_Frost_T19M.simc
@@ -22,11 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/frostbolt
+actions.precombat+=/variable,op=set,name=zannesu_belt_equipped,value=equipped.133970
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
 actions+=/ice_lance,if=buff.fingers_of_frost.react=0&prev_gcd.1.flurry
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.icy_veins.remains<1|target.time_to_die<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.icy_veins.remains<1|target.time_to_die<50))
 actions+=/call_action_list,name=cooldowns
 actions+=/call_action_list,name=aoe,if=active_enemies>=4
 actions+=/call_action_list,name=single
@@ -64,7 +66,7 @@ actions.single+=/ice_lance,if=buff.fingers_of_frost.react>0&cooldown.icy_veins.r
 actions.single+=/frozen_orb
 actions.single+=/ice_nova
 actions.single+=/comet_storm
-actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
+actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(variable.zannesu_belt_equipped&buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
 actions.single+=/ebonbolt,if=buff.brain_freeze.react=0
 actions.single+=/glacial_spike
 actions.single+=/frostbolt

--- a/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
@@ -22,10 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/arcane_blast
+actions.precombat+=/variable,op=set,name=mystic_kilt_equipped,value=equipped.132451
+actions.precombat+=/variable,op=set,name=rhonins_bracers_equipped,value=equipped.132413
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(equipped.132410&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
+actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(variable.shard_ring_equipped&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
 actions+=/mirror_image,if=buff.arcane_power.down
 actions+=/stop_burn_phase,if=prev_gcd.1.evocation&burn_phase_duration>gcd.max
 actions+=/mark_of_aluneth,if=cooldown.arcane_power.remains>20
@@ -42,7 +45,7 @@ actions.build+=/arcane_explosion,if=active_enemies>1
 actions.build+=/arcane_blast
 
 actions.burn=call_action_list,name=cooldowns
-actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
+actions.burn+=/charged_up,if=(variable.mystic_kilt_equipped&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
 actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
@@ -54,18 +57,18 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up|buff.arcane_power.remain
 actions.burn+=/supernova,if=mana.pct<100
 actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.arcane_power.down)
 actions.burn+=/arcane_explosion,if=active_enemies>1
-actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
+actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(variable.mystic_kilt_equipped&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3
 actions.conserve+=/arcane_blast,if=mana.pct>99
 actions.conserve+=/nether_tempest,if=(refreshable|!ticking)
-actions.conserve+=/arcane_blast,if=buff.rhonins_assaulting_armwraps.up&equipped.132413
+actions.conserve+=/arcane_blast,if=variable.rhonins_bracers_equipped&buff.rhonins_assaulting_armwraps.up
 actions.conserve+=/arcane_missiles
 actions.conserve+=/supernova,if=mana.pct<100
-actions.conserve+=/arcane_explosion,if=mana.pct>=82&equipped.132451&active_enemies>1
-actions.conserve+=/arcane_blast,if=mana.pct>=82&equipped.132451
+actions.conserve+=/arcane_explosion,if=mana.pct>=82&variable.mystic_kilt_equipped&active_enemies>1
+actions.conserve+=/arcane_blast,if=mana.pct>=82&variable.mystic_kilt_equipped
 actions.conserve+=/arcane_barrage,if=mana.pct<100&cooldown.arcane_power.remains>5
 actions.conserve+=/arcane_explosion,if=active_enemies>1
 actions.conserve+=/arcane_blast

--- a/profiles/Tier19M_NH/Mage_Fire_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Mage_Fire_T19M_NH.simc
@@ -21,10 +21,14 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/pyroblast
+actions.precombat+=/variable,op=set,name=marquee_bracers_equipped,value=equipped.132406
+actions.precombat+=/variable,op=set,name=darcklis_helm_equipped,value=equipped.132863
+actions.precombat+=/variable,op=set,name=koralons_belt_equipped,value=equipped.132454
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
 actions+=/mirror_image,if=buff.combustion.down
 actions+=/rune_of_power,if=cooldown.combustion.remains>40&buff.combustion.down&!talent.kindling.enabled|target.time_to_die.remains<11|talent.kindling.enabled&(charges_fractional>1.8|time<40)&cooldown.combustion.remains>40
 actions+=/call_action_list,name=combustion_phase,if=cooldown.combustion.remains<=action.rune_of_power.cast_time+(!talent.kindling.enabled*gcd)|buff.combustion.up
@@ -34,7 +38,7 @@ actions+=/call_action_list,name=standard_rotation
 actions.active_talents=blast_wave,if=(buff.combustion.down)|(buff.combustion.up&action.fire_blast.charges<1&action.phoenixs_flames.charges<1)
 actions.active_talents+=/meteor,if=cooldown.combustion.remains>15|(cooldown.combustion.remains>target.time_to_die)|buff.rune_of_power.up
 actions.active_talents+=/cinderstorm,if=cooldown.combustion.remains<cast_time&(buff.rune_of_power.up|!talent.rune_on_power.enabled)|cooldown.combustion.remains>10*spell_haste&!buff.combustion.up
-actions.active_talents+=/dragons_breath,if=equipped.132863|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
+actions.active_talents+=/dragons_breath,if=variable.darcklis_helm_equipped|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
 actions.active_talents+=/living_bomb,if=active_enemies>1&buff.combustion.down
 
 actions.combustion_phase=rune_of_power,if=buff.combustion.down
@@ -44,22 +48,22 @@ actions.combustion_phase+=/potion,name=deadly_grace
 actions.combustion_phase+=/blood_fury
 actions.combustion_phase+=/berserking
 actions.combustion_phase+=/arcane_torrent
-actions.combustion_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
+actions.combustion_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
 actions.combustion_phase+=/pyroblast,if=buff.hot_streak.up
 actions.combustion_phase+=/fire_blast,if=buff.heating_up.up
 actions.combustion_phase+=/phoenixs_flames
 actions.combustion_phase+=/scorch,if=buff.combustion.remains>cast_time
 actions.combustion_phase+=/dragons_breath,if=buff.hot_streak.down&action.fire_blast.charges<1&action.phoenixs_flames.charges<1
-actions.combustion_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.combustion_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 
 actions.rop_phase=rune_of_power
 actions.rop_phase+=/flamestrike,if=((talent.flame_patch.enabled&active_enemies>1)|(active_enemies>3))&buff.hot_streak.up
 actions.rop_phase+=/pyroblast,if=buff.hot_streak.up
 actions.rop_phase+=/call_action_list,name=active_talents
-actions.rop_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.rop_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.rop_phase+=/fire_blast,if=!prev_off_gcd.fire_blast
 actions.rop_phase+=/phoenixs_flames,if=!prev_gcd.1.phoenixs_flames
-actions.rop_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.rop_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.rop_phase+=/dragons_breath,if=active_enemies>2
 actions.rop_phase+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>2)|active_enemies>5
 actions.rop_phase+=/fireball
@@ -68,15 +72,15 @@ actions.standard_rotation=flamestrike,if=((talent.flame_patch.enabled&active_ene
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&buff.hot_streak.remains<action.fireball.execute_time
 actions.standard_rotation+=/phoenixs_flames,if=charges_fractional>2.7&active_enemies>2
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&!prev_gcd.1.pyroblast
-actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&equipped.132454
-actions.standard_rotation+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&variable.koralons_belt_equipped
+actions.standard_rotation+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.standard_rotation+=/call_action_list,name=active_talents
 actions.standard_rotation+=/fire_blast,if=!talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.4|cooldown.combustion.remains<40)&(3-charges_fractional)*(12*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/fire_blast,if=talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.5|cooldown.combustion.remains<40)&(3-charges_fractional)*(18*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up|buff.incanters_flow.stack>3|talent.mirror_image.enabled)&artifact.phoenix_reborn.enabled&(4-charges_fractional)*13<cooldown.combustion.remains+5|target.time_to_die.remains<10
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up)&(4-charges_fractional)*30<cooldown.combustion.remains+5
 actions.standard_rotation+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>1)|active_enemies>5
-actions.standard_rotation+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.standard_rotation+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.standard_rotation+=/fireball
 
 head=nighthold_custodians_hood,id=140851,bonus_id=3445

--- a/profiles/Tier19M_NH/Mage_Frost_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Mage_Frost_T19M_NH.simc
@@ -22,11 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/frostbolt
+actions.precombat+=/variable,op=set,name=zannesu_belt_equipped,value=equipped.133970
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
 actions+=/ice_lance,if=buff.fingers_of_frost.react=0&prev_gcd.1.flurry
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.icy_veins.remains<1|target.time_to_die<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.icy_veins.remains<1|target.time_to_die<50))
 actions+=/call_action_list,name=cooldowns
 actions+=/call_action_list,name=aoe,if=active_enemies>=4
 actions+=/call_action_list,name=single
@@ -63,7 +65,7 @@ actions.single+=/ice_lance,if=buff.fingers_of_frost.react>0&cooldown.icy_veins.r
 actions.single+=/frozen_orb
 actions.single+=/ice_nova
 actions.single+=/comet_storm
-actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
+actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(variable.zannesu_belt_equipped&buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
 actions.single+=/ebonbolt,if=buff.brain_freeze.react=0
 actions.single+=/glacial_spike
 actions.single+=/frostbolt

--- a/profiles/Tier19P/Mage_Arcane_T19P.simc
+++ b/profiles/Tier19P/Mage_Arcane_T19P.simc
@@ -22,10 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/arcane_blast
+actions.precombat+=/variable,op=set,name=mystic_kilt_equipped,value=equipped.132451
+actions.precombat+=/variable,op=set,name=rhonins_bracers_equipped,value=equipped.132413
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(equipped.132410&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
+actions+=/time_warp,if=(buff.bloodlust.down)&((time=0)|(variable.shard_ring_equipped&buff.arcane_power.up&prev_off_gcd.arcane_power)|(target.time_to_die<40))
 actions+=/mirror_image,if=buff.arcane_power.down
 actions+=/stop_burn_phase,if=prev_gcd.1.evocation&burn_phase_duration>gcd.max
 actions+=/mark_of_aluneth,if=cooldown.arcane_power.remains>20
@@ -42,7 +45,7 @@ actions.build+=/arcane_explosion,if=active_enemies>1
 actions.build+=/arcane_blast
 
 actions.burn=call_action_list,name=cooldowns
-actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
+actions.burn+=/charged_up,if=(variable.mystic_kilt_equipped&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
 actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
@@ -54,18 +57,18 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up|buff.arcane_power.remain
 actions.burn+=/supernova,if=mana.pct<100
 actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.arcane_power.down)
 actions.burn+=/arcane_explosion,if=active_enemies>1
-actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
+actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(variable.mystic_kilt_equipped&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3
 actions.conserve+=/arcane_blast,if=mana.pct>99
 actions.conserve+=/nether_tempest,if=(refreshable|!ticking)
-actions.conserve+=/arcane_blast,if=buff.rhonins_assaulting_armwraps.up&equipped.132413
+actions.conserve+=/arcane_blast,if=variable.rhonins_bracers_equipped&buff.rhonins_assaulting_armwraps.up
 actions.conserve+=/arcane_missiles
 actions.conserve+=/supernova,if=mana.pct<100
-actions.conserve+=/arcane_explosion,if=mana.pct>=82&equipped.132451&active_enemies>1
-actions.conserve+=/arcane_blast,if=mana.pct>=82&equipped.132451
+actions.conserve+=/arcane_explosion,if=mana.pct>=82&variable.mystic_kilt_equipped&active_enemies>1
+actions.conserve+=/arcane_blast,if=mana.pct>=82&variable.mystic_kilt_equipped
 actions.conserve+=/arcane_barrage,if=mana.pct<100&cooldown.arcane_power.remains>5
 actions.conserve+=/arcane_explosion,if=active_enemies>1
 actions.conserve+=/arcane_blast

--- a/profiles/Tier19P/Mage_Fire_T19P.simc
+++ b/profiles/Tier19P/Mage_Fire_T19P.simc
@@ -21,10 +21,14 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/pyroblast
+actions.precombat+=/variable,op=set,name=marquee_bracers_equipped,value=equipped.132406
+actions.precombat+=/variable,op=set,name=darcklis_helm_equipped,value=equipped.132863
+actions.precombat+=/variable,op=set,name=koralons_belt_equipped,value=equipped.132454
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.combustion.remains<1|target.time_to_die.remains<50))
 actions+=/mirror_image,if=buff.combustion.down
 actions+=/rune_of_power,if=cooldown.combustion.remains>40&buff.combustion.down&!talent.kindling.enabled|target.time_to_die.remains<11|talent.kindling.enabled&(charges_fractional>1.8|time<40)&cooldown.combustion.remains>40
 actions+=/call_action_list,name=combustion_phase,if=cooldown.combustion.remains<=action.rune_of_power.cast_time+(!talent.kindling.enabled*gcd)|buff.combustion.up
@@ -34,7 +38,7 @@ actions+=/call_action_list,name=standard_rotation
 actions.active_talents=blast_wave,if=(buff.combustion.down)|(buff.combustion.up&action.fire_blast.charges<1&action.phoenixs_flames.charges<1)
 actions.active_talents+=/meteor,if=cooldown.combustion.remains>15|(cooldown.combustion.remains>target.time_to_die)|buff.rune_of_power.up
 actions.active_talents+=/cinderstorm,if=cooldown.combustion.remains<cast_time&(buff.rune_of_power.up|!talent.rune_on_power.enabled)|cooldown.combustion.remains>10*spell_haste&!buff.combustion.up
-actions.active_talents+=/dragons_breath,if=equipped.132863|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
+actions.active_talents+=/dragons_breath,if=variable.darcklis_helm_equipped|(talent.alexstraszas_fury.enabled&buff.hot_streak.down)
 actions.active_talents+=/living_bomb,if=active_enemies>1&buff.combustion.down
 
 actions.combustion_phase=rune_of_power,if=buff.combustion.down
@@ -44,22 +48,22 @@ actions.combustion_phase+=/potion,name=deadly_grace
 actions.combustion_phase+=/blood_fury
 actions.combustion_phase+=/berserking
 actions.combustion_phase+=/arcane_torrent
-actions.combustion_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
+actions.combustion_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&buff.combustion.remains>execute_time
 actions.combustion_phase+=/pyroblast,if=buff.hot_streak.up
 actions.combustion_phase+=/fire_blast,if=buff.heating_up.up
 actions.combustion_phase+=/phoenixs_flames
 actions.combustion_phase+=/scorch,if=buff.combustion.remains>cast_time
 actions.combustion_phase+=/dragons_breath,if=buff.hot_streak.down&action.fire_blast.charges<1&action.phoenixs_flames.charges<1
-actions.combustion_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.combustion_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 
 actions.rop_phase=rune_of_power
 actions.rop_phase+=/flamestrike,if=((talent.flame_patch.enabled&active_enemies>1)|(active_enemies>3))&buff.hot_streak.up
 actions.rop_phase+=/pyroblast,if=buff.hot_streak.up
 actions.rop_phase+=/call_action_list,name=active_talents
-actions.rop_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.rop_phase+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.rop_phase+=/fire_blast,if=!prev_off_gcd.fire_blast
 actions.rop_phase+=/phoenixs_flames,if=!prev_gcd.1.phoenixs_flames
-actions.rop_phase+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.rop_phase+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.rop_phase+=/dragons_breath,if=active_enemies>2
 actions.rop_phase+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>2)|active_enemies>5
 actions.rop_phase+=/fireball
@@ -68,15 +72,15 @@ actions.standard_rotation=flamestrike,if=((talent.flame_patch.enabled&active_ene
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&buff.hot_streak.remains<action.fireball.execute_time
 actions.standard_rotation+=/phoenixs_flames,if=charges_fractional>2.7&active_enemies>2
 actions.standard_rotation+=/pyroblast,if=buff.hot_streak.up&!prev_gcd.1.pyroblast
-actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&equipped.132454
-actions.standard_rotation+=/pyroblast,if=buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
+actions.standard_rotation+=/pyroblast,if=buff.hot_streak.react&target.health.pct<=30&variable.koralons_belt_equipped
+actions.standard_rotation+=/pyroblast,if=variable.marquee_bracers_equipped&buff.kaelthas_ultimate_ability.react&execute_time<buff.kaelthas_ultimate_ability.remains
 actions.standard_rotation+=/call_action_list,name=active_talents
 actions.standard_rotation+=/fire_blast,if=!talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.4|cooldown.combustion.remains<40)&(3-charges_fractional)*(12*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/fire_blast,if=talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled|charges_fractional>1.5|cooldown.combustion.remains<40)&(3-charges_fractional)*(18*spell_haste)<cooldown.combustion.remains+3|target.time_to_die.remains<4
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up|buff.incanters_flow.stack>3|talent.mirror_image.enabled)&artifact.phoenix_reborn.enabled&(4-charges_fractional)*13<cooldown.combustion.remains+5|target.time_to_die.remains<10
 actions.standard_rotation+=/phoenixs_flames,if=(buff.combustion.up|buff.rune_of_power.up)&(4-charges_fractional)*30<cooldown.combustion.remains+5
 actions.standard_rotation+=/flamestrike,if=(talent.flame_patch.enabled&active_enemies>1)|active_enemies>5
-actions.standard_rotation+=/scorch,if=target.health.pct<=30&equipped.132454
+actions.standard_rotation+=/scorch,if=target.health.pct<=30&variable.koralons_belt_equipped
 actions.standard_rotation+=/fireball
 
 head=collar_of_enclosure,id=134424,bonus_id=1727

--- a/profiles/Tier19P/Mage_Frost_T19P.simc
+++ b/profiles/Tier19P/Mage_Frost_T19P.simc
@@ -22,11 +22,13 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/mirror_image
 actions.precombat+=/potion,name=deadly_grace
 actions.precombat+=/frostbolt
+actions.precombat+=/variable,op=set,name=zannesu_belt_equipped,value=equipped.133970
+actions.precombat+=/variable,op=set,name=shard_ring_equipped,value=equipped.132410
 
 # Executed every time the actor is available.
 actions=counterspell,if=target.debuff.casting.react
 actions+=/ice_lance,if=buff.fingers_of_frost.react=0&prev_gcd.1.flurry
-actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&equipped.132410&(cooldown.icy_veins.remains<1|target.time_to_die<50))
+actions+=/time_warp,if=(time=0&buff.bloodlust.down)|(buff.bloodlust.down&variable.shard_ring_equipped&(cooldown.icy_veins.remains<1|target.time_to_die<50))
 actions+=/call_action_list,name=cooldowns
 actions+=/call_action_list,name=aoe,if=active_enemies>=4
 actions+=/call_action_list,name=single
@@ -63,7 +65,7 @@ actions.single+=/ice_lance,if=buff.fingers_of_frost.react>0&cooldown.icy_veins.r
 actions.single+=/frozen_orb
 actions.single+=/ice_nova
 actions.single+=/comet_storm
-actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
+actions.single+=/blizzard,if=talent.arctic_gale.enabled|active_enemies>1|(variable.zannesu_belt_equipped&buff.zannesu_journey.stack=5&buff.zannesu_journey.remains>cast_time)
 actions.single+=/ebonbolt,if=buff.brain_freeze.react=0
 actions.single+=/glacial_spike
 actions.single+=/frostbolt


### PR DESCRIPTION
I think it would be helpful for the reader to know at a glance what a line is doing without having to know an item id. To that end I've added `variable` actions for any legendary items that were being tracked in each spec's APL; any legendaries that weren't already present were left out, but we can easily add the rest.

There were also some inconsistencies with actions checking for legendary buffs/effects, e.g. Arcane would check for the bracers buff being up as well as the item being equipped, whereas Fire would only check for the buff. I've added the appropriate variable checks to those actions so there's a clearer connection between item and buff.