### PR TITLE
Update Elemental T20 trinkets

### DIFF
--- a/profiles/Tier20H/Shaman_Elemental_Gambling_T20H.simc
+++ b/profiles/Tier20H/Shaman_Elemental_Gambling_T20H.simc
@@ -151,18 +151,18 @@ legs=legguards_of_the_skybreaker,id=147179,ilevel=915
 feet=the_deceivers_blood_pact,id=137035,ilevel=970
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=925,enchant=200haste
 finger2=scaled_band_of_servitude,id=147020,ilevel=915,enchant=200haste
-trinket1=tarnished_sentinel_medallion,id=147017,ilevel=915
+trinket1=tome_of_unraveling_sanity,id=147019,ilevel=925
 trinket2=whispers_in_the_dark,id=140809,ilevel=895
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=915/925/915
 off_hand=the_highkeepers_ward,id=128936
 
 # Gear Summary
-# gear_ilvl=924.25
+# gear_ilvl=924.88
 # gear_stamina=41596
-# gear_intellect=42570
+# gear_intellect=45174
 # gear_crit_rating=5408
 # gear_haste_rating=11560
-# gear_mastery_rating=7026
+# gear_mastery_rating=5778
 # gear_versatility_rating=2435
 # gear_armor=3203
 # set_bonus=tier20_2pc=1

--- a/profiles/Tier20H/Shaman_Elemental_T20H.simc
+++ b/profiles/Tier20H/Shaman_Elemental_T20H.simc
@@ -152,14 +152,14 @@ feet=starstalker_treads,id=147046,ilevel=925
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=925,enchant=200haste
 finger2=eye_of_the_twisting_nether,id=137050,ilevel=970,gems=200intellect,enchant=200haste
 trinket1=tarnished_sentinel_medallion,id=147017,ilevel=915
-trinket2=whispers_in_the_dark,id=140809,ilevel=895
+trinket2=tome_of_unraveling_sanity,id=147019,ilevel=925
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=915/925/915
 off_hand=the_highkeepers_ward,id=128936
 
 # Gear Summary
-# gear_ilvl=924.88
+# gear_ilvl=926.75
 # gear_stamina=41400
-# gear_intellect=41701
+# gear_intellect=42337
 # gear_crit_rating=5228
 # gear_haste_rating=12491
 # gear_mastery_rating=7296

--- a/profiles/Tier20H/generate_Shaman_T20H.simc
+++ b/profiles/Tier20H/generate_Shaman_T20H.simc
@@ -20,7 +20,7 @@ feet=starstalker_treads,id=147046,ilevel=925
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=925,enchant=200haste
 finger2=eye_of_the_twisting_nether,id=137050,ilevel=970,enchant=200haste,gems=200intellect
 trinket1=tarnished_sentinel_medallion,id=147017,ilevel=915
-trinket2=whispers_in_the_dark,id=140809,ilevel=895
+trinket2=tome_of_unraveling_sanity,id=147019,ilevel=925
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=915/925/915
 off_hand=the_highkeepers_ward,id=128936
 save=Shaman_Elemental_T20H.simc
@@ -46,7 +46,7 @@ legs=legguards_of_the_skybreaker,id=147179,ilevel=915
 feet=the_deceivers_blood_pact,id=137035,ilevel=970
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=925,enchant=200haste
 finger2=scaled_band_of_servitude,id=147020,ilevel=915,enchant=200haste
-trinket1=tarnished_sentinel_medallion,id=147017,ilevel=915
+trinket1=tome_of_unraveling_sanity,id=147019,ilevel=925
 trinket2=whispers_in_the_dark,id=140809,ilevel=895
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=915/925/915
 off_hand=the_highkeepers_ward,id=128936

--- a/profiles/Tier20M/Shaman_Elemental_Gambling_T20M.simc
+++ b/profiles/Tier20M/Shaman_Elemental_Gambling_T20M.simc
@@ -151,18 +151,18 @@ legs=legguards_of_the_skybreaker,id=147179,ilevel=930
 feet=the_deceivers_blood_pact,id=137035,ilevel=970
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=940,enchant=200haste
 finger2=scaled_band_of_servitude,id=147020,ilevel=930,enchant=200haste
-trinket1=tarnished_sentinel_medallion,id=147017,ilevel=930
+trinket1=tome_of_unraveling_sanity,id=147019,ilevel=940
 trinket2=whispers_in_the_dark,id=140809,ilevel=910
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=930/940/930
 off_hand=the_highkeepers_ward,id=128936
 
 # Gear Summary
-# gear_ilvl=937.38
+# gear_ilvl=938.00
 # gear_stamina=46429
-# gear_intellect=47992
+# gear_intellect=50986
 # gear_crit_rating=5718
 # gear_haste_rating=12312
-# gear_mastery_rating=7455
+# gear_mastery_rating=6135
 # gear_versatility_rating=2624
 # gear_armor=3319
 # set_bonus=tier20_2pc=1

--- a/profiles/Tier20M/Shaman_Elemental_T20M.simc
+++ b/profiles/Tier20M/Shaman_Elemental_T20M.simc
@@ -152,14 +152,14 @@ feet=starstalker_treads,id=147046,ilevel=940
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=940,enchant=200haste
 finger2=eye_of_the_twisting_nether,id=137050,ilevel=970,gems=200intellect,enchant=200haste
 trinket1=tarnished_sentinel_medallion,id=147017,ilevel=930
-trinket2=whispers_in_the_dark,id=140809,ilevel=910
+trinket2=tome_of_unraveling_sanity,id=147019,ilevel=940
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=930/940/930
 off_hand=the_highkeepers_ward,id=128936
 
 # Gear Summary
-# gear_ilvl=938.00
+# gear_ilvl=939.88
 # gear_stamina=46379
-# gear_intellect=47430
+# gear_intellect=48160
 # gear_crit_rating=5587
 # gear_haste_rating=13112
 # gear_mastery_rating=7580

--- a/profiles/Tier20M/generate_Shaman_T20M.simc
+++ b/profiles/Tier20M/generate_Shaman_T20M.simc
@@ -20,7 +20,7 @@ feet=starstalker_treads,id=147046,ilevel=940
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=940,enchant=200haste
 finger2=eye_of_the_twisting_nether,id=137050,ilevel=970,enchant=200haste,gems=200intellect
 trinket1=tarnished_sentinel_medallion,id=147017,ilevel=930
-trinket2=whispers_in_the_dark,id=140809,ilevel=910
+trinket2=tome_of_unraveling_sanity,id=147019,ilevel=940
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=930/940/930
 off_hand=the_highkeepers_ward,id=128936
 save=Shaman_Elemental_T20M.simc
@@ -46,7 +46,7 @@ legs=legguards_of_the_skybreaker,id=147179,ilevel=930
 feet=the_deceivers_blood_pact,id=137035,ilevel=970
 finger1=seal_of_the_second_duumvirate,id=147195,ilevel=940,enchant=200haste
 finger2=scaled_band_of_servitude,id=147020,ilevel=930,enchant=200haste
-trinket1=tarnished_sentinel_medallion,id=147017,ilevel=930
+trinket1=tome_of_unraveling_sanity,id=147019,ilevel=940
 trinket2=whispers_in_the_dark,id=140809,ilevel=910
 main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=147112/147095/147112,relic_ilevel=930/940/930
 off_hand=the_highkeepers_ward,id=128936


### PR DESCRIPTION
Use Tome of Unraveling Sanity in T20 base profiles

This trinket appears to have received a small buff around the
7.2.5 patch launch, which has once again put it above Whispers
in our tests.

Note: testing also indicates Whispers is still incredibly valuable
for the gambling build, being the single best trinket available.
So, this only alters the base T20 profiles, not the gambling profiles.

Tome was selected over Terror for reasons of practicality.
Terror gains 0 value in any multi-target situation, whereas Tome's
crit buff does affect AOE damage in the face of multiple targets.

Based on updated sims in https://github.com/stormearthandlava/sims/commit/7de2267a4a619aa3b0ff38dfaca69be37be39639

T20M:

<img width="581" alt="screen shot 2017-06-25 at 2 44 36 am" src="https://user-images.githubusercontent.com/203/27514212-89d52718-5951-11e7-9e30-2915c68e3cfb.png">

T20M Gambling:

<img width="577" alt="screen shot 2017-06-25 at 2 54 22 am" src="https://user-images.githubusercontent.com/203/27514217-9d6f1360-5951-11e7-91a2-b0da2935890c.png">
