### PR TITLE
Improve Razor Coral Usage for Blood APL

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7596,6 +7596,7 @@ void death_knight_t::default_apl_blood()
   def -> add_action( "use_items,if=cooldown.dancing_rune_weapon.remains>90" );
   def -> add_action( "use_item,name=razdunks_big_red_button" );
   def -> add_action( "use_item,name=merekthas_fang" );
+  def -> add_action( "use_item,name=ashvanes_razor_coral,if=debuff.razor_coral_debuff.down|buff.dancing_rune_weapon.up&debuff.razor_coral_debuff.up );
 
   // Cooldowns
   def -> add_action( "potion,if=buff.dancing_rune_weapon.up" );


### PR DESCRIPTION
This change attempts to use the Razor Coral trinket more intelligently, so it lines up with Dancing Rune Weapon. Might have unintended consequences with other on-use trinkets, especially ones you might try to use at the same time (IE ones that give more stats). Should be compatible with stat sticks or other trinkets that you use simply for damage.

Can see DPS improvements on a specific death knight setup here:
https://www.raidbots.com/simbot/report/j7pnwiRNDGcZr7PZceM6LL