### PR TITLE
changing trinket to enhancement t21 profile

### DIFF
--- a/profiles/generators/Tier21/T21_Generate_Shaman.simc
+++ b/profiles/generators/Tier21/T21_Generate_Shaman.simc
@@ -63,7 +63,7 @@ feet=greatboots_of_the_searing_tempest,id=152684,bonus_id=3612/1502
 finger1=eye_of_the_twisting_nether,id=137050,bonus_id=3630,gem_id=151583,enchant=binding_of_haste
 finger2=loop_of_the_lifebinder,id=152688,bonus_id=3612/1502,enchant=binding_of_haste
 trinket1=golganneths_vitality,id=154174,bonus_id=4213
-trinket2=gorshalachs_legacy,id=152093,bonus_id=3612/1502
+trinket2=cradle_of_anguish,id=147010,bonus_id=3563/1512
 main_hand=doomhammer,id=128819,gem_id=155849/155855/155853,relic_id=3612:1512/3612:1512/3612:1512
 off_hand=fury_of_the_stonemother,id=128873
 


### PR DESCRIPTION
930 Cradle pushes ahead of any other 960 trinket in Antorus