### PR TITLE
[Priest] APL updates

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1951,13 +1951,18 @@ void priest_t::generate_apl_shadow()
                       "cooldown.shadow_word_death.remains<gcd.max)" );
   single->add_talent( this, "Surrender to Madness", "if=buff.voidform.stack>10+(10*buff.bloodlust.up)" );
   single->add_talent( this, "Dark Void", "if=raid_event.adds.in>10" );
-  single->add_talent( this, "Mindbender" );
+  single->add_talent( this, "Mindbender", "if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)" );
   single->add_talent( this, "Shadow Word: Death",
                       "if=!buff.voidform.up|"
                       "(cooldown.shadow_word_death.charges=2&"
                       "buff.voidform.stack<15)" );
   single->add_talent( this, "Shadow Crash", "if=raid_event.adds.in>5&raid_event.adds.duration<20" );
-  single->add_action( this, "Mind Blast", "if=variable.dots_up" );
+  // Bank the Shadow Word: Void charges for a bit to try and avoid overcapping on Insanity.
+  single->add_action( this, "Mind Blast",
+                      "if=variable.dots_up&"
+                      "(!talent.shadow_word_void.enabled|buff.voidform.down|"
+                      "buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|"
+                      "buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))" );
   single->add_talent( this, "Void Torrent",
                       "if=dot.shadow_word_pain.remains>4&"
                       "dot.vampiric_touch.remains>4&buff.voidform.up" );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1960,7 +1960,8 @@ void priest_t::generate_apl_shadow()
   // Bank the Shadow Word: Void charges for a bit to try and avoid overcapping on Insanity.
   single->add_action( this, "Mind Blast",
                       "if=variable.dots_up&"
-                      "(!talent.shadow_word_void.enabled|buff.voidform.down|"
+                      "((raid_event.movement.in>cast_time+0.5&raid_event.movement.in<4)|"
+                      "!talent.shadow_word_void.enabled|buff.voidform.down|"
                       "buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|"
                       "buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))" );
   single->add_talent( this, "Void Torrent",

--- a/profiles/DungeonSlice/DS_Priest_Shadow.simc
+++ b/profiles/DungeonSlice/DS_Priest_Shadow.simc
@@ -72,7 +72,7 @@ actions.single+=/dark_void,if=raid_event.adds.in>10
 actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
+actions.single+=/mind_blast,if=variable.dots_up&((raid_event.movement.in>cast_time+0.5&raid_event.movement.in<4)|!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/DungeonSlice/DS_Priest_Shadow.simc
+++ b/profiles/DungeonSlice/DS_Priest_Shadow.simc
@@ -69,10 +69,10 @@ actions.single+=/mind_sear,if=buff.harvested_thoughts.up&cooldown.void_bolt.rema
 actions.single+=/shadow_word_death,if=target.time_to_die<3|cooldown.shadow_word_death.charges=2|(cooldown.shadow_word_death.charges=1&cooldown.shadow_word_death.remains<gcd.max)
 actions.single+=/surrender_to_madness,if=buff.voidform.stack>10+(10*buff.bloodlust.up)
 actions.single+=/dark_void,if=raid_event.adds.in>10
-actions.single+=/mindbender
+actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up
+actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/PreRaids/PR_Priest_Shadow.simc
+++ b/profiles/PreRaids/PR_Priest_Shadow.simc
@@ -72,7 +72,7 @@ actions.single+=/dark_void,if=raid_event.adds.in>10
 actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
+actions.single+=/mind_blast,if=variable.dots_up&((raid_event.movement.in>cast_time+0.5&raid_event.movement.in<4)|!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/PreRaids/PR_Priest_Shadow.simc
+++ b/profiles/PreRaids/PR_Priest_Shadow.simc
@@ -69,10 +69,10 @@ actions.single+=/mind_sear,if=buff.harvested_thoughts.up&cooldown.void_bolt.rema
 actions.single+=/shadow_word_death,if=target.time_to_die<3|cooldown.shadow_word_death.charges=2|(cooldown.shadow_word_death.charges=1&cooldown.shadow_word_death.remains<gcd.max)
 actions.single+=/surrender_to_madness,if=buff.voidform.stack>10+(10*buff.bloodlust.up)
 actions.single+=/dark_void,if=raid_event.adds.in>10
-actions.single+=/mindbender
+actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up
+actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/Tier22/T22_Priest_Shadow.simc
+++ b/profiles/Tier22/T22_Priest_Shadow.simc
@@ -70,10 +70,10 @@ actions.single+=/mind_sear,if=buff.harvested_thoughts.up&cooldown.void_bolt.rema
 actions.single+=/shadow_word_death,if=target.time_to_die<3|cooldown.shadow_word_death.charges=2|(cooldown.shadow_word_death.charges=1&cooldown.shadow_word_death.remains<gcd.max)
 actions.single+=/surrender_to_madness,if=buff.voidform.stack>10+(10*buff.bloodlust.up)
 actions.single+=/dark_void,if=raid_event.adds.in>10
-actions.single+=/mindbender
+actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up
+actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/Tier22/T22_Priest_Shadow.simc
+++ b/profiles/Tier22/T22_Priest_Shadow.simc
@@ -73,7 +73,7 @@ actions.single+=/dark_void,if=raid_event.adds.in>10
 actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
+actions.single+=/mind_blast,if=variable.dots_up&((raid_event.movement.in>cast_time+0.5&raid_event.movement.in<4)|!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/Tier23/T23_Priest_Shadow.simc
+++ b/profiles/Tier23/T23_Priest_Shadow.simc
@@ -70,10 +70,10 @@ actions.single+=/mind_sear,if=buff.harvested_thoughts.up&cooldown.void_bolt.rema
 actions.single+=/shadow_word_death,if=target.time_to_die<3|cooldown.shadow_word_death.charges=2|(cooldown.shadow_word_death.charges=1&cooldown.shadow_word_death.remains<gcd.max)
 actions.single+=/surrender_to_madness,if=buff.voidform.stack>10+(10*buff.bloodlust.up)
 actions.single+=/dark_void,if=raid_event.adds.in>10
-actions.single+=/mindbender
+actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up
+actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)

--- a/profiles/Tier23/T23_Priest_Shadow.simc
+++ b/profiles/Tier23/T23_Priest_Shadow.simc
@@ -73,7 +73,7 @@ actions.single+=/dark_void,if=raid_event.adds.in>10
 actions.single+=/mindbender,if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)
 actions.single+=/shadow_word_death,if=!buff.voidform.up|(cooldown.shadow_word_death.charges=2&buff.voidform.stack<15)
 actions.single+=/shadow_crash,if=raid_event.adds.in>5&raid_event.adds.duration<20
-actions.single+=/mind_blast,if=variable.dots_up&(!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
+actions.single+=/mind_blast,if=variable.dots_up&((raid_event.movement.in>cast_time+0.5&raid_event.movement.in<4)|!talent.shadow_word_void.enabled|buff.voidform.down|buff.voidform.stack>14&(insanity<70|charges_fractional>1.33)|buff.voidform.stack<=14&(insanity<60|charges_fractional>1.33))
 actions.single+=/void_torrent,if=dot.shadow_word_pain.remains>4&dot.vampiric_touch.remains>4&buff.voidform.up
 actions.single+=/shadow_word_pain,if=refreshable&target.time_to_die>4&!talent.misery.enabled&!talent.dark_void.enabled
 actions.single+=/vampiric_touch,if=refreshable&target.time_to_die>6|(talent.misery.enabled&dot.shadow_word_pain.refreshable)


### PR DESCRIPTION
There are two main additions to the APL. ShadowFiend delay and Shadow Word: Void banking.

The current APL just uses ShadowFiend on CD instead of when we are in Void Form, causing the ShadowFiend to deal slightly less damage than it could and causing us to waste some insanity. Instead using it later on in VF increases the damage of the ShadowFiend and makes us have longer Void Forms. Since the CD of ShadowFiend is so long delaying it will not result in a dps loss.

Shadow Word: Void banking. In the current APL SW:V is used on CD, which causes us to overflow some of the insanity generated by it(even more apparent with WOTD). We can hold on to the charges for some time to decrease the amount of insanity overflow we get without losing out on any casts.

The APL changes the Insanity overflow from SW:V from 9.1% to 5.6%, and the ShadowFiend overflow from 2.29% to 0.32%. And results in an overall increase of 1.3% extra dps

[Raidbots report](https://www.raidbots.com/simbot/report/qAWrTedHQnoRi55frEuyjB)

I tested these APL changes on my main character, and verified them on the T23 profile(with 3111111 talents) and a T23 profile where I changed the chest to use WOTD. And saw an increase for both profiles using the new APL

T23 Profile dps comparisons:
![Capture](https://user-images.githubusercontent.com/9095312/54503602-51bb5480-4930-11e9-8bf9-ef2d6e5f2e78.PNG)
![Capture2](https://user-images.githubusercontent.com/9095312/54503607-5a138f80-4930-11e9-89a2-e88e04764fa9.PNG)
![Capture3](https://user-images.githubusercontent.com/9095312/54503612-5c75e980-4930-11e9-90ff-3b16211f3bf4.PNG)
