### PR TITLE
[Warlock] Tiny general cleanup

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -568,7 +568,6 @@ void warlock_t::init_gains()
   gains.shadow_bolt                     = get_gain( "shadow_bolt" );
   gains.soul_conduit                    = get_gain( "soul_conduit" );
 
-  gains.soulsnatcher                    = get_gain( "soulsnatcher" );
   gains.chaos_shards                    = get_gain( "chaos_shards" );
 }
 

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -521,9 +521,7 @@ void warlock_t::init_spells()
   spec.wild_imps                        = find_specialization_spell( "Wild Imps" );
   spec.demonic_core                     = find_specialization_spell( "Demonic Core" );
   spec.shadow_bite                      = find_specialization_spell( "Shadow Bite" );
-  spec.shadow_bite_2                    = find_specialization_spell( 231799 );
   spec.unending_resolve                 = find_specialization_spell( "Unending Resolve" );
-  spec.unending_resolve_2               = find_specialization_spell( 231794 );
   spec.firebolt                         = find_specialization_spell( "Firebolt" );
   spec.firebolt_2                       = find_specialization_spell( 231795 );
 

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -523,7 +523,6 @@ void warlock_t::init_spells()
   spec.shadow_bite                      = find_specialization_spell( "Shadow Bite" );
   spec.unending_resolve                 = find_specialization_spell( "Unending Resolve" );
   spec.firebolt                         = find_specialization_spell( "Firebolt" );
-  spec.firebolt_2                       = find_specialization_spell( 231795 );
 
   // Talents
   talents.demon_skin                    = find_talent_spell( "Fire and Brimstone" );

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -396,7 +396,6 @@ namespace warlock
       } spells;
 
       int initial_soul_shards;
-      bool allow_sephuz;
       std::string default_pet;
       timespan_t shard_react;
 

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -260,11 +260,9 @@ namespace warlock
         const spell_data_t* affliction;
         const spell_data_t* nightfall;
         const spell_data_t* unstable_affliction;
-        const spell_data_t* unstable_affliction_2;
         const spell_data_t* agony;
         const spell_data_t* agony_2;
         const spell_data_t* shadow_bite;
-        const spell_data_t* shadow_bite_2;
         const spell_data_t* shadow_bolt; // also demo
         const spell_data_t* summon_darkglare;
 
@@ -278,12 +276,11 @@ namespace warlock
         const spell_data_t* destruction;
         const spell_data_t* immolate;
         const spell_data_t* conflagrate;
-        const spell_data_t* conflagrate_2;
+        const spell_data_t* conflagrate_2; // Conflagrate has 2 charges
         const spell_data_t* havoc;
         const spell_data_t* unending_resolve;
-        const spell_data_t* unending_resolve_2;
         const spell_data_t* firebolt;
-        const spell_data_t* firebolt_2;
+        const spell_data_t* firebolt_2; // 50% damage increase to Firebolt for targets w/ Immolate
       } spec;
 
       // Buffs

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -365,8 +365,6 @@ namespace warlock
         gain_t* doom;
         gain_t* demonic_meteor;
         gain_t* baleful_invocation;
-
-        gain_t* soulsnatcher;
       } gains;
 
       // Procs

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -217,7 +217,6 @@ namespace warlock
         azerite_power_t pandemic_invocation;
 
         //Destro
-        azerite_power_t accelerant;
         azerite_power_t bursting_flare;
         azerite_power_t chaotic_inferno;
         azerite_power_t crashing_chaos;
@@ -327,7 +326,6 @@ namespace warlock
         propagate_const<buff_t*> grimoire_of_supremacy;
         propagate_const<buff_t*> dark_soul_instability;
 
-        propagate_const<buff_t*> accelerant;
         propagate_const<buff_t*> bursting_flare;
         propagate_const<buff_t*> chaotic_inferno;
         propagate_const<buff_t*> crashing_chaos;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -214,7 +214,6 @@ namespace warlock
         azerite_power_t inevitable_demise;
         azerite_power_t sudden_onset;
         azerite_power_t wracking_brilliance;
-        azerite_power_t deathbloom;
         azerite_power_t pandemic_invocation;
 
         //Destro

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -202,7 +202,6 @@ namespace warlock
 
         //Demo
         azerite_power_t demonic_meteor;
-        azerite_power_t forbidden_knowledge;
         azerite_power_t shadows_bite;
         azerite_power_t supreme_commander;
         azerite_power_t umbral_blaze;
@@ -319,7 +318,6 @@ namespace warlock
         propagate_const<buff_t*> prince_malchezaar;
         propagate_const<buff_t*> eyes_of_guldan;
 
-        propagate_const<buff_t*> forbidden_knowledge;
         propagate_const<buff_t*> shadows_bite;
         propagate_const<buff_t*> supreme_commander;
         propagate_const<buff_t*> explosive_potential;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -280,7 +280,6 @@ namespace warlock
         const spell_data_t* havoc;
         const spell_data_t* unending_resolve;
         const spell_data_t* firebolt;
-        const spell_data_t* firebolt_2; // 50% damage increase to Firebolt for targets w/ Immolate
       } spec;
 
       // Buffs

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -1021,7 +1021,6 @@ namespace warlock
     azerite.inevitable_demise           = find_azerite_spell("Inevitable Demise");
     azerite.sudden_onset                = find_azerite_spell("Sudden Onset");
     azerite.wracking_brilliance         = find_azerite_spell("Wracking Brilliance");
-    azerite.deathbloom                  = find_azerite_spell("Deathbloom");
     azerite.pandemic_invocation         = find_azerite_spell( "Pandemic Invocation" );
     // Actives
     active.pandemic_invocation          = new pandemic_invocation_t( this );

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -315,11 +315,6 @@ namespace warlock {
         {
           td(target)->debuffs_from_the_shadows->trigger();
         }
-
-        if (p()->azerite.forbidden_knowledge.ok())
-        {
-          p()->buffs.forbidden_knowledge->trigger();
-        }
       }
     };
 
@@ -951,10 +946,6 @@ namespace warlock {
       ->set_duration(talents.nether_portal->duration());
 
     // Azerite
-    buffs.forbidden_knowledge = make_buff( this, "forbidden_knowledge", azerite.forbidden_knowledge.spell_ref().effectN( 1 ).trigger() )
-      ->set_refresh_behavior( buff_refresh_behavior::DURATION )
-      // Forbidden Knowledge has a built in 30% reduction to the value of ranks 2 and 3. This is applied as a flat multiplier to the total value.
-      ->set_default_value( azerite.forbidden_knowledge.value() * ( ( 1.0 + 0.70 * ( azerite.forbidden_knowledge.n_items() - 1 ) ) / azerite.forbidden_knowledge.n_items() ) );
     buffs.shadows_bite = make_buff(this, "shadows_bite", azerite.shadows_bite)
       ->set_duration(find_spell(272945)->duration())
       ->set_default_value(azerite.shadows_bite.value());
@@ -1015,7 +1006,6 @@ namespace warlock {
 
     // Azerite
     azerite.demonic_meteor                  = find_azerite_spell( "Demonic Meteor" );
-    azerite.forbidden_knowledge             = find_azerite_spell( "Forbidden Knowledge" );
     azerite.shadows_bite                    = find_azerite_spell( "Shadow's Bite" );
     azerite.supreme_commander               = find_azerite_spell( "Supreme Commander" );
     azerite.umbral_blaze                    = find_azerite_spell( "Umbral Blaze" );

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -9,7 +9,6 @@ namespace warlock {
     {
     public:
       gain_t * gain;
-      bool can_feretory;
 
       demonology_spell_t(warlock_t* p, const std::string& n) :
         demonology_spell_t(n, p, p -> find_class_spell(n))
@@ -28,8 +27,6 @@ namespace warlock {
         tick_may_crit = true;
         weapon_multiplier = 0.0;
         gain = player->get_gain(name_str);
-
-        can_feretory = true;
       }
 
       void reset() override

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -980,9 +980,6 @@ namespace warlock {
       ->set_default_value( talents.dark_soul_instability->effectN( 1 ).percent() );
 
     // Azerite
-    buffs.accelerant = make_buff<stat_buff_t>( this, "accelerant", azerite.accelerant )
-      ->add_stat( STAT_HASTE_RATING, azerite.accelerant.value() )
-      ->set_duration( find_spell( 272957 )->duration() );
     buffs.bursting_flare = make_buff<stat_buff_t>( this, "bursting_flare", find_spell( 279913 ) )
       ->add_stat( STAT_MASTERY_RATING, azerite.bursting_flare.value() );
     buffs.chaotic_inferno = make_buff( this, "chaotic_inferno", find_spell( 279673 ) )
@@ -1032,7 +1029,6 @@ namespace warlock {
     talents.dark_soul_instability       = find_talent_spell( "Dark Soul: Instability" );
 
     // Azerite
-    azerite.accelerant                  = find_azerite_spell( "Accelerant" );
     azerite.bursting_flare              = find_azerite_spell( "Bursting Flare" );
     azerite.chaotic_inferno             = find_azerite_spell( "Chaotic Inferno" );
     azerite.crashing_chaos              = find_azerite_spell( "Crashing Chaos" );


### PR DESCRIPTION
Removed pre-8.1 Azerite traits (Deathbloom, Accelerant, Forbidden Knowledge), old Destruction Artifact trait Soulsnatcher, and a bunch of unused variables 