### PR TITLE
[Mage] Remove Arcane Blast usage in end burn

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -8314,7 +8314,6 @@ void mage_t::apl_arcane()
   burn      -> add_talent( this, "Charged Up", "if=(equipped.132451&buff.arcane_charge.stack<=1)" );
   burn      -> add_action( this, "Arcane Missiles", "if=buff.arcane_missiles.react=3" );
   burn      -> add_talent( this, "Nether Tempest", "if=dot.nether_tempest.remains<=2|!ticking" );
-  burn      -> add_action( this, "Arcane Blast", "if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die" );
   burn      -> add_action( this, "Arcane Explosion", "if=active_enemies>1&mana.pct%10*execute_time>target.time_to_die" );
   burn      -> add_action( this, "Presence of Mind", "if=buff.rune_of_power.remains<=2*action.arcane_blast.execute_time");
   burn      -> add_action( this, "Arcane Missiles", "if=buff.arcane_missiles.react>1" );

--- a/profiles/Tier19H/Mage_Arcane_T19H.simc
+++ b/profiles/Tier19H/Mage_Arcane_T19H.simc
@@ -45,7 +45,6 @@ actions.burn=call_action_list,name=cooldowns
 actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
-actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/arcane_explosion,if=active_enemies>1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/presence_of_mind,if=buff.rune_of_power.remains<=2*action.arcane_blast.execute_time
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react>1

--- a/profiles/Tier19M/Mage_Arcane_T19M.simc
+++ b/profiles/Tier19M/Mage_Arcane_T19M.simc
@@ -45,7 +45,6 @@ actions.burn=call_action_list,name=cooldowns
 actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
-actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/arcane_explosion,if=active_enemies>1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/presence_of_mind,if=buff.rune_of_power.remains<=2*action.arcane_blast.execute_time
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react>1

--- a/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
@@ -45,7 +45,6 @@ actions.burn=call_action_list,name=cooldowns
 actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
-actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/arcane_explosion,if=active_enemies>1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/presence_of_mind,if=buff.rune_of_power.remains<=2*action.arcane_blast.execute_time
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react>1

--- a/profiles/Tier19P/Mage_Arcane_T19P.simc
+++ b/profiles/Tier19P/Mage_Arcane_T19P.simc
@@ -45,7 +45,6 @@ actions.burn=call_action_list,name=cooldowns
 actions.burn+=/charged_up,if=(equipped.132451&buff.arcane_charge.stack<=1)
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react=3
 actions.burn+=/nether_tempest,if=dot.nether_tempest.remains<=2|!ticking
-actions.burn+=/arcane_blast,if=active_enemies<=1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/arcane_explosion,if=active_enemies>1&mana.pct%10*execute_time>target.time_to_die
 actions.burn+=/presence_of_mind,if=buff.rune_of_power.remains<=2*action.arcane_blast.execute_time
 actions.burn+=/arcane_missiles,if=buff.arcane_missiles.react>1


### PR DESCRIPTION
Based on [these sim results](https://docs.google.com/spreadsheets/d/1QnjZnY51jhRGwLUkmMv5tkRPW73bZF8mq4FslQqsERw/edit#gid=0), the Arcane Blast usage during "final burn" rotation often proves to be a DPS loss.