### PR TITLE
 [Marksmanship] Fix Computation Device in APL

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -5455,9 +5455,9 @@ void hunter_t::apl_mm()
   default_list -> add_action( special_use_item_action( "azsharas_font_of_power", "if=cooldown.trueshot.remains_guess<15|target.time_to_die<30" ) );
   default_list -> add_action( special_use_item_action( "lustrous_golden_plumage", "if=cooldown.trueshot.remains_guess<5|target.time_to_die<20" ) );
   default_list -> add_action( special_use_item_action( "galecallers_boon", "if=buff.trueshot.up|!talent.calling_the_shots.enabled|target.time_to_die<10" ) );
-  default_list -> add_action( special_use_item_action( "pocketsized_computation_device", "if=!buff.trueshot.up|target.time_to_die<5" ) );
   default_list -> add_action( special_use_item_action( "ashvanes_razor_coral", "if=buff.trueshot.up&ca_execute|debuff.razor_coral_debuff.down|target.time_to_die<20" ) );
 
+  default_list -> add_action( "use_item,name=pocketsized_computation_device,if=!buff.trueshot.up|target.time_to_die<5",
   default_list -> add_action( "use_items,if=buff.trueshot.up|!talent.calling_the_shots.enabled|target.time_to_die<20",
 	  "Try to line up activated trinkets with Trueshot" );
   default_list -> add_action( "call_action_list,name=cds" );

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -5457,7 +5457,7 @@ void hunter_t::apl_mm()
   default_list -> add_action( special_use_item_action( "galecallers_boon", "if=buff.trueshot.up|!talent.calling_the_shots.enabled|target.time_to_die<10" ) );
   default_list -> add_action( special_use_item_action( "ashvanes_razor_coral", "if=buff.trueshot.up&ca_execute|debuff.razor_coral_debuff.down|target.time_to_die<20" ) );
 
-  default_list -> add_action( "use_item,name=pocketsized_computation_device,if=!buff.trueshot.up|target.time_to_die<5",
+  default_list -> add_action( "use_item,name=pocketsized_computation_device,if=!buff.trueshot.up|target.time_to_die<5" );
   default_list -> add_action( "use_items,if=buff.trueshot.up|!talent.calling_the_shots.enabled|target.time_to_die<20",
 	  "Try to line up activated trinkets with Trueshot" );
   default_list -> add_action( "call_action_list,name=cds" );


### PR DESCRIPTION
Put the pocketsized computation device in the general APL because special_use_item_action of the hunter module doesn't support Punchcards.