### PR TITLE
Remove _NH from Raid_T20M profile

### DIFF
--- a/profiles/Tier20M/Raid_T20M.simc
+++ b/profiles/Tier20M/Raid_T20M.simc
@@ -5,9 +5,9 @@ Demon_Hunter_Havoc_T20M.simc
 
 Druid_Feral_T20M.simc
 
-Hunter_Beast_Mastery_T20M_NH.simc
-Hunter_Marksmanship_T20M_NH.simc
-Hunter_Survival_T20M_NH.simc
+Hunter_Beast_Mastery_T20M.simc
+Hunter_Marksmanship_T20M.simc
+Hunter_Survival_T20M.simc
 
 Mage_Fire_T20M.simc
 Mage_Frost_T20M.simc


### PR DESCRIPTION
All 3 hunter profiles were using this suffix still causing this profile to be invalid