### PR TITLE
[Priest] Holy module dust off

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -274,20 +274,35 @@ struct blessed_dawnlight_medallion_t : public priest_spell_t
 // ==========================================================================
 struct smite_t final : public priest_spell_t
 {
+  const spell_data_t* rank2;
   smite_t( priest_t& p, const std::string& options_str ) : priest_spell_t( "smite", p, p.find_class_spell( "Smite" ) )
   {
     parse_options( options_str );
 
-    procs_courageous_primal_diamond = false;
+    rank2 = priest().find_specialization_spell( 231687 );
   }
 
   void execute() override
   {
     priest_spell_t::execute();
 
-    priest().buffs.holy_evangelism->trigger();
-
-    priest().buffs.power_overwhelming->trigger();
+    double hf_proc_chance = priest().find_specialization_spell( 231687 ) -> effectN( 1 ).percent();
+    if ( sim->debug )
+    {
+      sim->out_debug.printf(
+      "%s tried to reset holy fire %s cast. ",
+      priest().name(), name() );
+    }
+    if( rank2->ok() && rng().roll( hf_proc_chance ) )
+    {
+      if ( sim->debug )
+      {
+        sim->out_debug.printf(
+      "%s reset holy fire %s cooldown ",
+      priest().name(), name() );
+    }
+      priest().cooldowns.holy_fire -> reset(true);
+    }
   }
 };
 
@@ -442,7 +457,7 @@ void mangazas_madness( special_effect_t& effect )
 
   if ( priest->active_items.mangazas_madness )
   {
-    priest->cooldowns.mind_blast->charges += 
+    priest->cooldowns.mind_blast->charges +=
       (int)(float) priest->active_items.mangazas_madness->driver()->effectN( 1 ).base_value();
   }
 }
@@ -639,6 +654,7 @@ void priest_t::create_cooldowns()
   cooldowns.chakra            = get_cooldown( "chakra" );
   cooldowns.mindbender        = get_cooldown( "mindbender" );
   cooldowns.penance           = get_cooldown( "penance" );
+  cooldowns.holy_fire         = get_cooldown( "holy_fire" );
   cooldowns.power_word_shield = get_cooldown( "power_word_shield" );
   cooldowns.shadowfiend       = get_cooldown( "shadowfiend" );
   cooldowns.silence           = get_cooldown( "silence" );

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -257,6 +257,9 @@ public:
     // Holy
     const spell_data_t* holy;  /// General holy data
     const spell_data_t* rapid_renewal;
+    const spell_data_t* holy_word_chastise;
+    const spell_data_t* holy_nova;
+    const spell_data_t* holy_fire;
     const spell_data_t* serendipity;
     const spell_data_t* divine_providence;
 
@@ -294,6 +297,9 @@ public:
     propagate_const<cooldown_t*> psychic_horror;
     propagate_const<cooldown_t*> sephuzs_secret;
     propagate_const<cooldown_t*> dark_ascension;
+
+    propagate_const<cooldown_t*> holy_word_chastise;
+    propagate_const<cooldown_t*> holy_fire;
   } cooldowns;
 
   // Gains
@@ -351,6 +357,7 @@ public:
     propagate_const<proc_t*> surge_of_light_overflow;
     propagate_const<proc_t*> void_eruption_has_dots;
     propagate_const<proc_t*> void_eruption_no_dots;
+    propagate_const<proc_t*> holy_fire_cd;
   } procs;
 
   struct realppm_t
@@ -363,7 +370,7 @@ public:
   struct
   {
     propagate_const<actions::spells::mind_sear_tick_t*> mind_sear_tick;
-    propagate_const<actions::spells::shadowy_apparition_spell_t*> shadowy_apparitions;   
+    propagate_const<actions::spells::shadowy_apparition_spell_t*> shadowy_apparitions;
   } active_spells;
 
   struct
@@ -990,7 +997,7 @@ public:
       return true;
     }
     return false;
-  }
+  };
 
   bool trigger_zeks()
   {

--- a/engine/class_modules/priest/sc_priest_holy.cpp
+++ b/engine/class_modules/priest/sc_priest_holy.cpp
@@ -17,7 +17,6 @@ struct holy_fire_base_t : public priest_spell_t
 {
   holy_fire_base_t( const std::string& name, priest_t& p, const spell_data_t* sd ) : priest_spell_t( name, p, sd )
   {
-    procs_courageous_primal_diamond = false;
   }
 
   void execute() override
@@ -42,6 +41,30 @@ struct holy_fire_t final : public holy_fire_base_t
 {
   holy_fire_t( priest_t& player, const std::string& options_str )
     : holy_fire_base_t( "holy_fire", player, player.find_class_spell( "Holy Fire" ) )
+  {
+    parse_options( options_str );
+
+    auto rank2 = priest().find_specialization_spell( 231687 );
+    if( rank2 -> ok() )
+    {
+    dot_max_stack += rank2 -> effectN( 2 ).base_value();
+    }
+  }
+};
+
+struct holy_word_chastise_t final : public priest_spell_t
+{
+  holy_word_chastise_t( priest_t& player, const std::string& options_str )
+    : priest_spell_t( "holy_word_chastise", player, player.find_class_spell( "Holy Word: Chastise" ) )
+  {
+    parse_options( options_str );
+  }
+};
+
+struct holy_nova_t final : public priest_spell_t
+{
+  holy_nova_t( priest_t& player, const std::string& options_str )
+    : priest_spell_t( "holy_nova", player, player.find_class_spell( "Holy Nova" ) )
   {
     parse_options( options_str );
   }
@@ -124,6 +147,15 @@ action_t* priest_t::create_action_holy( const std::string& name, const std::stri
     return new holy_fire_t( *this, options_str );
   }
 
+  if ( name == "holy_nova" )
+  {
+    return new holy_nova_t( *this, options_str );
+  }
+
+  if ( name == "holy_word_chastise" )
+  {
+    return new holy_word_chastise_t( *this, options_str );
+  }
   return nullptr;
 }
 


### PR DESCRIPTION
Checking files, adding in core rotational spells.
Changes / added:
-MoP legendary removed
-Legacy buffs removed
-Holy word: chastise added
-Smite holy fire reset added
-holy fire stacking effect added

Module is not ready yet, still missing:
-smite giving cdr to chastise
-the active talent which increases the cdr by 300%
-sacred flame azerite trait

holy is still turned queit for simming