### PR TITLE
#2775 - updated mistweaver flask for patch 8.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ addons:
       - libcurl3
       - libcurl4-gnutls-dev
 
+osx_image:
+  - xcode8.3
+  - xcode10
+
 #env:
   # Each line is a separate build in the build matrix. A build in the build
   # matrix is defined by the environment variables defined on the line, which

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ matrix:
 
 before_install:
   # Install bats on OSX through brew
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew install bats; fi
+  # retry via travis_retry because brew sometimes hangs
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then travis_retry brew update && travis_retry brew install bats; fi
 
 notifications:
   irc:

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -586,7 +586,7 @@ public:
   void combat_begin() override;
   demon_hunter_td_t* get_target_data( player_t* target ) const override;
   void interrupt() override;
-  double resource_gain( resource_e, double, gain_t* g = nullptr, action_t* a = nullptr );
+  double resource_gain( resource_e, double, gain_t* g = nullptr, action_t* a = nullptr ) override;
   void recalculate_resource_max( resource_e ) override;
   void reset() override;
   void merge( player_t& other ) override;

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -9500,7 +9500,9 @@ std::string monk_t::default_flask() const
         return "disabled";
       break;
     case MONK_MISTWEAVER:
-      if ( true_level > 110 )
+      if ( true_level > 119 )
+        return "greater_flask_of_endless_fathoms"; // lvl 120 should use best flask
+      else if ( true_level > 110 )
         return "endless_fathoms";
       else if ( true_level > 100 )
         return "whispered_pact";

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -7113,11 +7113,6 @@ void rogue_t::init_special_effects()
         options.memory_of_lucid_dreams_proc_chance = 0.15;
         break;
     }
-    default:
-    {
-      // 2019-09-09  - do nothing if non-rouge spec is given. junk in = junk out.
-      break;
-    }
   }
 }
 
@@ -7484,11 +7479,6 @@ void rogue_t::vision_of_perfection_proc()
       {
         this->buffs.adrenaline_rush->trigger( 1, buff_t::DEFAULT_VALUE(), -1.0, duration );
       }
-      break;
-    }
-    default:
-    {
-      // 2019-09-09  - do nothing if non-rouge spec is given. junk in = junk out.
       break;
     }
   }

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -7113,6 +7113,11 @@ void rogue_t::init_special_effects()
         options.memory_of_lucid_dreams_proc_chance = 0.15;
         break;
     }
+    default:
+    {
+      // 2019-09-09  - do nothing if non-rouge spec is given. junk in = junk out.
+      break;
+    }
   }
 }
 
@@ -7479,6 +7484,11 @@ void rogue_t::vision_of_perfection_proc()
       {
         this->buffs.adrenaline_rush->trigger( 1, buff_t::DEFAULT_VALUE(), -1.0, duration );
       }
+      break;
+    }
+    default:
+    {
+      // 2019-09-09  - do nothing if non-rouge spec is given. junk in = junk out.
       break;
     }
   }


### PR DESCRIPTION
- update to simulationcraft/simc#2775
 - [x] level 120 mist-weaver monks should use best flask (greater endless fathoms vs endless fathoms