### PR TITLE
Changing Blessed Hammer Strikes from 2 to 3

### DIFF
--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -981,7 +981,7 @@ void paladin_t::generate_action_prio_list_prot()
   def -> add_action( this, "Avenger's Shield", "if=cooldown_react" );
   def -> add_action( this, "Judgment","if=cooldown_react|!talent.crusaders_judgment.enabled" );
   def -> add_action( "lights_judgment,if=!talent.seraphim.enabled|buff.seraphim.up" );
-  def -> add_talent( this, "Blessed Hammer", "strikes=2" );
+  def -> add_talent( this, "Blessed Hammer", "strikes=3" );
   def -> add_action( this, "Hammer of the Righteous" );
   def -> add_action( this, "Consecration" );
 


### PR DESCRIPTION
Changing Blessed Hammer Strikes from 2 to 3 to better simulate raid bosses. 2 Strikes were decided on early on in the expansion were all we had was dungeon bosses and a few raid tests.