### PR TITLE
[Warrior] Shield Block increases Shield Slam damage

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -3552,7 +3552,7 @@ struct shield_slam_t: public warrior_attack_t
 
     if ( p() -> buff.shield_block -> up() )
     {
-      am *= 1.0 + heavy_repercussions;
+      am *= 1.3 + heavy_repercussions;
     }
 
     am *= 1.0 + p() -> buff.bindings_of_kakushan -> stack_value();


### PR DESCRIPTION
Shield Block previously only increased the damage of Shield Slam if Heavy Repercussions was talented, but it should increase it regardless. HR increases the modifier further, but not multiplicatively.