### PR TITLE
[Druid] Maul procs gore

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -40,6 +40,7 @@ namespace { // UNNAMED NAMESPACE
   Statistics?
   Incarnation CD modifier rework
   Check Galactic Guardian proc sources
+  Find missing damage multipliers
 
   Resto =====================================================================
   All the things

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -4030,8 +4030,8 @@ struct maul_t : public bear_attack_t
   maul_t( druid_t* player, const std::string& options_str ) :
     bear_attack_t( "maul", player, player -> find_specialization_spell( "Maul" ), options_str )
   {
-    weapon = &( player -> main_hand_weapon );
-    use_off_gcd = true;
+    gore = true;
+    normalize_weapon_speed = false;
 
     base_crit += player -> artifact.mauler.percent();
   }

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -4031,7 +4031,6 @@ struct maul_t : public bear_attack_t
     bear_attack_t( "maul", player, player -> find_specialization_spell( "Maul" ), options_str )
   {
     gore = true;
-    normalize_weapon_speed = false;
 
     base_crit += player -> artifact.mauler.percent();
   }


### PR DESCRIPTION
725 introduced several changes to maul, most of which were reflected in spelldata.  In addition to those changes, maul also procs Gore.

Also adds a todo for discovering the cause for consistently lower damage on abilities than what is seen in-game.