### PR TITLE
Add SC_DBC_GET_DATA() helper

### DIFF
--- a/engine/dbc/azerite.cpp
+++ b/engine/dbc/azerite.cpp
@@ -12,29 +12,12 @@
 
 util::span<const azerite_power_entry_t> azerite_power_entry_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const azerite_power_entry_t>( __ptr_azerite_power_data )
-                        : util::span<const azerite_power_entry_t>( __azerite_power_data );
-#else
-  ( void ) ptr;
-  const auto& data = __azerite_power_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __azerite_power_data, __ptr_azerite_power_data, ptr );
 }
 
 util::span<const azerite_essence_entry_t> azerite_essence_entry_t::data( bool ptr )
 {
-  ( void ) ptr;
-
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const azerite_essence_entry_t>( __ptr_azerite_essence_data )
-                        : util::span<const azerite_essence_entry_t>( __azerite_essence_data );
-#else
-  const auto& data = __azerite_essence_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __azerite_essence_data, __ptr_azerite_essence_data, ptr );
 }
 
 const azerite_essence_entry_t&
@@ -68,16 +51,7 @@ azerite_essence_entry_t::find( const std::string& name, bool tokenized, bool ptr
 
 util::span<const azerite_essence_power_entry_t> azerite_essence_power_entry_t::data( bool ptr )
 {
-  ( void ) ptr;
-
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const azerite_essence_power_entry_t>( __ptr_azerite_essence_power_data )
-                        : util::span<const azerite_essence_power_entry_t>( __azerite_essence_power_data );
-#else
-  const auto& data = __azerite_essence_power_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __azerite_essence_power_data, __ptr_azerite_essence_power_data, ptr );
 }
 
 util::span<const azerite_essence_power_entry_t>

--- a/engine/dbc/client_data.hpp
+++ b/engine/dbc/client_data.hpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 
+#include "config.hpp"
+
 namespace dbc
 {
 struct ilevel_member_policy_t
@@ -49,5 +51,13 @@ const T& find( unsigned key, bool ptr )
 }
 
 } // Namespace dbc ends
+
+#if defined(SC_USE_PTR) && (SC_USE_PTR != 0)
+# define SC_DBC_GET_DATA( _data__, _data_ptr__, _ptr_flag__ ) \
+    ((_ptr_flag__) ? ::util::make_span( _data_ptr__ ).subspan( 0 ) : ::util::make_span( _data__ ).subspan( 0 ))
+#else
+# define SC_DBC_GET_DATA( _data__, _data_ptr__, _ptr_flag__ ) \
+    ((void)(_ptr_flag__), ::util::make_span( _data__ ))
+#endif
 
 #endif /* CLIENT_DATA_HPP */

--- a/engine/dbc/gem_data.cpp
+++ b/engine/dbc/gem_data.cpp
@@ -11,15 +11,7 @@
 
 util::span<const gem_property_data_t> gem_property_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const gem_property_data_t>( __ptr_gem_property_data )
-                        : util::span<const gem_property_data_t>( __gem_property_data );
-#else
-  ( void ) ptr;
-  const auto& data = __gem_property_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __gem_property_data, __ptr_gem_property_data, ptr );
 }
 
 

--- a/engine/dbc/item_armor.cpp
+++ b/engine/dbc/item_armor.cpp
@@ -11,53 +11,21 @@
 
 util::span<const item_armor_quality_data_t> item_armor_quality_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_armor_quality_data_t>( __ptr_item_armor_quality_data )
-                        : util::span<const item_armor_quality_data_t>( __item_armor_quality_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_armor_quality_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_armor_quality_data, __ptr_item_armor_quality_data, ptr );
 }
 
 util::span<const item_armor_shield_data_t> item_armor_shield_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_armor_shield_data_t>( __ptr_item_armor_shield_data )
-                        : util::span<const item_armor_shield_data_t>( __item_armor_shield_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_armor_shield_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_armor_shield_data, __ptr_item_armor_shield_data, ptr );
 }
 
 util::span<const item_armor_total_data_t> item_armor_total_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_armor_total_data_t>( __ptr_item_armor_total_data )
-                        : util::span<const item_armor_total_data_t>( __item_armor_total_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_armor_total_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_armor_total_data, __ptr_item_armor_total_data, ptr );
 }
 
 util::span<const item_armor_location_data_t> item_armor_location_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_armor_location_data_t>( __ptr_armor_location_data )
-                        : util::span<const item_armor_location_data_t>( __armor_location_data );
-#else
-  ( void ) ptr;
-  const auto& data = __armor_location_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __armor_location_data, __ptr_armor_location_data, ptr );
 }
 

--- a/engine/dbc/item_bonus.cpp
+++ b/engine/dbc/item_bonus.cpp
@@ -13,14 +13,7 @@
 
 util::span<const item_bonus_entry_t> item_bonus_entry_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto& data = ptr ? __ptr_item_bonus_data :  __item_bonus_data;
-#else
-  ( void ) ptr;
-  const auto& data = __item_bonus_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_bonus_data, __ptr_item_bonus_data, ptr );
 }
 
 util::span<const item_bonus_entry_t> item_bonus_entry_t::find( unsigned bonus_id, bool ptr )

--- a/engine/dbc/item_child.cpp
+++ b/engine/dbc/item_child.cpp
@@ -11,15 +11,7 @@
 
 util::span<const item_child_equipment_t> item_child_equipment_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_child_equipment_t>( __ptr_item_child_equipment_data )
-                        : util::span<const item_child_equipment_t>( __item_child_equipment_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_child_equipment_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_child_equipment_data, __ptr_item_child_equipment_data, ptr );
 }
 
 

--- a/engine/dbc/item_effect.cpp
+++ b/engine/dbc/item_effect.cpp
@@ -12,15 +12,6 @@
 
 util::span<const item_effect_t> item_effect_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr
-    ? util::span<const item_effect_t>( __ptr_item_effect_data )
-    : util::span<const item_effect_t>( __item_effect_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_effect_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_effect_data, __ptr_item_effect_data, ptr );
 }
 

--- a/engine/dbc/item_naming.cpp
+++ b/engine/dbc/item_naming.cpp
@@ -11,14 +11,6 @@
 
 util::span<const item_name_description_t> item_name_description_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_name_description_t>( __ptr_item_name_description_data )
-                        : util::span<const item_name_description_t>( __item_name_description_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_name_description_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_name_description_data, __ptr_item_name_description_data, ptr );
 }
 

--- a/engine/dbc/item_scaling.cpp
+++ b/engine/dbc/item_scaling.cpp
@@ -13,29 +13,13 @@
 
 util::span<const scaling_stat_distribution_t> scaling_stat_distribution_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const scaling_stat_distribution_t>( __ptr_scaling_stat_distribution_data )
-                        : util::span<const scaling_stat_distribution_t>( __scaling_stat_distribution_data );
-#else
-  ( void ) ptr;
-  const auto& data = __scaling_stat_distribution_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __scaling_stat_distribution_data, __ptr_scaling_stat_distribution_data, ptr );
 }
 
 
 util::span<const curve_point_t> curve_point_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const curve_point_t>( __ptr_curve_point_data )
-                        : util::span<const curve_point_t>( __curve_point_data );
-#else
-  ( void ) ptr;
-  const auto& data = __curve_point_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __curve_point_data, __ptr_curve_point_data, ptr );
 }
 
 

--- a/engine/dbc/item_weapon.cpp
+++ b/engine/dbc/item_weapon.cpp
@@ -11,57 +11,21 @@
 
 util::span<const item_damage_one_hand_data_t> item_damage_one_hand_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr
-    ? util::span<const item_damage_one_hand_data_t>( __ptr_item_damage_one_hand_data )
-    : util::span<const item_damage_one_hand_data_t>( __item_damage_one_hand_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_damage_one_hand_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_damage_one_hand_data, __ptr_item_damage_one_hand_data, ptr );
 }
 
 util::span<const item_damage_one_hand_caster_data_t> item_damage_one_hand_caster_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr
-    ? util::span<const item_damage_one_hand_caster_data_t>( __ptr_item_damage_one_hand_caster_data )
-    : util::span<const item_damage_one_hand_caster_data_t>( __item_damage_one_hand_caster_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_damage_one_hand_caster_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_damage_one_hand_caster_data, __ptr_item_damage_one_hand_caster_data, ptr );
 }
 
 util::span<const item_damage_two_hand_data_t> item_damage_two_hand_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr
-    ? util::span<const item_damage_two_hand_data_t>( __ptr_item_damage_two_hand_data )
-    : util::span<const item_damage_two_hand_data_t>( __item_damage_two_hand_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_damage_two_hand_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_damage_two_hand_data, __ptr_item_damage_two_hand_data, ptr );
 }
 
 util::span<const item_damage_two_hand_caster_data_t> item_damage_two_hand_caster_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr
-    ? util::span<const item_damage_two_hand_caster_data_t>( __ptr_item_damage_two_hand_caster_data )
-    : util::span<const item_damage_two_hand_caster_data_t>( __item_damage_two_hand_caster_data );
-#else
-  ( void ) ptr;
-  const auto& data = __item_damage_two_hand_caster_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __item_damage_two_hand_caster_data, __ptr_item_damage_two_hand_caster_data, ptr );
 }
 

--- a/engine/dbc/rand_prop_points.cpp
+++ b/engine/dbc/rand_prop_points.cpp
@@ -11,14 +11,6 @@
 
 util::span<const random_prop_data_t> random_prop_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const random_prop_data_t>( __ptr_rand_prop_points_data )
-                        : util::span<const random_prop_data_t>( __rand_prop_points_data );
-#else
-  ( void ) ptr;
-  const auto& data = __rand_prop_points_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __rand_prop_points_data, __ptr_rand_prop_points_data, ptr );
 }
 

--- a/engine/dbc/spell_item_enchantment.cpp
+++ b/engine/dbc/spell_item_enchantment.cpp
@@ -11,14 +11,6 @@
 
 util::span<const item_enchantment_data_t> item_enchantment_data_t::data( bool ptr )
 {
-#if SC_USE_PTR == 1
-  const auto data = ptr ? util::span<const item_enchantment_data_t>( __ptr_spell_item_ench_data )
-                        : util::span<const item_enchantment_data_t>( __spell_item_ench_data );
-#else
-  ( void ) ptr;
-  const auto& data = __spell_item_ench_data;
-#endif
-
-  return data;
+  return SC_DBC_GET_DATA( __spell_item_ench_data, __ptr_spell_item_ench_data, ptr );
 }
 


### PR DESCRIPTION
Returns a 'dynamic' extent span to a corresponding data array depending on the
ptr flag. Hides all of the boilerplate associated with it:
* supression of -Wunused for the ptr flag in non-ptr builds
* possible error in a ternary with mismatching span extents

Aside from being more concise it also helps preventing bugs like in 76450d67