### PR TITLE
Make target changes no-op in ST sims

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1912,7 +1912,7 @@ bool action_t::ready()
     return false;
   }
 
-  if ( target_if_mode != TARGET_IF_NONE )
+  if ( target_if_mode != TARGET_IF_NONE && sim -> target_list.size() > 1 )
   {
     player_t* potential_target = select_target_if_target();
     if ( potential_target )
@@ -1934,7 +1934,7 @@ bool action_t::ready()
       return false;
   }
 
-  if ( option.cycle_targets )
+  if ( option.cycle_targets && sim -> target_list.size() > 1 )
   {
     player_t* saved_target = target;
     option.cycle_targets = false;


### PR DESCRIPTION
Provides a slight performance boost in single target conditions.

Follow-up to the previous discussion in #3926. Lemme know your thoughts!

**Patchwerk with 10k iterations, 4 threads ([t20.txt](https://github.com/simulationcraft/simc/files/1170026/t20.txt)):**

Before:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000 (2500, 2500, 2500, 2500)
  TotalEvents   = 1189955637
  MaxEventQueue = 1269
  TargetHealth  = 11433676292
  SimSeconds    = 3008477
  CpuSeconds    = 2524.469
  WallSeconds   = 641.052
  SpeedUp       = 1192
```

After:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000 (2500, 2500, 2500, 2500)
  TotalEvents   = 1205214138
  MaxEventQueue = 1273
  TargetHealth  = 10980498944
  SimSeconds    = 3007235
  CpuSeconds    = 2350.859
  WallSeconds   = 594.474
  SpeedUp       = 1279
```

**HecticAddCleave with 10k iterations, 4 threads ([t20_hectic.txt](https://github.com/simulationcraft/simc/files/1170027/t20_hectic.txt)):**

Before:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000 (2500, 2500, 2500, 2500)
  TotalEvents   = 1441584319
  MaxEventQueue = 1623
  TargetHealth  = 9741899208
  SimSeconds    = 3008565
  CpuSeconds    = 3144.188
  WallSeconds   = 794.419
  SpeedUp       = 957
```

After:
```
Baseline Performance:
  RNG Engine    = sse2-sfmt (deterministic)
  Iterations    = 10000 (2500, 2500, 2500, 2500)
  TotalEvents   = 1460146305
  MaxEventQueue = 1664
  TargetHealth  = 9532758705
  SimSeconds    = 3009763
  CpuSeconds    = 3124.109
  WallSeconds   = 786.577
  SpeedUp       = 963
```
