### PR TITLE
[Rogue] Use Darkflight for Thraxi's Tricksy Treads

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -6819,6 +6819,8 @@ void rogue_t::init_action_list()
     cds -> add_action( this, "Adrenaline Rush", "if=!buff.adrenaline_rush.up&energy.deficit>0" );
     cds -> add_talent( this, "Marked for Death", "target_if=min:target.time_to_die,if=target.time_to_die<combo_points.deficit|((raid_event.adds.in>40|buff.true_bearing.remains>15)&combo_points.deficit>=4+talent.deeper_strategem.enabled+talent.anticipation.enabled)" );
     cds -> add_action( this, "Sprint", "if=equipped.thraxis_tricksy_treads&!variable.ss_useable" );
+    if ( race == RACE_WORGEN )
+      cds -> add_action( "darkflight,if=equipped.thraxis_tricksy_treads&!variable.ss_useable&buff.sprint.down" );
     cds -> add_action( this, "Curse of the Dreadblades", "if=combo_points.deficit>=4&(!talent.ghostly_strike.enabled|debuff.ghostly_strike.up)" );
 
     // Finishers


### PR DESCRIPTION
Use the worgen racial Darkflight when Sprint is down to provide a
further damage boost when using Thraxi's Tricksy Treads.

The APL action is largely just an adaptation of the existing Sprint
action with the added condition of Sprint not already being up.