### PR TITLE
DEATH KNIGHT: updated T24 feast

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7534,7 +7534,7 @@ std::string death_knight_t::default_food() const
                             ( true_level >= 80 ) ? "seafood_magnifique_feast" :
                             "disabled";
 
-  std::string blood_food =  ( true_level > 110 ) ? "famine_evaluator_and_snack_table" :
+  std::string blood_food =  ( true_level > 110 ) ? "mechdowels_big_mech" :
 	                    ( true_level > 100 ) ? "lavish_suramar_feast" :
                             ( true_level >  90 ) ? "pickled_eel" :
                             ( true_level >= 85 ) ? "sea_mist_rice_noodles" :

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7534,8 +7534,8 @@ std::string death_knight_t::default_food() const
                             ( true_level >= 80 ) ? "seafood_magnifique_feast" :
                             "disabled";
 
-  std::string blood_food =  ( true_level > 110 ) ? "bountiful_captains_feast" :
-	                          ( true_level > 100 ) ? "lavish_suramar_feast" :
+  std::string blood_food =  ( true_level > 110 ) ? "famine_evaluator_and_snack_table" :
+	                    ( true_level > 100 ) ? "lavish_suramar_feast" :
                             ( true_level >  90 ) ? "pickled_eel" :
                             ( true_level >= 85 ) ? "sea_mist_rice_noodles" :
                             ( true_level >= 80 ) ? "seafood_magnifique_feast" :


### PR DESCRIPTION
Changed deathknight blood spec default feast to the current feast T24 (famine_evaluator_and_snack_table)

also obsoletes PRs SimulationCraft/simc#4852 and SimulationCraft/simc#4948 in a clean way