### PR TITLE
Fix expression buff.potion to properly match only potions

### DIFF
--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -1927,7 +1927,9 @@ struct potion_spell_filter
 
   bool operator()( const item_data_t* item ) const
   {
-    return range::contains_value(item->id_spell, spell_id);
+    // Augment runes and other things look like potions. Only match things
+    // that trigger the potion shared cooldown.
+    return item->cooldown_group[0] == 4 && range::contains_value(item->id_spell, spell_id);
   }
 };
 }  // namespace
@@ -1948,7 +1950,7 @@ static buff_t* find_potion_buff( const std::vector<buff_t*>& buffs, player_t* so
 
     auto item =
         dbc::find_consumable( ITEM_SUBCLASS_POTION, maybe_ptr( b->player->dbc.ptr ), potion_spell_filter( b->data().id() ) );
-    if ( item )
+    if ( item && item->id != 0 )
     {
       return b;
     }


### PR DESCRIPTION
This is a fix for issue 4952.

Modifies how buff.potion is calculated so that it doesn't match nil_item_data nor things that don't trigger the shared potion cooldown, like augment runes.

As an aside, it's possible that potion_filter_t in engine/dbc/sc_item_data.cpp potion_filter_t is no longer required.