### PR TITLE
Correct spelleffect delta logic

### DIFF
--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -2143,12 +2143,7 @@ double dbc_t::effect_delta( const spelleffect_data_t* e, unsigned level ) const
 
   if ( e -> m_delta() != 0 && e -> spell() -> scaling_class() != 0 )
   {
-    unsigned scaling_level = level;
-    if ( e -> spell() -> max_scaling_level() > 0 )
-      scaling_level = std::min( scaling_level, e -> spell() -> max_scaling_level() );
-    double m_scale = spell_scaling( e -> spell() -> scaling_class(), scaling_level );
-
-    return e -> m_average() * e -> m_delta() * m_scale;
+    return  e -> m_delta();
   }
 
   return 0;
@@ -2202,7 +2197,7 @@ double dbc_t::effect_min( const spelleffect_data_t* e, unsigned level ) const
   if ( c_id != 0 && ( e -> m_average() != 0 || e -> m_delta() != 0 ) )
   {
     double delta = effect_delta( e, level );
-    result = avg - ( delta / 2 );
+    result = avg - ( avg * delta / 2 );
   }
   else
   {
@@ -2218,7 +2213,7 @@ double dbc_t::effect_min( const spelleffect_data_t* e, unsigned level ) const
     }
   }
 
-  return result;
+  return floor(result);
 }
 
 double dbc_t::effect_max( unsigned effect_id, unsigned level ) const
@@ -2239,7 +2234,7 @@ double dbc_t::effect_max( const spelleffect_data_t* e, unsigned level ) const
   {
     double delta = effect_delta( e, level );
 
-    result = avg + ( delta / 2 );
+    result = avg + ( avg * delta / 2 );
   }
   else
   {
@@ -2255,7 +2250,7 @@ double dbc_t::effect_max( const spelleffect_data_t* e, unsigned level ) const
     }
   }
 
-  return result;
+  return ceil(result);
 }
 
 unsigned dbc_t::talent_ability_id( player_e c, specialization_e spec, const char* spell_name, bool name_tokenized ) const


### PR DESCRIPTION
Spelleffects with delta coeff are not calculating the min and max values correctly.


Ingame:
https://vgy.me/2Zqs8l.png
https://vgy.me/Wu06NR.png




simc output before changes:
simc spell_query=spell.id=17528
Name             : Mighty Rage (id=17528) [Scaling Spell (-1), Spell Family (13)]
School           : Physical
Max Scaling Level: 46
Duration         : 20 seconds
Category         : 4
Attributes       : ........ ........ ........ ...x....   ........ ..x..... ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ .x...... ........   ........ ........ ........ ........
Effects          :
#1 (id=69328)    : Energize Power (30)
                   Base Value: 600 | **Scaled Value: 600** (avg=0, dl=1) | Misc Value: rage | Target: Self (1)
#2 (id=69329)    : Apply Aura (6) | Attribute (29)
                   Base Value: 0 | Scaled Value: 47.60998 (avg=2.069999) | SP Coefficient: 1.00000 | Target: Self (1)
Description      : Instantly generates ${$m1/10} to ${$M1/10} rage and increases Strength by $s2 for $d.
Tooltip          : Strength increased by $s2.



simc spell_query=spell.id=85948
Name             : Festering Strike (id=85948) [Scaling Spell (-1), Spell Family (15)]
Class            : Unholy Death Knight
School           : Physical
Resource         : 2 Rune (5) (id=6275)
Resource         : -20 Runic Power (6) (id=10658)
Spell Level      : 55
Range            : 5 yards
GCD              : 1.5 seconds
Affecting spells : Death Knight (137005 effect#2), Frost Death Knight (137006 effect#1), Unholy Death Knight (137007 effect#1), Blood Death Knight (137008 effect#1), Master of Ghouls (246995 effect#1), Festering Doom (272741 effect#1), Cankerous Wounds (278482 effect#1)
Attributes       : ....x... ........ ..x..... ........   ........ .x...... ........ ...x....
                 : ........ ........ ........ ........   ........ ..x..... ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   x....... ........ ........ ........
                 : Requires main-hand weapon (106)
Effects          :
#1 (id=87374)    : School Damage (2): physical
                   Base Value: 0 | Scaled Value: 0 | AP Coefficient: 1.01088 | Target: Enemy (6)
#2 (id=87375)    : Dummy (3)
                   Base Value: 2.5 | **Scaled Value: 2.5** (avg=0, dl=0.4) | Target: Enemy (6)
Description      : Strikes for $s1 Physical damage and infects the target with $m2-$M2 Festering Wounds.

|Tinterface\icons\spell_yorsahj_bloodboil_purpleoil.blp:24|t |cFFFFFFFFFestering Wound|r
$@spelldesc194310


simc output post changes:

simc spell_query=spell.id=17528
SimulationCraft 801-01 for World of Warcraft 8.0.1 bfa-BETA (wow build 26095)

Name             : Mighty Rage (id=17528) [Scaling Spell (-1), Spell Family (13)]
School           : Physical
Max Scaling Level: 46
Duration         : 20 seconds
Category         : 4
Attributes       : ........ ........ ........ ...x....   ........ ..x..... ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ .x...... ........   ........ ........ ........ ........
Effects          :
#1 (id=69328)    : Energize Power (30)
                   Base Value: 600 | **Scaled Value: 300 - 900** (avg=0, dl=1) | Misc Value: rage | Target: Self (1)
#2 (id=69329)    : Apply Aura (6) | Attribute (29)
                   Base Value: 0 | Scaled Value: 47 - 48 (avg=2.069999) | SP Coefficient: 1.00000 | Target: Self (1)
Description      : Instantly generates ${$m1/10} to ${$M1/10} rage and increases Strength by $s2 for $d.
Tooltip          : Strength increased by $s2.

simc spell_query=spell.id=85948
SimulationCraft 801-01 for World of Warcraft 8.0.1 bfa-BETA (wow build 26095)

Name             : Festering Strike (id=85948) [Scaling Spell (-1), Spell Family (15)]
Class            : Unholy Death Knight
School           : Physical
Resource         : 2 Rune (5) (id=6275)
Resource         : -20 Runic Power (6) (id=10658)
Spell Level      : 55
Range            : 5 yards
GCD              : 1.5 seconds
Affecting spells : Death Knight (137005 effect#2), Frost Death Knight (137006 effect#1), Unholy Death Knight (137007 effect#1), Blood Death Knight (137008 effect#1), Master of Ghouls (246995 effect#1), Festering Doom (272741 effect#1), Cankerous Wounds (278482 effect#1)
Attributes       : ....x... ........ ..x..... ........   ........ .x...... ........ ...x....
                 : ........ ........ ........ ........   ........ ..x..... ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   x....... ........ ........ ........
                 : Requires main-hand weapon (106)
Effects          :
#1 (id=87374)    : School Damage (2): physical
                   Base Value: 0 | Scaled Value: 0 | AP Coefficient: 1.01088 | Target: Enemy (6)
#2 (id=87375)    : Dummy (3)
                   Base Value: 2.5 | **Scaled Value: 2 - 3** (avg=0, dl=0.4) | Target: Enemy (6)
Description      : Strikes for $s1 Physical damage and infects the target with $m2-$M2 Festering Wounds.

|Tinterface\icons\spell_yorsahj_bloodboil_purpleoil.blp:24|t |cFFFFFFFFFestering Wound|r
$@spelldesc194310



I tried to find more examples but its kinda a pain to look for spells that actually use them in their descriptions.
