### PR TITLE
Fix NoNetwork Compile

### DIFF
--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -57,7 +57,10 @@ int main( int argc, char *argv[] )
   unique_gear::register_hotfixes();
   unique_gear::register_special_effects();
   unique_gear::sort_special_effects();
+  
+  #ifndef SC_NO_NETWORKING
   bcp_api::token_load();
+  #endif
 
   hotfix::apply();
 
@@ -131,7 +134,10 @@ int main( int argc, char *argv[] )
   auto ret = a.exec();
 
   dbc::de_init();
+
+  #ifndef SC_NO_NETWORKING
   bcp_api::token_save();
+  #endif
 
   return ret;
 }

--- a/vs/simcqt_vs2017.vcxproj
+++ b/vs/simcqt_vs2017.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug-WebEngine|x64">
@@ -211,7 +211,7 @@
     <ClCompile>
       <Optimization>Full</Optimization>
       <AdditionalIncludeDirectories>$(QTDIR)\include\QtWebEngineCore;$(QTDIR)\include\QtWebEngineCore;$(QTDIR)\include\QtCore;$(QTDIR)\include\QtGui;$(QTDIR)\include\QtWebEngineWidgets;$(QTDIR)\include\QtWebEngine;$(QTDIR)\include;$(QTDIR)\include\ActiveQt;$(QTDIR)\include\QtANGLE;$(QTDIR)\mkspecs\default;$(SolutionDir);$(SolutionDir)vs;$(SolutionDir)engine;$(SolutionDir)engine/util;%(AdditionalIncludeDirectories);$(QTDIR)\include\QtWebEngineCore</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>SC_DEFAULT_APIKEY="$(SC_DEFAULT_APIKEY)";SC_USE_WEBENGINE;QT_NO_DEBUG_OUTPUT;QT_NO_DEBUG;NDEBUG;_WINDOWS;UNICODE;WIN32;Q_OS_WIN;QT_LARGEFILE_SUPPORT;QT_VERSION_5;QT_DLL;QT_WEBENGINE_LIB;QT_GUI_LIB;QT_CORE_LIB;QT_THREAD_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SC_DEFAULT_APIKEY="$(SC_DEFAULT_APIKEY)";SC_USE_WEBENGINE;SC_NO_NETWORKING;QT_NO_DEBUG_OUTPUT;QT_NO_DEBUG;NDEBUG;_WINDOWS;UNICODE;WIN32;Q_OS_WIN;QT_LARGEFILE_SUPPORT;QT_VERSION_5;QT_DLL;QT_WEBENGINE_LIB;QT_GUI_LIB;QT_CORE_LIB;QT_THREAD_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FunctionLevelLinking>true</FunctionLevelLinking>


### PR DESCRIPTION
I was trying to build SimC GUI on Windows (VS2017) using the NoNetwork config, but the build kept failing due to it trying to use curl (which I didn't have installed/set up).

After some digging it seems like `SC_NO_NETWORKING` was never added as a Preprocessing Definition on the NoNetwork config, so I added that in.

Additionally, there were a couple of functions that were being called that were only defined if `SC_NO_NETWORKING` was *not* added, so I added a check for that as well.