### PR TITLE
Touch up range:: stuff a bit

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -137,7 +137,7 @@ struct player_data_t
 
   action_data_t* get( const action_t* a )
   {
-    auto it = range::find_if( data_, [ a ] ( const record_t& r ) { return a -> name_str == r.first; } );
+    auto it = range::find( data_, a -> name_str, &record_t::first );
     if ( it != data_.cend() )
       return it -> second.get();
 
@@ -646,7 +646,7 @@ public:
   template <typename T, typename... Ts>
   T* get_background_action( const std::string& n, Ts&&... args )
   {
-    auto it = range::find_if( background_actions, [ &n ]( action_t* a ) { return a -> name_str == n; } );
+    auto it = range::find( background_actions, n, &action_t::name_str );
     if ( it != background_actions.cend() )
       return dynamic_cast<T*>( *it );
 

--- a/engine/dbc/azerite.cpp
+++ b/engine/dbc/azerite.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <array>
 
 #include "config.hpp"
@@ -86,22 +85,13 @@ azerite_essence_power_entry_t::data_by_essence_id( unsigned essence_id, bool ptr
 {
   const auto __data = data( ptr );
 
-  auto begin = std::lower_bound( __data.cbegin(), __data.cend(), essence_id,
-                              []( const azerite_essence_power_entry_t& a, const unsigned& id ) {
-                                return a.essence_id < id;
-                              } );
-
-  if ( begin == __data.cend() )
+  auto r = range::equal_range( __data, essence_id, {}, &azerite_essence_power_entry_t::essence_id );
+  if ( r.first == __data.end() )
   {
     return {};
   }
 
-  auto end = std::upper_bound( __data.cbegin(), __data.cend(), essence_id,
-                              []( const unsigned& id, const azerite_essence_power_entry_t& a ) {
-                                return id < a.essence_id;
-                              } );
-
-  return util::span<const azerite_essence_power_entry_t>( begin, end );
+  return util::span<const azerite_essence_power_entry_t>( r.first, r.second );
 }
 
 const azerite_essence_power_entry_t&

--- a/engine/dbc/item_bonus.cpp
+++ b/engine/dbc/item_bonus.cpp
@@ -1,9 +1,10 @@
-#include <algorithm>
 #include <array>
 
 #include "config.hpp"
 
 #include "item_bonus.hpp"
+
+#include "util/generic.hpp"
 
 #include "generated/item_bonus.inc"
 #if SC_USE_PTR == 1
@@ -26,19 +27,11 @@ util::span<const item_bonus_entry_t> item_bonus_entry_t::find( unsigned bonus_id
 {
   const auto __data = data( ptr );
 
-  auto low = std::lower_bound( __data.cbegin(), __data.cend(), bonus_id,
-                              []( const item_bonus_entry_t& entry, const unsigned& id ) {
-                                return entry.bonus_id < id;
-                              } );
-  if ( low == __data.end() )
+  auto r = range::equal_range( __data, bonus_id, {}, &item_bonus_entry_t::bonus_id );
+  if ( r.first == __data.end() )
   {
     return {};
   }
 
-  auto high = std::upper_bound( __data.cbegin(), __data.cend(), bonus_id,
-                              []( const unsigned& id, const item_bonus_entry_t& entry ) {
-                                return id < entry.bonus_id;
-                              } );
-
-  return util::span<const item_bonus_entry_t>( low, high );
+  return util::span<const item_bonus_entry_t>( r.first, r.second );
 }

--- a/engine/dbc/item_scaling.cpp
+++ b/engine/dbc/item_scaling.cpp
@@ -4,6 +4,8 @@
 
 #include "item_scaling.hpp"
 
+#include "util/generic.hpp"
+
 #include "generated/item_scaling.inc"
 #if SC_USE_PTR == 1
 #include "generated/item_scaling_ptr.inc"
@@ -41,20 +43,12 @@ util::span<const curve_point_t> curve_point_t::find( unsigned id, bool ptr )
 {
   const auto __data = data( ptr );
 
-  auto low = std::lower_bound( __data.cbegin(), __data.cend(), id,
-                              []( const curve_point_t& entry, const unsigned& id ) {
-                                return entry.curve_id < id;
-                              } );
-  if ( low == __data.cend() )
+  auto r = range::equal_range( __data, id, {}, &curve_point_t::curve_id );
+  if ( r.first == __data.end() )
   {
     return {};
   }
 
-  auto high = std::upper_bound( __data.cbegin(), __data.cend(), id,
-                              []( const unsigned& id, const curve_point_t& entry ) {
-                                return id < entry.curve_id;
-                              } );
-
-  return util::span<const curve_point_t>( low, high );
+  return util::span<const curve_point_t>( r.first, r.second );
 }
 

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -4568,18 +4568,12 @@ void proc_attack_t::override_data(const special_effect_t& e)
 
 } // unique_gear
 
-namespace
-{
-bool cmp_dbitem( const special_effect_db_item_t& elem, unsigned id )
-{ return elem.spell_id < id; }
-}
-
 static unique_gear::special_effect_set_t do_find_special_effect_db_item(
     const std::vector<special_effect_db_item_t>& db, unsigned spell_id )
 {
   special_effect_set_t entries;
 
-  auto it = std::lower_bound( db.begin(), db.end(), spell_id, cmp_dbitem );
+  auto it = range::lower_bound( db, spell_id, {}, &special_effect_db_item_t::spell_id );
 
   if ( it == db.end() || it -> spell_id != spell_id )
   {

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -4120,7 +4120,7 @@ void sim_t::enable_debug_seed()
   }
   else
   {
-    auto it = std::lower_bound( debug_seed.begin(), debug_seed.end(), seed );
+    auto it = range::lower_bound( debug_seed, seed );
     enabled = it != debug_seed.end() && *it == seed;
   }
 
@@ -4169,7 +4169,7 @@ void sim_t::disable_debug_seed()
   }
   else
   {
-    auto it = std::lower_bound( debug_seed.begin(), debug_seed.end(), seed );
+    auto it = range::lower_bound( debug_seed, seed );
     enabled = it != debug_seed.end() && *it == seed;
   }
 

--- a/engine/util/generic.hpp
+++ b/engine/util/generic.hpp
@@ -358,6 +358,15 @@ inline iterator_t<Range> find( Range& r, T const& t )
   return std::find( range::begin( r ), range::end( r ), t );
 }
 
+template <typename Range, typename T, typename Proj>
+inline iterator_t<Range> find( Range& r, T const& value, Proj proj )
+{
+  const auto pred = [&value, &proj]( auto&& v ) {
+    return range::invoke( proj, std::forward<decltype(v)>( v ) ) == value;
+  };
+  return std::find_if( range::begin( r ), range::end( r ), pred );
+}
+
 template <typename Range, typename UnaryPredicate>
 inline iterator_t<Range> find_if( Range& r, UnaryPredicate p )
 {


### PR DESCRIPTION
Clean up some stuff.
Add range versions of binary search related routines.
Add projection-enabled `range::find()` overload.

Mostly to tickle ci (vs).