### PR TITLE
Subtlety Rogue 7.2.5 PTR Changes

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -2629,6 +2629,16 @@ struct backstab_t : public rogue_attack_t
 
     return rogue_attack_t::ready();
   }
+
+  void execute() override
+  {
+    rogue_attack_t::execute();
+
+    if ( maybe_ptr( p() -> dbc.ptr ) )
+    {
+      p() -> trigger_energetic_stabbing( execute_state );
+    }
+  }
 };
 
 // Between the Eyes =========================================================

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -4283,7 +4283,7 @@ struct shadowstrike_t : public rogue_attack_t
     requires_stealth = true;
     energize_amount += p -> talent.premeditation -> effectN( 2 ).base_value();
     base_multiplier *= 1.0 + p -> artifact.precision_strike.percent();
-    range += p -> spec.shadowstrike_2 -> effectN( 1 ).base_value();
+    range += maybe_ptr( p -> dbc.ptr ) ? 0 : p -> spec.shadowstrike_2 -> effectN( 1 ).base_value();
 
     if ( maybe_ptr( p -> dbc.ptr ) )
       crit_bonus += p -> artifact.weak_point.percent();
@@ -4337,6 +4337,18 @@ struct shadowstrike_t : public rogue_attack_t
     }
   }
 
+  double action_multiplier() const override
+  {
+    double m = rogue_attack_t::action_multiplier();
+
+    if ( maybe_ptr ( p() -> dbc.ptr ) && ! p() -> in_combat )
+    {
+      m *= 1.0 + p() -> spec.shadowstrike_2 -> effectN( 2 ).percent();
+    }
+
+    return m;
+  }
+
   double composite_crit_chance() const override
   {
     if ( p() -> buffs.death -> up() )
@@ -4356,7 +4368,12 @@ struct shadowstrike_t : public rogue_attack_t
       return 0;
     }
 
-    return data().max_range();
+    if ( maybe_ptr( p() -> dbc.ptr ) && ! p() -> in_combat )
+    {
+      return range + p() -> spec.shadowstrike_2 -> effectN( 1 ).base_value();
+    }
+
+    return maybe_ptr( p() -> dbc.ptr ) ? 0 : data().max_range();
   }
 };
 
@@ -7475,7 +7492,7 @@ void rogue_t::init_spells()
   spec.eviscerate           = find_specialization_spell( "Eviscerate" );
   spec.eviscerate_2         = find_specialization_spell( 231716 );
   spec.shadowstrike         = find_specialization_spell( "Shadowstrike" );
-  spec.shadowstrike_2       = find_specialization_spell( 231718 );
+  spec.shadowstrike_2       = maybe_ptr( dbc.ptr ) ? find_specialization_spell( 245623 ) : find_specialization_spell( 231718 );
 
   // Masteries
   mastery.potent_poisons    = find_mastery_spell( ROGUE_ASSASSINATION );

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -5880,17 +5880,25 @@ void rogue_t::trigger_relentless_strikes( const action_state_t* state )
     return;
   }
 
-  double proc_chance = rogue_attack_t::cast_state( state ) -> cp * spec.relentless_strikes -> effectN( 2 ).percent();
   double grant_energy = 0;
-  if ( proc_chance > 1 )
-  {
-    grant_energy += spell.relentless_strikes_energize -> effectN( 1 ).resource( RESOURCE_ENERGY );
-    proc_chance -= 1;
-  }
 
-  if ( rng().roll( proc_chance ) )
+  if ( maybe_ptr( dbc.ptr ) )
   {
-    grant_energy += spell.relentless_strikes_energize -> effectN( 1 ).resource( RESOURCE_ENERGY );
+    grant_energy += rogue_attack_t::cast_state( state ) -> cp * spell.relentless_strikes_energize -> effectN( 1 ).resource( RESOURCE_ENERGY );
+  }
+  else
+  {
+    double proc_chance = rogue_attack_t::cast_state( state ) -> cp * spec.relentless_strikes -> effectN( 2 ).percent();
+    if ( proc_chance > 1 )
+    {
+      grant_energy += spell.relentless_strikes_energize -> effectN( 1 ).resource( RESOURCE_ENERGY );
+      proc_chance -= 1;
+    }
+
+    if ( rng().roll( proc_chance ) )
+    {
+      grant_energy += spell.relentless_strikes_energize -> effectN( 1 ).resource( RESOURCE_ENERGY );
+    }
   }
 
   if ( grant_energy > 0 )

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -488,6 +488,7 @@ struct rogue_t : public player_t
 
     const spell_data_t* premeditation;
     const spell_data_t* enveloping_shadows;
+    const spell_data_t* dark_shadow;
 
     // Tier 7 - Level 100
     const spell_data_t* venom_rush;
@@ -6163,6 +6164,11 @@ struct shadow_dance_t : public stealth_like_buff_t
   {
     buff_duration += p -> talent.subterfuge -> effectN( 2 ).time_value();
     procs_mantle_of_the_master_assassin = false;
+
+    if ( p -> talent.dark_shadow -> ok() )
+    {
+      add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
+    }
   }
 };
 
@@ -6635,6 +6641,10 @@ double rogue_t::composite_player_multiplier( school_e school ) const
   if ( buffs.symbols_of_death -> up() )
   {
     m *= buffs.symbols_of_death -> check_value();
+  }
+  if ( talent.dark_shadow -> ok() && buffs.shadow_dance -> up() )
+  {
+    m *= 1.0 + talent.dark_shadow -> effectN( 1 ).percent();
   }
   m *= 1.0 + buffs.master_of_subtlety -> stack_value();
   m *= 1.0 + buffs.master_of_subtlety_aura -> stack_value();
@@ -7476,6 +7486,7 @@ void rogue_t::init_spells()
 
   talent.premeditation      = find_talent_spell( "Premeditation" );
   talent.enveloping_shadows = find_talent_spell( "Enveloping Shadows" );
+  talent.dark_shadow        = find_talent_spell( "Dark Shadow" );
 
   talent.master_of_shadows  = find_talent_spell( "Master of Shadows" );
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -1202,6 +1202,14 @@ struct rogue_attack_t : public melee_attack_t
       m *= 1.0 + tdata -> debuffs.vendetta -> value();
     }
 
+    if ( maybe_ptr( p() -> dbc.ptr ) )
+    {
+      if ( tdata -> dots.nightblade -> is_ticking() && data().affected_by( tdata -> dots.nightblade -> current_action -> data().effectN( 6 ) ) )
+      {
+        m *= 1.0 + tdata -> dots.nightblade -> current_action -> data().effectN( 6 ).percent();
+      }
+    }
+
     return m;
   }
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -3666,6 +3666,9 @@ struct marked_for_death_t : public rogue_attack_t
     may_miss = may_crit = harmful = callbacks = false;
     energize_type = ENERGIZE_ON_CAST;
     energize_amount += p -> talent.deeper_stratagem -> effectN( 6 ).base_value();
+
+    if ( maybe_ptr( p -> dbc.ptr ) )
+      cooldown -> duration += timespan_t::from_millis( p -> spec.subtlety_rogue -> effectN( 7 ).base_value() );
   }
 
   // Defined after marked_for_death_debuff_t. Sigh.

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -7157,12 +7157,13 @@ void rogue_t::init_action_list()
     // Pre-Combat
     precombat -> add_action( "variable,name=ssw_refund,value=equipped.shadow_satyrs_walk*(6+ssw_refund_offset)", "Defined variables that doesn't change during the fight" );
     precombat -> add_action( "variable,name=stealth_threshold,value=(15+talent.vigor.enabled*35+talent.master_of_shadows.enabled*25+variable.ssw_refund)" );
-    precombat -> add_action( "variable,name=shd_fractionnal,value=2.45" );
-    precombat -> add_talent( this, "Enveloping Shadows", "if=combo_points>=5" );
-    precombat -> add_action( this, "Shadow Dance", "if=talent.subterfuge.enabled&bugs", "In 7.1.5, casting Shadow Dance before going in combat let you extends the stealth buff, so it's worth to use with Subterfuge talent. Will likely be fixed in 7.2!" ); // Before SoD because we do it while not in stealth in-game
+    precombat -> add_action( "variable,name=shd_fractionnal,value=ptr*(1.725+0.6*talent.enveloping_shadows.enabled)+(1-ptr)*2.45" );
+    precombat -> add_talent( this, "Enveloping Shadows", "if=combo_points>=5&ptr=0" );
+    precombat -> add_action( this, "Shadow Dance", "if=talent.subterfuge.enabled&bugs", "Since 7.1.5, casting Shadow Dance before going in combat let you extends the stealth buff, so it's worth to use with Subterfuge talent. Has not been fixed in 7.2.5!" ); // Before SoD because we do it while not in stealth in-game
     precombat -> add_action( this, "Symbols of Death" );
 
     // Main Rotation
+    def -> add_action( "run_action_list,name=ptr_default,if=ptr" ); // Redirect to PTR APL
     def -> add_action( "run_action_list,name=sprinted,if=buff.faster_than_light_trigger.up" );
     def -> add_action( "call_action_list,name=cds" );
     def -> add_action( "run_action_list,name=stealthed,if=stealthed.all", "Fully switch to the Stealthed Rotation (by doing so, it forces pooling if nothing is available)" );
@@ -7236,6 +7237,81 @@ void rogue_t::init_action_list()
     stealthed -> add_action( this, "Shuriken Storm", "if=buff.shadowmeld.down&((combo_points.deficit>=3&spell_targets.shuriken_storm>=2+talent.premeditation.enabled+equipped.shadow_satyrs_walk)|(combo_points.deficit>=1+buff.shadow_blades.up&buff.the_dreadlords_deceit.stack>=29))" );
     stealthed -> add_action( "call_action_list,name=finish,if=combo_points>=5&combo_points.deficit<2+talent.premeditation.enabled+buff.shadow_blades.up-equipped.mantle_of_the_master_assassin" );
     stealthed -> add_action( this, "Shadowstrike" );
+
+    // PTR APL for 7.2.5
+    // Main Rotation
+    action_priority_list_t* ptr_def = get_action_priority_list( "ptr_default" );
+    ptr_def -> add_action( "run_action_list,name=ptr_sprinted,if=buff.faster_than_light_trigger.up" );
+    ptr_def -> add_action( "call_action_list,name=ptr_cds" );
+    ptr_def -> add_action( "run_action_list,name=ptr_stealthed,if=stealthed.all", "Fully switch to the Stealthed Rotation (by doing so, it forces pooling if nothing is available)" );
+    ptr_def -> add_action( this, "Nightblade", "if=target.time_to_die>8&remains<gcd.max&combo_points>=4" );
+    ptr_def -> add_action( this, "Sprint", "if=!equipped.draught_of_souls&mantle_duration=0&energy.time_to_max>=1.5&cooldown.shadow_dance.charges_fractional<variable.shd_fractionnal&!cooldown.vanish.up&target.time_to_die>=8&(dot.nightblade.remains>=14|target.time_to_die<=45)" );
+    ptr_def -> add_action( this, "Sprint", "if=equipped.draught_of_souls&trinket.cooldown.up&mantle_duration=0" );
+    ptr_def -> add_action( "call_action_list,name=ptr_stealth_als,if=(combo_points.deficit>=2+talent.premeditation.enabled|cooldown.shadow_dance.charges_fractional>=2.9)" );
+    ptr_def -> add_action( "call_action_list,name=ptr_finish,if=combo_points>=5|(combo_points>=4&combo_points.deficit<=2&spell_targets.shuriken_storm>=3&spell_targets.shuriken_storm<=4)" );
+    ptr_def -> add_action( "call_action_list,name=ptr_build,if=energy.deficit<=variable.stealth_threshold" );
+
+    // Builders
+    action_priority_list_t* ptr_build = get_action_priority_list( "ptr_build", "Builders" );
+    ptr_build -> add_action( this, "Shuriken Storm", "if=spell_targets.shuriken_storm>=2" );
+    ptr_build -> add_talent( this, "Gloomblade" );
+    ptr_build -> add_action( this, "Backstab" );
+
+    // Cooldowns
+    action_priority_list_t* ptr_cds = get_action_priority_list( "ptr_cds", "Cooldowns" );
+    ptr_cds -> add_action( "potion,name=old_war,if=buff.bloodlust.react|target.time_to_die<=25|buff.shadow_blades.up" );
+    for ( size_t i = 0; i < items.size(); i++ )
+    {
+      if ( items[i].has_special_effect( SPECIAL_EFFECT_SOURCE_ITEM, SPECIAL_EFFECT_USE ) && items[i].name_str != "draught_of_souls" )
+        ptr_cds -> add_action( "use_item,name=" + items[i].name_str + ",if=(buff.shadow_blades.up&stealthed.rogue)|target.time_to_die<20" );
+    }
+    for ( size_t i = 0; i < racial_actions.size(); i++ )
+    {
+      if ( racial_actions[i] == "arcane_torrent" )
+        ptr_cds -> add_action( racial_actions[i] + ",if=stealthed.rogue&energy.deficit>70" );
+      else
+        ptr_cds -> add_action( racial_actions[i] + ",if=stealthed.rogue" );
+    }
+    ptr_cds -> add_action( this, "Symbols of Death", "if=!stealthed.all" );
+    ptr_cds -> add_action( this, "Shadow Blades", "if=combo_points.deficit>=2+stealthed.all-equipped.mantle_of_the_master_assassin&(cooldown.sprint.remains>buff.shadow_blades.duration*0.5|mantle_duration>0|cooldown.shadow_dance.charges_fractional>variable.shd_fractionnal|cooldown.vanish.up|target.time_to_die<=buff.shadow_blades.duration*1.1)" );
+    ptr_cds -> add_action( this, "Goremaw's Bite", "if=!stealthed.all&cooldown.shadow_dance.charges_fractional<=variable.shd_fractionnal&((combo_points.deficit>=4-(time<10)*2&energy.deficit>50+talent.vigor.enabled*25-(time>=10)*15)|(combo_points.deficit>=1&target.time_to_die<8))" );
+    ptr_cds -> add_talent( this, "Marked for Death", "target_if=min:target.time_to_die,if=target.time_to_die<combo_points.deficit|(raid_event.adds.in>40&combo_points.deficit>=cp_max_spend)" );
+
+    // Finishers
+    action_priority_list_t* ptr_finish = get_action_priority_list( "ptr_finish", "Finishers" );
+    ptr_finish -> add_talent( this, "Death from Above", "if=spell_targets.death_from_above>=5" );
+      // It is not worth to override a normal nightblade for a finality one outside of pandemic threshold, it is worth to wait the end of the finality to refresh it unless you already got the finality buff.
+    ptr_finish -> add_action( this, "Nightblade", "if=target.time_to_die-remains>8&(mantle_duration=0|remains<=mantle_duration)&((refreshable&(!finality|buff.finality_nightblade.up))|remains<tick_time*2)" );
+    ptr_finish -> add_action( this, "Nightblade", "cycle_targets=1,if=target.time_to_die-remains>8&mantle_duration=0&((refreshable&(!finality|buff.finality_nightblade.up))|remains<tick_time*2)" );
+    ptr_finish -> add_talent( this, "Death from Above" );
+    ptr_finish -> add_action( this, "Eviscerate" );
+
+    action_priority_list_t* ptr_sprinted = get_action_priority_list( "ptr_sprinted", "Sprinted" );
+    ptr_sprinted -> add_action( "cancel_autoattack" );
+    ptr_sprinted -> add_action( "use_item,name=draught_of_souls" );
+
+    // Stealth Action List Starter
+    action_priority_list_t* ptr_stealth_als = get_action_priority_list( "ptr_stealth_als", "Stealth Action List Starter" );
+    ptr_stealth_als -> add_action( "call_action_list,name=ptr_stealth_cds,if=energy.deficit<=variable.stealth_threshold&(!equipped.shadow_satyrs_walk|cooldown.shadow_dance.charges_fractional>=variable.shd_fractionnal|energy.deficit>=10)" );
+    ptr_stealth_als -> add_action( "call_action_list,name=ptr_stealth_cds,if=mantle_duration>2.3" );
+    ptr_stealth_als -> add_action( "call_action_list,name=ptr_stealth_cds,if=spell_targets.shuriken_storm>=5" );
+    ptr_stealth_als -> add_action( "call_action_list,name=ptr_stealth_cds,if=(cooldown.shadowmeld.up&!cooldown.vanish.up&cooldown.shadow_dance.charges<=1)" );
+    ptr_stealth_als -> add_action( "call_action_list,name=ptr_stealth_cds,if=target.time_to_die<12*cooldown.shadow_dance.charges_fractional*(1+equipped.shadow_satyrs_walk*0.5)" );
+
+    // Stealth Cooldowns
+    action_priority_list_t* ptr_stealth_cds = get_action_priority_list( "ptr_stealth_cds", "Stealth Cooldowns" );
+    ptr_stealth_cds -> add_action( this, "Vanish", "if=mantle_duration=0&cooldown.shadow_dance.charges_fractional<variable.shd_fractionnal+(equipped.mantle_of_the_master_assassin&time<30)*0.3" );
+    ptr_stealth_cds -> add_action( this, "Shadow Dance", "if=charges_fractional>=variable.shd_fractionnal" );
+    ptr_stealth_cds -> add_action( "pool_resource,for_next=1,extra_amount=40" );
+    ptr_stealth_cds -> add_action( "shadowmeld,if=energy>=40&energy.deficit>=10+variable.ssw_refund" );
+    ptr_stealth_cds -> add_action( this, "Shadow Dance", "if=combo_points.deficit>=5-talent.vigor.enabled" );
+
+    // Stealthed Rotation
+    action_priority_list_t* ptr_stealthed = get_action_priority_list( "ptr_stealthed", "Stealthed Rotation" );
+    ptr_stealthed -> add_action( "call_action_list,name=ptr_finish,if=combo_points>=5&(spell_targets.shuriken_storm>=2+talent.premeditation.enabled+equipped.shadow_satyrs_walk|(mantle_duration<=1.3&mantle_duration-gcd.remains>=0.3))" );
+    ptr_stealthed -> add_action( this, "Shuriken Storm", "if=buff.shadowmeld.down&((combo_points.deficit>=3&spell_targets.shuriken_storm>=2+talent.premeditation.enabled+equipped.shadow_satyrs_walk)|(combo_points.deficit>=1+buff.shadow_blades.up&buff.the_dreadlords_deceit.stack>=29))" );
+    ptr_stealthed -> add_action( "call_action_list,name=ptr_finish,if=combo_points>=5&combo_points.deficit<2+talent.premeditation.enabled+buff.shadow_blades.up-equipped.mantle_of_the_master_assassin" );
+    ptr_stealthed -> add_action( this, "Shadowstrike" );
   }
 
   use_default_action_list = true;

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -561,6 +561,7 @@ struct rogue_t : public player_t
     artifact_power_t shadows_whisper;
     artifact_power_t soul_shadows;
     artifact_power_t the_quiet_knife;
+    artifact_power_t weak_point;
 
 
     // Majors
@@ -2606,6 +2607,9 @@ struct backstab_t : public rogue_attack_t
     requires_weapon = WEAPON_DAGGER;
 
     base_multiplier *= 1.0 + p -> artifact.the_quiet_knife.percent();
+
+    if ( maybe_ptr( p -> dbc.ptr ) )
+      crit_bonus += p -> artifact.weak_point.percent();
   }
 
   double composite_da_multiplier( const action_state_t* state ) const override
@@ -3153,6 +3157,9 @@ struct gloomblade_t : public rogue_attack_t
     requires_weapon = WEAPON_DAGGER;
     weapon = &( p -> main_hand_weapon );
     base_multiplier *= 1.0 + p -> artifact.the_quiet_knife.percent();
+
+    if ( maybe_ptr( p -> dbc.ptr ) )
+      crit_bonus += p -> artifact.weak_point.percent();
   }
 };
 
@@ -4266,6 +4273,9 @@ struct shadowstrike_t : public rogue_attack_t
     energize_amount += p -> talent.premeditation -> effectN( 2 ).base_value();
     base_multiplier *= 1.0 + p -> artifact.precision_strike.percent();
     range += p -> spec.shadowstrike_2 -> effectN( 1 ).base_value();
+
+    if ( maybe_ptr( p -> dbc.ptr ) )
+      crit_bonus += p -> artifact.weak_point.percent();
 
     if ( p -> soul_rip )
     {
@@ -7565,6 +7575,7 @@ void rogue_t::init_spells()
   artifact.shadows_whisper    = find_artifact_spell( "Shadow's Whisper" );
   artifact.soul_shadows       = find_artifact_spell( "Soul Shadows" );
   artifact.the_quiet_knife    = find_artifact_spell( "The Quiet Knife" );
+  artifact.weak_point         = find_artifact_spell( "Weak Point" );
 
   artifact.bag_of_tricks             = find_artifact_spell( "Bag of Tricks" );
   artifact.blood_of_the_assassinated = find_artifact_spell( "Blood of the Assassinated" );

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -4181,6 +4181,10 @@ struct shadow_dance_t : public rogue_attack_t
     harmful = may_miss = may_crit = false;
     dot_duration = timespan_t::zero(); // No need to have a tick here
     icd -> duration = data().cooldown();
+    if ( maybe_ptr( p -> dbc.ptr ) && p -> talent.enveloping_shadows -> ok() )
+    {
+      cooldown -> charges += p -> talent.enveloping_shadows -> effectN( 2 ).base_value();
+    }
   }
 
   void execute() override
@@ -5537,7 +5541,21 @@ void rogue_t::trigger_deepening_shadows( const action_state_t* state )
     return;
   }
 
-  timespan_t adjustment = timespan_t::from_seconds( -1 * spec.deepening_shadows -> effectN( 2 ).base_value() * s -> cp );
+  timespan_t adjustment;
+  if ( maybe_ptr( dbc.ptr ) )
+  {
+    // Note: this changed to be 10 * seconds as of 2017-04-19
+    int cdr = spec.deepening_shadows -> effectN( 1 ).base_value();
+    if ( talent.enveloping_shadows -> ok() )
+    {
+      cdr += talent.enveloping_shadows -> effectN( 1 ).base_value();
+    }
+    adjustment = timespan_t::from_seconds( -0.1 * cdr * s -> cp );
+  }
+  else
+  {
+    adjustment = timespan_t::from_seconds( -1 * spec.deepening_shadows -> effectN( 2 ).base_value() * s -> cp );
+  }
   cooldowns.shadow_dance -> adjust( adjustment, s -> cp >= 5 );
 }
 


### PR DESCRIPTION
This should cover all of the current PTR changes for Subtlety Rogues and introduces an additional APL that is run when ptr is set. The PTR APL only contains minor changes for now, though.