### PR TITLE
Update outdated catweaving conditions

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -8756,7 +8756,7 @@ void druid_t::apl_guardian()
     default_list -> add_action( this, "Rake", "if=buff.prowl.up&buff.cat_form.up" );
     default_list -> add_action( "auto_attack" );
     default_list -> add_action( "call_action_list,name=cooldowns" );
-    default_list -> add_action( "call_action_list,name=cat,if=talent.feral_affinity.enabled&((cooldown.thrash_bear.remains>0&cooldown.mangle.remains>0&rage<45&buff.incarnation.down&buff.galactic_guardian.down)|(buff.cat_form.up&energy>20)|(dot.rip.ticking&dot.rip.remains<3&target.health.pct<25))" );
+    default_list -> add_action( "call_action_list,name=cat,if=talent.feral_affinity.enabled&((cooldown.thrash_bear.remains>0&cooldown.mangle.remains>0&rage<40&buff.incarnation.down&buff.galactic_guardian.down)|(buff.cat_form.up&energy>20))" );
     default_list -> add_action( "call_action_list,name=bear" );
 
     bear -> add_action( this, "Bear Form" );
@@ -8775,7 +8775,7 @@ void druid_t::apl_guardian()
 
     cat -> add_action( this, "Cat Form" );
     cat -> add_action( "rip,if=dot.rip.refreshable&combo_points=5" );
-    cat -> add_action( "ferocious_bite,if=combo_points=5" );
+    cat -> add_action( "ferocious_bite,if=(combo_points=5&energy>=50)" );
     cat -> add_action( "rake,if=dot.rake.refreshable&combo_points<5" );
     cat -> add_action( this, "Shred" );
   } else {


### PR DESCRIPTION
Updated rage threshold to leave bear form from 45 to 40 to reflect the current cost of maul.
Removed conditions related to refreshing Rip with Ferocious Bite as that no longer works.
Changed Ferocious Bite condition to wait for 50 energy.