### PR TITLE
Set scaling class 12 to return DEMON_HUNTER

### DIFF
--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -1141,6 +1141,7 @@ public:
       case 9:  return WARLOCK;
       case 10: return MONK;
       case 11: return DRUID;
+      case 12: return DEMON_HUNTER;
       default: break;
     }
 


### PR DESCRIPTION
Noticed this while combing thru the code, scalling class 12 is for demon hunters and effects the following spells

258922 | Immolation Aura
257938 | Hungering Glaive
244785 | Hungering Glaive
222826 | Chaos Nova
211813 | Throw Glaive
211052 | Fel Barrage
188667 | Throw Glaive
212548 | Holy Missile
192991 | Fel Barrage

