### PR TITLE
Fetch correct primary stat for Aman'Thuls proc for tanks

### DIFF
--- a/engine/player/sc_unique_gear_x7.cpp
+++ b/engine/player/sc_unique_gear_x7.cpp
@@ -1565,7 +1565,7 @@ void item::amanthuls_vision( special_effect_t& effect )
   auto empower_spell = effect.player -> find_spell( 256832 );
   auto empower_amount = empower_spell -> effectN( 1 ).average( effect.item );
   stat_buff_t* empower_buff = stat_buff_creator_t( effect.player, "amanthuls_grandeur", empower_spell, effect.item )
-    .add_stat( effect.player -> primary_stat(), empower_amount );
+    .add_stat( effect.player -> convert_hybrid_stat( STAT_STR_AGI_INT ), empower_amount );
 
   effect.player -> sim -> expansion_data.pantheon_proxy -> register_pantheon_effect( effect.custom_buff, [ empower_buff ]() {
     empower_buff -> trigger();


### PR DESCRIPTION
Aman'Thul's Vision incorrectly procs Stamina for tanks (it procs Str/Agi/Int in-game).

This fixes the issue by using `convert_hybrid_stat(STAT_STR_AGI_INT)` rather than `primary_stat()`.