### PR TITLE
Adjust use_items to give it a cast time when the on-use has one

### DIFF
--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -8417,6 +8417,22 @@ struct use_items_t : public action_t
     return RESULT_HIT;
   }
 
+  timespan_t execute_time() const override
+  {
+    timespan_t et = action_t::execute_time();
+
+    for ( auto action : use_actions )
+    {
+      if ( action->ready() && action->action )
+      {
+        et += action->action->base_execute_time * action->action->composite_haste();
+        break;
+      }
+    }
+
+    return et;
+  }
+
   void execute() override
   {
     // Execute first ready sub-action. Note that technically an on-use action can go "unavailable"

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -8291,7 +8291,7 @@ struct use_item_t : public action_t
     if ( triggered && action && ( !buff || buff->check() == buff->max_stack() ) )
     {
       action->target = target;
-      action->schedule_execute();
+      action->execute();
 
       // Decide whether to expire the buff even with 1 max stack
       if ( buff && buff->max_stack() > 1 )
@@ -8425,7 +8425,7 @@ struct use_items_t : public action_t
     {
       if ( action->ready() && action->action )
       {
-        et += action->action->base_execute_time * action->action->composite_haste();
+        et += action->action->execute_time();
         break;
       }
     }

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -8282,6 +8282,11 @@ struct use_item_t : public action_t
     }
   }
 
+  timespan_t execute_time() const override
+  {
+    return action ? action->execute_time() : action_t::execute_time();
+  }
+
   void execute() override
   {
     bool triggered = buff == 0;

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -8424,18 +8424,15 @@ struct use_items_t : public action_t
 
   timespan_t execute_time() const override
   {
-    timespan_t et = action_t::execute_time();
-
     for ( auto action : use_actions )
     {
       if ( action->ready() && action->action )
       {
-        et += action->action->execute_time();
-        break;
+        return action->action->execute_time();
       }
     }
 
-    return et;
+    return action_t::execute_time();
   }
 
   void execute() override


### PR DESCRIPTION
The top level action use_items has two sublevels of background action, use_item_<item name> and the execute_action from the on-use special_effect. As only the topl level use_items is a foreground action, any cast time from the on-use effect will not apply to the actor. The changes here pull the cast time from the on-use action during ready() and execute_time() is adjusted accordingly