### PR TITLE
Remove two unnecessary http redirects from avatar url

### DIFF
--- a/engine/interfaces/sc_bcp_api.cpp
+++ b/engine/interfaces/sc_bcp_api.cpp
@@ -946,7 +946,7 @@ player_t* parse_player( sim_t*             sim,
     p -> origin_str = player.origin;
 
   if ( profile.HasMember( "thumbnail" ) )
-    p -> report_information.thumbnail_url = "http://" + p -> region_str + ".battle.net/static-render/" +
+    p -> report_information.thumbnail_url = "https://render-api-" + p -> region_str + ".worldofwarcraft.com/static-render/" +
                                             p -> region_str + '/' + profile[ "thumbnail" ].GetString();
 
   if ( profile.HasMember( "professions" ) )


### PR DESCRIPTION
Saves two redirects for loading the avatar thumbnail.
First from http://eu.battle.net to https://eu.battle.net via `307` 
and then to https://render-api-eu.worldofwarcraft.com via `301`

Examples:
http://eu.battle.net/static-render/eu/blackmoore/59/125200699-avatar.jpg

![image](https://cloud.githubusercontent.com/assets/432127/25618866/fb0c5a2e-2f48-11e7-895b-1e5c0b76ab33.png)
