### PR TITLE
Add `initial_targets` expression

### DIFF
--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -2809,6 +2809,9 @@ bool sim_t::time_to_think( timespan_t proc_time )
 expr_t* sim_t::create_expression( action_t* a,
                                   const std::string& name_str )
 {
+  if ( name_str == "initial_targets" )
+    return expr_t::create_constant( name_str, target_list.size() );
+
   if ( name_str == "time" )
     return make_ref_expr( name_str, event_mgr.current_time );
 


### PR DESCRIPTION
Goal
--
Create an expression that can be used in `talent_override` to switch talents based on number of enemies. This is already in use, but nonfunctional, in the [Havoc Demon Hunter profile](https://github.com/simulationcraft/simc/blob/legion-dev/profiles/Tier19M_NH/Demon_Hunter_Havoc_T19M_NH.simc).

Problem
---
`active_enemies` is not set until `player_t::arise()`, which is called during `player_t::combat_begin()`; thus, will always be 0 before combat starts.

Motivation
---
Similar functionality is possible, with some caveats.

### `desired_targets`
If we do not explicitly define enemies, we can use `desired_targets`:
```ini
desired_targets=3
talent_override=resonance,if=desired_targets>1
```

### `raid_event.adds`
With `fight_style=HecticAddCleave`, for example, we can look for a raid event to do the override:
```ini
fight_style=HecticAddCleave
talent_override=resonance,if=raid_event.adds.exists
```

However, this does not work for a council fight.

Solution
---
A new expression with a constant value, `initial_targets`, that simply exposes the size of the target list. Regardless of how enemies are defined, this will be updated accordingly, and will be accurate during precombat.