### PR TITLE
Persist copied target list between calls

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1943,7 +1943,11 @@ bool action_t::ready()
     // Note, need to take a copy of the original target list here, instead of a reference. Otherwise
     // if spell_targets (or any expression that uses the target list) modifies it, the loop below
     // may break, since the number of elements on the vector is not the same as it originally was
-    std::vector< player_t* > ctl = target_list();
+
+    // Since this is a hot function, declare this vector static as an optimization to persist the
+    // copied vector instance between calls, since constructing it from scratch is expensive.
+    static std::vector< player_t* > ctl;
+    ctl = target_list();
     size_t num_targets = ctl.size();
 
     if ( ( option.max_cycle_targets > 0 ) && ( ( size_t ) option.max_cycle_targets < num_targets ) )


### PR DESCRIPTION
In `action_t::ready()` and while cycling targets, recreating the `std::vector` for the copied target list calls is a rather expensive operation, and the function is called very frequently during a simulation. Declaring it `static` persists it between calls and results in a minor to modest performance increase depending on the sim.

I did some performance analysis testing, and this seemed like low-hanging fruit. As far as I've been able to tell the function is only called from the main thread, so a `static` declaration should be a safe and "easy" enough fix, but might be a bit hacky. Perhaps it should be implemented in some other way, though. Let me know what you think!

To benchmark, I repeatedly ran [this SimC script](https://github.com/simulationcraft/simc/files/1169681/t20.txt) which includes most T20 sample profiles, running via the SimC CLI built locally with VS 2015. It might require more extensive testing that I'm not aware of.

**Multi-threaded:**

```
deterministic=1
threads=4
iterations=10000
```

Before:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000 (2500, 2500, 2500, 2500)
  TotalEvents   = 1189955637
  MaxEventQueue = 1269
  TargetHealth  = 11433676292
  SimSeconds    = 3008477
  CpuSeconds    = 2460.969
  WallSeconds   = 627.227
  SpeedUp       = 1222
```

After:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000 (2500, 2500, 2500, 2500)
  TotalEvents   = 1189787064
  MaxEventQueue = 1282
  TargetHealth  = 11429384357
  SimSeconds    = 3007994
  CpuSeconds    = 2333.859
  WallSeconds   = 588.722
  SpeedUp       = 1289
```

**Single-threaded:**

```
deterministic=1
threads=1
iterations=10000
```

Before:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000
  TotalEvents   = 1189806900
  MaxEventQueue = 1298
  TargetHealth  = 11430916356
  SimSeconds    = 3007278
  CpuSeconds    = 1560.375
  WallSeconds   = 1563.768
  SpeedUp       = 1927
```

After:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000
  TotalEvents   = 1189806900
  MaxEventQueue = 1298
  TargetHealth  = 11430916356
  SimSeconds    = 3007278
  CpuSeconds    = 1449.297
  WallSeconds   = 1451.828
  SpeedUp       = 2075
```