### PR TITLE
Fix arcane burn duration value to return previous burn length

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -67,7 +67,7 @@ public:
   {
     if ( !state )
     {
-      return timespan_t::zero();
+      return last_disable - last_enable;
     }
     return now - last_enable;
   }


### PR DESCRIPTION
if outside burn phase (or current burn duration if inside one). last_disable and last_enable default to timespan_t::zero() anyway so in the scenario that neither has been set and we are outside burn (I.E. before the first burn takes place) they will return 0 duration as previous anyway.