### PR TITLE
Fix expression buff.potion to properly match only potions

### DIFF
--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -1927,7 +1927,9 @@ struct potion_spell_filter
 
   bool operator()( const item_data_t* item ) const
   {
-    return range::contains_value(item->id_spell, spell_id);
+    // Augment runes and other things look like potions. Only match things
+    // that trigger the potion shared cooldown.
+    return item->cooldown_group[0] == ITEM_COOLDOWN_GROUP_POTION && range::contains_value(item->id_spell, spell_id);
   }
 };
 }  // namespace
@@ -1948,7 +1950,7 @@ static buff_t* find_potion_buff( const std::vector<buff_t*>& buffs, player_t* so
 
     auto item =
         dbc::find_consumable( ITEM_SUBCLASS_POTION, maybe_ptr( b->player->dbc.ptr ), potion_spell_filter( b->data().id() ) );
-    if ( item )
+    if ( item && item->id != 0 )
     {
       return b;
     }

--- a/engine/dbc/data_enums.hh
+++ b/engine/dbc/data_enums.hh
@@ -530,6 +530,11 @@ enum item_mod_type {
   ITEM_MOD_STRENGTH_INTELLECT       = 74,
 };
 
+enum item_cooldown_group {
+  ITEM_COOLDOWN_GROUP_NONE          = 0,
+  ITEM_COOLDOWN_GROUP_POTION        = 4,
+};
+
 enum rating_mod_type {
   RATING_MOD_DODGE        = 0x00000004,
   RATING_MOD_PARRY        = 0x00000008,


### PR DESCRIPTION
This is a fix for issue 4952 (resubmit with enum).

Modifies how buff.potion is calculated so that it doesn't match nil_item_data nor things that don't trigger the shared potion cooldown, but which simc forces to appear as potions, like augment runes.