### PR TITLE
Add `target_error_role` option for target_error behavior

### DIFF
--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -11745,7 +11745,11 @@ void player_collected_data_t::collect_data( const player_t& p )
   {
     double metric=0;
 
-    switch( p.primary_role() )
+    // ROLE is used here primarily to stay in-line with the previous version of the code.
+    // An ideal implementation is probably to rewrite this to allow specification of a scale_metric_e
+    // to make it more flexible. That was beyond my capability/available time and it would also likely be
+    // very, very low use (as of legion/bfa, almost all tanks are simming DPS, not survival).
+    switch( p.sim -> target_error_role )
     {
     case ROLE_ATTACK:
     case ROLE_SPELL:

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -11745,11 +11745,17 @@ void player_collected_data_t::collect_data( const player_t& p )
   {
     double metric=0;
 
+    role_e target_error_role = p.sim -> target_error_role;
+    // use player's role if sim didn't provide an override
+    if (target_error_role == ROLE_NONE) {
+      target_error_role = p.primary_role();
+    }
+
     // ROLE is used here primarily to stay in-line with the previous version of the code.
     // An ideal implementation is probably to rewrite this to allow specification of a scale_metric_e
     // to make it more flexible. That was beyond my capability/available time and it would also likely be
     // very, very low use (as of legion/bfa, almost all tanks are simming DPS, not survival).
-    switch( p.sim -> target_error_role )
+    switch( target_error_role )
     {
     case ROLE_ATTACK:
     case ROLE_SPELL:

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -11747,8 +11747,14 @@ void player_collected_data_t::collect_data( const player_t& p )
 
     role_e target_error_role = p.sim -> target_error_role;
     // use player's role if sim didn't provide an override
-    if (target_error_role == ROLE_NONE) {
+    if (target_error_role == ROLE_NONE)
+    {
       target_error_role = p.primary_role();
+      // exception for tanks - use DPS by default.
+      if (target_error_role == ROLE_TANK)
+      {
+        target_error_role = ROLE_DPS;
+      }
     }
 
     // ROLE is used here primarily to stay in-line with the previous version of the code.

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -861,6 +861,19 @@ bool parse_process_priority( sim_t*             sim,
   return true;
 }
 
+bool parse_target_error_role( sim_t * sim,
+                              const std::string& name,
+                              const std::string& value )
+{
+  role_e parsed_role = util::parse_role_type( value );
+
+  if (parsed_role != ROLE_NONE) {
+    sim -> target_error_role = util::parse_role_type( value );
+  }
+
+  return true;
+}
+
 bool parse_maximize_reporting( sim_t*             sim,
                                    const std::string& name,
                                    const std::string& v )
@@ -1336,6 +1349,7 @@ sim_t::sim_t() :
   iterations( 0 ),
   canceled( 0 ),
   target_error( 0 ),
+  target_error_role( ROLE_DPS ),
   current_error( 0 ),
   current_mean( 0 ),
   analyze_error_interval( 100 ),
@@ -3167,6 +3181,7 @@ void sim_t::create_options()
   add_option( opt_int( "iterations", iterations ) );
   add_option( opt_bool( "cleanup_threads", cleanup_threads ) );
   add_option( opt_float( "target_error", target_error ) );
+  add_option( opt_func( "target_error_role", parse_target_error_role ) );
   add_option( opt_int( "analyze_error_interval", analyze_error_interval ) );
   add_option( opt_func( "process_priority", parse_process_priority ) );
   add_option( opt_timespan( "max_time", max_time, timespan_t::zero(), timespan_t::max() ) );

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -862,14 +862,10 @@ bool parse_process_priority( sim_t*             sim,
 }
 
 bool parse_target_error_role( sim_t * sim,
-                              const std::string& name,
+                              const std::string& /* name */,
                               const std::string& value )
 {
-  role_e parsed_role = util::parse_role_type( value );
-
-  if (parsed_role != ROLE_NONE) {
-    sim -> target_error_role = util::parse_role_type( value );
-  }
+  sim -> target_error_role = util::parse_role_type( value );
 
   return true;
 }

--- a/engine/simulationcraft.hpp
+++ b/engine/simulationcraft.hpp
@@ -1543,6 +1543,7 @@ struct sim_t : private sc_thread_t
   int current_iteration, iterations;
   bool canceled;
   double target_error;
+  role_e target_error_role;
   double current_error;
   double current_mean;
   int analyze_error_interval, analyze_number;


### PR DESCRIPTION
Allows user choice of which role to use for target_error. Default has
been changed to DPS rather than decide based on the player role. I
believe this matches the vast majority of SimC usage.

It may be worth looking into allowing choice over the specific metric
rather than just role but that would have required deeper work in the
target metric code which I wasn't comfortable with (and, again, isn't
used very much today)