### PR TITLE
Update ele relics + food

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7574,13 +7574,13 @@ std::string shaman_t::default_flask() const
 
 std::string shaman_t::default_food() const
 {
-  std::string elemental_food = ( true_level > 100  ) ? "lavish_suramar_feast" :
+  std::string elemental_food = ( true_level > 100  ) ? "lemon_herb_filet" :
                                ( true_level > 90   ) ? "pickled_eel" :
                                ( true_level >= 90  ) ? "mogu_fish_stew" :
                                ( true_level >= 80  ) ? "seafood_magnifique_feast" :
                                "disabled";
 
-  std::string enhance_food = ( true_level >  100 ) ? "lavish_suramar_feast" :
+  std::string enhance_food = ( true_level >  100 ) ? "lemon_herb_filet" :
                              ( true_level >  90  ) ? "buttered_sturgeon" :
                              ( true_level >= 90  ) ? "sea_mist_rice_noodles" :
                              ( true_level >= 80  ) ? "seafood_magnifique_feast" :

--- a/profiles/Tier21/T21_Shaman_Elemental.simc
+++ b/profiles/Tier21/T21_Shaman_Elemental.simc
@@ -11,7 +11,7 @@ crucible=1739:3:1589:3:1777:3
 # Default consumables
 potion=prolonged_power
 flask=whispered_pact
-food=hungry_magister
+food=lemon_herb_filet
 augmentation=defiled
 
 # This default action priority list is automatically created based on your character.
@@ -154,16 +154,16 @@ finger1=sullied_seal_of_the_pantheon,id=151972,ilevel=970,enchant=200crit
 finger2=band_of_the_sargerite_smith,id=152064,ilevel=960,enchant=200crit
 trinket1=acrid_catalyst_injector,id=151955,ilevel=960
 trinket2=amanthuls_vision,id=154172,ilevel=1000
-main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=152059/155850/152059,relic_ilevel=960/970/960
+main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=155853/155850/155853,relic_ilevel=970/970/970
 off_hand=the_highkeepers_ward,id=128936
 
 # Gear Summary
-# gear_ilvl=973.50
-# gear_stamina=62886
-# gear_intellect=67062
-# gear_crit_rating=11831
+# gear_ilvl=974.25
+# gear_stamina=63328
+# gear_intellect=68977
+# gear_crit_rating=11858
 # gear_haste_rating=9060
-# gear_mastery_rating=11322
+# gear_mastery_rating=11348
 # gear_versatility_rating=4719
 # gear_armor=3662
 # set_bonus=tier21_2pc=1

--- a/profiles/generators/Tier21/T21_Generate_Shaman.simc
+++ b/profiles/generators/Tier21/T21_Generate_Shaman.simc
@@ -11,7 +11,7 @@ crucible=1739:3:1589:3:1777:3
 # Default consumables
 potion=prolonged_power
 flask=whispered_pact
-food=hungry_magister
+food=lemon_herb_filet
 augmentation=defiled
 
 head=helm_of_the_awakened_soul,id=152423,ilevel=970

--- a/profiles/generators/Tier21/T21_Generate_Shaman.simc
+++ b/profiles/generators/Tier21/T21_Generate_Shaman.simc
@@ -28,7 +28,7 @@ finger1=sullied_seal_of_the_pantheon,id=151972,ilevel=970,enchant=200crit
 finger2=band_of_the_sargerite_smith,id=152064,ilevel=960,enchant=200crit
 trinket1=acrid_catalyst_injector,id=151955,ilevel=960
 trinket2=amanthuls_vision,id=154172,ilevel=1000
-main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=152059/155850/152059,relic_ilevel=960/970/960
+main_hand=the_fist_of_raden,id=128935,bonus_id=744,gem_id=155853/155850/155853,relic_ilevel=970/970/970
 off_hand=the_highkeepers_ward,id=128936
 
 save=T21_Shaman_Elemental.simc


### PR DESCRIPTION
These changes account for an ~30k (1.2%-ish) DPS increase.

* Update storm relics to favor item level over single target traits (this accounts for about 28-29k of the gains above)
* Update food to make use of the versatility fish food (h/t @Gengirawr, this accounts for about 1-2k of the gains above)

cc @Bloodmallet 