### PR TITLE
[Death Knight] Update Blood APL to cast Grongs trinket later

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7512,6 +7512,7 @@ void death_knight_t::default_apl_blood()
   standard -> add_talent( this, "Consumption" );
   standard -> add_action( this, "Blood Boil" );
   standard -> add_action( this, "Heart Strike", "if=rune.time_to_3<gcd|buff.bone_shield.stack>6" );
+  standard -> add_action( "use_item,name=grongs_primal_rage" ); // Because this prevents all casting it should be used during downtime
   standard -> add_talent( this, "Rune Strike" );
   standard -> add_action( "arcane_torrent,if=runic_power.deficit>20" );
 }

--- a/profiles/DungeonSlice/DS_Death_Knight_Blood.simc
+++ b/profiles/DungeonSlice/DS_Death_Knight_Blood.simc
@@ -54,6 +54,7 @@ actions.standard+=/death_and_decay,if=buff.crimson_scourge.up|talent.rapid_decom
 actions.standard+=/consumption
 actions.standard+=/blood_boil
 actions.standard+=/heart_strike,if=rune.time_to_3<gcd|buff.bone_shield.stack>6
+actions.standard+=/use_item,name=grongs_primal_rage
 actions.standard+=/rune_strike
 actions.standard+=/arcane_torrent,if=runic_power.deficit>20
 

--- a/profiles/PreRaids/PR_Death_Knight_Blood.simc
+++ b/profiles/PreRaids/PR_Death_Knight_Blood.simc
@@ -54,6 +54,7 @@ actions.standard+=/death_and_decay,if=buff.crimson_scourge.up|talent.rapid_decom
 actions.standard+=/consumption
 actions.standard+=/blood_boil
 actions.standard+=/heart_strike,if=rune.time_to_3<gcd|buff.bone_shield.stack>6
+actions.standard+=/use_item,name=grongs_primal_rage
 actions.standard+=/rune_strike
 actions.standard+=/arcane_torrent,if=runic_power.deficit>20
 

--- a/profiles/Tier22/T22_Death_Knight_Blood.simc
+++ b/profiles/Tier22/T22_Death_Knight_Blood.simc
@@ -54,6 +54,7 @@ actions.standard+=/death_and_decay,if=buff.crimson_scourge.up|talent.rapid_decom
 actions.standard+=/consumption
 actions.standard+=/blood_boil
 actions.standard+=/heart_strike,if=rune.time_to_3<gcd|buff.bone_shield.stack>6
+actions.standard+=/use_item,name=grongs_primal_rage
 actions.standard+=/rune_strike
 actions.standard+=/arcane_torrent,if=runic_power.deficit>20
 

--- a/profiles/Tier23/T23_Death_Knight_Blood.simc
+++ b/profiles/Tier23/T23_Death_Knight_Blood.simc
@@ -54,6 +54,7 @@ actions.standard+=/death_and_decay,if=buff.crimson_scourge.up|talent.rapid_decom
 actions.standard+=/consumption
 actions.standard+=/blood_boil
 actions.standard+=/heart_strike,if=rune.time_to_3<gcd|buff.bone_shield.stack>6
+actions.standard+=/use_item,name=grongs_primal_rage
 actions.standard+=/rune_strike
 actions.standard+=/arcane_torrent,if=runic_power.deficit>20
 


### PR DESCRIPTION
Grong's primal rage does more damage when you use it during downtime in the BDK rotation

Example Runs:
Default APL:
https://www.raidbots.com/simbot/report/pLQCUjtRftRPPpYQzzCYmn

New APL:
https://www.raidbots.com/simbot/report/vvff42DKcBP34ZrypmCu8D