### PR TITLE
Add consistent stats reporting to JSON

### DIFF
--- a/engine/report/sc_report_json.cpp
+++ b/engine/report/sc_report_json.cpp
@@ -574,7 +574,8 @@ js::sc_js_t to_json(
   return node;
 }
 
-void to_json( JsonOutput root, const player_collected_data_t::buffed_stats_t& bs,
+void to_json( JsonOutput root, const player_t& p,
+                               const player_collected_data_t::buffed_stats_t& bs,
                                const std::vector<resource_e>& relevant_resources )
 {
   for ( attribute_e a = ATTRIBUTE_NONE; a < ATTRIBUTE_MAX; ++a )
@@ -602,6 +603,36 @@ void to_json( JsonOutput root, const player_collected_data_t::buffed_stats_t& bs
   add_non_zero( root[ "stats" ], "damage_versatility", bs.damage_versatility );
   add_non_zero( root[ "stats" ], "heal_versatility", bs.heal_versatility );
   add_non_zero( root[ "stats" ], "mitigation_versatility", bs.mitigation_versatility );
+
+  // some of these secondaries are dupes from above. Duplication is intended to preserve backwards compatibility while
+  // making a few names more consistent with the game. they're intended to be a quicker/simpler reference to match paper
+  // doll stats in-game. crit and haste pick the max between melee/spell which seems to be the game logic
+
+  add_non_zero( root[ "stats" ], "crit_rating",
+                                p.composite_melee_crit_rating() > p.composite_spell_crit_rating()
+                                ? p.composite_melee_crit_rating()
+                                : p.composite_spell_crit_rating());
+  add_non_zero( root[ "stats" ], "crit_pct",
+                                 bs.attack_crit_chance > bs.spell_crit_chance
+                                 ? bs.attack_crit_chance
+                                 : bs.spell_crit_chance);
+
+  double attack_haste_pct = 1 / bs.attack_haste - 1;
+  double spell_haste_pct = 1 / bs.spell_haste - 1;
+  add_non_zero( root[ "stats" ], "haste_rating",
+                                 p.composite_melee_haste_rating() > p.composite_spell_haste_rating()
+                                 ? p.composite_melee_haste_rating()
+                                 : p.composite_spell_haste_rating());
+  add_non_zero( root[ "stats" ], "haste_pct",
+                                 attack_haste_pct > spell_haste_pct
+                                 ? attack_haste_pct
+                                 : spell_haste_pct);
+
+  add_non_zero( root[ "stats" ], "mastery_rating", p.composite_mastery_rating());
+  add_non_zero( root[ "stats" ], "mastery_pct", bs.mastery_value);
+
+  add_non_zero( root[ "stats" ], "versatility_rating", p.composite_damage_versatility_rating());
+  add_non_zero( root[ "stats" ], "versatility_pct", bs.damage_versatility);
 
   add_non_zero( root[ "stats" ], "leech", bs.leech );
   add_non_zero( root[ "stats" ], "speed", bs.run_speed );
@@ -849,23 +880,27 @@ void collected_data_to_json( JsonOutput root, const player_t& p )
     root[ "target_metric" ] = cd.target_metric;
   }
 
+  // Key off of resource loss to figure out what resources are even relevant
+  std::vector<resource_e> relevant_resources;
+  for ( size_t i = 0, end = cd.resource_lost.size(); i < end; ++i )
+  {
+    auto r = static_cast<resource_e>( i );
+
+    if ( cd.resource_lost[ r ].mean() > 0 )
+    {
+      relevant_resources.push_back( r );
+    }
+  }
+
+  // always include buffed_stats in JSON
+  to_json( root[ "buffed_stats" ], p, cd.buffed_stats_snapshot, relevant_resources );
+
   if ( sim.report_details != 0 )
   {
-    // Key off of resource loss to figure out what resources are even relevant
-    std::vector<resource_e> relevant_resources;
-    for ( size_t i = 0, end = cd.resource_lost.size(); i < end; ++i )
-    {
-      auto r = static_cast<resource_e>( i );
-
-      if ( cd.resource_lost[ r ].mean() > 0 )
-      {
-        root[ "resource_lost" ][ util::resource_type_string( r ) ] = cd.resource_lost[ r ];
-        relevant_resources.push_back( r );
-      }
-    }
-
     // Rest of the resource summaries are printed only based on relevant resources
     range::for_each( relevant_resources, [ &root, &cd ]( resource_e r ) {
+      root[ "resource_lost" ][ util::resource_type_string( r ) ] = cd.resource_lost[ r ];
+
       if ( r < cd.combat_end_resource.size() )
       {
         // Combat ending resources
@@ -907,8 +942,6 @@ void collected_data_to_json( JsonOutput root, const player_t& p )
     {
       to_json( root[ "action_sequence" ], cd.action_sequence, relevant_resources, sim );
     }
-
-    to_json( root[ "buffed_stats" ], cd.buffed_stats_snapshot, relevant_resources );
   }
 }
 

--- a/engine/report/sc_report_json.cpp
+++ b/engine/report/sc_report_json.cpp
@@ -634,9 +634,12 @@ void to_json( JsonOutput root, const player_t& p,
   add_non_zero( root[ "stats" ], "versatility_rating", p.composite_damage_versatility_rating());
   add_non_zero( root[ "stats" ], "versatility_pct", bs.damage_versatility);
 
-  add_non_zero( root[ "stats" ], "leech", bs.leech );
-  add_non_zero( root[ "stats" ], "speed", bs.run_speed );
-  add_non_zero( root[ "stats" ], "avoidance", bs.avoidance );
+  add_non_zero( root[ "stats" ], "avoidance_rating", p.composite_avoidance_rating());
+  add_non_zero( root[ "stats" ], "avoidance_pct", bs.avoidance );
+  add_non_zero( root[ "stats" ], "leech_rating", p.composite_leech_rating());
+  add_non_zero( root[ "stats" ], "leech_pct", bs.leech );
+  add_non_zero( root[ "stats" ], "speed_rating", p.composite_speed_rating());
+  add_non_zero( root[ "stats" ], "speed_pct", bs.run_speed );
 
   add_non_zero( root[ "stats" ], "manareg_per_second", bs.manareg_per_second );
 

--- a/engine/sim/sc_profileset.cpp
+++ b/engine/sim/sc_profileset.cpp
@@ -1231,9 +1231,12 @@ void save_output_data( profile_set_t& profileset, const player_t* parent_player,
 
     // tertiary stats
 
-    profileset.output_data().avoidance( buffed_stats.avoidance );
-    profileset.output_data().leech( buffed_stats.leech );
-    profileset.output_data().speed( buffed_stats.run_speed );
+    profileset.output_data().avoidance_rating( player -> composite_avoidance_rating() );
+    profileset.output_data().avoidance_pct( buffed_stats.avoidance );
+    profileset.output_data().leech_rating( player -> composite_leech_rating() );
+    profileset.output_data().leech_pct( buffed_stats.leech );
+    profileset.output_data().speed_rating( player -> composite_spell_haste_rating() );
+    profileset.output_data().speed_pct( buffed_stats.run_speed );
   }
 }
 
@@ -1291,9 +1294,12 @@ void fetch_output_data( const profile_output_data_t output_data, js::JsonOutput&
     ovr[ "stats" ][ "versatility_rating" ] = output_data.versatility_rating();
     ovr[ "stats" ][ "versatility_pct" ] = output_data.versatility_pct();
 
-    ovr[ "stats" ][ "avoidance" ] = output_data.avoidance();
-    ovr[ "stats" ][ "leech" ] = output_data.leech();
-    ovr[ "stats" ][ "speed" ] = output_data.speed();
+    ovr[ "stats" ][ "avoidance_rating" ] = output_data.avoidance_rating();
+    ovr[ "stats" ][ "avoidance_pct" ] = output_data.avoidance_pct();
+    ovr[ "stats" ][ "leech_rating" ] = output_data.leech_rating();
+    ovr[ "stats" ][ "leech_pct" ] = output_data.leech_pct();
+    ovr[ "stats" ][ "speed_rating" ] = output_data.speed_rating();
+    ovr[ "stats" ][ "speed_pct" ] = output_data.speed_pct();
   }
 }
 

--- a/engine/sim/sc_profileset.cpp
+++ b/engine/sim/sc_profileset.cpp
@@ -127,7 +127,7 @@ void simulate_profileset( sim_t* parent, profile_set_t& set, sim_t*& profile_sim
   {
     const auto parent_player = parent -> player_no_pet_list.data().front();
     range::for_each( parent -> profileset_output_data, [ & ]( const std::string& option ) {
-        save_output_data( &set, parent_player, player, option );
+        save_output_data( set, parent_player, player, option );
     } );
   }
 
@@ -1123,13 +1123,13 @@ statistical_data_t metric_data( const player_t* player, scale_metric_e metric )
   }
 }
 
-void save_output_data( profile_set_t* profileset, const player_t* parent_player, const player_t* player, std::string option )
+void save_output_data( profile_set_t& profileset, const player_t* parent_player, const player_t* player, std::string option )
 {
   // TODO: Make an enum to proper use a switch instead of if/else
   if ( option == "race") {
     if ( parent_player -> race != player -> race )
     {
-      profileset -> output_data().race( player -> race );
+      profileset.output_data().race( player -> race );
     }
   } else if ( option == "talents" ) {
     if ( parent_player -> talents_str != player -> talents_str ) {
@@ -1157,18 +1157,18 @@ void save_output_data( profile_set_t* profileset, const player_t* parent_player,
       }
       if ( saved_talents.size() > 0 )
       {
-        profileset -> output_data().talents( saved_talents );
+        profileset.output_data().talents( saved_talents );
       }
     }
   } else if ( option == "artifact" ) {
     if ( parent_player -> artifact -> encode() != player -> artifact -> encode() )
     {
-      profileset -> output_data().artifact( player -> artifact -> encode() );
+      profileset.output_data().artifact( player -> artifact -> encode() );
     }
   } else if ( option == "crucible" ) {
     if ( parent_player -> artifact -> encode_crucible() != player -> artifact -> encode_crucible() )
     {
-      profileset -> output_data().crucible( player -> artifact -> encode_crucible() );
+      profileset.output_data().crucible( player -> artifact -> encode_crucible() );
     }
   } else if ( option == "gear" ) {
     const auto& parent_items = parent_player -> items;
@@ -1194,46 +1194,46 @@ void save_output_data( profile_set_t* profileset, const player_t* parent_player,
     }
     if ( saved_gear.size() > 0 )
     {
-      profileset -> output_data().gear( saved_gear );
+      profileset.output_data().gear( saved_gear );
     }
   } else if ( option == "stats" ) {
     const auto& buffed_stats = player -> collected_data.buffed_stats_snapshot;
 
     // primary stats
 
-    profileset -> output_data().stamina( util::floor( buffed_stats.attribute[ ATTR_STAMINA ] ) );
-    profileset -> output_data().agility( util::floor( buffed_stats.attribute[ ATTR_AGILITY ] ) );
-    profileset -> output_data().intellect( util::floor( buffed_stats.attribute[ ATTR_INTELLECT ] ) );
-    profileset -> output_data().strength( util::floor( buffed_stats.attribute[ ATTR_STRENGTH ] ) );
+    profileset.output_data().stamina( util::floor( buffed_stats.attribute[ ATTR_STAMINA ] ) );
+    profileset.output_data().agility( util::floor( buffed_stats.attribute[ ATTR_AGILITY ] ) );
+    profileset.output_data().intellect( util::floor( buffed_stats.attribute[ ATTR_INTELLECT ] ) );
+    profileset.output_data().strength( util::floor( buffed_stats.attribute[ ATTR_STRENGTH ] ) );
 
     // secondary stats
 
-    profileset -> output_data().crit_rating( util::floor( player -> composite_melee_crit_rating() > player -> composite_spell_crit_rating()
+    profileset.output_data().crit_rating( util::floor( player -> composite_melee_crit_rating() > player -> composite_spell_crit_rating()
                        ? player -> composite_melee_crit_rating()
                        : player -> composite_spell_crit_rating() ) );
-    profileset -> output_data().crit_pct( buffed_stats.attack_crit_chance > buffed_stats.spell_crit_chance
+    profileset.output_data().crit_pct( buffed_stats.attack_crit_chance > buffed_stats.spell_crit_chance
                        ? buffed_stats.attack_crit_chance
                        : buffed_stats.spell_crit_chance );
 
-    profileset -> output_data().haste_rating( util::floor( player -> composite_melee_haste_rating() > player -> composite_spell_haste_rating()
+    profileset.output_data().haste_rating( util::floor( player -> composite_melee_haste_rating() > player -> composite_spell_haste_rating()
                        ? player -> composite_melee_haste_rating()
                        : player -> composite_spell_haste_rating() ) );
 
     double attack_haste_pct = 1 / buffed_stats.attack_haste - 1;
     double spell_haste_pct = 1 / buffed_stats.spell_haste - 1;
-    profileset -> output_data().haste_pct( attack_haste_pct > spell_haste_pct ? attack_haste_pct : spell_haste_pct );
+    profileset.output_data().haste_pct( attack_haste_pct > spell_haste_pct ? attack_haste_pct : spell_haste_pct );
 
-    profileset -> output_data().mastery_rating( util::floor( player -> composite_mastery_rating() ) );
-    profileset -> output_data().mastery_pct( buffed_stats.mastery_value );
+    profileset.output_data().mastery_rating( util::floor( player -> composite_mastery_rating() ) );
+    profileset.output_data().mastery_pct( buffed_stats.mastery_value );
 
-    profileset -> output_data().versatility_rating( util::floor( player -> composite_damage_versatility_rating() ) );
-    profileset -> output_data().versatility_pct( buffed_stats.damage_versatility );
+    profileset.output_data().versatility_rating( util::floor( player -> composite_damage_versatility_rating() ) );
+    profileset.output_data().versatility_pct( buffed_stats.damage_versatility );
 
     // tertiary stats
 
-    profileset -> output_data().avoidance( buffed_stats.avoidance );
-    profileset -> output_data().leech( buffed_stats.leech );
-    profileset -> output_data().speed( buffed_stats.run_speed );
+    profileset.output_data().avoidance( buffed_stats.avoidance );
+    profileset.output_data().leech( buffed_stats.leech );
+    profileset.output_data().speed( buffed_stats.run_speed );
   }
 }
 

--- a/engine/sim/sc_profileset.hpp
+++ b/engine/sim/sc_profileset.hpp
@@ -524,7 +524,7 @@ void create_options( sim_t* sim );
 
 statistical_data_t collect( const extended_sample_data_t& c );
 statistical_data_t metric_data( const player_t* player, scale_metric_e metric );
-void save_output_data( profile_set_t* profileset, const player_t* parent_player, const player_t* player, std::string option );
+void save_output_data( profile_set_t& profileset, const player_t* parent_player, const player_t* player, std::string option );
 void fetch_output_data( const profile_output_data_t output_data, js::JsonOutput& ovr );
 
 // Filter non-profilest options into a new control object, caller is responsible for deleting the

--- a/engine/sim/sc_profileset.hpp
+++ b/engine/sim/sc_profileset.hpp
@@ -206,9 +206,12 @@ class profile_output_data_t
             m_strength,
             m_intellect,
             m_stamina,
-            m_avoidance,
-            m_leech,
-            m_speed;
+            m_avoidance_rating,
+            m_avoidance_pct,
+            m_leech_rating,
+            m_leech_pct,
+            m_speed_rating,
+            m_speed_pct;
 
 public:
   profile_output_data_t() : m_race ( RACE_NONE )
@@ -316,23 +319,41 @@ public:
   profile_output_data_t& stamina( double d )
   { m_stamina = d; return *this; }
 
-  double avoidance() const
-  { return m_avoidance; }
+  double avoidance_rating() const
+  { return m_avoidance_rating; }
 
-  profile_output_data_t& avoidance( double d )
-  { m_avoidance = d; return *this; }
+  profile_output_data_t& avoidance_rating( double d )
+  { m_avoidance_rating = d; return *this; }
 
-  double leech() const
-  { return m_leech; }
+  double avoidance_pct() const
+  { return m_avoidance_pct; }
 
-  profile_output_data_t& leech( double d )
-  { m_leech = d; return *this; }
+  profile_output_data_t& avoidance_pct( double d )
+  { m_avoidance_pct = d; return *this; }
 
-  double speed() const
-  { return m_speed; }
+  double leech_rating() const
+  { return m_leech_rating; }
 
-  profile_output_data_t& speed( double d )
-  { m_speed = d; return *this; }
+  profile_output_data_t& leech_rating( double d )
+  { m_leech_rating = d; return *this; }
+
+  double leech_pct() const
+  { return m_leech_pct; }
+
+  profile_output_data_t& leech_pct( double d )
+  { m_leech_pct = d; return *this; }
+
+  double speed_rating() const
+  { return m_speed_rating; }
+
+  profile_output_data_t& speed_rating( double d )
+  { m_speed_rating = d; return *this; }
+
+  double speed_pct() const
+  { return m_speed_pct; }
+
+  profile_output_data_t& speed_pct( double d )
+  { m_speed_pct = d; return *this; }
 };
 
 class profile_set_t

--- a/engine/sim/sc_profileset.hpp
+++ b/engine/sim/sc_profileset.hpp
@@ -188,11 +188,27 @@ public:
 
 class profile_output_data_t
 {
-  race_e                                  m_race;
-  std::vector<talent_data_t*>             m_talents;
-  std::string                             m_artifact;
-  std::string                             m_crucible;
-  std::vector<profile_output_data_item_t> m_gear;
+  race_e                                       m_race;
+  std::vector<talent_data_t*>                  m_talents;
+  std::string                                  m_artifact;
+  std::string                                  m_crucible;
+  std::vector<profile_output_data_item_t>      m_gear;
+
+  double    m_crit_rating,
+            m_crit_pct,
+            m_haste_rating,
+            m_haste_pct,
+            m_mastery_rating,
+            m_mastery_pct,
+            m_versatility_rating,
+            m_versatility_pct,
+            m_agility,
+            m_strength,
+            m_intellect,
+            m_stamina,
+            m_avoidance,
+            m_leech,
+            m_speed;
 
 public:
   profile_output_data_t() : m_race ( RACE_NONE )
@@ -227,6 +243,96 @@ public:
 
   profile_output_data_t& gear( const std::vector<profile_output_data_item_t>& v )
   { m_gear = v; return *this; }
+
+  double crit_rating() const
+  { return m_crit_rating; }
+
+  profile_output_data_t& crit_rating( double d )
+  { m_crit_rating = d; return *this; }
+
+  double haste_rating() const
+  { return m_haste_rating; }
+
+  profile_output_data_t& haste_rating( double d )
+  { m_haste_rating = d; return *this; }
+
+  double mastery_rating() const
+  { return m_mastery_rating; }
+
+  profile_output_data_t& mastery_rating( double d )
+  { m_mastery_rating = d; return *this; }
+
+  double versatility_rating() const
+  { return m_versatility_rating; }
+
+  profile_output_data_t& versatility_rating( double d )
+  { m_versatility_rating = d; return *this; }
+
+  double crit_pct() const
+  { return m_crit_pct; }
+
+  profile_output_data_t& crit_pct( double d )
+  { m_crit_pct = d; return *this; }
+
+  double haste_pct() const
+  { return m_haste_pct; }
+
+  profile_output_data_t& haste_pct( double d )
+  { m_haste_pct = d; return *this; }
+
+  double mastery_pct() const
+  { return m_mastery_pct; }
+
+  profile_output_data_t& mastery_pct( double d )
+  { m_mastery_pct = d; return *this; }
+
+  double versatility_pct() const
+  { return m_versatility_pct; }
+
+  profile_output_data_t& versatility_pct( double d )
+  { m_versatility_pct = d; return *this; }
+
+  double agility() const
+  { return m_agility; }
+
+  profile_output_data_t& agility( double d )
+  { m_agility = d; return *this; }
+
+  double strength() const
+  { return m_strength; }
+
+  profile_output_data_t& strength( double d )
+  { m_strength = d; return *this; }
+
+  double intellect() const
+  { return m_intellect; }
+
+  profile_output_data_t& intellect( double d )
+  { m_intellect = d; return *this; }
+
+  double stamina() const
+  { return m_stamina; }
+
+  profile_output_data_t& stamina( double d )
+  { m_stamina = d; return *this; }
+
+  double avoidance() const
+  { return m_avoidance; }
+
+  profile_output_data_t& avoidance( double d )
+  { m_avoidance = d; return *this; }
+
+  double leech() const
+  { return m_leech; }
+
+  profile_output_data_t& leech( double d )
+  { m_leech = d; return *this; }
+
+  double speed() const
+  { return m_speed; }
+
+  profile_output_data_t& speed( double d )
+  { m_speed = d; return *this; }
 };
 
 class profile_set_t
@@ -418,7 +524,7 @@ void create_options( sim_t* sim );
 
 statistical_data_t collect( const extended_sample_data_t& c );
 statistical_data_t metric_data( const player_t* player, scale_metric_e metric );
-void save_output_data( std::unique_ptr<profile_set_t>& profileset, const player_t* parent_player, const player_t* player, std::string option );
+void save_output_data( profile_set_t* profileset, const player_t* parent_player, const player_t* player, std::string option );
 void fetch_output_data( const profile_output_data_t output_data, js::JsonOutput& ovr );
 
 // Filter non-profilest options into a new control object, caller is responsible for deleting the


### PR DESCRIPTION
* Add crit/haste/mast/vers percents to actor
collected_data.buffed_stats. Add consistently named stats to JSON
* Get `profileset_output_data` working again
* Add "stats" arg to `profileset_output_data` which will add
`overrides.stats` to profileset JSON output.

I think this is mostly fine but there are probably some questionable choices I made. I'll highlight them in comments to see if anyone has a strong feeling about fixing/changing them.