### PR TITLE
[Hunter] Enable fixed_time by default for MM

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -6970,6 +6970,12 @@ std::string hunter_t::create_profile( save_e stype )
   std::string profile_str = player_t::create_profile( stype );
 
   profile_str += "summon_pet=" + summon_pet_str + "\n";
+  
+  if ( stype == SAVE_ALL )
+  {
+    if ( !hunter_fixed_time )
+      profile_str += "hunter_fixed_time=" + util::to_string( hunter_fixed_time ) + "\n";
+  }
 
   return profile_str;
 }


### PR DESCRIPTION
Results in a longer execute phase which is closer to live fights and helps the accuracy of time_to_x numbers before execute starts which improves the usage of important cooldowns.