### PR TITLE
[Priest] Remove silence/mindbomb from apl if sephuz is disabled

### DIFF
--- a/engine/class_modules/sc_priest.cpp
+++ b/engine/class_modules/sc_priest.cpp
@@ -5161,9 +5161,10 @@ void priest_t::apl_shadow()
       "25&(cooldown.void_bolt.up|cooldown.void_torrent.up|cooldown.shadow_word_"
       "death.up|buff.shadowy_insight.up)&target.time_to_die<=variable.s2mcheck-"
       "(buff.insanity_drain_stacks.value)" );
-  vf->add_action( this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
-      "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
-      "&buff.insanity_drain_stacks.value>10,cycle_targets=1" );
+  if ( !priest_suppress_sephuz )
+    vf->add_action( this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
+        "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
+        "&buff.insanity_drain_stacks.value>10,cycle_targets=1" );
   vf->add_action( this, "Void Bolt" );
   vf->add_action( this, "Shadow Word: Death", "if=equipped.zeks_exterminatus&equipped."
       "mangazas_madness&buff.zeks_exterminatus.react" );
@@ -5171,9 +5172,10 @@ void priest_t::apl_shadow()
     vf->add_action(
         "arcane_torrent,if=buff.insanity_drain_stacks.value>=20&(insanity-"
         "(current_insanity_drain*gcd.max)+15)<100" );
-  vf->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
-      "secret.remains<1&!buff.sephuzs_secret.up&buff.insanity_drain_stacks.value>10"
-      ",cycle_targets=1" );
+  if ( !priest_suppress_sephuz )
+    vf->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
+        "secret.remains<1&!buff.sephuzs_secret.up&buff.insanity_drain_stacks.value>10"
+        ",cycle_targets=1" );
   vf->add_talent( this, "Shadow Crash", "if=talent.shadow_crash.enabled" );
   vf->add_action( this, "Void Torrent", "if=dot.shadow_word_pain.remains>5.5&dot.vampiric_touch.remains"
       ">5.5&(!talent.surrender_to_madness.enabled|(talent.surrender_to_madness."

--- a/engine/class_modules/sc_priest.cpp
+++ b/engine/class_modules/sc_priest.cpp
@@ -5086,12 +5086,12 @@ void priest_t::apl_shadow()
   main->add_action( this, "Shadow Word: Pain" );
 
   // Surrender to Madness APL
-  if ( !p.options.priest_ignore_healing )
+  if ( !options.priest_suppress_sephuz )
     s2m->add_action(this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
         "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
         ",cycle_targets=1" );
   s2m->add_action( this, "Void Bolt", "if=buff.insanity_drain_stacks.value<6&set_bonus.tier19_4pc" );
-  if ( !p.options.priest_ignore_healing )
+  if ( !options.priest_suppress_sephuz )
     s2m->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
         "secret.remains<1&!buff.sephuzs_secret.up,cycle_targets=1" );
   s2m->add_talent( this, "Shadow Crash", "if=talent.shadow_crash.enabled" );
@@ -5163,7 +5163,7 @@ void priest_t::apl_shadow()
       "25&(cooldown.void_bolt.up|cooldown.void_torrent.up|cooldown.shadow_word_"
       "death.up|buff.shadowy_insight.up)&target.time_to_die<=variable.s2mcheck-"
       "(buff.insanity_drain_stacks.value)" );
-  if ( !p.options.priest_ignore_healing )
+  if ( !options.priest_suppress_sephuz )
     vf->add_action( this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
         "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
         "&buff.insanity_drain_stacks.value>10,cycle_targets=1" );
@@ -5174,7 +5174,7 @@ void priest_t::apl_shadow()
     vf->add_action(
         "arcane_torrent,if=buff.insanity_drain_stacks.value>=20&(insanity-"
         "(current_insanity_drain*gcd.max)+15)<100" );
-  if ( !p.options.priest_ignore_healing )
+  if ( !options.priest_suppress_sephuz )
     vf->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
         "secret.remains<1&!buff.sephuzs_secret.up&buff.insanity_drain_stacks.value>10"
         ",cycle_targets=1" );

--- a/engine/class_modules/sc_priest.cpp
+++ b/engine/class_modules/sc_priest.cpp
@@ -5086,12 +5086,14 @@ void priest_t::apl_shadow()
   main->add_action( this, "Shadow Word: Pain" );
 
   // Surrender to Madness APL
-  s2m->add_action(this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
-      "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
-      ",cycle_targets=1" );
+  if ( !p.options.priest_ignore_healing )
+    s2m->add_action(this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
+        "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
+        ",cycle_targets=1" );
   s2m->add_action( this, "Void Bolt", "if=buff.insanity_drain_stacks.value<6&set_bonus.tier19_4pc" );
-  s2m->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
-      "secret.remains<1&!buff.sephuzs_secret.up,cycle_targets=1" );
+  if ( !p.options.priest_ignore_healing )
+    s2m->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
+        "secret.remains<1&!buff.sephuzs_secret.up,cycle_targets=1" );
   s2m->add_talent( this, "Shadow Crash", "if=talent.shadow_crash.enabled" );
   s2m->add_talent( this, "Mindbender", "if=cooldown.shadow_word_death.charges=0&buff.voidform.stack>(45"
       "+25*set_bonus.tier20_4pc)" );
@@ -5161,7 +5163,7 @@ void priest_t::apl_shadow()
       "25&(cooldown.void_bolt.up|cooldown.void_torrent.up|cooldown.shadow_word_"
       "death.up|buff.shadowy_insight.up)&target.time_to_die<=variable.s2mcheck-"
       "(buff.insanity_drain_stacks.value)" );
-  if ( !priest_suppress_sephuz )
+  if ( !p.options.priest_ignore_healing )
     vf->add_action( this, "Silence", "if=equipped.sephuzs_secret&(target.is_add|target.debuff.casting."
         "react)&cooldown.buff_sephuzs_secret.up&!buff.sephuzs_secret.up"
         "&buff.insanity_drain_stacks.value>10,cycle_targets=1" );
@@ -5172,7 +5174,7 @@ void priest_t::apl_shadow()
     vf->add_action(
         "arcane_torrent,if=buff.insanity_drain_stacks.value>=20&(insanity-"
         "(current_insanity_drain*gcd.max)+15)<100" );
-  if ( !priest_suppress_sephuz )
+  if ( !p.options.priest_ignore_healing )
     vf->add_talent( this, "Mind Bomb", "if=equipped.sephuzs_secret&target.is_add&cooldown.buff_sephuzs_"
         "secret.remains<1&!buff.sephuzs_secret.up&buff.insanity_drain_stacks.value>10"
         ",cycle_targets=1" );


### PR DESCRIPTION
When using `priest_suppress_sephuz` the apl should not cast silence or mind bomb.