### PR TITLE
[Hunter] Implement Aspect of the Wild GCD reduction from 7.2.5 PTR

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -759,14 +759,15 @@ void action_t::parse_effect_data( const spelleffect_data_t& spelleffect_data )
           break;
         case A_ADD_FLAT_MODIFIER:
           switch ( spelleffect_data.misc_value1() )
-          case E_APPLY_AURA:
-          switch ( spelleffect_data.subtype() )
           {
             case P_CRIT:
               base_crit += 0.01 * spelleffect_data.base_value();
               break;
             case P_COOLDOWN:
               cooldown -> duration += spelleffect_data.time_value();
+              break;
+            case P_GCD:
+              // XXX: Can we modify the GCD for all the player attacks here?
               break;
             default: break;
           }

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -793,6 +793,11 @@ struct hunter_ranged_attack_t: public hunter_action_t < ranged_attack_t >
 {
   bool may_proc_mm_feet;
   bool may_proc_bullseye;
+
+  struct {
+    bool aspect_of_the_wild_gcd;
+  } affected_by;
+
   hunter_ranged_attack_t( const std::string& n, hunter_t* player,
                           const spell_data_t* s = spell_data_t::nil() ):
                           base_t( n, player, s ),
@@ -807,11 +812,27 @@ struct hunter_ranged_attack_t: public hunter_action_t < ranged_attack_t >
     if ( player -> main_hand_weapon.group() != WEAPON_RANGED )
       background = true;
 
+    if ( maybe_ptr( p() -> dbc.ptr ) ) {
+      affected_by.aspect_of_the_wild_gcd =
+        data().affected_by( p() -> buffs.aspect_of_the_wild -> data().effectN( 3 ) );
+    }
+
     base_t::init();
   }
 
   virtual bool usable_moving() const override
   { return true; }
+
+  virtual timespan_t gcd() const override {
+    auto t = base_t::gcd();
+    if ( maybe_ptr( p() -> dbc.ptr ) ) {
+      if ( affected_by.aspect_of_the_wild_gcd &&
+           t != timespan_t::zero() && p() -> buffs.aspect_of_the_wild -> check() ) {
+        t += p() -> buffs.aspect_of_the_wild -> data().effectN( 3 ).time_value();
+      }
+    }
+    return t;
+  }
 
   virtual void execute() override
   {


### PR DESCRIPTION
Following the implementation of the Adrenaline Rush GCD modification in sc_rogue.cpp.

Also remove two spurious lines in sc_action.cpp: P_{CRIT,COOLDOWN}
are valid values for misc_value1() but not for subtype().