### PR TITLE
Fix simc-cli compilation issues on FreeBSD.

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -54,7 +54,7 @@ endif
 
 
 MKDIR      = mkdir
-CXX        = g++
+CXX        = c++
 CPP_FLAGS  = -Wall -Wextra -W -I. -I./util -DSC_SHARED_DATA=\"$(SHARED_DATA)\" --std=c++14 -O3 -MMD -MP \
 -Wpedantic \
 -Wcast-qual \
@@ -158,6 +158,12 @@ ifeq (UNIX,${OS})
   COPY       = cp
   REMOVE     = rm -f
   PATHSEP    = /
+endif
+
+# Additional include paths for FreeBSD
+ifeq (FreeBSD,${FLAVOR})
+  CPP_FLAGS += -I/usr/local/include
+  LINK_FLAGS += -L/usr/local/lib
 endif
 
 # Windows platform with MinGW32

--- a/engine/interfaces/sc_bcp_api.cpp
+++ b/engine/interfaces/sc_bcp_api.cpp
@@ -9,6 +9,10 @@
 #include "util/rapidjson/stringbuffer.h"
 #include "util/rapidjson/prettywriter.h"
 
+#ifndef SC_NO_NETWORKING
+#include <curl/curl.h>
+#endif
+
 // ==========================================================================
 // Blizzard Community Platform API
 // ==========================================================================
@@ -48,8 +52,6 @@ static bool authorization_failed = false;
 mutex_t token_mutex;
 
 #ifndef SC_NO_NETWORKING
-
-#include <curl/curl.h>
 
 size_t data_cb( void* contents, size_t size, size_t nmemb, void* usr )
 {


### PR DESCRIPTION
Change the makefile to use "c++" instead of "g++" which is more standard across unix-like systems.
Added additional include/linking paths when on compiling FreeBSD.
Resolve compilation issue from including curl.h within a namespace by moving the include outside of the namespace. (Sample of issue is below.)

```
In file included from interfaces/sc_bcp_api.cpp:52:
In file included from /usr/local/include/curl/curl.h:87:
/usr/include/sys/time.h:225:5: error: member access into incomplete type
      'struct timespec'
        _ts->tv_sec = _bt->sec;
           ^
/usr/include/sys/socket.h:676:8: note: forward declaration of '(anonymous
      namespace)::timespec'
struct timespec;
       ^
```