### PR TITLE
Adjust use_items to give it a cast time when the on-use has one

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -5554,7 +5554,7 @@ void hunter_t::apl_surv()
 	
   // Essences
   cds->add_action( "focused_azerite_beam" );
-  cds->add_action( "memory_of_lucid_dreams,if=buff.coordinated_assault.up" );
+  cds->add_action( "memory_of_lucid_dreams,if=focus<focus.max-30&buff.coordinated_assault.up" );
   cds->add_action( "blood_of_the_enemy,if=buff.coordinated_assault.up" );
   cds->add_action( "purifying_blast" );
   cds->add_action( "guardian_of_azeroth" );
@@ -5571,7 +5571,7 @@ void hunter_t::apl_surv()
   st -> add_action( this, "Serpent_Sting", "if=buff.vipers_venom.up&buff.vipers_venom.remains<1.5*gcd" );
   st -> add_action( this, "Kill Command", "if=focus+cast_regen<focus.max" );
   st -> add_talent( this, "Steel Trap", "if=focus+cast_regen<focus.max" );
-  st -> add_action( this, "Wildfire Bomb", "if=focus+cast_regen<focus.max&!ticking&(full_recharge_time<1.5*gcd|!dot.wildfire_bomb.ticking&!buff.coordinated_assault.up)" );
+  st -> add_action( this, "Wildfire Bomb", "if=focus+cast_regen<focus.max&!ticking&!buff.memory_of_lucid_dreams.up&(full_recharge_time<1.5*gcd|!dot.wildfire_bomb.ticking&!buff.coordinated_assault.up)" );
   st -> add_talent( this, "Mongoose Bite", "if=buff.mongoose_fury.stack>5&!cooldown.coordinated_assault.remains" );
   st -> add_action( this, "Serpent Sting", "if=buff.vipers_venom.up&dot.serpent_sting.remains<4*gcd|dot.serpent_sting.refreshable&!buff.coordinated_assault.up" );
   st -> add_talent( this, "A Murder of Crows", "if=!buff.coordinated_assault.up" );
@@ -5587,7 +5587,7 @@ void hunter_t::apl_surv()
   apst -> add_talent( this, "Flanking Strike", "if=focus+cast_regen<focus.max" );
   apst -> add_action( this, "Kill Command", "if=full_recharge_time<1.5*gcd&focus+cast_regen<focus.max-10" );
   apst -> add_talent( this, "Steel Trap", "if=focus+cast_regen<focus.max" );
-  apst -> add_action( this, "Wildfire Bomb", "if=focus+cast_regen<focus.max&!ticking&(full_recharge_time<1.5*gcd|!dot.wildfire_bomb.ticking&!buff.coordinated_assault.up)" );
+  apst -> add_action( this, "Wildfire Bomb", "if=focus+cast_regen<focus.max&!ticking&!buff.memory_of_lucid_dreams.up&(full_recharge_time<1.5*gcd|!dot.wildfire_bomb.ticking&!buff.coordinated_assault.up)" );
   apst -> add_action( this, "Serpent Sting", "if=!dot.serpent_sting.ticking&!buff.coordinated_assault.up" );
   apst -> add_action( this, "Kill Command", "if=focus+cast_regen<focus.max&(buff.mongoose_fury.stack<5|focus<action.mongoose_bite.cost)" );
   apst -> add_action( this, "Serpent Sting", "if=refreshable&!buff.coordinated_assault.up&buff.mongoose_fury.stack<5" );

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -5382,8 +5382,7 @@ void hunter_t::apl_bm()
   cds -> add_action("lights_judgment,if=pet.cat.buff.frenzy.up&pet.cat.buff.frenzy.remains>gcd.max|!pet.cat.buff.frenzy.up");
   cds -> add_action( "potion,if=buff.bestial_wrath.up&buff.aspect_of_the_wild.up&(target.health.pct<35|!talent.killer_instinct.enabled)|target.time_to_die<25" );
  
-  // TODO if=buff.lifeblood.stack<2 when buff is made to always exist
-  cds -> add_action( "worldvein_resonance" );
+  cds -> add_action( "worldvein_resonance,if=buff.lifeblood.stack<4" );
   cds -> add_action( "guardian_of_azeroth" );
   cds -> add_action( "ripple_in_space" );
   cds -> add_action( "memory_of_lucid_dreams" );
@@ -5401,8 +5400,7 @@ void hunter_t::apl_bm()
   st -> add_action( "purifying_blast" );
   st -> add_action( "concentrated_flame" );
   st -> add_action( "blood_of_the_enemy" );
-  // TODO if=buff.reckless_force.up|buff.reckless_force_counter.stack<10 when buff is made to always exist
-  st -> add_action( "the_unbound_force" );
+  st -> add_action( "the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10" );
   st -> add_talent( this, "Barrage" );
   st -> add_action( this, "Cobra Shot", "if=(focus-cost+focus.regen*(cooldown.kill_command.remains-1)>action.kill_command.cost|cooldown.kill_command.remains>1+gcd|buff.memory_of_lucid_dreams.up)&cooldown.kill_command.remains>1" );
   st -> add_talent( this, "Spitting Cobra" );
@@ -5424,8 +5422,7 @@ void hunter_t::apl_bm()
   cleave -> add_action( "purifying_blast" );
   cleave -> add_action( "concentrated_flame" );
   cleave -> add_action( "blood_of_the_enemy" );
-  // TODO if=buff.reckless_force.up|buff.reckless_force_counter.stack<10 when buff is made to always exist
-  cleave -> add_action( "the_unbound_force" );
+  cleave -> add_action( "the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10" );
   cleave -> add_action( this, "Multi-Shot", "if=azerite.rapid_reload.enabled&active_enemies>2");
   cleave -> add_action( this, "Cobra Shot", "if=cooldown.kill_command.remains>focus.time_to_max&(active_enemies<3|!azerite.rapid_reload.enabled)" );
   cleave -> add_talent( this, "Spitting Cobra" );
@@ -5473,8 +5470,7 @@ void hunter_t::apl_mm()
   cds -> add_action( "fireblood,if=buff.trueshot.up&(target.time_to_die>cooldown.fireblood.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<9" );
   cds -> add_action( "lights_judgment" );
 
-  // TODO if=buff.lifeblood.stack<2 when buff is made to always exist
-  cds -> add_action( "worldvein_resonance" );
+  cds -> add_action( "worldvein_resonance,if=buff.lifeblood.stack<4" );
   cds -> add_action( "guardian_of_azeroth,if=cooldown.trueshot.remains<15" );
   cds -> add_action( "ripple_in_space,if=cooldown.trueshot.remains<7" );
   cds -> add_action( "memory_of_lucid_dreams" );
@@ -5495,8 +5491,7 @@ void hunter_t::apl_mm()
   st -> add_action( "purifying_blast" );
   st -> add_action( "concentrated_flame" );
   st -> add_action( "blood_of_the_enemy" );
-  // TODO if=buff.reckless_force.up|buff.reckless_force_counter.stack<10 when buff is made to always exist
-  st -> add_action( "the_unbound_force" );
+  st -> add_action( "the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10" );
   st -> add_action( this, "Arcane Shot", "if=buff.trueshot.down&(buff.precise_shots.up&(focus>41|buff.master_marksman.up)|(focus>50&azerite.focused_fire.enabled|focus>75)&(cooldown.trueshot.remains>5|focus>80)|target.time_to_die<5)" );
   st -> add_action( this, "Steady Shot" );
 
@@ -5511,8 +5506,7 @@ void hunter_t::apl_mm()
   trickshots -> add_action( "purifying_blast" );
   trickshots -> add_action( "concentrated_flame" );
   trickshots -> add_action( "blood_of_the_enemy" );
-  // TODO if=buff.reckless_force.up|buff.reckless_force_counter.stack<10 when buff is made to always exist
-  trickshots -> add_action( "the_unbound_force" );
+  trickshots -> add_action( "the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10" );
   trickshots -> add_talent( this, "Piercing Shot" );
   trickshots -> add_talent( this, "A Murder of Crows" );
   trickshots -> add_talent( this, "Serpent Sting", "if=refreshable&!action.serpent_sting.in_flight" );

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -3122,6 +3122,16 @@ void player_t::create_buffs()
         ->add_invalidate(CACHE_CRIT_CHANCE)
         ->set_default_value( find_spell( 302932 )->effectN( 1 ).percent() );
 
+      buffs.reckless_force_counter = make_buff( this, "reckless_force_counter", find_spell( 302917 ) );
+
+      auto worldvein_resonance = find_azerite_essence( "Worldvein Resonance" );
+      buffs.lifeblood = make_buff<stat_buff_t>( this, "lifeblood", find_spell( 295137 ) );
+      buffs.lifeblood->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
+      buffs.lifeblood->set_duration( find_spell( 295114 )->duration() 
+        * ( 1.0 + worldvein_resonance.spell( 2, essence_spell::UPGRADE, essence_type::MINOR )->effectN( 1 ).percent() ) );
+      buffs.lifeblood->add_stat( convert_hybrid_stat( STAT_STR_AGI_INT ), 
+        worldvein_resonance.spell( 1, essence_type::MINOR )->effectN( 5 ).average( worldvein_resonance.item() ) );
+
       buffs.seething_rage = make_buff( this, "seething_rage", find_spell( 297126 ) )
         ->set_default_value( find_spell( 297126 )->effectN( 1 ).percent() );
 

--- a/engine/simulationcraft.hpp
+++ b/engine/simulationcraft.hpp
@@ -3880,7 +3880,9 @@ struct player_t : public actor_t
     /// 8.2 Azerite Essences
     stat_buff_t* memory_of_lucid_dreams;
     stat_buff_t* lucid_dreams; // Versatility Buff from Rank 3
-    buff_t* reckless_force; // The Unbound Force minor - crit proc when counter hits 20
+    buff_t* reckless_force; // The Unbound Force minor - crit chance
+    buff_t* reckless_force_counter; // The Unbound Force minor - max 20 stack counter
+    stat_buff_t* lifeblood; // Worldvein Resonance - grant primary stat per shard, max 4
     buff_t* seething_rage; // Blood of the Enemy major - 25% crit dam
     stat_buff_t* reality_shift; // Ripple in Space minor - primary stat on moving 25yds
     buff_t* guardian_of_azeroth; // Condensed Life-Force major - R3 stacking haste on pet cast

--- a/profiles/DungeonSlice/DS_Druid_Balance.simc
+++ b/profiles/DungeonSlice/DS_Druid_Balance.simc
@@ -47,10 +47,10 @@ actions+=/lights_judgment,if=buff.ca_inc.up
 actions+=/fireblood,if=buff.ca_inc.up
 actions+=/ancestral_call,if=buff.ca_inc.up
 # CDs
-actions+=/use_item,name=balefire_branch,if=equipped.159630&cooldown.ca_inc.remains>30
-actions+=/use_item,name=dread_gladiators_badge,if=equipped.161902&cooldown.ca_inc.remains>30
-actions+=/use_item,name=azurethos_singed_plumage,if=equipped.161377&cooldown.ca_inc.remains>30
+actions+=/use_item,name=azsharas_font_of_power,if=equipped.169314&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
+actions+=/guardian_of_azeroth,if=(!talent.starlord.enabled|buff.starlord.up)&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_item,name=tidestorm_codex,if=equipped.165576
+actions+=/use_item,name=pocketsized_computation_device,if=equipped.167555&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_items,if=cooldown.ca_inc.remains>30
 actions+=/blood_of_the_enemy,if=cooldown.ca_inc.remains>30
 actions+=/memory_of_lucid_dreams,if=dot.sunfire.remains>10&dot.moonfire.remains>10&(!talent.stellar_flare.enabled|dot.stellar_flare.remains>10)&!buff.ca_inc.up&(astral_power<25|cooldown.ca_inc.remains>30)
@@ -60,7 +60,6 @@ actions+=/concentrated_flame
 actions+=/the_unbound_force,if=buff.reckless_force.up|time<5
 actions+=/worldvein_resonance
 actions+=/focused_azerite_beam
-actions+=/guardian_of_azeroth,if=!talent.starlord.enabled|buff.starlord.up
 actions+=/thorns
 actions+=/warrior_of_elune
 actions+=/innervate,if=azerite.lively_spirit.enabled&(cooldown.incarnation.remains<2|cooldown.celestial_alignment.remains<12)

--- a/profiles/DungeonSlice/DS_Hunter_Beast_Mastery.simc
+++ b/profiles/DungeonSlice/DS_Hunter_Beast_Mastery.simc
@@ -48,7 +48,7 @@ actions.cds+=/berserking,if=buff.aspect_of_the_wild.up&(target.time_to_die>coold
 actions.cds+=/blood_fury,if=buff.aspect_of_the_wild.up&(target.time_to_die>cooldown.blood_fury.duration+duration|(target.health.pct<35|!talent.killer_instinct.enabled))|target.time_to_die<16
 actions.cds+=/lights_judgment,if=pet.cat.buff.frenzy.up&pet.cat.buff.frenzy.remains>gcd.max|!pet.cat.buff.frenzy.up
 actions.cds+=/potion,if=buff.bestial_wrath.up&buff.aspect_of_the_wild.up&(target.health.pct<35|!talent.killer_instinct.enabled)|target.time_to_die<25
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth
 actions.cds+=/ripple_in_space
 actions.cds+=/memory_of_lucid_dreams
@@ -69,7 +69,7 @@ actions.cleave+=/focused_azerite_beam
 actions.cleave+=/purifying_blast
 actions.cleave+=/concentrated_flame
 actions.cleave+=/blood_of_the_enemy
-actions.cleave+=/the_unbound_force
+actions.cleave+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.cleave+=/multishot,if=azerite.rapid_reload.enabled&active_enemies>2
 actions.cleave+=/cobra_shot,if=cooldown.kill_command.remains>focus.time_to_max&(active_enemies<3|!azerite.rapid_reload.enabled)
 actions.cleave+=/spitting_cobra
@@ -87,7 +87,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/barrage
 actions.st+=/cobra_shot,if=(focus-cost+focus.regen*(cooldown.kill_command.remains-1)>action.kill_command.cost|cooldown.kill_command.remains>1+gcd|buff.memory_of_lucid_dreams.up)&cooldown.kill_command.remains>1
 actions.st+=/spitting_cobra

--- a/profiles/DungeonSlice/DS_Hunter_Marksmanship.simc
+++ b/profiles/DungeonSlice/DS_Hunter_Marksmanship.simc
@@ -51,7 +51,7 @@ actions.cds+=/blood_fury,if=buff.trueshot.up&(target.time_to_die>cooldown.blood_
 actions.cds+=/ancestral_call,if=buff.trueshot.up&(target.time_to_die>cooldown.ancestral_call.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<16
 actions.cds+=/fireblood,if=buff.trueshot.up&(target.time_to_die>cooldown.fireblood.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<9
 actions.cds+=/lights_judgment
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth,if=cooldown.trueshot.remains<15
 actions.cds+=/ripple_in_space,if=cooldown.trueshot.remains<7
 actions.cds+=/memory_of_lucid_dreams
@@ -71,7 +71,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/arcane_shot,if=buff.trueshot.down&(buff.precise_shots.up&(focus>41|buff.master_marksman.up)|(focus>50&azerite.focused_fire.enabled|focus>75)&(cooldown.trueshot.remains>5|focus>80)|target.time_to_die<5)
 actions.st+=/steady_shot
 
@@ -86,7 +86,7 @@ actions.trickshots+=/focused_azerite_beam
 actions.trickshots+=/purifying_blast
 actions.trickshots+=/concentrated_flame
 actions.trickshots+=/blood_of_the_enemy
-actions.trickshots+=/the_unbound_force
+actions.trickshots+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.trickshots+=/piercing_shot
 actions.trickshots+=/a_murder_of_crows
 actions.trickshots+=/serpent_sting,if=refreshable&!action.serpent_sting.in_flight

--- a/profiles/PreRaids/PR_Druid_Balance.simc
+++ b/profiles/PreRaids/PR_Druid_Balance.simc
@@ -47,10 +47,10 @@ actions+=/lights_judgment,if=buff.ca_inc.up
 actions+=/fireblood,if=buff.ca_inc.up
 actions+=/ancestral_call,if=buff.ca_inc.up
 # CDs
-actions+=/use_item,name=balefire_branch,if=equipped.159630&cooldown.ca_inc.remains>30
-actions+=/use_item,name=dread_gladiators_badge,if=equipped.161902&cooldown.ca_inc.remains>30
-actions+=/use_item,name=azurethos_singed_plumage,if=equipped.161377&cooldown.ca_inc.remains>30
+actions+=/use_item,name=azsharas_font_of_power,if=equipped.169314&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
+actions+=/guardian_of_azeroth,if=(!talent.starlord.enabled|buff.starlord.up)&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_item,name=tidestorm_codex,if=equipped.165576
+actions+=/use_item,name=pocketsized_computation_device,if=equipped.167555&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_items,if=cooldown.ca_inc.remains>30
 actions+=/blood_of_the_enemy,if=cooldown.ca_inc.remains>30
 actions+=/memory_of_lucid_dreams,if=dot.sunfire.remains>10&dot.moonfire.remains>10&(!talent.stellar_flare.enabled|dot.stellar_flare.remains>10)&!buff.ca_inc.up&(astral_power<25|cooldown.ca_inc.remains>30)
@@ -60,7 +60,6 @@ actions+=/concentrated_flame
 actions+=/the_unbound_force,if=buff.reckless_force.up|time<5
 actions+=/worldvein_resonance
 actions+=/focused_azerite_beam
-actions+=/guardian_of_azeroth,if=!talent.starlord.enabled|buff.starlord.up
 actions+=/thorns
 actions+=/warrior_of_elune
 actions+=/innervate,if=azerite.lively_spirit.enabled&(cooldown.incarnation.remains<2|cooldown.celestial_alignment.remains<12)

--- a/profiles/PreRaids/PR_Hunter_Beast_Mastery.simc
+++ b/profiles/PreRaids/PR_Hunter_Beast_Mastery.simc
@@ -48,7 +48,7 @@ actions.cds+=/berserking,if=buff.aspect_of_the_wild.up&(target.time_to_die>coold
 actions.cds+=/blood_fury,if=buff.aspect_of_the_wild.up&(target.time_to_die>cooldown.blood_fury.duration+duration|(target.health.pct<35|!talent.killer_instinct.enabled))|target.time_to_die<16
 actions.cds+=/lights_judgment,if=pet.cat.buff.frenzy.up&pet.cat.buff.frenzy.remains>gcd.max|!pet.cat.buff.frenzy.up
 actions.cds+=/potion,if=buff.bestial_wrath.up&buff.aspect_of_the_wild.up&(target.health.pct<35|!talent.killer_instinct.enabled)|target.time_to_die<25
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth
 actions.cds+=/ripple_in_space
 actions.cds+=/memory_of_lucid_dreams
@@ -69,7 +69,7 @@ actions.cleave+=/focused_azerite_beam
 actions.cleave+=/purifying_blast
 actions.cleave+=/concentrated_flame
 actions.cleave+=/blood_of_the_enemy
-actions.cleave+=/the_unbound_force
+actions.cleave+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.cleave+=/multishot,if=azerite.rapid_reload.enabled&active_enemies>2
 actions.cleave+=/cobra_shot,if=cooldown.kill_command.remains>focus.time_to_max&(active_enemies<3|!azerite.rapid_reload.enabled)
 actions.cleave+=/spitting_cobra
@@ -87,7 +87,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/barrage
 actions.st+=/cobra_shot,if=(focus-cost+focus.regen*(cooldown.kill_command.remains-1)>action.kill_command.cost|cooldown.kill_command.remains>1+gcd|buff.memory_of_lucid_dreams.up)&cooldown.kill_command.remains>1
 actions.st+=/spitting_cobra

--- a/profiles/PreRaids/PR_Hunter_Marksmanship.simc
+++ b/profiles/PreRaids/PR_Hunter_Marksmanship.simc
@@ -51,7 +51,7 @@ actions.cds+=/blood_fury,if=buff.trueshot.up&(target.time_to_die>cooldown.blood_
 actions.cds+=/ancestral_call,if=buff.trueshot.up&(target.time_to_die>cooldown.ancestral_call.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<16
 actions.cds+=/fireblood,if=buff.trueshot.up&(target.time_to_die>cooldown.fireblood.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<9
 actions.cds+=/lights_judgment
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth,if=cooldown.trueshot.remains<15
 actions.cds+=/ripple_in_space,if=cooldown.trueshot.remains<7
 actions.cds+=/memory_of_lucid_dreams
@@ -71,7 +71,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/arcane_shot,if=buff.trueshot.down&(buff.precise_shots.up&(focus>41|buff.master_marksman.up)|(focus>50&azerite.focused_fire.enabled|focus>75)&(cooldown.trueshot.remains>5|focus>80)|target.time_to_die<5)
 actions.st+=/steady_shot
 
@@ -86,7 +86,7 @@ actions.trickshots+=/focused_azerite_beam
 actions.trickshots+=/purifying_blast
 actions.trickshots+=/concentrated_flame
 actions.trickshots+=/blood_of_the_enemy
-actions.trickshots+=/the_unbound_force
+actions.trickshots+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.trickshots+=/piercing_shot
 actions.trickshots+=/a_murder_of_crows
 actions.trickshots+=/serpent_sting,if=refreshable&!action.serpent_sting.in_flight

--- a/profiles/Tier22/T22_Druid_Balance.simc
+++ b/profiles/Tier22/T22_Druid_Balance.simc
@@ -47,10 +47,10 @@ actions+=/lights_judgment,if=buff.ca_inc.up
 actions+=/fireblood,if=buff.ca_inc.up
 actions+=/ancestral_call,if=buff.ca_inc.up
 # CDs
-actions+=/use_item,name=balefire_branch,if=equipped.159630&cooldown.ca_inc.remains>30
-actions+=/use_item,name=dread_gladiators_badge,if=equipped.161902&cooldown.ca_inc.remains>30
-actions+=/use_item,name=azurethos_singed_plumage,if=equipped.161377&cooldown.ca_inc.remains>30
+actions+=/use_item,name=azsharas_font_of_power,if=equipped.169314&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
+actions+=/guardian_of_azeroth,if=(!talent.starlord.enabled|buff.starlord.up)&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_item,name=tidestorm_codex,if=equipped.165576
+actions+=/use_item,name=pocketsized_computation_device,if=equipped.167555&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_items,if=cooldown.ca_inc.remains>30
 actions+=/blood_of_the_enemy,if=cooldown.ca_inc.remains>30
 actions+=/memory_of_lucid_dreams,if=dot.sunfire.remains>10&dot.moonfire.remains>10&(!talent.stellar_flare.enabled|dot.stellar_flare.remains>10)&!buff.ca_inc.up&(astral_power<25|cooldown.ca_inc.remains>30)
@@ -60,7 +60,6 @@ actions+=/concentrated_flame
 actions+=/the_unbound_force,if=buff.reckless_force.up|time<5
 actions+=/worldvein_resonance
 actions+=/focused_azerite_beam
-actions+=/guardian_of_azeroth,if=!talent.starlord.enabled|buff.starlord.up
 actions+=/thorns
 actions+=/warrior_of_elune
 actions+=/innervate,if=azerite.lively_spirit.enabled&(cooldown.incarnation.remains<2|cooldown.celestial_alignment.remains<12)

--- a/profiles/Tier22/T22_Hunter_Beast_Mastery.simc
+++ b/profiles/Tier22/T22_Hunter_Beast_Mastery.simc
@@ -48,7 +48,7 @@ actions.cds+=/berserking,if=buff.aspect_of_the_wild.up&(target.time_to_die>coold
 actions.cds+=/blood_fury,if=buff.aspect_of_the_wild.up&(target.time_to_die>cooldown.blood_fury.duration+duration|(target.health.pct<35|!talent.killer_instinct.enabled))|target.time_to_die<16
 actions.cds+=/lights_judgment,if=pet.cat.buff.frenzy.up&pet.cat.buff.frenzy.remains>gcd.max|!pet.cat.buff.frenzy.up
 actions.cds+=/potion,if=buff.bestial_wrath.up&buff.aspect_of_the_wild.up&(target.health.pct<35|!talent.killer_instinct.enabled)|target.time_to_die<25
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth
 actions.cds+=/ripple_in_space
 actions.cds+=/memory_of_lucid_dreams
@@ -69,7 +69,7 @@ actions.cleave+=/focused_azerite_beam
 actions.cleave+=/purifying_blast
 actions.cleave+=/concentrated_flame
 actions.cleave+=/blood_of_the_enemy
-actions.cleave+=/the_unbound_force
+actions.cleave+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.cleave+=/multishot,if=azerite.rapid_reload.enabled&active_enemies>2
 actions.cleave+=/cobra_shot,if=cooldown.kill_command.remains>focus.time_to_max&(active_enemies<3|!azerite.rapid_reload.enabled)
 actions.cleave+=/spitting_cobra
@@ -87,7 +87,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/barrage
 actions.st+=/cobra_shot,if=(focus-cost+focus.regen*(cooldown.kill_command.remains-1)>action.kill_command.cost|cooldown.kill_command.remains>1+gcd|buff.memory_of_lucid_dreams.up)&cooldown.kill_command.remains>1
 actions.st+=/spitting_cobra

--- a/profiles/Tier22/T22_Hunter_Marksmanship.simc
+++ b/profiles/Tier22/T22_Hunter_Marksmanship.simc
@@ -50,7 +50,7 @@ actions.cds+=/blood_fury,if=buff.trueshot.up&(target.time_to_die>cooldown.blood_
 actions.cds+=/ancestral_call,if=buff.trueshot.up&(target.time_to_die>cooldown.ancestral_call.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<16
 actions.cds+=/fireblood,if=buff.trueshot.up&(target.time_to_die>cooldown.fireblood.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<9
 actions.cds+=/lights_judgment
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth,if=cooldown.trueshot.remains<15
 actions.cds+=/ripple_in_space,if=cooldown.trueshot.remains<7
 actions.cds+=/memory_of_lucid_dreams
@@ -70,7 +70,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/arcane_shot,if=buff.trueshot.down&(buff.precise_shots.up&(focus>41|buff.master_marksman.up)|(focus>50&azerite.focused_fire.enabled|focus>75)&(cooldown.trueshot.remains>5|focus>80)|target.time_to_die<5)
 actions.st+=/steady_shot
 
@@ -85,7 +85,7 @@ actions.trickshots+=/focused_azerite_beam
 actions.trickshots+=/purifying_blast
 actions.trickshots+=/concentrated_flame
 actions.trickshots+=/blood_of_the_enemy
-actions.trickshots+=/the_unbound_force
+actions.trickshots+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.trickshots+=/piercing_shot
 actions.trickshots+=/a_murder_of_crows
 actions.trickshots+=/serpent_sting,if=refreshable&!action.serpent_sting.in_flight

--- a/profiles/Tier23/T23_Druid_Balance.simc
+++ b/profiles/Tier23/T23_Druid_Balance.simc
@@ -47,10 +47,10 @@ actions+=/lights_judgment,if=buff.ca_inc.up
 actions+=/fireblood,if=buff.ca_inc.up
 actions+=/ancestral_call,if=buff.ca_inc.up
 # CDs
-actions+=/use_item,name=balefire_branch,if=equipped.159630&cooldown.ca_inc.remains>30
-actions+=/use_item,name=dread_gladiators_badge,if=equipped.161902&cooldown.ca_inc.remains>30
-actions+=/use_item,name=azurethos_singed_plumage,if=equipped.161377&cooldown.ca_inc.remains>30
+actions+=/use_item,name=azsharas_font_of_power,if=equipped.169314&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
+actions+=/guardian_of_azeroth,if=(!talent.starlord.enabled|buff.starlord.up)&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_item,name=tidestorm_codex,if=equipped.165576
+actions+=/use_item,name=pocketsized_computation_device,if=equipped.167555&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_items,if=cooldown.ca_inc.remains>30
 actions+=/blood_of_the_enemy,if=cooldown.ca_inc.remains>30
 actions+=/memory_of_lucid_dreams,if=dot.sunfire.remains>10&dot.moonfire.remains>10&(!talent.stellar_flare.enabled|dot.stellar_flare.remains>10)&!buff.ca_inc.up&(astral_power<25|cooldown.ca_inc.remains>30)
@@ -60,7 +60,6 @@ actions+=/concentrated_flame
 actions+=/the_unbound_force,if=buff.reckless_force.up|time<5
 actions+=/worldvein_resonance
 actions+=/focused_azerite_beam
-actions+=/guardian_of_azeroth,if=!talent.starlord.enabled|buff.starlord.up
 actions+=/thorns
 actions+=/warrior_of_elune
 actions+=/innervate,if=azerite.lively_spirit.enabled&(cooldown.incarnation.remains<2|cooldown.celestial_alignment.remains<12)

--- a/profiles/Tier23/T23_Hunter_Beast_Mastery.simc
+++ b/profiles/Tier23/T23_Hunter_Beast_Mastery.simc
@@ -48,7 +48,7 @@ actions.cds+=/berserking,if=buff.aspect_of_the_wild.up&(target.time_to_die>coold
 actions.cds+=/blood_fury,if=buff.aspect_of_the_wild.up&(target.time_to_die>cooldown.blood_fury.duration+duration|(target.health.pct<35|!talent.killer_instinct.enabled))|target.time_to_die<16
 actions.cds+=/lights_judgment,if=pet.cat.buff.frenzy.up&pet.cat.buff.frenzy.remains>gcd.max|!pet.cat.buff.frenzy.up
 actions.cds+=/potion,if=buff.bestial_wrath.up&buff.aspect_of_the_wild.up&(target.health.pct<35|!talent.killer_instinct.enabled)|target.time_to_die<25
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth
 actions.cds+=/ripple_in_space
 actions.cds+=/memory_of_lucid_dreams
@@ -69,7 +69,7 @@ actions.cleave+=/focused_azerite_beam
 actions.cleave+=/purifying_blast
 actions.cleave+=/concentrated_flame
 actions.cleave+=/blood_of_the_enemy
-actions.cleave+=/the_unbound_force
+actions.cleave+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.cleave+=/multishot,if=azerite.rapid_reload.enabled&active_enemies>2
 actions.cleave+=/cobra_shot,if=cooldown.kill_command.remains>focus.time_to_max&(active_enemies<3|!azerite.rapid_reload.enabled)
 actions.cleave+=/spitting_cobra
@@ -87,7 +87,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/barrage
 actions.st+=/cobra_shot,if=(focus-cost+focus.regen*(cooldown.kill_command.remains-1)>action.kill_command.cost|cooldown.kill_command.remains>1+gcd|buff.memory_of_lucid_dreams.up)&cooldown.kill_command.remains>1
 actions.st+=/spitting_cobra

--- a/profiles/Tier23/T23_Hunter_Marksmanship.simc
+++ b/profiles/Tier23/T23_Hunter_Marksmanship.simc
@@ -51,7 +51,7 @@ actions.cds+=/blood_fury,if=buff.trueshot.up&(target.time_to_die>cooldown.blood_
 actions.cds+=/ancestral_call,if=buff.trueshot.up&(target.time_to_die>cooldown.ancestral_call.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<16
 actions.cds+=/fireblood,if=buff.trueshot.up&(target.time_to_die>cooldown.fireblood.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<9
 actions.cds+=/lights_judgment
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth,if=cooldown.trueshot.remains<15
 actions.cds+=/ripple_in_space,if=cooldown.trueshot.remains<7
 actions.cds+=/memory_of_lucid_dreams
@@ -71,7 +71,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/arcane_shot,if=buff.trueshot.down&(buff.precise_shots.up&(focus>41|buff.master_marksman.up)|(focus>50&azerite.focused_fire.enabled|focus>75)&(cooldown.trueshot.remains>5|focus>80)|target.time_to_die<5)
 actions.st+=/steady_shot
 
@@ -86,7 +86,7 @@ actions.trickshots+=/focused_azerite_beam
 actions.trickshots+=/purifying_blast
 actions.trickshots+=/concentrated_flame
 actions.trickshots+=/blood_of_the_enemy
-actions.trickshots+=/the_unbound_force
+actions.trickshots+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.trickshots+=/piercing_shot
 actions.trickshots+=/a_murder_of_crows
 actions.trickshots+=/serpent_sting,if=refreshable&!action.serpent_sting.in_flight

--- a/profiles/Tier24/T24_Druid_Balance.simc
+++ b/profiles/Tier24/T24_Druid_Balance.simc
@@ -47,10 +47,10 @@ actions+=/lights_judgment,if=buff.ca_inc.up
 actions+=/fireblood,if=buff.ca_inc.up
 actions+=/ancestral_call,if=buff.ca_inc.up
 # CDs
-actions+=/use_item,name=balefire_branch,if=equipped.159630&cooldown.ca_inc.remains>30
-actions+=/use_item,name=dread_gladiators_badge,if=equipped.161902&cooldown.ca_inc.remains>30
-actions+=/use_item,name=azurethos_singed_plumage,if=equipped.161377&cooldown.ca_inc.remains>30
+actions+=/use_item,name=azsharas_font_of_power,if=equipped.169314&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
+actions+=/guardian_of_azeroth,if=(!talent.starlord.enabled|buff.starlord.up)&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_item,name=tidestorm_codex,if=equipped.165576
+actions+=/use_item,name=pocketsized_computation_device,if=equipped.167555&dot.moonfire.ticking&dot.sunfire.ticking&(!talent.stellar_flare.enabled|dot.stellar_flare.ticking)
 actions+=/use_items,if=cooldown.ca_inc.remains>30
 actions+=/blood_of_the_enemy,if=cooldown.ca_inc.remains>30
 actions+=/memory_of_lucid_dreams,if=dot.sunfire.remains>10&dot.moonfire.remains>10&(!talent.stellar_flare.enabled|dot.stellar_flare.remains>10)&!buff.ca_inc.up&(astral_power<25|cooldown.ca_inc.remains>30)
@@ -60,7 +60,6 @@ actions+=/concentrated_flame
 actions+=/the_unbound_force,if=buff.reckless_force.up|time<5
 actions+=/worldvein_resonance
 actions+=/focused_azerite_beam
-actions+=/guardian_of_azeroth,if=!talent.starlord.enabled|buff.starlord.up
 actions+=/thorns
 actions+=/warrior_of_elune
 actions+=/innervate,if=azerite.lively_spirit.enabled&(cooldown.incarnation.remains<2|cooldown.celestial_alignment.remains<12)

--- a/profiles/Tier24/T24_Hunter_Beast_Mastery.simc
+++ b/profiles/Tier24/T24_Hunter_Beast_Mastery.simc
@@ -48,7 +48,7 @@ actions.cds+=/berserking,if=buff.aspect_of_the_wild.up&(target.time_to_die>coold
 actions.cds+=/blood_fury,if=buff.aspect_of_the_wild.up&(target.time_to_die>cooldown.blood_fury.duration+duration|(target.health.pct<35|!talent.killer_instinct.enabled))|target.time_to_die<16
 actions.cds+=/lights_judgment,if=pet.cat.buff.frenzy.up&pet.cat.buff.frenzy.remains>gcd.max|!pet.cat.buff.frenzy.up
 actions.cds+=/potion,if=buff.bestial_wrath.up&buff.aspect_of_the_wild.up&(target.health.pct<35|!talent.killer_instinct.enabled)|target.time_to_die<25
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth
 actions.cds+=/ripple_in_space
 actions.cds+=/memory_of_lucid_dreams
@@ -69,7 +69,7 @@ actions.cleave+=/focused_azerite_beam
 actions.cleave+=/purifying_blast
 actions.cleave+=/concentrated_flame
 actions.cleave+=/blood_of_the_enemy
-actions.cleave+=/the_unbound_force
+actions.cleave+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.cleave+=/multishot,if=azerite.rapid_reload.enabled&active_enemies>2
 actions.cleave+=/cobra_shot,if=cooldown.kill_command.remains>focus.time_to_max&(active_enemies<3|!azerite.rapid_reload.enabled)
 actions.cleave+=/spitting_cobra
@@ -87,7 +87,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/barrage
 actions.st+=/cobra_shot,if=(focus-cost+focus.regen*(cooldown.kill_command.remains-1)>action.kill_command.cost|cooldown.kill_command.remains>1+gcd|buff.memory_of_lucid_dreams.up)&cooldown.kill_command.remains>1
 actions.st+=/spitting_cobra

--- a/profiles/Tier24/T24_Hunter_Marksmanship.simc
+++ b/profiles/Tier24/T24_Hunter_Marksmanship.simc
@@ -51,7 +51,7 @@ actions.cds+=/blood_fury,if=buff.trueshot.up&(target.time_to_die>cooldown.blood_
 actions.cds+=/ancestral_call,if=buff.trueshot.up&(target.time_to_die>cooldown.ancestral_call.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<16
 actions.cds+=/fireblood,if=buff.trueshot.up&(target.time_to_die>cooldown.fireblood.duration+duration|(target.health.pct<20|!talent.careful_aim.enabled))|target.time_to_die<9
 actions.cds+=/lights_judgment
-actions.cds+=/worldvein_resonance
+actions.cds+=/worldvein_resonance,if=buff.lifeblood.stack<4
 actions.cds+=/guardian_of_azeroth,if=cooldown.trueshot.remains<15
 actions.cds+=/ripple_in_space,if=cooldown.trueshot.remains<7
 actions.cds+=/memory_of_lucid_dreams
@@ -71,7 +71,7 @@ actions.st+=/focused_azerite_beam
 actions.st+=/purifying_blast
 actions.st+=/concentrated_flame
 actions.st+=/blood_of_the_enemy
-actions.st+=/the_unbound_force
+actions.st+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.st+=/arcane_shot,if=buff.trueshot.down&(buff.precise_shots.up&(focus>41|buff.master_marksman.up)|(focus>50&azerite.focused_fire.enabled|focus>75)&(cooldown.trueshot.remains>5|focus>80)|target.time_to_die<5)
 actions.st+=/steady_shot
 
@@ -86,7 +86,7 @@ actions.trickshots+=/focused_azerite_beam
 actions.trickshots+=/purifying_blast
 actions.trickshots+=/concentrated_flame
 actions.trickshots+=/blood_of_the_enemy
-actions.trickshots+=/the_unbound_force
+actions.trickshots+=/the_unbound_force,if=buff.reckless_force.up|buff.reckless_force_counter.stack<10
 actions.trickshots+=/piercing_shot
 actions.trickshots+=/a_murder_of_crows
 actions.trickshots+=/serpent_sting,if=refreshable&!action.serpent_sting.in_flight


### PR DESCRIPTION
The top level action use_items has two sublevels of actions, use_item_[item name] and the execute_action from the on-use special_effect. As only the top level use_items is a foreground action, any cast time from the on-use effect will not apply to the actor. The changes here pull the cast time from the on-use action during ready() and execute_time() is adjusted accordingly