### PR TITLE
Fix wrong decimal point for European LC_NUMERIC

### DIFF
--- a/engine/report/sc_highchart.cpp
+++ b/engine/report/sc_highchart.cpp
@@ -146,7 +146,7 @@ std::string chart_t::to_target_div() const
 std::string chart_t::to_data() const
 {
   rapidjson::StringBuffer b;
-  sc_json_writer_t<rapidjson::StringBuffer> writer( b, sim_ );
+  rapidjson::Writer<rapidjson::StringBuffer> writer( b );
 
   js_.Accept( writer );
   std::string str_ = "{ \"target\": \"" + id_str_ + "\", \"data\": ";
@@ -159,7 +159,7 @@ std::string chart_t::to_data() const
 std::string chart_t::to_aggregate_string( bool on_click ) const
 {
   rapidjson::StringBuffer b;
-  sc_json_writer_t<rapidjson::StringBuffer> writer( b, sim_ );
+  rapidjson::Writer<rapidjson::StringBuffer> writer( b );
 
   js_.Accept( writer );
   std::string javascript = b.GetString();
@@ -186,7 +186,7 @@ std::string chart_t::to_aggregate_string( bool on_click ) const
 std::string chart_t::to_string() const
 {
   rapidjson::StringBuffer b;
-  sc_json_writer_t<rapidjson::StringBuffer> writer( b, sim_ );
+  rapidjson::Writer<rapidjson::StringBuffer> writer( b );
 
   js_.Accept( writer );
   std::string javascript = b.GetString();
@@ -496,23 +496,4 @@ histogram_chart_t::histogram_chart_t( const std::string& id_str,
 
   set( "xAxis.tickLength", 0 );
   set( "xAxis.type", "category" );
-}
-
-template <typename Stream>
-sc_json_writer_t<Stream>::sc_json_writer_t( Stream& stream, const sim_t& s )
-  : rapidjson::Writer<Stream>( stream ), sim( s )
-{
-}
-
-template <typename Stream>
-bool sc_json_writer_t<Stream>::Double( double d )
-{
-  this->Prefix( rapidjson::kNumberType );
-  fmt::memory_buffer buffer;
-  fmt::format_to(buffer, "{:.{}f}", d, sim.report_precision );
-  for ( unsigned i = 0; i < buffer.size(); ++i )
-  {
-    this->os_->Put( buffer.data()[ i ] );
-  }
-  return true;
 }

--- a/engine/report/sc_highchart.hpp
+++ b/engine/report/sc_highchart.hpp
@@ -122,17 +122,6 @@ struct histogram_chart_t : public chart_t
 {
   histogram_chart_t( const std::string& id_str, const sim_t& sim );
 };
-
-// Custom data formatter, we need to output doubles in a different way to save
-// some room.
-template <typename Stream>
-struct sc_json_writer_t : public rapidjson::Writer<Stream>
-{
-  const sim_t& sim;
-
-  sc_json_writer_t( Stream& stream, const sim_t& s );
-  bool Double( double d );
-};
 }
 
 #endif


### PR DESCRIPTION
There is an issue with the generation of doubles in json in the German (DE_DE) LC_NUMERIC locale.
Due to the indirect use of _vprint_  in the custom _sc_json_writer_t_ doubles are printed as 1,22 instead of 1.22 resulting in this (While generously ignoring setlocale in the main function):

`... {"y":6,00,"name":"10848 to 10892"},{"y":16,00,"name":"10892 to 10936"},{"y":22,00,"name":"10936 to 10980"},{"y":49,00,"name":"10980 to 11024"},{"y":73,00,"name":"11024 to 11068"},{"y":155,00,"name":"11068 to 11112"},{"y":220,00,"name":"11112 to 11156"},{"y":350,00,"name":"11156 to 11200"},{"y":558,00,"name":"11200 to 11244"},{"y":850,00,"name":"11244 to 11288"},{"y":1171,00,"name":"11288 to 11332"},{"y":1692,00,"name":"11332 to 11376"} ...`

Honestly i did not understand why doubles need to be limited to precision in machine-read json files so i removed the custom _sc_json_writer_t_ and defaulted to rapidjson's really good dtoa implementation.

If you find you need the fixed point doubles in the json output another possibillity ist to simply replace the comma (but i find this pretty ugly...):

**engine/report/sc_highchart.cpp:513ff**
```
for ( unsigned i = 0; i < buffer.size(); ++i )
  {
    if(buffer.data()[ i ] == ',')
         this->os_->Put( '.' );
    else
         this->os_->Put(` buffer.data()[ i ] );
  }
```