### PR TITLE
[Mage] Add missing set bonuses and traits into spell data

### DIFF
--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -1455,6 +1455,8 @@ class SpellDataGenerator(DataGenerator):
           ( 225119, 5 ),                            # Arcane Familiar attack, Arcane Assault
           ( 210833, 0 ),                            # Touch of the Magi
           ( 228358, 0 ),                            # Winter's Chill
+          ( 242253, 0 ),                            # Frost T20 2P Frozen Mass
+          ( 240689, 0 ),                            # Aluneth - Time and Space
         ),
 
         # Warlock:


### PR DESCRIPTION
[Frozen Mass](http://ptr.wowhead.com/spell=242253/frozen-mass) - Frost T20 2pc
[Time and Space](http://ptr.wowhead.com/spell=240689/time-and-space) - damage effect of a trait with the same name