### PR TITLE
Add precombat Recklessness to the Fury APL

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -4846,6 +4846,11 @@ void warrior_t::default_apl_dps_precombat()
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
 
   precombat->add_action( "potion" );
+  
+  if ( specialization() == WARRIOR_FURY )
+  {
+    precombat->add_action( this, "Recklessness", "if=!talent.furious_slash.enabled&!talent.reckless_abandon.enabled" );
+  }
 }
 
 // Fury Warrior Action Priority List ========================================
@@ -4854,12 +4859,10 @@ void warrior_t::apl_fury()
 {
   std::vector<std::string> racial_actions = get_racial_actions();
 
+  default_apl_dps_precombat();
   action_priority_list_t* default_list  = get_action_priority_list( "default" );
   action_priority_list_t* movement      = get_action_priority_list( "movement" );
   action_priority_list_t* single_target = get_action_priority_list( "single_target" );
-  action_priority_list_t* precombat     = get_action_priority_list( "precombat" );
-  
-  precombat->add_action( this, "Recklessness", "if=!talent.furious_slash.enabled&!talent.reckless_abandon.enabled" );
 
   default_list->add_action( "auto_attack" );
   default_list->add_action( this, "Charge" );

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -4854,11 +4854,12 @@ void warrior_t::apl_fury()
 {
   std::vector<std::string> racial_actions = get_racial_actions();
 
-  default_apl_dps_precombat();
-
   action_priority_list_t* default_list  = get_action_priority_list( "default" );
   action_priority_list_t* movement      = get_action_priority_list( "movement" );
   action_priority_list_t* single_target = get_action_priority_list( "single_target" );
+  action_priority_list_t* precombat     = get_action_priority_list( "precombat" );
+  
+  precombat->add_action( this, "Recklessness", "if=!talent.furious_slash.enabled&!talent.reckless_abandon.enabled" );
 
   default_list->add_action( "auto_attack" );
   default_list->add_action( this, "Charge" );


### PR DESCRIPTION
Casting Recklessness precombat is a DPS increase and is the recommended opener. Now that Recklessness got flagged as non-harmful in an earlier commit this opener can be added to the APL. 
https://www.raidbots.com/simbot/report/3FVUM9GGpsdu91tVUdoCLd