### PR TITLE
[Warlock] Fix Havoc behavior and cleaned up unused code

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -47,7 +47,7 @@ namespace warlock {
           if ( !target->is_sleeping() )
           {
             tl.push_back( target );
-            if ( !p()->havoc_target->is_sleeping() && use_havoc() )
+            if ( use_havoc() && !p()->havoc_target->is_sleeping() )
               tl.push_back(p()->havoc_target);
           }
         }

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -545,6 +545,7 @@ namespace warlock {
         if ( p()->talents.fire_and_brimstone->ok() )
         {
           fnb_action->set_target( execute_state->target );
+          target_cache.is_valid = false;
           fnb_action->execute();
         }
       }

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -66,7 +66,7 @@ namespace warlock {
 
 		if (can_havoc)
 		{
-          base_aoe_multiplier *= ()->spec.havoc->effectN( 1 ).percent();
+          base_aoe_multiplier *= p()->spec.havoc->effectN( 1 ).percent();
 		  //available_targets() will handle Havoc target selection
 		  aoe = -1;
 		}

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -55,11 +55,6 @@ namespace warlock {
 		return tl.size();
 	  }
 
-      void reset() override
-      {
-        warlock_spell_t::reset();
-      }
-
       void init() override
       {
         warlock_spell_t::init();
@@ -70,17 +65,6 @@ namespace warlock {
 		  //available_targets() will handle Havoc target selection
 		  aoe = -1;
 		}
-      }
-
-      double cost() const override
-      {
-        double c = warlock_spell_t::cost();
-        return c;
-      }
-
-      void execute() override
-      {
-        warlock_spell_t::execute();
       }
 
       void consume_resource() override
@@ -119,11 +103,6 @@ namespace warlock {
             p()->procs.reverse_entropy->occur();
           }
         }
-      }
-
-      virtual void update_ready(timespan_t cd_duration) override
-      {
-        warlock_spell_t::update_ready(cd_duration);
       }
 
       double composite_target_multiplier(player_t* t) const override
@@ -375,7 +354,10 @@ namespace warlock {
         if (result_is_hit(s->result))
         {
           if ( p()->talents.roaring_blaze->ok() )
+		  {
+            roaring_blaze->set_target( s->target );
             roaring_blaze->execute();
+		  }
         }
       }
 
@@ -448,19 +430,16 @@ namespace warlock {
           tl.erase(it);
         }
 
-        // nor the havoced target
-        it = range::find(tl, p()->havoc_target);
-        if (it != tl.end())
-        {
-          tl.erase(it);
-        }
-
+        // nor the havoced target if applicable
+		if (use_havoc() )
+		{
+          it = range::find(tl, p()->havoc_target);
+          if (it != tl.end())
+          {
+            tl.erase(it);
+          }
+		}
         return tl.size();
-      }
-
-      void execute() override
-      {
-        destruction_spell_t::execute();
       }
 
       void impact(action_state_t* s) override

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -44,8 +44,10 @@ namespace warlock {
 		if (use_havoc())
 		{
 		  tl.clear();
-		  tl.push_back( target );
-		  tl.push_back(p()->havoc_target);
+		  if ( !target->is_sleeping() )
+            tl.push_back( target );
+		  if ( !p()->havoc_target->is_sleeping())
+		    tl.push_back(p()->havoc_target);
 		}
 		else
 		{
@@ -124,9 +126,7 @@ namespace warlock {
         if (p()->mastery_spells.chaotic_energies->ok() && destro_mastery)
         {
           double destro_mastery_value = p()->cache.mastery_value() / 2.0;
-          double chaotic_energies_rng;
-
-          chaotic_energies_rng = rng().range(0, destro_mastery_value);
+          double chaotic_energies_rng = rng().range(0, destro_mastery_value);
 
           pm *= 1.0 + chaotic_energies_rng + (destro_mastery_value);
         }

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -41,17 +41,19 @@ namespace warlock {
 
       size_t available_targets(std::vector<player_t*>& tl) const override
       {
-        if (use_havoc())
+        if (can_havoc)
         {
           tl.clear();
           if ( !target->is_sleeping() )
+          {
             tl.push_back( target );
-          if ( !p()->havoc_target->is_sleeping())
-            tl.push_back(p()->havoc_target);
+            if ( !p()->havoc_target->is_sleeping() && use_havoc() )
+              tl.push_back(p()->havoc_target);
+          }
         }
         else
         {
-           warlock_spell_t::available_targets( tl );
+          warlock_spell_t::available_targets( tl );
         }
 
         return tl.size();
@@ -67,6 +69,15 @@ namespace warlock {
           //available_targets() will handle Havoc target selection
           aoe = -1;
         }
+      }
+
+      //TODO: Implement triggering on Havoc buff trigger/expiration instead of invalidating on every possible call
+      std::vector<player_t*>& target_list() const override
+      {
+        if(can_havoc)
+          target_cache.is_valid = false;
+
+        return warlock_spell_t::target_list();
       }
 
       void consume_resource() override
@@ -643,7 +654,9 @@ namespace warlock {
 
         if(p()->azerite.chaotic_inferno.ok())
           p()->buffs.chaotic_inferno->trigger();
+
         p()->buffs.crashing_chaos->decrement();
+        p()->buffs.backdraft->decrement();
       }
 
       // Force spell to always crit

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -36,37 +36,37 @@ namespace warlock {
 
       bool use_havoc() const
       {
-		return can_havoc && target != p()->havoc_target && p()->havoc_target != nullptr && p()->buffs.active_havoc->check();
+        return can_havoc && target != p()->havoc_target && p()->havoc_target != nullptr && p()->buffs.active_havoc->check();
       }
 
-	  size_t available_targets(std::vector<player_t*>& tl) const override
-	  {
-		if (use_havoc())
-		{
-		  tl.clear();
-		  if ( !target->is_sleeping() )
+      size_t available_targets(std::vector<player_t*>& tl) const override
+      {
+        if (use_havoc())
+        {
+          tl.clear();
+          if ( !target->is_sleeping() )
             tl.push_back( target );
-		  if ( !p()->havoc_target->is_sleeping())
-		    tl.push_back(p()->havoc_target);
-		}
-		else
-		{
-		  warlock_spell_t::available_targets( tl );
-		}
+          if ( !p()->havoc_target->is_sleeping())
+            tl.push_back(p()->havoc_target);
+        }
+        else
+        {
+           warlock_spell_t::available_targets( tl );
+        }
 
-		return tl.size();
-	  }
+        return tl.size();
+      }
 
       void init() override
       {
         warlock_spell_t::init();
 
-		if (can_havoc)
-		{
+        if (can_havoc)
+        {
           base_aoe_multiplier *= p()->spec.havoc->effectN( 1 ).percent();
-		  //available_targets() will handle Havoc target selection
-		  aoe = -1;
-		}
+          //available_targets() will handle Havoc target selection
+          aoe = -1;
+        }
       }
 
       void consume_resource() override
@@ -118,7 +118,7 @@ namespace warlock {
         return m;
       }
 
-	  //TODO: Check order of multipliers on Havoc'd spells
+      //TODO: Check order of multipliers on Havoc'd spells
       double action_multiplier() const override
       {
         double pm = warlock_spell_t::action_multiplier();
@@ -207,9 +207,9 @@ namespace warlock {
         destruction_spell_t("shadowburn", p, p -> talents.shadowburn)
       {
         parse_options(options_str);
-		energize_type = ENERGIZE_PER_HIT;
-		energize_resource = RESOURCE_SOUL_SHARD;
-		energize_amount = ( p->find_spell( 245731 )->effectN( 1 ).base_value() ) / 10.0;
+        energize_type = ENERGIZE_PER_HIT;
+        energize_resource = RESOURCE_SOUL_SHARD;
+        energize_amount = ( p->find_spell( 245731 )->effectN( 1 ).base_value() ) / 10.0;
         can_havoc = true;
       }
 
@@ -224,7 +224,7 @@ namespace warlock {
       }
     };
 
-	//TODO: Check the status of the comment below
+    //TODO: Check the status of the comment below
     struct roaring_blaze_t : public destruction_spell_t {
       roaring_blaze_t(warlock_t* p) :
         destruction_spell_t("roaring_blaze", p, p -> find_spell(265931))
@@ -280,7 +280,7 @@ namespace warlock {
       }
     };
 
-	//TODO: Check if initial damage of Immolate is reduced on Havoc'd target
+    //TODO: Check if initial damage of Immolate is reduced on Havoc'd target
     struct immolate_t : public destruction_spell_t
     {
       immolate_t(warlock_t* p, const std::string& options_str) :
@@ -291,7 +291,7 @@ namespace warlock {
 
         can_havoc = true;
 
-		//All of the DoT data for Immolate is in spell 157736
+        //All of the DoT data for Immolate is in spell 157736
         base_tick_time = dmg_spell->effectN(1).period();
         dot_duration = dmg_spell->duration();
         spell_power_mod.tick = dmg_spell->effectN(1).sp_coeff();
@@ -332,8 +332,8 @@ namespace warlock {
         can_havoc = true;
 
         energize_type = ENERGIZE_PER_HIT;
-		energize_resource = RESOURCE_SOUL_SHARD;
-		energize_amount = ( p->find_spell( 245330 )->effectN( 1 ).base_value() ) / 10.0;
+        energize_resource = RESOURCE_SOUL_SHARD;
+        energize_amount = ( p->find_spell( 245330 )->effectN( 1 ).base_value() ) / 10.0;
 
         cooldown->charges += p->spec.conflagrate_2->effectN(1).base_value();
 
@@ -354,10 +354,10 @@ namespace warlock {
         if (result_is_hit(s->result))
         {
           if ( p()->talents.roaring_blaze->ok() )
-		  {
+          {
             roaring_blaze->set_target( s->target );
             roaring_blaze->execute();
-		  }
+          }
         }
       }
 
@@ -365,8 +365,8 @@ namespace warlock {
       {
         destruction_spell_t::execute();
 
-		//This used to be in impact() but in game it occurs on cast and does not generate a second stack when copied with Havoc
-		p()->buffs.backdraft->trigger( 1 + (p()->talents.flashover->ok() ? p()->talents.flashover->effectN( 1 ).base_value() : 0) );
+        //This used to be in impact() but in game it occurs on cast and does not generate a second stack when copied with Havoc
+        p()->buffs.backdraft->trigger( 1 + (p()->talents.flashover->ok() ? p()->talents.flashover->effectN( 1 ).base_value() : 0) );
 
         auto td = this->td(target);
         if (p()->azerite.bursting_flare.ok() && td->dots_immolate->is_ticking())
@@ -431,14 +431,14 @@ namespace warlock {
         }
 
         // nor the havoced target if applicable
-		if (use_havoc() )
-		{
+        if (use_havoc() )
+        {
           it = range::find(tl, p()->havoc_target);
           if (it != tl.end())
           {
             tl.erase(it);
           }
-		}
+        }
         return tl.size();
       }
 
@@ -728,7 +728,7 @@ namespace warlock {
         immolate_action_id = p()->find_action_id("immolate");
       }
 
-	  //TODO: This is suboptimal, can this be changed to available_targets() in some way?
+      //TODO: This is suboptimal, can this be changed to available_targets() in some way?
       std::vector< player_t* >& target_list() const override
       {
         target_cache.list = destruction_spell_t::target_list();

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -63,6 +63,13 @@ namespace warlock {
       void init() override
       {
         warlock_spell_t::init();
+
+		if (can_havoc)
+		{
+          base_aoe_multiplier *= ()->spec.havoc->effectN( 1 ).percent();
+		  //available_targets() will handle Havoc target selection
+		  aoe = -1;
+		}
       }
 
       double cost() const override
@@ -73,17 +80,7 @@ namespace warlock {
 
       void execute() override
       {
-		if ( use_havoc() )
-		{
-			aoe = 2;
-			base_aoe_multiplier = p()->spec.havoc->effectN( 1 ).percent();
-			warlock_spell_t::execute();
-			aoe = 0;
-		}
-		else
-		{
-		  warlock_spell_t::execute();
-		}
+        warlock_spell_t::execute();
       }
 
       void consume_resource() override
@@ -173,7 +170,7 @@ namespace warlock {
         parse_options(options_str);
         energize_type = ENERGIZE_PER_HIT;
         energize_resource = RESOURCE_SOUL_SHARD;
-        energize_amount = (std::double_t(p->find_spell( 281490 )->effectN( 1 ).base_value()) / 10);
+        energize_amount = (p->find_spell( 281490 )->effectN( 1 ).base_value()) / 10.0;
 
         can_havoc = true;
       }
@@ -233,7 +230,7 @@ namespace warlock {
         parse_options(options_str);
 		energize_type = ENERGIZE_PER_HIT;
 		energize_resource = RESOURCE_SOUL_SHARD;
-		energize_amount = ( std::double_t( p->find_spell( 245731 )->effectN( 1 ).base_value() ) ) / 10;
+		energize_amount = ( p->find_spell( 245731 )->effectN( 1 ).base_value() ) / 10.0;
         can_havoc = true;
       }
 
@@ -357,7 +354,7 @@ namespace warlock {
 
         energize_type = ENERGIZE_PER_HIT;
 		energize_resource = RESOURCE_SOUL_SHARD;
-		energize_amount = ( std::double_t( p->find_spell( 245330 )->effectN( 1 ).base_value() ) ) / 10;
+		energize_amount = ( p->find_spell( 245330 )->effectN( 1 ).base_value() ) / 10.0;
 
         cooldown->charges += p->spec.conflagrate_2->effectN(1).base_value();
 
@@ -421,7 +418,7 @@ namespace warlock {
           base_multiplier *= p->talents.fire_and_brimstone->effectN(1).percent();
           energize_type = ENERGIZE_PER_HIT;
           energize_resource = RESOURCE_SOUL_SHARD;
-          energize_amount = std::double_t(p->talents.fire_and_brimstone->effectN(2).base_value()) / 10;
+          energize_amount = (p->talents.fire_and_brimstone->effectN(2).base_value()) / 10.0;
           gain = p->gains.incinerate_fnb;
         }
       }
@@ -506,7 +503,7 @@ namespace warlock {
 
         energize_type = ENERGIZE_PER_HIT;
         energize_resource = RESOURCE_SOUL_SHARD;
-        energize_amount = std::double_t(p->find_spell(244670)->effectN(1).base_value()) / 10;
+        energize_amount = (p->find_spell(244670)->effectN(1).base_value()) / 10.0;
       }
 
       double bonus_da( const action_state_t* s ) const override
@@ -535,7 +532,7 @@ namespace warlock {
       {
         timespan_t t = action_t::gcd();
 
-        if (t == timespan_t::zero())
+        if (t == 0_ms)
           return t;
 
         if (p()->buffs.backdraft->check() && !p()->buffs.chaotic_inferno->check() )
@@ -623,7 +620,7 @@ namespace warlock {
       {
         timespan_t t = warlock_spell_t::gcd();
 
-        if (t == timespan_t::zero())
+        if (t == 0_ms)
           return t;
 
         if (p()->buffs.backdraft->check())
@@ -811,7 +808,7 @@ namespace warlock {
         aoe = -1;
         background = true;
         dual = true;
-        trigger_gcd = timespan_t::zero();
+        trigger_gcd = 0_ms;
       }
     };
 
@@ -827,7 +824,7 @@ namespace warlock {
         parse_options(options_str);
 
         harmful = may_crit = false;
-        infernal_duration = p->find_spell(111685)->duration() + timespan_t::from_millis(1);
+        infernal_duration = p->find_spell(111685)->duration() + 1_ms;
         infernal_awakening = new infernal_awakening_t(p);
         infernal_awakening->stats = stats;
         radius = infernal_awakening->radius;
@@ -891,10 +888,10 @@ namespace warlock {
       {
         parse_options(options_str);
         aoe = -1;
-        dot_duration = timespan_t::zero();
+        dot_duration = 0_ms;
         may_miss = may_crit = false;
         base_tick_time = data().duration() / 8.0; // ticks 8 times (missing from spell data)
-        base_execute_time = timespan_t::zero(); // HOTFIX
+        base_execute_time = 0_ms; // HOTFIX
 
         if (!p->active.rain_of_fire)
         {
@@ -984,7 +981,7 @@ namespace warlock {
     buffs.active_havoc = make_buff( this, "active_havoc" )
       ->set_tick_behavior( buff_tick_behavior::NONE )
       ->set_refresh_behavior( buff_refresh_behavior::DURATION )
-      ->set_duration( timespan_t::from_seconds( 10 ) );
+      ->set_duration( 10_s );
 
     buffs.reverse_entropy = make_buff( this, "reverse_entropy", talents.reverse_entropy )
       ->set_default_value( find_spell( 266030 )->effectN( 1 ).percent() )

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -376,7 +376,6 @@ namespace warlock {
       {
         destruction_spell_t::execute();
 
-        //This used to be in impact() but in game it occurs on cast and does not generate a second stack when copied with Havoc
         p()->buffs.backdraft->trigger( 1 + (p()->talents.flashover->ok() ? p()->talents.flashover->effectN( 1 ).base_value() : 0) );
 
         auto td = this->td(target);

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -545,7 +545,7 @@ namespace warlock {
         if ( p()->talents.fire_and_brimstone->ok() )
         {
           fnb_action->set_target( execute_state->target );
-          target_cache.is_valid = false;
+          fnb_action->target_cache.is_valid = false;
           fnb_action->execute();
         }
       }

--- a/vs/simc_vs2017.vcxproj
+++ b/vs/simc_vs2017.vcxproj
@@ -23,7 +23,7 @@
     <RootNamespace>simc</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>simc</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='WebEngine|x64'" Label="Configuration">

--- a/vs/simc_vs2017.vcxproj
+++ b/vs/simc_vs2017.vcxproj
@@ -23,7 +23,7 @@
     <RootNamespace>simc</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>simc</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='WebEngine|x64'" Label="Configuration">


### PR DESCRIPTION
A fix for Issue #4676 and related bugs discovered while investigating it. Havoc no longer triggers a second copy of the spell with target reassignment, but instead uses aoe and generates a two-target list using available_targets().

Generation of Soul Shards is now done with ENERGIZE_PER_HIT behavior to properly account for this change. Affected spells are Immolate, Conflagrate, Incinerate (non-fnb), Soul Fire, and Shadowburn.

Additionally, the change to Havoc functionality corrects a major bug where Chaos Bolt would consume double the appropriate number of Soul Shards when a second bolt was fired due to Havoc.

Since execution of spells are no longer done twice for Havoc situations, execute vs hit counting in reporting should now be accurate.

Unused Legion/WoD effect code was also removed from the Destruction module.