### PR TITLE
[BrM] GotOx bugfix + fixed default food/potion

### DIFF
--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -7144,7 +7144,7 @@ struct gift_of_the_ox_buff_t : public monk_buff_t<buff_t>
   void decrement( int stacks, double value ) override
   {
     monk_t* p = debug_cast<monk_t*>( player );
-    if ( stacks > 0 && p->current_health() < p->max_health() )
+    if ( stacks > 0 )
     {
       p->active_actions.gift_of_the_ox_trigger->execute();
 

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -9513,7 +9513,7 @@ std::string monk_t::default_potion() const
   {
     case MONK_BREWMASTER:
       if ( true_level > 110 )
-        return "superior_battle_potion_of_agility";
+        return "unbridled_fury";
       else if ( true_level > 100 )
         return "prolonged_power";
       else if ( true_level > 90 )
@@ -9578,7 +9578,7 @@ std::string monk_t::default_food() const
   {
     case MONK_BREWMASTER:
       if ( true_level > 110 )
-        return "famine_evaluator_and_snack_table";
+        return "biltong";
       else if ( true_level > 100 )
         return "fishbrul_special";
       else if ( true_level > 90 )


### PR DESCRIPTION
Gift of the Ox would not actually consume an orb if you were at max hp, so if you simmed a character with enough Resounding Protection, the sim would just spam Expel Harm. Fixed this by removing a condition from the `decrement` override for GotOx. This doesn't appear to break anything on the HPS end, and fixes the issue with RP.

I also changed the default food/potion to Bil'Tong (Vers) and Unbridled Fury, respectively. Versatility food is *usually* going to be the best DPS food for Brewmasters at this point, due to the interactions with corruptions and other on-hit effects.