### PR TITLE
Update buff_t in order to take into account Bone Shield's ICD on gains

### DIFF
--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -1168,8 +1168,10 @@ bool buff_t::trigger( int stacks, double value, double chance, timespan_t durati
   if ( _max_stack == 0 || chance == 0 )
     return false;
 
-  if ( cooldown->down() )
-    return false;
+  if ( cooldown->down() ) {
+    if (name_str != "bone_shield" || stacks <= 0)
+      return false;
+  }
 
   if ( player && player->is_sleeping() )
     return false;


### PR DESCRIPTION
A newcomer on Acherus spotted the default APL marrowrending 3 times during DRW in quick succession. Turns out the issue is that
the Bone Shield ICD is copied to the cooldown value on buff_t, which then prevents stacks from being granted.

As I could see no way to fix this without inadvertently breaking other things, and since simc does not seem
to be thoroughly covered by automatic tests on this regard, I opted to fix it in a slightly kludgey way -
if the stacks are positive and the buff is bone_shield, the cooldown check is considered void.

In the future, it may be worth separating cooldown and internal_cooldown to avoid such issues.

fixes #4637