### PR TITLE
Actually cache the results of timespan_t::{zero,min,max}.

### DIFF
--- a/engine/sc_timespan.hpp
+++ b/engine/sc_timespan.hpp
@@ -250,18 +250,22 @@ namespace timespan_adl_barrier
       return timespan_t(t);
     }
 
-    static constexpr timespan_t zero()
+    static timespan_t zero()
     {
-      return timespan_t();
+      static constexpr timespan_t cached_zero = timespan_t();
+      return cached_zero;
     }
-    static constexpr timespan_t max()
+    static timespan_t max()
     {
-      return timespan_t(std::numeric_limits<time_t>::max());
+      static constexpr timespan_t cached_max = timespan_t( std::numeric_limits<time_t>::max() );
+      return cached_max;
     }
-    static constexpr timespan_t min()
+    static timespan_t min()
     {
-      return std::is_floating_point<time_t>::value ? timespan_t(-std::numeric_limits<time_t>::max()) :
-          timespan_t(std::numeric_limits<time_t>::min());
+      static constexpr timespan_t cached_min = std::is_floating_point<time_t>::value
+                                                   ? timespan_t( -std::numeric_limits<time_t>::max() )
+                                                   : timespan_t( std::numeric_limits<time_t>::min() );
+      return cached_min;
     }
   };
 


### PR DESCRIPTION
Simc creates the timespans in timespan_t::{zero,min,max} repeatedly.

`constexpr` on functions is only honored when used in a `constexpr`; many callers of the above functions do not have that property.  This effect is more noticeable in debug mode because the operators on timespan_t have assertions in them that call these functions. In debug mode this change was a ~5-10% CPU savings, in NDEBUG it was closer to ~1-1.5%. 

[Approximate Profile Data, simming a DH with defaults.](https://docs.google.com/spreadsheets/d/e/2PACX-1vRS09q4NirSxYKB_kcf1Tfs0PizbWnxBjZ9AEIxmzo7EcFN1359ir022qt5ylnRV1-Bv3el85TCsuDx/pubhtml)


