### PR TITLE
[Druid] Fix Brutal Slash not awarding combo points

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -2896,7 +2896,7 @@ struct brutal_slash_t : public cat_attack_t
     cat_attack_t( "brutal_slash", p, p -> talent.brutal_slash, options_str )
   {
     aoe = -1;
-    energize_amount = data().effectN( 1 ).base_value();
+    energize_amount = data().effectN( 2 ).base_value();
     energize_resource = RESOURCE_COMBO_POINT;
     energize_type = ENERGIZE_ON_HIT;
     cooldown -> hasted = true;


### PR DESCRIPTION
Effect no. 1 for Brutal Slash is the AP mod, so it wasn't awarding any combo points when used.