### PR TITLE
[Warrior] Update APL for prot warrior to delay trinkets for avatar

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -5299,7 +5299,8 @@ void warrior_t::apl_prot()
 
   default_list -> add_action( "auto_attack" );
   default_list -> add_action( this, "Intercept", "if=time=0" );
-  default_list -> add_action( "use_items" );
+  default_list -> add_action( "use_items,if=cooldown.avatar.remains>20" );
+  default_list -> add_action( "use_item,name=grongs_primal_rage,if=buff.avatar.down" );
   
   for ( size_t i = 0; i < racial_actions.size(); i++ )
     default_list -> add_action( racial_actions[ i ] );

--- a/profiles/DungeonSlice/DS_Warrior_Protection.simc
+++ b/profiles/DungeonSlice/DS_Warrior_Protection.simc
@@ -30,7 +30,8 @@ actions.precombat+=/potion
 # Executed every time the actor is available.
 actions=auto_attack
 actions+=/intercept,if=time=0
-actions+=/use_items
+actions+=/use_items,if=cooldown.avatar.remains>20
+actions+=/use_item,name=grongs_primal_rage,if=buff.avatar.down
 actions+=/blood_fury
 actions+=/berserking
 actions+=/arcane_torrent

--- a/profiles/Tier22/T22_Warrior_Protection.simc
+++ b/profiles/Tier22/T22_Warrior_Protection.simc
@@ -30,7 +30,8 @@ actions.precombat+=/potion
 # Executed every time the actor is available.
 actions=auto_attack
 actions+=/intercept,if=time=0
-actions+=/use_items
+actions+=/use_items,if=cooldown.avatar.remains>20
+actions+=/use_item,name=grongs_primal_rage,if=buff.avatar.down
 actions+=/blood_fury
 actions+=/berserking
 actions+=/arcane_torrent

--- a/profiles/Tier23/T23_Warrior_Protection.simc
+++ b/profiles/Tier23/T23_Warrior_Protection.simc
@@ -30,7 +30,8 @@ actions.precombat+=/potion
 # Executed every time the actor is available.
 actions=auto_attack
 actions+=/intercept,if=time=0
-actions+=/use_items
+actions+=/use_items,if=cooldown.avatar.remains>20
+actions+=/use_item,name=grongs_primal_rage,if=buff.avatar.down
 actions+=/blood_fury
 actions+=/berserking
 actions+=/arcane_torrent


### PR DESCRIPTION
This delays trinket usage to line up with Avatar, on ST it's ~neutral, but on hectic add cleave it is quite a bit better

Old APL, Patchwerk:
https://www.raidbots.com/simbot/report/7Ax36PwpUYcXxKGa3Xn8Qm

New APL: Patchwerk:
https://www.raidbots.com/simbot/report/f6DBpWBCTDLgM1og2V3JmY

Old APL: Hectic Add Cleave:
https://www.raidbots.com/simbot/report/7c3wrJbS2FFYhLsrXJVzzv

New APL: Hectic Add Cleave:
https://www.raidbots.com/simbot/report/d1hpfu4vzKyHpTSNrZSGS4