### PR TITLE
Updated Relics T21_Generate_Demon_Hunter.simc

### DIFF
--- a/profiles/generators/Tier21/T21_Generate_Demon_Hunter.simc
+++ b/profiles/generators/Tier21/T21_Generate_Demon_Hunter.simc
@@ -22,7 +22,7 @@ finger1=anger_of_the_halfgiants,id=137038,bonus_id=3630,gems=200crit,enchant=bin
 finger2=band_of_the_sargerite_smith,id=152064,bonus_id=3612/1502,enchant=binding_of_critical_strike
 trinket1=seeping_scourgewing,id=151964,bonus_id=3612/1502
 trinket2=golganneths_vitality,id=154174,bonus_id=3997
-main_hand=twinblades_of_the_deceiver,id=127829,bonus_id=719,gem_id=152033/155852/152033/0,relic_id=3612:1502/3612:1512/3612:1502
+main_hand=twinblades_of_the_deceiver,id=127829,bonus_id=719,gem_id=155848/155852/155848/0,relic_id=3612:1512/3612:1512/3612:1512
 off_hand=twinblades_of_the_deceiver,id=127830,gem_id=0/0/0/0,relic_id=0/0
 
 save=T21_Demon_Hunter_Havoc.simc


### PR DESCRIPTION
Swapping out the 960 Sliver of Corruption relics for 970 Condensed Blight Orb relics is a dps increase.