### PR TITLE
[Mage] Add Arcane Missiles to end of burns

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -8328,6 +8328,7 @@ void mage_t::apl_arcane()
   burn      -> add_action( this, "Arcane Explosion", "if=active_enemies>1" );
   burn      -> add_action( this, "Arcane Barrage", "if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))" );
   burn      -> add_action( this, "Arcane Blast" );
+  burn      -> add_action( this, "Arcane Missiles" );
   burn      -> add_action( this, "Evocation", "interrupt_if=mana.pct>99" );
 
 }

--- a/profiles/Tier19H/Mage_Arcane_T19H.simc
+++ b/profiles/Tier19H/Mage_Arcane_T19H.simc
@@ -55,6 +55,7 @@ actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.a
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
+actions.burn+=/arcane_missiles
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3

--- a/profiles/Tier19M/Mage_Arcane_T19M.simc
+++ b/profiles/Tier19M/Mage_Arcane_T19M.simc
@@ -55,6 +55,7 @@ actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.a
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
+actions.burn+=/arcane_missiles
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3

--- a/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
@@ -55,6 +55,7 @@ actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.a
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
+actions.burn+=/arcane_missiles
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3

--- a/profiles/Tier19P/Mage_Arcane_T19P.simc
+++ b/profiles/Tier19P/Mage_Arcane_T19P.simc
@@ -55,6 +55,7 @@ actions.burn+=/arcane_missiles,if=mana.pct>10&(talent.overpowered.enabled|buff.a
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_barrage,if=talent.charged_up.enabled&(equipped.132451&cooldown.charged_up.remains=0&mana.pct<(100-(buff.arcane_charge.stack*0.03)))
 actions.burn+=/arcane_blast
+actions.burn+=/arcane_missiles
 actions.burn+=/evocation,interrupt_if=mana.pct>99
 
 actions.conserve=arcane_missiles,if=buff.arcane_missiles.react=3


### PR DESCRIPTION
Usually get around ~4k DPS increase by expending Arcane Missiles at end of burns (when current mana < Arcane Blast cost).

![image](https://cloud.githubusercontent.com/assets/206867/23033203/34aa735e-f445-11e6-9ae4-011358d4e2bb.png)