### PR TITLE
[Warlock] Make Chaos Shards trait trigger for all specs

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -568,8 +568,8 @@ void warlock_t::init_gains()
   gains.shadow_bolt                     = get_gain( "shadow_bolt" );
   gains.soul_conduit                    = get_gain( "soul_conduit" );
 
-  gains.soulsnatcher					          = get_gain( "soulsnatcher" );
-  gains.chaos_shards					          = get_gain( "chaos_shards" );
+  gains.soulsnatcher                    = get_gain( "soulsnatcher" );
+  gains.chaos_shards                    = get_gain( "chaos_shards" );
 }
 
 void warlock_t::init_procs()

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -384,13 +384,13 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
       expansion::bfa::trigger_leyshocks_grand_compilation( STAT_VERSATILITY_RATING, this );
     }
 
-	// Chaos Shards triggers for all specializations
+    // Chaos Shards triggers for all specializations
     if ( azerite.chaos_shards.ok() )
     {
       // Check if soul shard was filled
       if ( std::floor( resources.current[ RESOURCE_SOUL_SHARD ] ) < std::floor( std::min( resources.current[ RESOURCE_SOUL_SHARD ] + amount, 5.0 ) ) )
       {
-		if ( rng().roll( azerite.chaos_shards.spell_ref().effectN( 1 ).percent() / 10.0 ) )
+        if ( rng().roll( azerite.chaos_shards.spell_ref().effectN( 1 ).percent() / 10.0 ) )
           buffs.chaos_shards->trigger();
       }
     }
@@ -568,8 +568,8 @@ void warlock_t::init_gains()
   gains.shadow_bolt                     = get_gain( "shadow_bolt" );
   gains.soul_conduit                    = get_gain( "soul_conduit" );
 
-  gains.soulsnatcher					= get_gain( "soulsnatcher" );
-  gains.chaos_shards					= get_gain( "chaos_shards" );
+  gains.soulsnatcher					          = get_gain( "soulsnatcher" );
+  gains.chaos_shards					          = get_gain( "chaos_shards" );
 }
 
 void warlock_t::init_procs()

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -384,12 +384,13 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
       expansion::bfa::trigger_leyshocks_grand_compilation( STAT_VERSATILITY_RATING, this );
     }
 
-    if ( specialization() == WARLOCK_DESTRUCTION && azerite.chaos_shards.ok() )
+	// Chaos Shards triggers for all specializations
+    if ( azerite.chaos_shards.ok() )
     {
       // Check if soul shard was filled
-      if ( std::floor(resources.current[RESOURCE_SOUL_SHARD]) < std::floor(std::min(resources.current[RESOURCE_SOUL_SHARD] + amount, 5.0)) )
+      if ( std::floor( resources.current[ RESOURCE_SOUL_SHARD ] ) < std::floor( std::min( resources.current[ RESOURCE_SOUL_SHARD ] + amount, 5.0 ) ) )
       {
-        if ( rng().roll( azerite.chaos_shards.spell_ref().effectN( 1 ).percent() / 10.0 ) )
+		if ( rng().roll( azerite.chaos_shards.spell_ref().effectN( 1 ).percent() / 10.0 ) )
           buffs.chaos_shards->trigger();
       }
     }
@@ -567,7 +568,8 @@ void warlock_t::init_gains()
   gains.shadow_bolt                     = get_gain( "shadow_bolt" );
   gains.soul_conduit                    = get_gain( "soul_conduit" );
 
-  gains.soulsnatcher                    = get_gain( "soulsnatcher" );
+  gains.soulsnatcher					= get_gain( "soulsnatcher" );
+  gains.chaos_shards					= get_gain( "chaos_shards" );
 }
 
 void warlock_t::init_procs()

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -1055,7 +1055,6 @@ namespace warlock {
     gains.infernal                      = get_gain( "infernal" );
     gains.shadowburn_shard              = get_gain( "shadowburn_shard" );
     gains.inferno                       = get_gain( "inferno" );
-    gains.chaos_shards                  = get_gain( "chaos_shards" );
   }
 
   void warlock_t::init_rng_destruction() {


### PR DESCRIPTION
Originally Destruction only (or at least it seems like it was intended this way) trait Chaos Shards can proc for other specs too, from all shard generating abilities (personally tested ingame, apart from situations like Chaos Shards procs from *both* Demonbolt shards or multiple procs from Soul Conduit, which should technically be possible, but is in the order of 0,0003% chance or so).