### PR TITLE
[Warlock] Improve Implosion and Implement Demonic Consumption Bug

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -374,7 +374,7 @@ namespace warlock {
         double casts_left = 5.0;
         pets::warlock_pet_t* next_imp;
 
-        implosion_aoe_t(warlock_t* p, std::vector<pets::warlock_pet_t*> imps = {}) :
+        implosion_aoe_t(warlock_t* p) :
           demonology_spell_t("implosion_aoe", p, p -> find_spell(196278))
         {
           aoe = -1;
@@ -506,7 +506,9 @@ namespace warlock {
             // Spelldata unknown. In-game testing shows Demonic Consumption provides 10% damage per 20 energy an imp has.
             demonic_consumption_multiplier += available / 10 * 5;
             imp->demonic_consumption = true;
-            imp->dismiss();
+            //Demonic Consumption does not appear to immediately despawn imps.
+            //This bug allows spells like Implosion to trigger partially.
+            make_event(sim, p()->bugs ? 15_ms : 0_ms, [imp] {imp->dismiss();});
           }
 
           for ( auto dt : p()->warlock_pet_list.demonic_tyrants )

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -345,19 +345,61 @@ namespace warlock {
 
     struct implosion_t : public demonology_spell_t
     {
+      struct implosion_state_t : public action_state_t
+      {
+        pets::warlock_pet_t* source_imp;
+
+        implosion_state_t(action_t* a, player_t* t) :
+          action_state_t(a, t)
+        {
+          source_imp = nullptr;
+        }
+
+        void copy_state(const action_state_t* s) override
+        {
+          action_state_t::copy_state(s);
+          auto is = debug_cast<const implosion_state_t*>(s);
+          source_imp = is->source_imp;
+        }
+
+        void initialize() override
+        {
+          action_state_t::initialize();
+          source_imp = nullptr;
+        }
+      };
+
       struct implosion_aoe_t : public demonology_spell_t
       {
         double casts_left = 5.0;
+        pets::warlock_pet_t* next_imp;
 
-        implosion_aoe_t(warlock_t* p) :
+        implosion_aoe_t(warlock_t* p, std::vector<pets::warlock_pet_t*> imps = {}) :
           demonology_spell_t("implosion_aoe", p, p -> find_spell(196278))
         {
           aoe = -1;
           dual = true;
           background = true;
           callbacks = false;
-
+          //Travel speed is not in spell data, in game test appears to be 40 yds/sec
+          travel_speed = 40;
           p->spells.implosion_aoe = this;
+        }
+
+        void impact(action_state_t* s) override
+        {
+          pets::warlock_pet_t* imp = debug_cast<implosion_state_t*>(s)->source_imp;
+          if(!imp || imp->is_sleeping())
+            return;
+
+          demonology_spell_t::impact(s);
+          imp->dismiss();
+        }
+
+        void snapshot_state(action_state_t* s, dmg_e rt) override
+        {
+          debug_cast<implosion_state_t*>(s)->source_imp = next_imp;
+          action_t::snapshot_state(s, rt);
         }
 
         double composite_target_multiplier(player_t* t) const override
@@ -371,6 +413,9 @@ namespace warlock {
 
           return m;
         }
+
+        action_state_t* new_state() override
+        { return new implosion_state_t(this, target); }
       };
 
       implosion_aoe_t* explosion;
@@ -398,14 +443,28 @@ namespace warlock {
 
         auto imps_consumed = p() -> warlock_pet_list.wild_imps.n_active_pets();
 
+        int launch_counter = 0;
         for ( auto imp : p() -> warlock_pet_list.wild_imps )
         {
           if ( !imp->is_sleeping() )
           {
-            explosion->casts_left = ( imp->resources.current[RESOURCE_ENERGY] / 20 );
-            explosion->set_target( this->target );
-            explosion->execute();
-            imp->dismiss();
+            implosion_aoe_t* ex = explosion;
+            player_t* tar = this->target;
+            double dist = p()->get_player_distance(*tar);
+
+            //Imps launched with Implosion appear to be staggered and snapshot when they start flying
+            make_event( sim, 100_ms*launch_counter, [ ex, tar, imp, dist ] {
+              if (imp && !imp->is_sleeping()){
+                ex->casts_left = ( imp->resources.current[RESOURCE_ENERGY] / 20 );
+                ex->set_target(tar);
+                imp->trigger_movement(dist, MOVEMENT_TOWARDS);
+                imp->interrupt();
+                ex->next_imp = imp;
+                ex->execute();
+              }
+            } );
+
+            launch_counter++;
           }
         }
 

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -381,8 +381,7 @@ namespace warlock {
           dual = true;
           background = true;
           callbacks = false;
-          //Travel speed is not in spell data, in game test appears to be 40 yds/sec
-          travel_speed = 40;
+
           p->spells.implosion_aoe = this;
         }
 
@@ -424,6 +423,8 @@ namespace warlock {
       {
         parse_options(options_str);
         add_child(explosion);
+        //Travel speed is not in spell data, in game test appears to be 40 yds/sec
+        travel_speed = 40;
       }
 
       bool ready() override
@@ -452,13 +453,14 @@ namespace warlock {
             player_t* tar = this->target;
             double dist = p()->get_player_distance(*tar);
 
-            //Imps launched with Implosion appear to be staggered and snapshot when they start flying
-            make_event( sim, 100_ms*launch_counter, [ ex, tar, imp, dist ] {
+            imp->trigger_movement(dist, MOVEMENT_TOWARDS);
+            imp->interrupt();
+
+            //Imps launched with Implosion appear to be staggered and snapshot when they impact
+            make_event( sim, 100_ms*launch_counter+this->travel_time(), [ ex, tar, imp, dist ] {
               if (imp && !imp->is_sleeping()){
                 ex->casts_left = ( imp->resources.current[RESOURCE_ENERGY] / 20 );
                 ex->set_target(tar);
-                imp->trigger_movement(dist, MOVEMENT_TOWARDS);
-                imp->interrupt();
                 ex->next_imp = imp;
                 ex->execute();
               }


### PR DESCRIPTION
Currently in game it is possible to queue a cast of Implosion while casting Summon Demonic Tyrant. When talented into Demonic Consumption, the Wild Imps should be consumed at the end of the Tyrant cast. However, executing the Implosion spell at the same time will trigger the Explosive Potential azerite buff, but the Implosion will do no damage, as the imps will despawn quickly due to Demonic Consumption.

A slight delay of 15 ms is added to the dismissal of pets from Demonic Consumption to model this.

Additionally, Implosion snapshots damage when the Wild Imp ~~is launched~~ impacts (which happens in a staggered fashion, one by one for the imps), and the spell has a travel time. These effects are now modeled in the module.

Imps are sent moving and have their casts interrupted to simulate their "flight".