### PR TITLE
Adding Grongs Primal Rage to Protection Paladin

### DIFF
--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -967,6 +967,7 @@ void paladin_t::generate_action_prio_list_prot()
   cds -> add_action( "potion,if=buff.avenging_wrath.up" );
 
   cds -> add_action( "use_items,if=buff.seraphim.up|!talent.seraphim.enabled" );
+  cds -> add_action( "use_item,name=grongs_primal_rage,if=((cooldown.judgment.full_recharge_time>4|(!talent.crusaders_judgment.enabled&prev_gcd.1.judgment))&cooldown.avengers_shield.remains>4&buff.seraphim.remains>4)|(buff.seraphim.remains<4)" );
   cds -> add_action( "use_item,name=merekthas_fang,if=!buff.avenging_wrath.up&(buff.seraphim.up|!talent.seraphim.enabled)" );
   cds -> add_action( "use_item,name=razdunks_big_red_button" );
 

--- a/profiles/generators/Tier23/T23_Generate_Paladin.simc
+++ b/profiles/generators/Tier23/T23_Generate_Paladin.simc
@@ -28,7 +28,7 @@ save=T23_Paladin_Retribution.simc
 paladin="T23_Paladin_Protection"
 source=default
 level=120
-race=blood_elf
+race=lightforged_draenei
 role=tank
 position=front
 talents=3200003
@@ -46,7 +46,7 @@ legs=arcing_thunderlizard_legplates,id=165560,bonus_id=4824/1537
 feet=coinage_stampers,id=165561,bonus_id=4824/1537
 finger1=lord_admirals_signet,id=165566,bonus_id=4824/1537,enchant=pact_of_haste
 finger2=seal_of_the_zandalari_empire,id=165567,bonus_id=4824/1537,enchant=pact_of_haste
-trinket1=ramping_amplitude_gigavolt_engine,id=165580,bonus_id=4824/1537
+trinket1=grongs_primal_rage,id=165574,bonus_id=4824/1537
 trinket2=everchill_anchor,id=165570,bonus_id=4824/1537
 main_hand=servoclaw_smasher,id=165598,bonus_id=4824/1537,enchant=quick_navigation
 off_hand=sunburst_crest,id=165584,bonus_id=4824/1537


### PR DESCRIPTION
Adding support for Grongs Primal Rage in APL and equipping it as the default trinket.