### PR TITLE
Updated Trinkets and Unholy Frenzy

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7720,9 +7720,11 @@ void death_knight_t::default_apl_unholy()
   def -> add_action( "blood_fury,if=pet.gargoyle.active|!talent.summon_gargoyle.enabled" );
   def -> add_action( "berserking,if=buff.unholy_frenzy.up|pet.gargoyle.active|!talent.summon_gargoyle.enabled" );
   def -> add_action( "use_items", "Custom trinkets usage" );
+  def -> add_action( "use_item,name=ramping_amplitude_gigavolt_engine,if=((talent.unholy_frenzy.enabled|azerite.magus_of_the_dead.enabled)&(cooldown.army_of_the_dead.remains>=420|cooldown.apocalypse.remains))|raid_event.adds.in<5" );
   def -> add_action( "use_item,name=bygone_bee_almanac,if=cooldown.summon_gargoyle.remains>60|!talent.summon_gargoyle.enabled" );
   def -> add_action( "use_item,name=jes_howler,if=pet.gargoyle.active|!talent.summon_gargoyle.enabled" );
   def -> add_action( "use_item,name=galecallers_beak,if=pet.gargoyle.active|!talent.summon_gargoyle.enabled" );
+  def -> add_action( "use_item,name=grongs_primal_rage,if=(!equipped.ramping_amplitude_gigavolt_engine&buff.unholy_frenzy.remains)|(cooldown.apocalypse.remains>20&equipped.ramping_amplitude_gigavolt_engine)" );
   def -> add_action( "potion,if=cooldown.army_of_the_dead.ready|pet.gargoyle.active|buff.unholy_frenzy.up" );
   // Maintain Virulent Plague
   def -> add_action( this, "Outbreak", "target_if=dot.virulent_plague.remains<=gcd", "Maintaining Virulent Plague is a priority" );
@@ -7735,7 +7737,8 @@ void death_knight_t::default_apl_unholy()
   cooldowns -> add_action( this, "Apocalypse", "if=debuff.festering_wound.stack>=4" );
   cooldowns -> add_action( this, "Dark Transformation", "if=!raid_event.adds.exists|raid_event.adds.in>15" );
   cooldowns -> add_talent( this, "Summon Gargoyle", "if=runic_power.deficit<14" );
-  cooldowns -> add_talent( this, "Unholy Frenzy", "if=debuff.festering_wound.stack<4" );
+  cooldowns -> add_talent( this, "Unholy Frenzy", "if=debuff.festering_wound.stack<4&(!equipped.165580|!azerite.magus_of_the_dead.enabled)" );
+  cooldowns -> add_talent( this, "Unholy Frenzy", "if=cooldown.apocalypse.remains<=2&(equipped.165580|azerite.magus_of_the_dead.enabled)" );
   cooldowns -> add_talent( this, "Unholy Frenzy", "if=active_enemies>=2&((cooldown.death_and_decay.remains<=gcd&!talent.defile.enabled)|(cooldown.defile.remains<=gcd&talent.defile.enabled))" );
   cooldowns -> add_talent( this, "Soul Reaper", "target_if=target.time_to_die<8&target.time_to_die>4" );
   cooldowns -> add_talent( this, "Soul Reaper", "if=(!raid_event.adds.exists|raid_event.adds.in>20)&rune<=(1-buff.unholy_frenzy.up)" );


### PR DESCRIPTION
Added [Ramping Amplitude Gigavolt Engine] and [Grong's Primal Rage] to on use trinkets and updated [Unholy Frenzy] conditions to go with these trinkets as well as the [Magus of the Dead] azerite trait.

sims showing upgrade: https://www.raidbots.com/simbot/report/ge2xAQYQDJLD93EoNRQ2MH