### PR TITLE
[Arcane] Change APL to not use random arcane blasts during burn phase…

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -6460,7 +6460,7 @@ void mage_t::apl_arcane()
   burn -> add_talent( this, "Charged Up", "if=buff.arcane_charge.stack<=1", "Less than 1 instead of equals to 0, because of pre-cast Arcane Blast" );
   burn -> add_talent( this, "Mirror Image" );
   burn -> add_talent( this, "Nether Tempest", "if=(refreshable|!ticking)&buff.arcane_charge.stack=buff.arcane_charge.max_stack&buff.rune_of_power.down&buff.arcane_power.down" );
-  burn -> add_action( this, "Arcane Blast", "if=buff.rule_of_threes.up&talent.overpowered.enabled",
+  burn -> add_action( this, "Arcane Blast", "if=buff.rule_of_threes.up&talent.overpowered.enabled&active_enemies<3",
                     "When running Overpowered, and we got a Rule of Threes proc (AKA we got our 4th Arcane Charge via "
                     "Charged Up), use it before using RoP+AP, because the mana reduction is otherwise largely wasted "
                     "since the AB was free anyway." );

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -6483,7 +6483,7 @@ void mage_t::apl_arcane()
   burn -> add_action( this, "Arcane Barrage", "if=active_enemies>=3&(buff.arcane_charge.stack=buff.arcane_charge.max_stack)" );
   burn -> add_action( this, "Arcane Explosion", "if=active_enemies>=3" );
   burn -> add_action( this, "Arcane Missiles", "if=buff.clearcasting.react&active_enemies<3&(talent.amplification.enabled|(!talent.overpowered.enabled&azerite.arcane_pummeling.rank>=2)|buff.arcane_power.down),chain=1", "Ignore Arcane Missiles during Arcane Power, aside from some very specific exceptions, like not having Overpowered talented & running 3x Arcane Pummeling." );
-  burn -> add_action( this, "Arcane Blast" );
+  burn -> add_action( this, "Arcane Blast", "if=active_enemies<3");
   burn -> add_action( "variable,name=average_burn_length,op=set,value=(variable.average_burn_length*variable.total_burns-variable.average_burn_length+(burn_phase_duration))%variable.total_burns", "Now that we're done burning, we can update the average_burn_length with the length of this burn." );
   burn -> add_action( this, "Evocation", "interrupt_if=mana.pct>=85,interrupt_immediate=1" );
   burn -> add_action( this, "Arcane Barrage", "", "For the rare occasion where we go oom before evocation is back up. (Usually because we get very bad rng so the burn is cut very short)" );


### PR DESCRIPTION
… in AoE situations

The line being changed only exists for the situation where on single-target encounters, the mage ends up with a Ro3 buff (due to using charged up or arcane orb) in the burn phase. The line however also triggered for AoE situations because it is constantly getting rule of threes during the burn phase due to arcane explosion usage.