### PR TITLE
Small VDH updates

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5199,6 +5199,7 @@ void demon_hunter_t::apl_vengeance()
   action_priority_list_t* apl_default = get_action_priority_list( "default" );
 
   apl_default->add_action( "auto_attack" );
+  // Only triggers if there is something to steal
   apl_default->add_action( this, "Consume Magic" );
   apl_default->add_action( "call_action_list,name=brand,if=talent.charred_flesh.enabled" );
   apl_default->add_action( "call_action_list,name=defensives" );
@@ -5207,7 +5208,6 @@ void demon_hunter_t::apl_vengeance()
 
   action_priority_list_t* apl_defensives = get_action_priority_list( "defensives", "Defensives" );
   apl_defensives->add_action( this, "Demon Spikes" );
-  // apl_defensives->add_talent( this, "Soul Barrier" );
   apl_defensives->add_action( this, "Metamorphosis" );
   apl_defensives->add_action( this, "Fiery Brand" );
 
@@ -5231,9 +5231,9 @@ void demon_hunter_t::apl_vengeance()
   apl_brand->add_action( this, "Sigil of Flame", "if=dot.fiery_brand.ticking" );
 
   action_priority_list_t* apl_normal = get_action_priority_list( "normal", "Normal Rotation" );
-  apl_normal->add_action( this, "Infernal Strike" );
-  apl_normal->add_talent( this, "Spirit Bomb", "if=soul_fragments>=4" );
-  apl_normal->add_action( this, "Soul Cleave", "if=!talent.spirit_bomb.enabled" );
+  apl_normal->add_action( this, "Infernal Strike" , "if=(!talent.flame_crash.enabled|(dot.sigil_of_flame.remains<3&!action.infernal_strike.sigil_placed))");
+  apl_normal->add_talent( this, "Spirit Bomb", "if=((buff.metamorphosis.up&soul_fragments>=3)|soul_fragments>=4)" );
+  apl_normal->add_action( this, "Soul Cleave", "if=(!talent.spirit_bomb.enabled&((buff.metamorphosis.up&soul_fragments>=3)|soul_fragments>=4))" );
   apl_normal->add_action( this, "Soul Cleave", "if=talent.spirit_bomb.enabled&soul_fragments=0" );
   apl_normal->add_action( this, "Immolation Aura", "if=pain<=90" );
   apl_normal->add_talent( this, "Felblade", "if=pain<=70" );

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5037,7 +5037,7 @@ std::string demon_hunter_t::default_flask() const
 
 std::string demon_hunter_t::default_potion() const
 {
-  return (true_level > 110) ? (specialization() == DEMON_HUNTER_HAVOC ? "potion_of_unbridled_fury" : "steelskin_potion") :
+  return (true_level > 110) ? "potion_of_unbridled_fury" :
          (true_level > 100) ? (specialization() == DEMON_HUNTER_HAVOC ? "prolonged_power" : "unbending_potion") :
          (true_level >= 90) ? (specialization() == DEMON_HUNTER_HAVOC ? "draenic_agility" : "draenic_versatility") :
          (true_level >= 85) ? "virmens_bite" :

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4749,8 +4749,9 @@ void demon_hunter_t::init_rng()
     rppm.felblade = get_rppm( "felblade", find_spell( 203557 ) );
     rppm.gluttony = get_rppm( "gluttony", talent.gluttony );
     // 6/27/2018 -- Removed from spell data, but still seems to be RPPM
+    // 1/9/2020  -- It has actually been 2.0 since uldir
     if ( rppm.gluttony->get_frequency() == 0 )
-      rppm.gluttony->set_frequency( 1.0 );
+      rppm.gluttony->set_frequency( 2.0 );
   }
 
   player_t::init_rng();


### PR DESCRIPTION
Made some tweaks to the DH class modules:

- Gluttony has had a rppm rate of 2.0 for donkey's years, as visible in logs from uldir ( https://www.warcraftlogs.com/reports/rL8vCK3cVRa7G26w#fight=1&type=auras&source=4&ability=187827 , https://www.warcraftlogs.com/reports/28Va3H4JkPcbQY1K#fight=8&type=auras&source=18&ability=187827 ), BoD ( https://www.warcraftlogs.com/reports/9kDgmJy6hjLFHf8Y#fight=20&type=auras&source=6&ability=187827 ), and EP ( https://www.warcraftlogs.com/reports/MfgXQbCP6apTmcx9#fight=10&type=auras&source=15&ability=187827 ). Now that the build is gaining traction, fixing the hardcoded rppm seems a judicious choice
- Fixed the use of `sigil of flame` and `infernal strike`:
  * Infernal strike no longer munches its own sigil
  * Infernal strike no longer munches a sigil from sigil of flame
  * Sigil of flame no longer munches an infernal strike sigil
- Fixed the consumption and generation of soul fragments while in meta. While in meta, an additional soul fragment is generated for both fracture and shear. As such, before these changes, a soul fragment would be wasted every two fractures (3 -> 6 with a limit of 5). Also fixed a spurious (but mostly inconsequential) line casting soul cleave if it was even remotely available.

Total gain on the tier23 profile is ~1% with the spirit bomb build, and around 5% with glut.