### PR TITLE
[Warlock] Affliction Fixes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -7,6 +7,7 @@ namespace warlock
 // Spells
   namespace actions
   {
+    //TOCHECK: Does the damage proc affect Seed of Corruption? If so, this needs to be split into specs as well
     struct grimoire_of_sacrifice_t : public warlock_spell_t
     {
       grimoire_of_sacrifice_t( warlock_t* p, const std::string& options_str ) :

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -7,42 +7,6 @@ namespace warlock
 // Spells
   namespace actions
   {
-    struct drain_life_t : public warlock_spell_t
-    {
-      drain_life_t( warlock_t* p, const std::string& options_str ) :
-        warlock_spell_t( p, "Drain Life" )
-      {
-        parse_options( options_str );
-        channeled = true;
-        hasted_ticks = false;
-        may_crit = false;
-      }
-
-      void execute() override
-      {
-        warlock_spell_t::execute();
-
-        p()->buffs.drain_life->trigger();
-      }
-
-      double bonus_ta(const action_state_t* s) const override
-      {
-        double ta = warlock_spell_t::bonus_ta(s);
-
-        ta += p()->buffs.inevitable_demise->check_stack_value();
-
-        return ta;
-      }
-
-      void last_tick( dot_t* d ) override
-      {
-        p()->buffs.drain_life->expire();
-        p()->buffs.inevitable_demise->expire();
-
-        warlock_spell_t::last_tick( d );
-      }
-    };
-
     struct grimoire_of_sacrifice_t : public warlock_spell_t
     {
       grimoire_of_sacrifice_t( warlock_t* p, const std::string& options_str ) :
@@ -421,7 +385,7 @@ action_t* warlock_t::create_action( const std::string& action_name, const std::s
   if ( action_name == "summon_imp"            ) return new                summon_main_pet_t( "imp", this );
   if ( action_name == "summon_pet"            ) return new          summon_main_pet_t( default_pet, this );
   // Base Spells
-  if ( action_name == "drain_life"            ) return new               drain_life_t( this, options_str );
+  //if ( action_name == "drain_life"            ) return new               drain_life_t( this, options_str );
   if ( action_name == "grimoire_of_sacrifice" ) return new    grimoire_of_sacrifice_t( this, options_str ); //aff and destro
 
   if ( specialization() == WARLOCK_AFFLICTION )

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -445,6 +445,7 @@ namespace warlock
       double    composite_armor() const override;
       void      halt() override;
       void      combat_begin() override;
+      void      init_assessors() override;
       expr_t*   create_expression( const std::string& name_str ) override;
       std::string       default_potion() const override;
       std::string       default_flask() const override;

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -153,6 +153,42 @@ namespace warlock
 
     const std::array<int, MAX_UAS> ua_spells = { { 233490, 233496, 233497, 233498, 233499 } };
 
+    struct drain_life_t : public affliction_spell_t
+    {
+      drain_life_t( warlock_t* p, const std::string& options_str ) :
+        affliction_spell_t( p, "Drain Life" )
+      {
+        parse_options( options_str );
+        channeled = true;
+        hasted_ticks = false;
+        may_crit = false;
+      }
+
+      void execute() override
+      {
+        affliction_spell_t::execute();
+
+        p()->buffs.drain_life->trigger();
+      }
+
+      double bonus_ta(const action_state_t* s) const override
+      {
+        double ta = affliction_spell_t::bonus_ta(s);
+
+        ta += p()->buffs.inevitable_demise->check_stack_value();
+
+        return ta;
+      }
+
+      void last_tick( dot_t* d ) override
+      {
+        p()->buffs.drain_life->expire();
+        p()->buffs.inevitable_demise->expire();
+
+        affliction_spell_t::last_tick( d );
+      }
+    };
+
     struct shadow_bolt_t : public affliction_spell_t
     {
       shadow_bolt_t(warlock_t* p, const std::string& options_str) :
@@ -982,6 +1018,7 @@ namespace warlock
     if ( action_name == "agony" ) return new                          agony_t( this, options_str );
     if ( action_name == "unstable_affliction" ) return new            unstable_affliction_t( this, options_str );
     if ( action_name == "summon_darkglare") return new                summon_darkglare_t(this, options_str);
+    if ( action_name == "drain_life" ) return new                     drain_life_t( this, options_str );
     // aoe
     if ( action_name == "seed_of_corruption" ) return new             seed_of_corruption_t( this, options_str );
     // talents

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -129,70 +129,6 @@ namespace warlock
 
     const std::array<int, MAX_UAS> ua_spells = { { 233490, 233496, 233497, 233498, 233499 } };
 
-    struct drain_life_t : public affliction_spell_t
-    {
-      int id_tick;
-
-      drain_life_t( warlock_t* p, const std::string& options_str ) :
-        affliction_spell_t( p, "Drain Life" )
-      {
-        parse_options( options_str );
-        channeled = true;
-        hasted_ticks = false;
-        may_crit = false;
-      }
-
-      void init() override
-      {
-        id_tick = -1;
-        
-        affliction_spell_t::init();
-      }
-
-      void execute() override
-      {
-        affliction_spell_t::execute();
-
-        p()->buffs.drain_life->trigger();
-      }
-
-      double bonus_ta(const action_state_t* s) const override
-      {
-        double ta = affliction_spell_t::bonus_ta(s);
-
-        ta += p()->buffs.inevitable_demise->check_stack_value();
-
-        return ta;
-      }
-
-      void tick(dot_t* d) override
-      {
-        //TOCHECK: Will id_tick reset with last_tick() on a cancelled channel?
-        if (p()->azerite.inevitable_demise.ok() && p()->buffs.inevitable_demise->check() > 0)
-        {
-          if (d->current_tick <= id_tick)
-          {
-            p()->buffs.inevitable_demise->expire();
-            id_tick = -1;
-          }
-          else
-          {
-            id_tick = d->current_tick;
-          }
-        }
-
-        affliction_spell_t::tick(d);
-      }
-
-      void last_tick( dot_t* d ) override
-      {
-        p()->buffs.drain_life->expire();
-        p()->buffs.inevitable_demise->expire();
-
-        affliction_spell_t::last_tick( d );
-      }
-    };
-
     struct shadow_bolt_t : public affliction_spell_t
     {
       shadow_bolt_t(warlock_t* p, const std::string& options_str) :
@@ -1035,7 +971,6 @@ namespace warlock
     if ( action_name == "agony" ) return new                          agony_t( this, options_str );
     if ( action_name == "unstable_affliction" ) return new            unstable_affliction_t( this, options_str );
     if ( action_name == "summon_darkglare") return new                summon_darkglare_t(this, options_str);
-    if ( action_name == "drain_life" ) return new                     drain_life_t( this, options_str );
     // aoe
     if ( action_name == "seed_of_corruption" ) return new             seed_of_corruption_t( this, options_str );
     // talents

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -85,10 +85,10 @@ namespace warlock
         }
         else
         {
-          if (db_duration <= dot_tick_time)
+          if (db_duration <= dot_tick_time && dot->time_to_next_tick() >= db_duration)
           {
             //All that's left is a partial tick
-            ticks_left = dot->time_to_next_tick()/dot_tick_time;
+            ticks_left = db_duration/dot_tick_time;
           }
           else
           {

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -695,7 +695,9 @@ namespace warlock
       void tick( dot_t* d ) override
       {
         affliction_spell_t::tick(d);
-        make_event( sim, 0_ms, [ d ] { d->cancel(); } );
+        
+        if(d->remains() > 0_ms)
+          d->cancel();
       }
 
       void last_tick(dot_t* d) override

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -84,32 +84,6 @@ namespace warlock {
       }
     };
 
-    struct drain_life_t : public demonology_spell_t
-    {
-      drain_life_t( warlock_t* p, const std::string& options_str ) :
-        demonology_spell_t( p, "Drain Life" )
-      {
-        parse_options( options_str );
-        channeled = true;
-        hasted_ticks = false;
-        may_crit = false;
-      }
-
-      void execute() override
-      {
-        demonology_spell_t::execute();
-
-        p()->buffs.drain_life->trigger();
-      }
-
-      void last_tick( dot_t* d ) override
-      {
-        p()->buffs.drain_life->expire();
-
-        demonology_spell_t::last_tick( d );
-      }
-    };
-
     struct shadow_bolt_t : public demonology_spell_t
     {
       shadow_bolt_t(warlock_t* p, const std::string& options_str) :
@@ -916,7 +890,6 @@ namespace warlock {
     if (action_name == "demonbolt") return new              demonbolt_t(this, options_str);
     if (action_name == "hand_of_guldan") return new         hand_of_guldan_t(this, options_str);
     if (action_name == "implosion") return new              implosion_t(this, options_str);
-    if (action_name == "drain_life") return new             drain_life_t( this, options_str );
 
     if (action_name == "demonic_strength") return new       demonic_strength_t(this, options_str);
     if (action_name == "bilescourge_bombers") return new    bilescourge_bombers_t(this, options_str);

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -84,6 +84,32 @@ namespace warlock {
       }
     };
 
+    struct drain_life_t : public demonology_spell_t
+    {
+      drain_life_t( warlock_t* p, const std::string& options_str ) :
+        demonology_spell_t( p, "Drain Life" )
+      {
+        parse_options( options_str );
+        channeled = true;
+        hasted_ticks = false;
+        may_crit = false;
+      }
+
+      void execute() override
+      {
+        demonology_spell_t::execute();
+
+        p()->buffs.drain_life->trigger();
+      }
+
+      void last_tick( dot_t* d ) override
+      {
+        p()->buffs.drain_life->expire();
+
+        demonology_spell_t::last_tick( d );
+      }
+    };
+
     struct shadow_bolt_t : public demonology_spell_t
     {
       shadow_bolt_t(warlock_t* p, const std::string& options_str) :
@@ -890,6 +916,7 @@ namespace warlock {
     if (action_name == "demonbolt") return new              demonbolt_t(this, options_str);
     if (action_name == "hand_of_guldan") return new         hand_of_guldan_t(this, options_str);
     if (action_name == "implosion") return new              implosion_t(this, options_str);
+    if (action_name == "drain_life") return new             drain_life_t( this, options_str );
 
     if (action_name == "demonic_strength") return new       demonic_strength_t(this, options_str);
     if (action_name == "bilescourge_bombers") return new    bilescourge_bombers_t(this, options_str);

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -315,7 +315,6 @@ namespace warlock {
       }
     };
 
-    //TODO: Check if initial damage of Immolate is reduced on Havoc'd target
     struct immolate_t : public destruction_spell_t
     {
       immolate_t(warlock_t* p, const std::string& options_str) :

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -160,33 +160,6 @@ namespace warlock {
       }
     };
 
-    struct drain_life_t : public destruction_spell_t
-    {
-      drain_life_t( warlock_t* p, const std::string& options_str ) :
-        destruction_spell_t( p, "Drain Life" )
-      {
-        parse_options( options_str );
-        channeled = true;
-        hasted_ticks = false;
-        may_crit = false;
-        can_havoc = false;
-      }
-
-      void execute() override
-      {
-        destruction_spell_t::execute();
-
-        p()->buffs.drain_life->trigger();
-      }
-
-      void last_tick( dot_t* d ) override
-      {
-        p()->buffs.drain_life->expire();
-
-        destruction_spell_t::last_tick( d );
-      }
-    };
-
     //Talents
     struct soul_fire_t : public destruction_spell_t
     {
@@ -982,7 +955,6 @@ namespace warlock {
       if (action_name == "rain_of_fire") return new                     rain_of_fire_t(this, options_str);
       if (action_name == "havoc") return new                            havoc_t(this, options_str);
       if (action_name == "summon_infernal") return new                  summon_infernal_t(this, options_str);
-      if (action_name == "drain_life") return new                       drain_life_t( this, options_str );
 
       //Talents
       if (action_name == "soul_fire") return new                        soul_fire_t(this, options_str);

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -160,6 +160,33 @@ namespace warlock {
       }
     };
 
+    struct drain_life_t : public destruction_spell_t
+    {
+      drain_life_t( warlock_t* p, const std::string& options_str ) :
+        destruction_spell_t( p, "Drain Life" )
+      {
+        parse_options( options_str );
+        channeled = true;
+        hasted_ticks = false;
+        may_crit = false;
+        can_havoc = false;
+      }
+
+      void execute() override
+      {
+        destruction_spell_t::execute();
+
+        p()->buffs.drain_life->trigger();
+      }
+
+      void last_tick( dot_t* d ) override
+      {
+        p()->buffs.drain_life->expire();
+
+        destruction_spell_t::last_tick( d );
+      }
+    };
+
     //Talents
     struct soul_fire_t : public destruction_spell_t
     {
@@ -956,6 +983,7 @@ namespace warlock {
       if (action_name == "rain_of_fire") return new                     rain_of_fire_t(this, options_str);
       if (action_name == "havoc") return new                            havoc_t(this, options_str);
       if (action_name == "summon_infernal") return new                  summon_infernal_t(this, options_str);
+      if (action_name == "drain_life") return new                       drain_life_t( this, options_str );
 
       //Talents
       if (action_name == "soul_fire") return new                        soul_fire_t(this, options_str);


### PR DESCRIPTION
Several fixes and clean up for the Warlock modules, particularly regarding Drain Life and Seed of Corruption. Changes are as follows:

~~Split Drain Life into each spec separately, to handle Affliction specific behavior (Seed of Corruption)~~ (Replaced in later commit with general handling that includes pet damage and procs).
~~Drain Life now affected by Mastery for Destruction.~~ This is not necessary.
Inevitable Demise now expires if Drain Life is recast mid channel.
Simplified Chaos Shards expression.
Removed Sephuz code.
Fixed edge cases regarding Seed of Corruption refreshing.