### PR TITLE
[Death Knight] 7.3 PTR things

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7399,8 +7399,6 @@ double death_knight_t::composite_melee_haste() const
 
   haste *= 1.0 / ( 1.0 + buffs.sephuzs_secret -> check_value() );
 
-  haste *= 1.0 / ( 1.0 + spec.veteran_of_the_third_war -> effectN( 6 ).percent() );
-
   haste *= 1.0 / ( 1.0 + buffs.soul_reaper -> stack_value() );
 
   if ( buffs.bone_shield -> up() )
@@ -7434,7 +7432,7 @@ double death_knight_t::composite_spell_haste() const
 {
   double haste = player_t::composite_spell_haste();
 
-  haste *= 1.0 / ( 1.0 + spec.veteran_of_the_third_war -> effectN( 6 ).percent() );
+  haste *= 1.0 / ( 1.0 + buffs.sephuzs_secret -> check_value() );
 
   haste *= 1.0 / ( 1.0 + buffs.soul_reaper -> stack_value() );
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5014,10 +5014,12 @@ struct frostscythe_t : public death_knight_melee_attack_t
     aoe = -1;
 
     // T21 2P bonus : damage increase to Howling Blast, Frostscythe and Obliterate
-    if ( p -> sets -> has_set_bonus( DEATH_KNIGHT_FROST, T21, B2 ) )
-    {
-       base_multiplier *= ( 1.0 + p-> find_spell( 251873 ) -> effectN( 3 ).percent() );
-    }
+    if ( maybe_ptr( p -> dbc.ptr ) ) 
+      if ( p -> sets -> has_set_bonus( DEATH_KNIGHT_FROST, T21, B2 ) )
+      {
+        base_multiplier *= ( 1.0 + p-> find_spell( 251873 ) -> effectN( 3 ).percent() );
+      }
+    
     crit_bonus_multiplier *= 1.0 + p -> spec.death_knight -> effectN( 5 ).percent();
   }
 
@@ -5259,10 +5261,11 @@ struct howling_blast_t : public death_knight_spell_t
     base_multiplier    *= 1.0 + p -> artifact.blast_radius.percent();
     
     // T21 2P bonus : damage increase to Howling Blast, Frostscythe and Obliterate
-    if ( p->sets->has_set_bonus( DEATH_KNIGHT_FROST, T21, B2 ))
-    {
-       base_multiplier *= ( 1.0 + p-> find_spell( 251873 ) -> effectN( 1 ).percent() );
-    }
+    if ( maybe_ptr( p -> dbc.ptr ) )
+      if ( p->sets->has_set_bonus( DEATH_KNIGHT_FROST, T21, B2 ))
+      {
+        base_multiplier *= ( 1.0 + p-> find_spell( 251873 ) -> effectN( 1 ).percent() );
+      }
   }
 
   double runic_power_generation_multiplier( const action_state_t* state ) const override
@@ -5590,10 +5593,11 @@ struct obliterate_strike_t : public death_knight_melee_attack_t
     weapon = w;
     
     // T21 2P bonus : damage increase to Howling Blast, Frostscythe and Obliterate
-    if ( p -> sets -> has_set_bonus( DEATH_KNIGHT_FROST , T21, B2 ) )
-    {
-       base_multiplier *= ( 1.0 + p-> find_spell( 251873 ) -> effectN( 2 ).percent() );
-    }
+    if ( maybe_ptr( p -> dbc.ptr ) ) 
+      if ( p -> sets -> has_set_bonus( DEATH_KNIGHT_FROST , T21, B2 ) )
+      {
+        base_multiplier *= ( 1.0 + p-> find_spell( 251873 ) -> effectN( 2 ).percent() );
+      }
 
     // 7.3 : Koltira's newfound will also increase Obliterate damage by 10%
     if ( maybe_ptr( p -> dbc.ptr ) ) 
@@ -8417,9 +8421,11 @@ double death_knight_t::bone_shield_handler( const action_state_t* state ) const
   buffs.bone_shield -> decrement( n_stacks );
   cooldown.bone_shield_icd -> start();
 
-  if ( n_stacks > 0 && sets -> has_set_bonus( DEATH_KNIGHT_BLOOD, T21, B2 ) )
-    p() -> cooldown.dancing_rune_weapon -> adjust( - timespan_t::from_millis(  find_spell( 251876 ) -> effectN( 1 ) ), false );
-
+  if ( maybe_ptr ( p() -> dbc.ptr ) )
+    if ( n_stacks > 0 && sets -> has_set_bonus( DEATH_KNIGHT_BLOOD, T21, B2 ) )
+    {
+      p() -> cooldown.dancing_rune_weapon -> adjust( - timespan_t::from_millis(  find_spell( 251876 ) -> effectN( 1 ) ), false );
+    }
   
   return absorbed;
 }

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -2287,19 +2287,20 @@ struct gargoyle_pet_t : public death_knight_pet_t
 
 struct valkyr_pet_t : public death_knight_pet_t
 {
-
   timespan_t confusion_time;
 
   struct general_confusion_t : public action_t
   {
     bool executed;
+    timespan_t confusion_time;
 
-    general_confusion_t( player_t* player ) : action_t( ACTION_OTHER, "general_confusion", player ),
+    general_confusion_t( player_t* player, timespan_t t ) : action_t( ACTION_OTHER, "general_confusion", player ),
       executed( false )
     {
       may_miss = false;
       dual = quiet = true;
       trigger_gcd = timespan_t::zero();
+      confusion_time = t;
     }
 
     result_e calculate_result( action_state_t* /* s */ ) const override
@@ -2375,7 +2376,7 @@ struct valkyr_pet_t : public death_knight_pet_t
   action_t* create_action( const std::string& name, const std::string& options_str ) override
   {
     if ( name == "valkyr_strike"     ) return new     valkyr_strike_t( this, options_str );
-    if ( name == "general_confusion" ) return new general_confusion_t( this );
+    if ( name == "general_confusion" ) return new general_confusion_t( this, confusion_time);
 
     return death_knight_pet_t::create_action( name, options_str );
   }
@@ -4175,7 +4176,7 @@ struct dark_arbiter_t : public death_knight_spell_t
     timespan_t confusion_time = timespan_t::from_seconds( rng().gauss( base, 0.25 ) );
     timespan_t duration_increase = timespan_t::from_seconds( 0 );
     
-    if ( maybe_ptr ( p -> dbc.ptr ) )
+    if ( maybe_ptr ( p() -> dbc.ptr ) )
       duration_increase = confusion_time;
 
     p() -> pets.dark_arbiter -> summon( data().duration() + duration_increase );

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -2295,13 +2295,13 @@ struct valkyr_pet_t : public death_knight_pet_t
     bool executed;
     timespan_t confusion_time;
 
-    general_confusion_t( player_t* player, timespan_t t ) : action_t( ACTION_OTHER, "general_confusion", player ),
-      executed( false )
+    general_confusion_t( player_t* player, timespan_t confusion ) : action_t( ACTION_OTHER, "general_confusion", player ),
+      executed( false ),
+      confusion_time( confusion )
     {
       may_miss = false;
       dual = quiet = true;
       trigger_gcd = timespan_t::zero();
-      confusion_time = t;
     }
 
     result_e calculate_result( action_state_t* /* s */ ) const override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7,7 +7,7 @@
 // Unholy
 // - Does Festering Wound (generation|consumption) require a positive hit result?
 // - Skelebro has an aoe spell (Arrow Spray), but the AI using it is very inconsistent
-// - T21 bonuses : 4P isn't even implemented on PTR (as of 2017-8-12)
+// - T21 bonuses : 4P isn't implemented on PTR yet (as of 2017-8-12)
 // Blood
 // - Fix APL
 // - Support legendaries
@@ -20,6 +20,7 @@
 //   It is implemented on PTR, but triggered really weirdly and doesn't match tooltip
 // Frost
 // - T21 4P Damage proc : Freezing Death, spellID : 253590, set bonus ID : 251875
+//   really low damage atm (2017-8-12), could only be placeholder
 
 #include "simulationcraft.hpp"
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -485,6 +485,7 @@ public:
     cooldown_t* avalanche;
     cooldown_t* blighted_rune_weapon;
     cooldown_t* bone_shield_icd;
+    cooldown_t* dancing_rune_weapon;
     cooldown_t* dark_transformation;
     cooldown_t* death_and_decay;
     cooldown_t* defile;
@@ -854,6 +855,7 @@ public:
     cooldown.blighted_rune_weapon = get_cooldown( "blighted_rune_weapon" ); 
     cooldown.bone_shield_icd = get_cooldown( "bone_shield_icd" );
     cooldown.bone_shield_icd -> duration = timespan_t::from_seconds( 2.0 );
+    cooldown.dancing_rune_weapon = get_cooldown( "dancing_rune_weapon" );
     cooldown.dark_transformation = get_cooldown( "dark_transformation" );
     cooldown.death_and_decay = get_cooldown( "death_and_decay" );
     cooldown.defile          = get_cooldown( "defile" );
@@ -8422,10 +8424,10 @@ double death_knight_t::bone_shield_handler( const action_state_t* state ) const
   buffs.bone_shield -> decrement( n_stacks );
   cooldown.bone_shield_icd -> start();
 
-  if ( maybe_ptr ( p() -> dbc.ptr ) )
+  if ( dbc.ptr )
     if ( n_stacks > 0 && sets -> has_set_bonus( DEATH_KNIGHT_BLOOD, T21, B2 ) )
     {
-      p() -> cooldown.dancing_rune_weapon -> adjust( - timespan_t::from_millis(  find_spell( 251876 ) -> effectN( 1 ) ), false );
+      cooldown.dancing_rune_weapon -> adjust( timespan_t::from_millis( find_spell( 251876 ) -> effectN( 1 ).base_value() ), false );
     }
   
   return absorbed;

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7948,6 +7948,8 @@ void death_knight_t::default_apl_unholy()
 
   // On-use items
   def->add_action("use_items");
+  def->add_action("use_item,name=feloiled_infernal_machine,"
+                  "if=pet.valkyr_battlemaiden.active");
   def->add_action("use_item,name=ring_of_collapsing_futures,"
                   "if=(buff.temptation.stack=0&target.time_to_die>60)|target.time_to_die<60");
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -8196,7 +8196,7 @@ void death_knight_t::create_buffs()
                               .add_invalidate(legendary.toravons ? CACHE_PLAYER_DAMAGE_MULTIPLIER : CACHE_NONE);
   buffs.rime                = buff_creator_t( this, "rime", spec.rime -> effectN( 1 ).trigger() )
                               .trigger_spell( spec.rime )
-                              .chance( spec.rime -> proc_chance() + sets -> set( DEATH_KNIGHT_FROST, T19, B2 ) -> effectN( 1 ).percent() );
+                              .chance( spec.rime -> effectN( 2 ).percent() + sets -> set( DEATH_KNIGHT_FROST, T19, B2 ) -> effectN( 1 ).percent() );
   buffs.riposte             = stat_buff_creator_t( this, "riposte", spec.riposte -> effectN( 1 ).trigger() )
                               .cd( spec.riposte -> internal_cooldown() )
                               .chance( spec.riposte -> proc_chance() )


### PR DESCRIPTION
- Refactored dark arbiter confusion time to fit PTR's latest update : the pet now lasts 20s starting from first cast start instead of 20s starting from spawn
- Added Blood's T21 2P bonus : dancing rune weapon cooldown reduction on bone shield consumed
- Adjusted some haste modifiers : removed a blood passive that didn't have anything to do with haste in spell data and added sephuz's 2% passive haste to spell haste (was only accounted in melee haste before)
- Updated Todo list

- T21 2P for unholy remains to be implemented

- Unholy APL now plays around fel oiled infernal machine

- Rime proc rate fix because blizzard changed spell data on PTR (fix shouldn't change live behaviour)