### PR TITLE
[Warlock] Soulstealer and Reap Souls RPPM

### DIFF
--- a/engine/class_modules/sc_warlock.cpp
+++ b/engine/class_modules/sc_warlock.cpp
@@ -1613,7 +1613,7 @@ double warlock_pet_t::composite_player_multiplier( school_e school ) const
 
   if ( o() -> specialization() == WARLOCK_AFFLICTION )
   {
-    m *= 1.0 + o() -> artifact.soulstealer.percent() * ( o() -> buffs.deadwind_harvester -> check() ? 2.0 : 1.0 );
+    m *= 1.0 + o() -> artifact.soulstealer.percent();
     m *= 1.0 + o() -> artifact.degradation_of_the_black_harvest.percent();
   }
 
@@ -6314,7 +6314,7 @@ double warlock_t::composite_player_multiplier( school_e school ) const
 
   if ( specialization() == WARLOCK_AFFLICTION )
   {
-    m *= 1.0 + artifact.soulstealer.percent() * ( buffs.deadwind_harvester -> check() ? 2.0 : 1.0 );
+    m *= 1.0 + artifact.soulstealer.percent();
     m *= 1.0 + artifact.degradation_of_the_black_harvest.percent();
   }
 

--- a/engine/class_modules/sc_warlock.cpp
+++ b/engine/class_modules/sc_warlock.cpp
@@ -7057,7 +7057,7 @@ void warlock_t::init_rng()
   demonic_power_rppm = get_rppm( "demonic_power", find_spell( 196099 ) );
   grimoire_of_synergy = get_rppm( "grimoire_of_synergy", talents.grimoire_of_synergy );
   grimoire_of_synergy_pet = get_rppm( "grimoire_of_synergy_pet", talents.grimoire_of_synergy );
-  tormented_souls_rppm = get_rppm( "tormented_souls", 5.0 ); // The only official post claimed 4.5 rppm but hours of logs suggest it's actually 5 rppm.
+  tormented_souls_rppm = get_rppm( "tormented_souls", 4.5 );
 }
 
 void warlock_t::init_gains()


### PR DESCRIPTION
Fix for two Affliction warlock issues.

- The "Soulstealer" trait explicitly says "unaffected by Reap Souls" but it is affected in the sim.
- Warlock codes Reap Souls RPPM as 5.0 even though it's 4.5 in the spelldata. This leads to Deadwind Harvester sim uptime of 80% while in practice 60-70% is more common.