### PR TITLE
Refactor SC_HIGH_PRECISION_STOPWATCH handling

### DIFF
--- a/engine/config.hpp
+++ b/engine/config.hpp
@@ -32,6 +32,10 @@
 #  define SC_SIGACTION
 #endif
 
+#if defined(__linux) || defined(__linux__) || defined(linux)
+#  define SC_LINUX
+#endif
+
 // ==========================================================================
 // Compiler Definitions
 // ==========================================================================


### PR DESCRIPTION
All of the stopwatch types can be represented 1-to-1 with clockid_t clocks with
recent enough (really, quite old) kernel + libc. Simplify stuff by using
clock_gettime() for everything.

Change CLOCK_REALTIME to CLOCK_MONOTONIC to align it with the Windows
implementation (which uses QPC). CLOCK_REALTIME is bad for stuff like this
anyway.

While at it make it unconditional on Linux. While the comment said we need to
link with -lrt, it got changed with glibc 2.17. That is old enough to be relied
upon. We require C++14 and all of the compilers supporting that were released
after that anyway. Distro wise both Debian 8 (Jessie) and Ubuntu 14.04 have
glibc 2.19.