### PR TITLE
Update to the Guardian default APL

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -8800,7 +8800,7 @@ void druid_t::apl_guardian()
   cooldowns -> add_talent( this, "Bristling Fur", "if=buff.bear_form.up" );
   cooldowns -> add_action( "incarnation,if=(dot.moonfire.ticking|active_enemies>1)&dot.thrash_bear.ticking" );
   cooldowns -> add_action( "use_item,name=ashvanes_razor_coral,target=Fluffy_Pillow,if=((equipped.cyclotronic_blast&cooldown.cyclotronic_blast.remains>25&debuff.razor_coral_debuff.down)|debuff.razor_coral_debuff.down|(debuff.razor_coral_debuff.up&debuff.conductive_ink_debuff.up&target.time_to_pct_30<=2)|(debuff.razor_coral_debuff.up&time_to_die<=20))" ); 
-  cooldowns -> add_action( "use_item,effect_name=cyclotronic_blast"
+  cooldowns -> add_action( "use_item,effect_name=cyclotronic_blast" );
   cooldowns -> add_action( "use_items" );
 			  
   essences -> add_action( "concentrated_flame,if=essence.the_crucible_of_flame.major&((!dot.concentrated_flame_burn.ticking&!action.concentrated_flame_missile.in_flight)^time_to_die<=7)" );

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -8799,7 +8799,7 @@ void druid_t::apl_guardian()
   cooldowns -> add_talent( this, "Lunar Beam", "if=buff.bear_form.up" );
   cooldowns -> add_talent( this, "Bristling Fur", "if=buff.bear_form.up" );
   cooldowns -> add_action( "incarnation,if=(dot.moonfire.ticking|active_enemies>1)&dot.thrash_bear.ticking" );
-  cooldowns -> add_action( "use_item,name=ashvanes_razor_coral,target=Fluffy_Pillow,if=((equipped.cyclotronic_blast&cooldown.cyclotronic_blast.remains>25&debuff.razor_coral_debuff.down)|debuff.razor_coral_debuff.down|(debuff.razor_coral_debuff.up&debuff.conductive_ink_debuff.up&target.time_to_pct_30<=2)|(debuff.razor_coral_debuff.up&time_to_die<=20))" ); 
+  cooldowns -> add_action( "use_item,name=ashvanes_razor_coral,if=((equipped.cyclotronic_blast&cooldown.cyclotronic_blast.remains>25&debuff.razor_coral_debuff.down)|debuff.razor_coral_debuff.down|(debuff.razor_coral_debuff.up&debuff.conductive_ink_debuff.up&target.time_to_pct_30<=2)|(debuff.razor_coral_debuff.up&time_to_die<=20))" ); 
   cooldowns -> add_action( "use_item,effect_name=cyclotronic_blast" );
   cooldowns -> add_action( "use_items" );
 			  


### PR DESCRIPTION
Added an action list for essences:

- Concentrated Flame now no longer overlap casts at the start of the fight.
- Added standard actions for essences with offensive value for future use.

Split the default rotation into Cleave and Multitarget rotations:

- Cleave rotation has a slight increase in dps on 2 target Patchwerk over the previous rotation
- Multitarget rotation has a significant increase in dps on 3-4 target Patchwerk over the previous rotation
- Other variations of Hectic Add Cleave and Patchwerk simulation have either the same dps output or slighty higher

Updated Razor Coral usage:

- Razor Coral is now only applied to main target and stacks are consumed as intended depending on trinket combos

Commented out the old rotation for ease of comparison if needed.
Fixed an issue with Ironfur not being cast at 3 Guardian's Wrath stacks because of the cost change from 45 to 40 rage on 8.2.

Current APL Patchwerk 1 Target > https://www.raidbots.com/simbot/report/niNsh2UZzfdcEKW5ARrr97
Updated APL Patchwerk 1 Target > https://www.raidbots.com/simbot/report/es7ii5KPizqiTZmykZBU3Q

Current APL Patchwerk 2 Targets > https://www.raidbots.com/simbot/report/jKYkQD44qNYdZS3TqekJKq
Updated APL Patchwerk 2 Targets > https://www.raidbots.com/simbot/report/pKJGo9kCjeJLD2VMC5mFvQ

Current APL Patchwerk 3 Targets > https://www.raidbots.com/simbot/report/rVNnhEt2UzYDJptvao1Mvh
Updated APL Patchwerk 3 Targets > https://www.raidbots.com/simbot/report/ibWyLovdjANBd2v8m3RZjz

Current APL Patchwerk 4 Targets > https://www.raidbots.com/simbot/report/pPryfmyeLsAch8xUusD94y
Updated APL Patchwerk 4 Targets > https://www.raidbots.com/simbot/report/bMHbFHncZ7ywedhJXSKV6j

Current APL Hectic Add Cleave > https://www.raidbots.com/simbot/report/iEzYBs2opymRsgJ6t5XRbM
Updated APL Hectic Add Cleave > https://www.raidbots.com/simbot/report/f2RcY7orp5mY8A3Z3RAVN6