### PR TITLE
Change some variable names to more accurately reflect their usage, and keep them consistent with the names blizzard uses internally

### DIFF
--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -3977,7 +3977,7 @@ class RandomPropertyPointsGenerator(DataGenerator):
         for id in ids + [ 0 ]:
             rpp = self._randproppoints_db[id]
 
-            fields = rpp.field('id', 'item_effect')
+            fields = rpp.field('id', 'damage_replace_stat')
             fields += [ '{ %s }' % ', '.join(rpp.field('epic_points_1', 'epic_points_2', 'epic_points_3', 'epic_points_4', 'epic_points_5')) ]
             fields += [ '{ %s }' % ', '.join(rpp.field('rare_points_1', 'rare_points_2', 'rare_points_3', 'rare_points_4', 'rare_points_5')) ]
             fields += [ '{ %s }' % ', '.join(rpp.field('uncm_points_1', 'uncm_points_2', 'uncm_points_3', 'uncm_points_4', 'uncm_points_5')) ]

--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -2717,7 +2717,7 @@ class SpellDataGenerator(DataGenerator):
                 continue
 
             #if index % 20 == 0:
-            #    self._out.write('//{     Id,Flags,   SpId,Idx, EffectType                  , EffectSubType                              ,       Average,         Delta,       Unknown,   Coefficient, APCoefficient,  Ampl,  Radius,  RadMax,   BaseV,   MiscV,  MiscV2, {     Flags1,     Flags2,     Flags3,     Flags4 }, Trigg,   DmgMul,  CboP, RealP,Die,Mech,ChTrg,0, 0 },\n')
+            #    self._out.write('//{     Id,Flags,   SpId,Idx, EffectType                  , EffectSubType                              ,       Coefficient,         Delta,       Unknown,   Coefficient, APCoefficient,  Ampl,  Radius,  RadMax,   BaseV,   MiscV,  MiscV2, {     Flags1,     Flags2,     Flags3,     Flags4 }, Trigg,   DmgMul,  CboP, RealP,Die,Mech,ChTrg,0, 0 },\n')
 
             hotfix_flags = 0
             hotfix_data = []
@@ -2740,11 +2740,11 @@ class SpellDataGenerator(DataGenerator):
 
             # 7, 8, 9
             if self._options.build < 25600:
-                fields += effect.get_link('scaling').field('average', 'delta', 'bonus')
-                f, hfd = effect.get_link('scaling').get_hotfix_info(('average', 6), ('delta', 7), ('bonus', 8))
+                fields += effect.get_link('scaling').field('coefficient', 'delta', 'bonus')
+                f, hfd = effect.get_link('scaling').get_hotfix_info(('coefficient', 6), ('delta', 7), ('bonus', 8))
             else:
-                fields += effect.field('average', 'delta', 'bonus')
-                f, hfd = effect.get_hotfix_info(('average', 6), ('delta', 7), ('bonus', 8))
+                fields += effect.field('coefficient', 'delta', 'bonus')
+                f, hfd = effect.get_hotfix_info(('coefficient', 6), ('delta', 7), ('bonus', 8))
             hotfix_flags |= f
             hotfix_data += hfd
             # 10, 11, 12

--- a/dbc_extract3/formats/25976.json
+++ b/dbc_extract3/formats/25976.json
@@ -454,7 +454,7 @@
     { "data_type": "I", "field": "unk_2", "block": true },
     { "data_type": "f", "field": "ap_coefficient", "block": true },
     { "data_type": "f", "field": "pvp_coefficient", "block": true },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26095.json
+++ b/dbc_extract3/formats/26095.json
@@ -463,7 +463,7 @@
     { "data_type": "I", "field": "unk_2", "block": true },
     { "data_type": "f", "field": "ap_coefficient", "block": true },
     { "data_type": "f", "field": "pvp_coefficient", "block": true },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26287.json
+++ b/dbc_extract3/formats/26287.json
@@ -464,7 +464,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26367.json
+++ b/dbc_extract3/formats/26367.json
@@ -463,7 +463,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26433.json
+++ b/dbc_extract3/formats/26433.json
@@ -464,7 +464,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26476.json
+++ b/dbc_extract3/formats/26476.json
@@ -462,7 +462,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26522.json
+++ b/dbc_extract3/formats/26522.json
@@ -463,7 +463,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26567.json
+++ b/dbc_extract3/formats/26567.json
@@ -463,7 +463,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26629.json
+++ b/dbc_extract3/formats/26629.json
@@ -338,7 +338,7 @@
     { "data_type": "b", "field": "index" }
   ],
   "RandPropPoints": [
-    { "data_type": "I", "field": "item_effect", "formats": { "cpp": "%5u" } },
+    { "data_type": "I", "field": "damage_replace_stat", "formats": { "cpp": "%5u" } },
     { "data_type": "H", "field": "epic_points", "elements": 5, "formats": { "cpp": "%5u" } },
     { "data_type": "H", "field": "rare_points", "elements": 5, "formats": { "cpp": "%5u" } },
     { "data_type": "H", "field": "uncm_points", "elements": 5, "formats": { "cpp": "%5u" } }

--- a/dbc_extract3/formats/26629.json
+++ b/dbc_extract3/formats/26629.json
@@ -479,7 +479,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26715.json
+++ b/dbc_extract3/formats/26715.json
@@ -339,7 +339,7 @@
     { "data_type": "b", "field": "index" }
   ],
   "RandPropPoints": [
-    { "data_type": "I", "field": "item_effect", "formats": { "cpp": "%5u" } },
+    { "data_type": "I", "field": "damage_replace_stat", "formats": { "cpp": "%5u" } },
     { "data_type": "H", "field": "epic_points", "elements": 5, "formats": { "cpp": "%5u" } },
     { "data_type": "H", "field": "rare_points", "elements": 5, "formats": { "cpp": "%5u" } },
     { "data_type": "H", "field": "uncm_points", "elements": 5, "formats": { "cpp": "%5u" } }

--- a/dbc_extract3/formats/26715.json
+++ b/dbc_extract3/formats/26715.json
@@ -484,7 +484,7 @@
     { "data_type": "I", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/dbc_extract3/formats/26788.json
+++ b/dbc_extract3/formats/26788.json
@@ -356,7 +356,7 @@
     { "data_type": "i", "field": "index" }
   ],
   "RandPropPoints": [
-    { "data_type": "i", "field": "item_effect", "formats": { "cpp": "%5u" } },
+    { "data_type": "i", "field": "damage_replace_stat", "formats": { "cpp": "%5u" } },
     { "data_type": "I", "field": "epic_points", "elements": 5, "formats": { "cpp": "%5u" } },
     { "data_type": "I", "field": "rare_points", "elements": 5, "formats": { "cpp": "%5u" } },
     { "data_type": "I", "field": "uncm_points", "elements": 5, "formats": { "cpp": "%5u" } }

--- a/dbc_extract3/formats/26788.json
+++ b/dbc_extract3/formats/26788.json
@@ -504,7 +504,7 @@
     { "data_type": "i", "field": "trigger_spell" },
     { "data_type": "f", "field": "ap_coefficient" },
     { "data_type": "f", "field": "pvp_coefficient" },
-    { "data_type": "f", "field": "average" },
+    { "data_type": "f", "field": "coefficient" },
     { "data_type": "f", "field": "delta" },
     { "data_type": "f", "field": "bonus" },
     { "data_type": "f", "field": "unk_24" },

--- a/engine/dbc/data_definitions.hh
+++ b/engine/dbc/data_definitions.hh
@@ -172,7 +172,7 @@ struct item_upgrade_t {
 
 struct random_prop_data_t {
   unsigned ilevel;
-  unsigned item_effect;
+  unsigned damage_replace_stat;
   double   p_epic[5];
   double   p_rare[5];
   double   p_uncommon[5];

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -599,7 +599,7 @@ public:
   unsigned         _type;            // 5 Effect type
   unsigned         _subtype;         // 6 Effect sub-type
   // SpellScaling.dbc
-  double           _m_avg;           // 7 Effect average spell scaling multiplier
+  double           _m_coeff;           // 7 Effect average spell scaling multiplier
   double           _m_delta;         // 8 Effect delta spell scaling multiplier
   double           _m_unk;           // 9 Unused effect scaling multiplier
   //
@@ -704,8 +704,8 @@ public:
   double chain_multiplier() const
   { return _m_chain; }
 
-  double m_average() const
-  { return _m_avg; }
+  double m_coefficient() const
+  { return _m_coeff; }
 
   double m_delta() const
   { return _m_delta; }

--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -1726,7 +1726,7 @@ double spelleffect_data_t::average( const item_t* item ) const
   else if ( _spell -> scaling_class() == PLAYER_SPECIAL_SCALE8 )
   {
     const auto& props = item -> player -> dbc.random_property( item -> item_level() );
-    budget = props.item_effect;
+    budget = props.damage_replace_stat;
   }
 
   return _m_coeff * budget;
@@ -1807,7 +1807,7 @@ double spelleffect_data_t::delta( const item_t* item ) const
   else if ( _spell -> scaling_class() == PLAYER_SPECIAL_SCALE8 )
   {
     const auto& props = item -> player -> dbc.random_property( item -> item_level() );
-    m_scale = props.item_effect;
+    m_scale = props.damage_replace_stat;
   }
 
   return scaled_delta( m_scale );

--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -1683,8 +1683,8 @@ spellpower_data_t* spellpower_data_t::list( bool ptr )
 
 double spelleffect_data_t::scaled_average( double budget, unsigned level ) const
 {
-  if ( _m_avg != 0 && _spell -> scaling_class() != 0 )
-    return _m_avg * budget;
+  if ( _m_coeff != 0 && _spell -> scaling_class() != 0 )
+    return _m_coeff * budget;
   else if ( _real_ppl != 0 )
   {
     if ( _spell -> max_level() > 0 )
@@ -1702,7 +1702,7 @@ double spelleffect_data_t::average( const player_t* p, unsigned level ) const
 
   double m_scale = 0;
 
-  if ( _m_avg != 0 && _spell -> scaling_class() != 0 )
+  if ( _m_coeff != 0 && _spell -> scaling_class() != 0 )
   {
     unsigned scaling_level = level ? level : p -> level();
     if ( _spell -> max_scaling_level() > 0 )
@@ -1729,7 +1729,7 @@ double spelleffect_data_t::average( const item_t* item ) const
     budget = props.item_effect;
   }
 
-  return _m_avg * budget;
+  return _m_coeff * budget;
 }
 
 double dbc_t::item_socket_cost( unsigned ilevel ) const
@@ -1769,7 +1769,7 @@ double dbc_t::npc_armor_mitigation_constant( unsigned level ) const
 double spelleffect_data_t::scaled_delta( double budget ) const
 {
   if ( _m_delta != 0 && budget > 0 )
-    return _m_avg * _m_delta * budget;
+    return _m_coeff * _m_delta * budget;
   else
     return 0;
 }
@@ -1823,7 +1823,7 @@ double spelleffect_data_t::scaled_min( double avg, double delta ) const
 {
   double result = 0;
 
-  if ( _m_avg != 0 || _m_delta != 0 )
+  if ( _m_coeff != 0 || _m_delta != 0 )
     result = avg - ( delta / 2 );
   else
   {
@@ -1846,7 +1846,7 @@ double spelleffect_data_t::scaled_max( double avg, double delta ) const
 {
   double result = 0;
 
-  if ( _m_avg != 0 || _m_delta != 0 )
+  if ( _m_coeff != 0 || _m_delta != 0 )
     result = avg + ( delta / 2 );
   else
   {
@@ -2136,14 +2136,14 @@ double dbc_t::effect_average( const spelleffect_data_t* e, unsigned level ) cons
 {
   assert( e && ( level > 0 ) && ( level <= MAX_SCALING_LEVEL ) );
 
-  if ( e -> m_average() != 0 && e -> spell() -> scaling_class() != 0 )
+  if ( e -> m_coefficient() != 0 && e -> spell() -> scaling_class() != 0 )
   {
     unsigned scaling_level = level;
     if ( e -> spell() -> max_scaling_level() > 0 )
       scaling_level = std::min( scaling_level, e -> spell() -> max_scaling_level() );
     double m_scale = spell_scaling( e -> spell() -> scaling_class(), scaling_level );
 
-    return e -> m_average() * m_scale;
+    return e -> m_coefficient() * m_scale;
   }
   else if ( e -> real_ppl() != 0 )
   {
@@ -2220,7 +2220,7 @@ double dbc_t::effect_min( const spelleffect_data_t* e, unsigned level ) const
   unsigned c_id = util::class_id( e -> _spell -> scaling_class() );
   avg = effect_average( e, level );
 
-  if ( c_id != 0 && ( e -> m_average() != 0 || e -> m_delta() != 0 ) )
+  if ( c_id != 0 && ( e -> m_coefficient() != 0 || e -> m_delta() != 0 ) )
   {
     double delta = effect_delta( e, level );
     result = avg - ( avg * delta / 2 );
@@ -2256,7 +2256,7 @@ double dbc_t::effect_max( const spelleffect_data_t* e, unsigned level ) const
   unsigned c_id = util::class_id( e -> _spell -> scaling_class() );
   avg = effect_average( e, level );
 
-  if ( c_id != 0 && ( e -> m_average() != 0 || e -> m_delta() != 0 ) )
+  if ( c_id != 0 && ( e -> m_coefficient() != 0 || e -> m_delta() != 0 ) )
   {
     double delta = effect_delta( e, level );
 

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -124,8 +124,8 @@ spelleffect_data_nil_t spelleffect_data_nil_t::singleton;
 
 bool spelleffect_data_t::override_field( const std::string& field, double value )
 {
-  if ( util::str_compare_ci( field, "average" ) )
-    _m_avg = value;
+  if ( util::str_compare_ci( field, "coefficient" ) )
+    _m_coeff = value;
   else if ( util::str_compare_ci( field, "delta" ) )
     _m_delta = value;
   else if ( util::str_compare_ci( field, "bonus" ) )
@@ -161,8 +161,8 @@ bool spelleffect_data_t::override_field( const std::string& field, double value 
 
 double spelleffect_data_t::get_field( const std::string& field ) const
 {
-  if ( util::str_compare_ci( field, "average" ) )
-    return _m_avg;
+  if ( util::str_compare_ci( field, "coefficient" ) )
+    return _m_coeff;
   else if ( util::str_compare_ci( field, "delta" ) )
     return _m_delta;
   else if ( util::str_compare_ci( field, "bonus" ) )

--- a/engine/dbc/sc_spell_data.cpp
+++ b/engine/dbc/sc_spell_data.cpp
@@ -45,7 +45,7 @@ const sdata_field_t _effect_data_fields[] =
   { SD_TYPE_UNSIGNED, "index",          O_SED( _index )           },
   { SD_TYPE_INT,      "type",           O_SED( _type )            },
   { SD_TYPE_INT,      "sub_type" ,      O_SED( _subtype )         },
-  { SD_TYPE_DOUBLE,   "m_average",      O_SED( _m_avg )           },
+  { SD_TYPE_DOUBLE,   "m_coefficient",  O_SED( _m_coeff )         },
   { SD_TYPE_DOUBLE,   "m_delta",        O_SED( _m_delta )         },
   { SD_TYPE_DOUBLE,   "m_bonus" ,       O_SED( _m_unk )           },
   { SD_TYPE_DOUBLE,   "coefficient",    O_SED( _sp_coeff )        },

--- a/engine/dbc/sc_spell_info.cpp
+++ b/engine/dbc/sc_spell_info.cpp
@@ -927,7 +927,7 @@ std::ostringstream& spell_info::effect_to_str( const dbc_t& dbc,
     }
     else if ( spell -> scaling_class() == PLAYER_SPECIAL_SCALE8 )
     {
-      item_budget = ilevel_data.item_effect;
+      item_budget = ilevel_data.damage_replace_stat;
     }
 
     s << item_budget * e -> m_coefficient() * coefficient;

--- a/engine/dbc/sc_spell_info.cpp
+++ b/engine/dbc/sc_spell_info.cpp
@@ -30,7 +30,7 @@ std::vector<std::string> _hotfix_effect_map = {
   "Index",
   "Type",
   "Sub Type",
-  "Average",
+  "Coefficient",
   "Delta",
   "Bonus",
   "SP Coefficient",
@@ -930,15 +930,15 @@ std::ostringstream& spell_info::effect_to_str( const dbc_t& dbc,
       item_budget = ilevel_data.item_effect;
     }
 
-    s << item_budget * e -> m_average() * coefficient;
+    s << item_budget * e -> m_coefficient() * coefficient;
 
   }
 
-  if ( e -> m_average() != 0 || e -> m_delta() != 0 )
+  if ( e -> m_coefficient() != 0 || e -> m_delta() != 0 )
   {
-    s << " (avg=" << e -> m_average();
+    s << " (coefficient=" << e -> m_coefficient();
     if ( e -> m_delta() != 0 )
-      s << ", dl=" << e -> m_delta();
+      s << ", delta coefficient=" << e -> m_delta();
     s << ")";
   }
 
@@ -1803,12 +1803,12 @@ void spell_info::effect_to_xml( const dbc_t& dbc,
     const random_prop_data_t& ilevel_data = dbc.random_property( level );
     double item_budget = ilevel_data.p_epic[ 0 ];
 
-    node -> add_parm( "scaled_value", item_budget * e -> m_average() );
+    node -> add_parm( "scaled_value", item_budget * e -> m_coefficient() );
   }
 
-  if ( e -> m_average() != 0 )
+  if ( e -> m_coefficient() != 0 )
   {
-    node -> add_parm( "multiplier_average", e -> m_average() );
+    node -> add_parm( "multiplier_coefficient", e -> m_coefficient() );
   }
 
   if ( e -> m_delta() != 0 )

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -51,7 +51,7 @@ double azerite_power_t::value( size_t index ) const
   for ( size_t budget_index = 0, end = budgets.size(); budget_index < end; ++budget_index )
   {
     auto budget = budgets[ budget_index ];
-    auto value = floor( m_spell -> effectN( index ).m_average() * budget + 0.5 );
+    auto value = floor( m_spell -> effectN( index ).m_coefficient() * budget + 0.5 );
 
     unsigned actual_level = m_ilevels[ budget_index ];
     if ( m_spell->max_scaling_level() > 0 && m_spell->max_scaling_level() < actual_level )

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -123,7 +123,7 @@ std::vector<double> azerite_power_t::budget() const
     if ( m_spell->scaling_class() == PLAYER_SPECIAL_SCALE8 )
     {
       const auto& props = m_player->dbc.random_property( min_ilevel );
-      budget = props.item_effect;
+      budget = props.damage_replace_stat;
     }
     b.push_back( budget );
   } );
@@ -154,7 +154,7 @@ bool azerite_power_t::check_combat_rating_penalty( size_t index ) const
   }
 
   return m_spell->effectN( index ).subtype() == A_MOD_RATING &&
-         m_spell->effectN( index ).m_average() != 0;
+         m_spell->effectN( index ).m_coefficient() != 0;
 }
 
 namespace azerite

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -2409,7 +2409,7 @@ void item::readiness( special_effect_t& effect )
 
   const spell_data_t* cdr_spell = p -> find_spell( effect.spell_id );
   const random_prop_data_t& budget = p -> dbc.random_property( effect.item -> item_level() );
-  double cdr = 1.0 / ( 1.0 + budget.p_epic[ 0 ] * cdr_spell -> effectN( 1 ).m_average() / 100.0 );
+  double cdr = 1.0 / ( 1.0 + budget.p_epic[ 0 ] * cdr_spell -> effectN( 1 ).m_coefficient() / 100.0 );
 
   if ( p -> level() > 90 )
   { // We have no clue how the trinket actually scales down with level. This will linearly decrease CDR until it hits .90 at level 100.
@@ -2476,7 +2476,7 @@ void item::amplification( special_effect_t& effect )
   }
 
   const random_prop_data_t& budget = p -> dbc.random_property( effect.item -> item_level() );
-  *amp_value = budget.p_epic[ 0 ] * amplify_spell -> effectN( 2 ).m_average() / 100.0;
+  *amp_value = budget.p_epic[ 0 ] * amplify_spell -> effectN( 2 ).m_coefficient() / 100.0;
   if ( p -> level() > 90 )
   { // We have no clue how the trinket actually scales down with level. This will linearly decrease amplification until it hits 0 at level 100.
     double level_nerf = ( static_cast<double>( p -> level() ) - 90 ) / 10.0;
@@ -2611,7 +2611,7 @@ void item::cleave( special_effect_t& effect )
 
   // Needs a damaging result
   effect.proc_flags2_ = PF2_ALL_HIT;
-  effect.proc_chance_ = budget.p_epic[ 0 ] * cleave_driver_spell -> effectN( 1 ).m_average() / 10000.0;
+  effect.proc_chance_ = budget.p_epic[ 0 ] * cleave_driver_spell -> effectN( 1 ).m_coefficient() / 10000.0;
 
   if ( p -> level() > 90 )
   { // We have no clue how the trinket actually scales down with level. This will linearly decrease amplification until it hits 0 at level 100.


### PR DESCRIPTION
During the BFA beta blizzards internal names used for DB2 files were leaked and can be seen here: https://github.com/Arctium/ClientDB-Structures/

I've spent a good amount of time reverse engineering the wow binary to get accurate spelltooltips. Comparing my work against simcraft was a big help but was made difficult by the sometimes obtuse names used for variables.

This PR focuses on changing two variables that I think are the best candidates for being renamed.


The first is the "_m_avg" variable. 
Blizzard internally refers to this as "Coefficient" and throughout the code that is how the variable is used.  By changing the name from _m_avg its use is made clear that it is not the average its self but is used in conjunction with the different forms of scaling to get the actual average.

The second is "item_effect"  which is referred to as DamageReplaceStat in both the SpellScaling.txt gametable and the RandPropPoint.db2 


I've had these changes made locally for a while now and keeping the naming of the variables consistent was a big help when tabbing between the reversed code and simcraft.