### PR TITLE
Add pet and base spell modifiers for Elemental Shaman spec aura

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -382,6 +382,7 @@ public:
     const spell_data_t* chain_lightning_2; // 7.1 Chain Lightning additional 2 targets passive
     const spell_data_t* elemental_focus;
     const spell_data_t* elemental_fury;
+    const spell_data_t* elemental_shaman;
     const spell_data_t* flame_shock_2; // 7.1 Flame Shock duration extension passive
     const spell_data_t* lava_burst_2; // 7.1 Lava Burst autocrit with FS passive
     const spell_data_t* lava_surge;
@@ -1050,6 +1051,12 @@ public:
 
       maelstrom_gain = effect.resource( RESOURCE_MAELSTROM );
       ab::energize_type = ENERGIZE_NONE; // disable resource generation from spell data.
+    }
+
+    if ( ab::data().affected_by( player -> spec.elemental_shaman -> effectN( 5 ) ) )
+    {
+      ab::base_multiplier *= 1.0 + player -> spec.elemental_shaman -> effectN( 5 ).percent();
+      ab::base_multiplier *= 1.0 + player -> spec.elemental_shaman -> effectN( 7 ).percent();
     }
 
     if ( ab::data().affected_by( player -> spec.enhancement_shaman -> effectN( 1 ) ) )
@@ -6383,6 +6390,7 @@ void shaman_t::init_spells()
   spec.chain_lightning_2     = find_specialization_spell( 231722 );
   spec.elemental_focus       = find_specialization_spell( "Elemental Focus" );
   spec.elemental_fury        = find_specialization_spell( "Elemental Fury" );
+  spec.elemental_shaman      = find_specialization_spell( "Elemental Shaman" );
   spec.flame_shock_2         = find_specialization_spell( 232643 );
   spec.lava_burst_2          = find_specialization_spell( 231721 );
   spec.lava_surge            = find_specialization_spell( "Lava Surge" );

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1856,8 +1856,6 @@ struct pet_action_t : public T_ACTION
 
     this -> special = true;
     this -> may_crit = true;
-
-    this->base_multiplier *= 1.0 + p() -> o() -> spec.elemental_shaman -> effectN( 7 ).percent();
     //this -> crit_bonus_multiplier *= 1.0 + p() -> o() -> spec.elemental_fury -> effectN( 1 ).percent();
   }
 
@@ -8036,6 +8034,10 @@ double shaman_t::composite_player_pet_damage_multiplier( const action_state_t* s
   m *= 1.0 + artifact.stormkeepers_power.percent();
   m *= 1.0 + artifact.power_of_the_earthen_ring.percent();
   m *= 1.0 + artifact.earthshattering_blows.percent();
+  if ( spec.elemental_shaman -> ok() )
+  {
+    m *= 1.0 + spec.elemental_shaman -> effectN( 7 ).percent();
+  }
 
   auto school = s -> action -> get_school();
   if ( ( dbc::is_school( school, SCHOOL_FIRE ) || dbc::is_school( school, SCHOOL_FROST ) ||

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1857,10 +1857,7 @@ struct pet_action_t : public T_ACTION
     this -> special = true;
     this -> may_crit = true;
 
-    if ( this->data().affected_by( p() -> o() -> spec.elemental_shaman -> effectN( 7 ) ) )
-    {
-      this->base_multiplier *= 1.0 + p() -> o() -> spec.elemental_shaman -> effectN( 7 ).percent();
-    }
+    this->base_multiplier *= 1.0 + p() -> o() -> spec.elemental_shaman -> effectN( 7 ).percent();
     //this -> crit_bonus_multiplier *= 1.0 + p() -> o() -> spec.elemental_fury -> effectN( 1 ).percent();
   }
 

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1056,7 +1056,6 @@ public:
     if ( ab::data().affected_by( player -> spec.elemental_shaman -> effectN( 5 ) ) )
     {
       ab::base_multiplier *= 1.0 + player -> spec.elemental_shaman -> effectN( 5 ).percent();
-      ab::base_multiplier *= 1.0 + player -> spec.elemental_shaman -> effectN( 7 ).percent();
     }
 
     if ( ab::data().affected_by( player -> spec.enhancement_shaman -> effectN( 1 ) ) )
@@ -1857,6 +1856,11 @@ struct pet_action_t : public T_ACTION
 
     this -> special = true;
     this -> may_crit = true;
+
+    if ( this->data().affected_by( p() -> o() -> spec.elemental_shaman -> effectN( 7 ) ) )
+    {
+      this->base_multiplier *= 1.0 + p() -> o() -> spec.elemental_shaman -> effectN( 7 ).percent();
+    }
     //this -> crit_bonus_multiplier *= 1.0 + p() -> o() -> spec.elemental_fury -> effectN( 1 ).percent();
   }
 


### PR DESCRIPTION
I'm not 100% sure this covers everything appropriately just yet, but should be a good starting point to implement support for the spec aura for Elemental Shaman, which recently got put to real use in the latest round of hotfixes.

cc @Bloodmallet for 👀 