### PR TITLE
Add data to JSON report, get consumables reporting spell data

### DIFF
--- a/engine/player/sc_consumable.cpp
+++ b/engine/player/sc_consumable.cpp
@@ -390,6 +390,10 @@ struct dbc_consumable_base_t : public action_t
       throw std::invalid_argument("Unable to find consumable.");
     }
 
+    // populate ID and spell data for better reporting
+    id = driver() -> id();
+    s_data = driver();
+
     auto effect = unique_gear::find_special_effect( player, driver() -> id(), SPECIAL_EFFECT_USE );
     // No special effect for this consumable found, so create one
     if ( ! effect )

--- a/engine/report/sc_report_json.cpp
+++ b/engine/report/sc_report_json.cpp
@@ -116,6 +116,8 @@ void gains_to_json( JsonOutput root, const player_t& p )
 void to_json( JsonOutput root, const buff_t* b )
 {
   root[ "name" ] = b -> name();
+  root[ "spell_name" ] = b->data().name_cstr();
+  root[ "spell_school" ] = util::school_type_string( b->data().get_school_type());
   add_non_zero( root, "spell", b -> data().id() );
   if ( b -> item )
   {
@@ -155,6 +157,18 @@ void buffs_to_json( JsonOutput root, const player_t& p )
 {
   root.make_array();
   range::for_each( p.buff_list, [ &root]( const buff_t* b ) {
+    if ( b -> avg_start.sum() == 0 )
+    {
+      return;
+    }
+    to_json( root.add(), b );
+  } );
+}
+void constant_buffs_to_json( JsonOutput root, const player_t& p )
+{
+  root.make_array();
+  // constant buffs
+  range::for_each( p.report_information.constant_buffs, [ &root]( const buff_t* b ) {
     if ( b -> avg_start.sum() == 0 )
     {
       return;
@@ -776,6 +790,7 @@ void to_json( JsonOutput& arr, const player_t& p )
   if ( p.sim -> report_details != 0 )
   {
     buffs_to_json( root[ "buffs" ], p );
+    constant_buffs_to_json( root[ "buffs_constant" ], p );
 
     if ( p.proc_list.size() > 0 )
     {

--- a/engine/report/sc_report_json.cpp
+++ b/engine/report/sc_report_json.cpp
@@ -246,6 +246,11 @@ void stats_to_json( JsonOutput root, const std::vector<stats_t*> stats_list, int
     if (a != nullptr) {
       node[ "id" ] = a -> id;
       node[ "spell_name" ] = a -> data().name_cstr();
+      if (a->item)
+      {
+        // grab item ID if available, can link trinket pets back to the item
+        node[ "item_id" ] = a->item->parsed.data.id;
+      }
     }
     node[ "name" ] = s -> name();
     if ( s -> school != SCHOOL_NONE )
@@ -258,6 +263,7 @@ void stats_to_json( JsonOutput root, const std::vector<stats_t*> stats_list, int
     {
       gain_to_json( node[ "resource_gain" ], s -> resource_gain );
     }
+
 
     node[ "num_executes" ] = s -> num_executes;
     node[ "compound_amount" ] = s -> compound_amount;


### PR DESCRIPTION
Add a bunch of spell data to JSON report (action sequence, buffs, etc).

Add stat children to JSON report.

Changes to the consumable code are potentially riskier since it changes spell data that wasn't previously present. I'm pretty sure this happens outside of the usual spell data inference code but I'd love some double checks to make sure consumables don't go all weird.

Consumable change also end up showing what consumables were used in the HTML report.