### PR TITLE
[Mage] Arcane/Frost proc tracking

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -1642,6 +1642,31 @@ struct arcane_missiles_t : public buff_t
   }
 };
 
+struct fingers_of_frost_t : public buff_t
+{
+  fingers_of_frost_t( mage_t* p ) :
+    buff_t(
+      buff_creator_t( p, "fingers_of_frost", p -> find_spell( 44544 ) )
+        .max_stack(
+          p -> find_spell( 44544 ) -> max_stacks()
+            + p -> sets.set( MAGE_FROST, T18, B4 ) -> effectN( 2 ).base_value()
+            + p -> artifact.icy_hand.rank()
+            + p -> talents.frozen_touch -> effectN( 2 ).base_value()
+        )
+    )
+  {};
+
+  void expire_override( int expiration_stacks, timespan_t remaining_duration ) override
+  {
+    buff_t::expire_override( expiration_stacks, remaining_duration );
+
+    mage_t* p = static_cast<mage_t*>( player );
+
+    if ( remaining_duration == timespan_t::zero() )
+      for ( auto i = 0; i < expiration_stacks; i++ )
+        p -> procs.fingers_of_frost_expired -> occur();
+  }
+};
 
 // Chilled debuff =============================================================
 
@@ -8168,11 +8193,7 @@ void mage_t::create_buffs()
   buffs.brain_freeze          = buff_creator_t( this, "brain_freeze", find_spell( 190446 ) );
   buffs.bone_chilling         = buff_creator_t( this, "bone_chilling", find_spell( 205766 ) )
                                   .add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
-  buffs.fingers_of_frost      = buff_creator_t( this, "fingers_of_frost", find_spell( 44544 ) )
-                                  .max_stack( find_spell( 44544 ) -> max_stacks() +
-                                              sets.set( MAGE_FROST, T18, B4 ) -> effectN( 2 ).base_value() +
-                                              artifact.icy_hand.rank()
-                                              + talents.frozen_touch -> effectN( 2 ).base_value() );
+  buffs.fingers_of_frost      = new buffs::fingers_of_frost_t( this );
   buffs.frozen_mass           = buff_creator_t( this, "frozen_mass", find_spell( 242253 ) );
 
   // Buff to track icicles. This does not, however, track the true amount of icicles present.

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -4605,6 +4605,8 @@ struct flurry_t : public frost_mage_spell_t
     flurry_bolt -> brain_freeze_buffed = p() -> buffs.brain_freeze -> up();
 
     p() -> buffs.brain_freeze -> expire();
+
+    p() -> procs.brain_freeze_removed -> occur();
   }
 
   void tick( dot_t* d ) override
@@ -5202,6 +5204,8 @@ struct ice_lance_t : public frost_mage_spell_t
     }
 
     p() -> buffs.fingers_of_frost -> decrement();
+
+    p() -> procs.fingers_of_frost_removed -> occur();
   }
 
   virtual void impact( action_state_t* s ) override

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2466,6 +2466,8 @@ struct frost_mage_spell_t : public mage_spell_t
       }
 
       mage -> buffs.brain_freeze -> trigger();
+
+      mage -> procs.brain_freeze_regenerated -> occur();
     }
   };
 
@@ -2513,6 +2515,8 @@ struct frost_mage_spell_t : public mage_spell_t
         }
 
         p() -> buffs.brain_freeze -> trigger();
+
+        p() -> procs.brain_freeze_generated -> occur();
       }
     }
   }

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -386,6 +386,16 @@ public:
           * arcane_missiles_expired, // AM buff expires
           * arcane_missiles_wasted; // Additional AM generated at max stacks
 
+    proc_t* brain_freeze_generated, // BF proc
+          * brain_freeze_removed, // Flurry cast
+          * brain_freeze_expired, // BF buff expires
+          * brain_freeze_wasted, // Additional BF generated with existing buff
+
+          * fingers_of_frost_generated, // FoF proc
+          * fingers_of_frost_removed, // Ice Lance cast
+          * fingers_of_frost_expired, // FoF buff expires
+          * fingers_of_frost_wasted; // Additional FoF generated at max stacks
+
     proc_t* heating_up_generated, // Crits without HU/HS
           * heating_up_removed, // Non-crits with HU >200ms after application
           * heating_up_ib_converted, // IBs used on HU
@@ -8216,6 +8226,15 @@ void mage_t::init_procs()
       procs.arcane_missiles_wasted = get_proc( "Arcane Missiles wasted" );
       break;
     case MAGE_FROST:
+      procs.brain_freeze_expired = get_proc( "Brain Freeze expired" );
+      procs.brain_freeze_generated = get_proc( "Brain Freeze generated" );
+      procs.brain_freeze_removed = get_proc( "Brain Freeze removed" );
+      procs.brain_freeze_wasted = get_proc( "Brain Freeze wasted" );
+
+      procs.fingers_of_frost_expired = get_proc( "Fingers of Frost expired" );
+      procs.fingers_of_frost_generated = get_proc( "Fingers of Frost generated" );
+      procs.fingers_of_frost_removed = get_proc( "Fingers of Frost removed" );
+      procs.fingers_of_frost_wasted = get_proc( "Fingers of Frost wasted" );
       break;
     case MAGE_FIRE:
       procs.heating_up_generated    = get_proc( "Heating Up generated" );

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -3549,7 +3549,6 @@ struct arcane_missiles_t : public arcane_mage_spell_t
     p() -> buffs.arcane_missiles -> decrement();
 
     p() -> procs.arcane_missiles_removed -> occur();
-
   }
 
   void last_tick ( dot_t * d ) override


### PR DESCRIPTION
Fire has several procs tracking Heating Up/Hot Streak events, but none exist for Arcane/Frost.

I've added procs for both specs: Arcane Missiles for Arcane, Fingers of Frost/Brain Freeze for Frost. For BF, I made a distinction between _generated_ (no current BF proc) and _regenerated_ (BF proc applied after delay).

There's admittedly a lot of copy/paste here so it might be worthwhile to refactor a bit and minimize code duplication. If everything else seems alright otherwise then I can look into that as well.