### PR TITLE
Move QApplication before setlocale because it resets the locale

### DIFF
--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -48,6 +48,13 @@ int main( int argc, char *argv[] )
   qInstallMessageHandler(messageOutput);
 #endif
 
+  #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    QCoreApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
+    qputenv( "QT_AUTO_SCREEN_SCALE_FACTOR", "1" );
+  #endif
+
+  QApplication a( argc, argv );
+
   QLocale::setDefault( QLocale( "C" ) );
   std::locale::global( std::locale( "C" ) );
   setlocale( LC_ALL, "C" );
@@ -63,13 +70,6 @@ int main( int argc, char *argv[] )
   #endif
 
   hotfix::apply();
-
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-  QCoreApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
-  qputenv( "QT_AUTO_SCREEN_SCALE_FACTOR", "1" );
-#endif
-
-  QApplication a( argc, argv );
 
   QApplication::setStyle( QStyleFactory::create( "Fusion" ) );
   QCoreApplication::setApplicationName( "SimulationCraft" );


### PR DESCRIPTION
This PR is connected to #4739. Both PRs fix the Problem on their own, but each of them a different cause.

Currently the LC_NUMERIC locale is not honored in the QT application resulting in json outputs like
`... {"y":6,00,"name":"10848 to 10892"},{"y":16,00,"name":"10892 to 10936"},{"y":22,00,"name":"10936 to 10980"},{"y":49,00,"name":"10980 to 11024"},{"y":73,00,"name":"11024 to 11068"},{"y":155,00,"name":"11068 to 11112"},{"y":220,00,"name":"11112 to 11156"},{"y":350,00,"name":"11156 to 11200"},{"y":558,00,"name":"11200 to 11244"},{"y":850,00,"name":"11244 to 11288"},{"y":1171,00,"name":"11288 to 11332"},{"y":1692,00,"name":"11332 to 11376"} ...`

On the one hand side this is caused by not using rapidjson's json-safe `WriteDouble` but a derivative of `vprinf`. (See #4739 )
On the other side by `vprinf` not honoring the setlocale made in the main function (qt/main.cpp).

The cause of this is the initialization of QApplication (qt/main.cpp) overwriting the locale: https://doc.qt.io/archives/qt-5.8/qcoreapplication.html - Locale Settings
In detail: http://bastian.rieck.ru/blog/posts/2013/qapplication_and_the_locale/

Therefore I moved the initialization before the set locale.
