### PR TITLE
Fix GUI qrc file not being built on Linux CMake builds.

### DIFF
--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -111,9 +111,6 @@ unix:!macx {
   locale.commands = @echo Installing localizations to $$SHAREPATH/locale
 }
 
-RESOURCES = \
-  qt/simcqt.qrc
-
 TRANSLATIONS = \
   ../locale/sc_de.ts \
   ../locale/sc_zh.ts \

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Qt5WebEngine CONFIG REQUIRED)
 find_package(Qt5WebEngineWidgets CONFIG REQUIRED)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Resource files

--- a/source_files/QT_engine.pri
+++ b/source_files/QT_engine.pri
@@ -263,3 +263,4 @@ SOURCES += engine/util/stopwatch.cpp
 SOURCES += engine/util/timeline.cpp
 SOURCES += engine/util/util.cpp
 SOURCES += engine/util/xml.cpp
+

--- a/source_files/QT_gui.pri
+++ b/source_files/QT_gui.pri
@@ -42,3 +42,5 @@ SOURCES += qt/util/sc_relativepopup.cpp
 SOURCES += qt/util/sc_searchbox.cpp
 SOURCES += qt/util/sc_tabbar.cpp
 SOURCES += qt/util/sc_textedit.cpp
+
+RESOURCES += qt/simcqt.qrc

--- a/source_files/cmake_gui.txt
+++ b/source_files/cmake_gui.txt
@@ -39,4 +39,5 @@ util/sc_relativepopup.cpp
 util/sc_searchbox.cpp
 util/sc_tabbar.cpp
 util/sc_textedit.cpp
+simcqt.qrc
 )

--- a/source_files/synchronize.py
+++ b/source_files/synchronize.py
@@ -17,7 +17,7 @@ def parse_qt(filename):
     out = []
     with open(filename, "r") as f:
         for line in f:
-            match = re.search(r"(\s*)(SOURCES|HEADERS|PRECOMPILED_HEADER)(\s*\+?\=\s*)([\.\w\/-]*)(\.\w*)", line)
+            match = re.search(r"(\s*)(SOURCES|HEADERS|PRECOMPILED_HEADER|RESOURCES)(\s*\+?\=\s*)([\.\w\/-]*)(\.\w*)", line)
             if match:
                 file_type = match.group(2)
                 fullpath = match.group(4) + match.group(5)
@@ -160,7 +160,7 @@ def create_vs_str(entries, gui=False):
 
 def create_cmake_str(entries):
     engine_source = list(entries)
-    engine_cpp_files = [fullpath for file_type, fullpath, dirname, ending in engine_source if file_type == "SOURCES" or file_type == "HEADERS"]
+    engine_cpp_files = [fullpath for file_type, fullpath, dirname, ending in engine_source if file_type in ["SOURCES", "HEADERS", "RESOURCES"]]
     engine_cpp_files = [pathlib.Path(f) for f in engine_cpp_files]
     engine_cpp_files = ["/".join(p.parts[1:]) for p in engine_cpp_files]
     output = "set(source_files\n{}\n)".format("\n".join(engine_cpp_files))
@@ -193,7 +193,8 @@ def create_qmake_str(file_type, path, excludes):
     output += qmake_type_str(file_type, path, ["*.hpp", "*.hh"], "HEADERS", excludes)
     output += "\n\n"
     output += qmake_type_str(file_type, path, ["*.cpp"], "SOURCES", excludes)
-
+    output += "\n\n"
+    output += qmake_type_str(file_type, path, ["*.qrc"], "RESOURCES", excludes)
     return output
 
 def glob_files(file_type, path, excludes):


### PR DESCRIPTION
I had issues on CMake Linux packages where the realm lists could not be loaded because the qrc file was not included in the build.

This change includes .qrc files in the globbing done in the synchronize.py script and adds them automatically to both qmake and cmake builds.
Also enables AUTORCC for cmake such that the qrc is built automatically.