### PR TITLE
Remove nonsensical ABarrs

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -7463,7 +7463,6 @@ void mage_t::apl_arcane()
   burn  -> add_action( "variable,name=total_burns,op=add,value=1,if=!burn_phase" );
   burn  -> add_action( "start_burn_phase,if=!burn_phase" );
   burn  -> add_action( "stop_burn_phase,if=prev_gcd.1.evocation&cooldown.evocation.charges=0&burn_phase_duration>0" );
-  burn  -> add_action( this, "Arcane Barrage", "if=buff.rune_of_power.remains>=travel_time&((cooldown.presence_of_mind.remains<=execute_time&set_bonus.tier20_2pc)|(talent.charged_up.enabled&cooldown.charged_up.remains<=execute_time))&buff.arcane_charge.stack=buff.arcane_charge.max_stack" );
   burn  -> add_talent( this, "Nether Tempest", "if=refreshable|!ticking" );
   burn  -> add_action( this, "Mark of Aluneth" );
   burn  -> add_talent( this, "Mirror Image" );
@@ -7485,7 +7484,6 @@ void mage_t::apl_arcane()
   burn  -> add_talent( this, "Supernova" );
   burn  -> add_action( this, "Arcane Explosion", "if=active_enemies>1" );
   burn  -> add_action( this, "Arcane Missiles", "if=variable.arcane_missiles_procs" );
-  burn  -> add_action( this, "Arcane Barrage", "if=buff.rune_of_power.remains<action.arcane_blast.cast_time&buff.rune_of_power.remains>=travel_time&cooldown.charged_up.remains<=execute_time" );
   burn  -> add_action( this, "Arcane Blast" );
   burn  -> add_action( "variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+burn_phase_duration)%variable.total_burns" );
   burn  -> add_action( this, "Evocation", "interrupt_if=ticks=2|mana.pct>=85,interrupt_immediate=1" );

--- a/profiles/Tier19H/Mage_Arcane_T19H.simc
+++ b/profiles/Tier19H/Mage_Arcane_T19H.simc
@@ -47,7 +47,6 @@ actions.build+=/arcane_blast
 actions.burn=variable,name=total_burns,op=add,value=1,if=!burn_phase
 actions.burn+=/start_burn_phase,if=!burn_phase
 actions.burn+=/stop_burn_phase,if=prev_gcd.1.evocation&cooldown.evocation.charges=0&burn_phase_duration>0
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains>=travel_time&((cooldown.presence_of_mind.remains<=execute_time&set_bonus.tier20_2pc)|(talent.charged_up.enabled&cooldown.charged_up.remains<=execute_time))&buff.arcane_charge.stack=buff.arcane_charge.max_stack
 actions.burn+=/nether_tempest,if=refreshable|!ticking
 actions.burn+=/mark_of_aluneth
 actions.burn+=/mirror_image
@@ -66,7 +65,6 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up
 actions.burn+=/supernova
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_missiles,if=variable.arcane_missiles_procs
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains<action.arcane_blast.cast_time&buff.rune_of_power.remains>=travel_time&cooldown.charged_up.remains<=execute_time
 actions.burn+=/arcane_blast
 actions.burn+=/variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+burn_phase_duration)%variable.total_burns
 actions.burn+=/evocation,interrupt_if=ticks=2|mana.pct>=85,interrupt_immediate=1

--- a/profiles/Tier19M/Mage_Arcane_T19M.simc
+++ b/profiles/Tier19M/Mage_Arcane_T19M.simc
@@ -47,7 +47,6 @@ actions.build+=/arcane_blast
 actions.burn=variable,name=total_burns,op=add,value=1,if=!burn_phase
 actions.burn+=/start_burn_phase,if=!burn_phase
 actions.burn+=/stop_burn_phase,if=prev_gcd.1.evocation&cooldown.evocation.charges=0&burn_phase_duration>0
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains>=travel_time&((cooldown.presence_of_mind.remains<=execute_time&set_bonus.tier20_2pc)|(talent.charged_up.enabled&cooldown.charged_up.remains<=execute_time))&buff.arcane_charge.stack=buff.arcane_charge.max_stack
 actions.burn+=/nether_tempest,if=refreshable|!ticking
 actions.burn+=/mark_of_aluneth
 actions.burn+=/mirror_image
@@ -66,7 +65,6 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up
 actions.burn+=/supernova
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_missiles,if=variable.arcane_missiles_procs
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains<action.arcane_blast.cast_time&buff.rune_of_power.remains>=travel_time&cooldown.charged_up.remains<=execute_time
 actions.burn+=/arcane_blast
 actions.burn+=/variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+burn_phase_duration)%variable.total_burns
 actions.burn+=/evocation,interrupt_if=ticks=2|mana.pct>=85,interrupt_immediate=1

--- a/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
+++ b/profiles/Tier19M_NH/Mage_Arcane_T19M_NH.simc
@@ -47,7 +47,6 @@ actions.build+=/arcane_blast
 actions.burn=variable,name=total_burns,op=add,value=1,if=!burn_phase
 actions.burn+=/start_burn_phase,if=!burn_phase
 actions.burn+=/stop_burn_phase,if=prev_gcd.1.evocation&cooldown.evocation.charges=0&burn_phase_duration>0
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains>=travel_time&((cooldown.presence_of_mind.remains<=execute_time&set_bonus.tier20_2pc)|(talent.charged_up.enabled&cooldown.charged_up.remains<=execute_time))&buff.arcane_charge.stack=buff.arcane_charge.max_stack
 actions.burn+=/nether_tempest,if=refreshable|!ticking
 actions.burn+=/mark_of_aluneth
 actions.burn+=/mirror_image
@@ -66,7 +65,6 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up
 actions.burn+=/supernova
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_missiles,if=variable.arcane_missiles_procs
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains<action.arcane_blast.cast_time&buff.rune_of_power.remains>=travel_time&cooldown.charged_up.remains<=execute_time
 actions.burn+=/arcane_blast
 actions.burn+=/variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+burn_phase_duration)%variable.total_burns
 actions.burn+=/evocation,interrupt_if=ticks=2|mana.pct>=85,interrupt_immediate=1

--- a/profiles/Tier19P/Mage_Arcane_T19P.simc
+++ b/profiles/Tier19P/Mage_Arcane_T19P.simc
@@ -47,7 +47,6 @@ actions.build+=/arcane_blast
 actions.burn=variable,name=total_burns,op=add,value=1,if=!burn_phase
 actions.burn+=/start_burn_phase,if=!burn_phase
 actions.burn+=/stop_burn_phase,if=prev_gcd.1.evocation&cooldown.evocation.charges=0&burn_phase_duration>0
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains>=travel_time&((cooldown.presence_of_mind.remains<=execute_time&set_bonus.tier20_2pc)|(talent.charged_up.enabled&cooldown.charged_up.remains<=execute_time))&buff.arcane_charge.stack=buff.arcane_charge.max_stack
 actions.burn+=/nether_tempest,if=refreshable|!ticking
 actions.burn+=/mark_of_aluneth
 actions.burn+=/mirror_image
@@ -66,7 +65,6 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up
 actions.burn+=/supernova
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_missiles,if=variable.arcane_missiles_procs
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains<action.arcane_blast.cast_time&buff.rune_of_power.remains>=travel_time&cooldown.charged_up.remains<=execute_time
 actions.burn+=/arcane_blast
 actions.burn+=/variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+burn_phase_duration)%variable.total_burns
 actions.burn+=/evocation,interrupt_if=ticks=2|mana.pct>=85,interrupt_immediate=1

--- a/profiles/Tier20M/Mage_Arcane_T20M.simc
+++ b/profiles/Tier20M/Mage_Arcane_T20M.simc
@@ -47,7 +47,6 @@ actions.build+=/arcane_blast
 actions.burn=variable,name=total_burns,op=add,value=1,if=!burn_phase
 actions.burn+=/start_burn_phase,if=!burn_phase
 actions.burn+=/stop_burn_phase,if=prev_gcd.1.evocation&cooldown.evocation.charges=0&burn_phase_duration>0
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains>=travel_time&((cooldown.presence_of_mind.remains<=execute_time&set_bonus.tier20_2pc)|(talent.charged_up.enabled&cooldown.charged_up.remains<=execute_time))&buff.arcane_charge.stack=buff.arcane_charge.max_stack
 actions.burn+=/nether_tempest,if=refreshable|!ticking
 actions.burn+=/mark_of_aluneth
 actions.burn+=/mirror_image
@@ -66,7 +65,6 @@ actions.burn+=/arcane_blast,if=buff.presence_of_mind.up
 actions.burn+=/supernova
 actions.burn+=/arcane_explosion,if=active_enemies>1
 actions.burn+=/arcane_missiles,if=variable.arcane_missiles_procs
-actions.burn+=/arcane_barrage,if=buff.rune_of_power.remains<action.arcane_blast.cast_time&buff.rune_of_power.remains>=travel_time&cooldown.charged_up.remains<=execute_time
 actions.burn+=/arcane_blast
 actions.burn+=/variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+burn_phase_duration)%variable.total_burns
 actions.burn+=/evocation,interrupt_if=ticks=2|mana.pct>=85,interrupt_immediate=1


### PR DESCRIPTION
These two Arcane Barrage lines don't even make sense (e.g., use of `travel_time`).

One of them doesn't even get executed, and the other causes a noticeable DPS loss with Charged Up:
![image](https://user-images.githubusercontent.com/206867/27831331-306ab636-6098-11e7-82f8-b2018d3bd0c8.png)

The effects with Kilt equipped are even more substantial:
![image](https://user-images.githubusercontent.com/206867/27831489-f53fbd8a-6098-11e7-8a83-4ad8c53fc09e.png)
