### PR TITLE
More libfmt usage

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -840,9 +840,9 @@ bool action_t::verify_actor_weapon() const
         types.emplace_back(util::weapon_subclass_string( wt ) );
       }
     }
-    sim->errorf( "Player %s attempting to use action %s without the required main-hand weapon "
-                 "(requires %s, wielded %s).\n",
-      player->name(), name(), util::string_join( types ).c_str(),
+    sim->error( "Player {} attempting to use action {} without the required main-hand weapon "
+                "(requires {}, wielded {}).\n",
+      player->name(), name(), fmt::join( types, ", " ),
       util::weapon_subclass_string( util::translate_weapon( player->main_hand_weapon.type ) ) );
     return false;
   }
@@ -858,9 +858,9 @@ bool action_t::verify_actor_weapon() const
         types.emplace_back(util::weapon_subclass_string( wt ) );
       }
     }
-    sim->errorf( "Player %s attempting to use action %s without the required off-hand weapon "
-                 "(requires %s, wielded %s).\n",
-      player->name(), name(), util::string_join( types ).c_str(),
+    sim->error( "Player {} attempting to use action {} without the required off-hand weapon "
+                "(requires {}, wielded {}).\n",
+      player->name(), name(), fmt::join( types, ", " ),
       util::weapon_subclass_string( util::translate_weapon( player->off_hand_weapon.type ) ) );
     return false;
   }

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -1230,13 +1230,8 @@ public:
 
   std::string to_str() const
   {
-    std::ostringstream s;
-
-    s << " (ok=" << ( ok() ? "true" : "false" ) << ")";
-    s << " id=" << id();
-    s << " name=" << name_cstr();
-    s << " school=" << util::school_type_string( get_school_type() );
-    return s.str();
+    return fmt::format( " (ok={}) id={} name={} school={}",
+                        ok(), id(), name_cstr(), util::school_type_string( get_school_type() ) );
   }
 
   bool affected_by_all( dbc_t& dbc, const spelleffect_data_t& effect ) const;

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -4,8 +4,10 @@
 // ==========================================================================
 
 #include "dbc.hpp"
+
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 using namespace hotfix;
 

--- a/engine/dbc/sc_item_data.cpp
+++ b/engine/dbc/sc_item_data.cpp
@@ -1192,7 +1192,7 @@ static std::string get_bonus_item_effect( util::span<const item_bonus_entry_t> e
         }
 
         entries_str.emplace_back( fmt::format( "{} ({})", spell->name_cstr(),
-          util::string_join( fields, ", " ) ) );
+          fmt::join( fields, ", " ) ) );
       }
     }
   } );

--- a/engine/player/rating.cpp
+++ b/engine/player/rating.cpp
@@ -99,11 +99,11 @@ void rating_t::init(dbc_t& dbc, int level)
 
 std::string rating_t::to_string()
 {
-  std::ostringstream s;
+  fmt::memory_buffer buf;
   for (rating_e i = static_cast<rating_e>(0); i < RATING_MAX; ++i)
   {
-    if (i > 0) s << " ";
-    s << util::cache_type_string(cache_from_rating(i)) << "=" << get(i); // hacky
+    fmt::format_to( buf, "{}{}={}",
+      i > 0 ? " " : "", util::cache_type_string(cache_from_rating(i)), get(i) ); // hacky
   }
-  return s.str();
+  return fmt::to_string( buf );
 }

--- a/engine/player/sc_set_bonus.cpp
+++ b/engine/player/sc_set_bonus.cpp
@@ -257,16 +257,12 @@ std::ostream& operator<<(std::ostream& os, const set_bonus_t& sb)
         if ( data.overridden >= 1 ||
            ( data.overridden == -1 && sb.set_bonus_spec_count[ idx ][ spec_role_idx ] >= data.bonus -> bonus ) )
         {
-          if ( i > 0 )
-            os << ", ";
-
-          std::string spec_role_str = util::specialization_string( sb.actor -> specialization() );
-
-          os << fmt::format("{{ {}, {}, {}, {} piece bonus {} }}",
+          fmt::print( os, "{}{{ {}, {}, {}, {} piece bonus {} }}",
+              i > 0 ? ", " : "",
               data.bonus -> set_name,
               data.bonus -> set_opt_name,
-              spec_role_str,
-              util::to_string( data.bonus -> bonus ),
+              util::specialization_string( sb.actor -> specialization() ),
+              data.bonus -> bonus,
               ( data.overridden >= 1 ) ? " (overridden)" : "");
           ++i;
         }

--- a/engine/report/report_helper.cpp
+++ b/engine/report/report_helper.cpp
@@ -446,14 +446,12 @@ bool report_helper::check_gear( player_t& p, sim_t& sim )
     {
       // Check azerite_level
       if ( item.parsed.azerite_level != hoa_level )
-        sim.errorf( "Player %s has HoA of level %s, level for %s should be %s.\n", p.name(),
-                    util::to_string( item.parsed.azerite_level ).c_str(), tier_name.c_str(),
-                    util::to_string( hoa_level ).c_str() );
+        sim.error( "Player {} has HoA of level {}, level for {} should be {}.\n", p.name(),
+                   item.parsed.azerite_level, tier_name, hoa_level );
       // Check final item level (since it's not only computed from azerite_level)
       if ( item.parsed.data.level != hoa_ilevel )
-        sim.errorf( "Player %s has HoA of ilevel %s, ilevel for %s should be %s.\n", p.name(),
-                    util::to_string( item.parsed.data.level ).c_str(), tier_name.c_str(),
-                    util::to_string( hoa_ilevel ).c_str() );
+        sim.error( "Player {} has HoA of ilevel {}, ilevel for {} should be {}.\n", p.name(),
+                   item.parsed.data.level, tier_name, hoa_ilevel );
     }
     // Azerite gear
     else if ( slot == SLOT_HEAD || slot == SLOT_SHOULDERS || slot == SLOT_CHEST )
@@ -466,8 +464,8 @@ bool report_helper::check_gear( player_t& p, sim_t& sim )
       {
         const auto& power = p.dbc->azerite_power( azerite_id );
         if ( power.id == 0 )
-          sim.errorf( "Player %s has %s with azerite power id %s which does not exists.", p.name(),
-                      util::slot_type_string( slot ), util::to_string( azerite_id ).c_str() );
+          sim.error( "Player {} has {} with azerite power id {} which does not exists.", p.name(),
+                     util::slot_type_string( slot ), azerite_id );
       }
       // Check if there is more than one azerite power per tier (two for tier 3) and less than one for all tiers but tier 1
       for ( unsigned i = 0; i < azerite_tiers; i++ )
@@ -480,29 +478,27 @@ bool report_helper::check_gear( player_t& p, sim_t& sim )
             powers++;
         }
         if ( i != 3 && powers > 1 )
-          sim.errorf( "Player %s has %s with %s azerite powers of tier %s, should have 1.", p.name(), util::slot_type_string( slot ),
-                      util::to_string( powers ).c_str(), util::to_string( i ).c_str() );
+          sim.error( "Player {} has {} with {} azerite powers of tier {}, should have 1.", p.name(),
+                      util::slot_type_string( slot ), powers, i );
         if ( i == 3 && powers > third_ring_traits )
-          sim.errorf( "Player %s has %s with %s azerite powers of tier %s, should have %s.", p.name(), util::slot_type_string( slot ),
-                      util::to_string( powers ).c_str(), util::to_string( i ).c_str(), util::to_string( third_ring_traits ) );
+          sim.error( "Player {} has {} with {} azerite powers of tier {}, should have {}.", p.name(),
+                     util::slot_type_string( slot ), powers, i, third_ring_traits );
         if ( i != 1 && powers == 0 )
-          sim.errorf( "Player %s has %s with 0 azerite power of tier %s, should have 1.", p.name(), util::slot_type_string( slot ),
-                      util::to_string( i ).c_str() );
+          sim.error( "Player {} has {} with 0 azerite power of tier {}, should have 1.", p.name(),
+                     util::slot_type_string( slot ), i );
       }
       // Check final item level (item level + bonus from azerite)
       if ( item.parsed.data.level > max_azerite_ilevel_allowed )
-        sim.errorf( "Player %s has %s of ilevel %s, maximum allowed ilevel for %s is %s.\n", p.name(),
-                    util::slot_type_string( slot ), util::to_string( item.parsed.data.level ).c_str(),
-                    tier_name.c_str(), util::to_string( max_azerite_ilevel_allowed ).c_str() );
+        sim.error( "Player {} has {} of ilevel {}, maximum allowed ilevel for {} is {}.\n", p.name(),
+                   util::slot_type_string( slot ), item.parsed.data.level, tier_name, max_azerite_ilevel_allowed );
     }
     // Legendary Cloak for T25 profile
     else if ( slot == SLOT_BACK && ( tier_name == "T25" || tier_name == "DS" ) )
     {
       // Check item level
       if ( item.parsed.data.level != max_cloak_ilevel )
-        sim.errorf( "Player %s has cloak of ilevel %s, ilevel for %s should be %s.\n", p.name(),
-                    util::to_string( item.parsed.data.level ).c_str(), tier_name.c_str(),
-                    util::to_string( max_cloak_ilevel ).c_str() );
+        sim.error( "Player {} has cloak of ilevel {}, ilevel for {} should be {}.\n", p.name(),
+                   item.parsed.data.level, tier_name, max_cloak_ilevel );
     }
     // Normal gear
     else
@@ -519,9 +515,8 @@ bool report_helper::check_gear( player_t& p, sim_t& sim )
       }
       // Check item level
       if ( !is_whitelisted && item.parsed.data.level > max_ilevel_allowed )
-        sim.errorf( "Player %s has %s of ilevel %s, maximum allowed ilevel for %s is %s.\n", p.name(),
-                    util::slot_type_string( slot ), util::to_string( item.parsed.data.level ).c_str(),
-                    tier_name.c_str(), util::to_string( max_ilevel_allowed ).c_str() );
+        sim.error( "Player {} has {} of ilevel {}, maximum allowed ilevel for {} is {}.\n", p.name(),
+                   util::slot_type_string( slot ), item.parsed.data.level, tier_name, max_ilevel_allowed );
     }
 
     size_t num_gems = 0;

--- a/engine/report/report_helper.hpp
+++ b/engine/report/report_helper.hpp
@@ -72,7 +72,7 @@ public:
       auto end            = std::chrono::high_resolution_clock::now();
       auto diff           = end - start_time;
       using float_seconds = std::chrono::duration<double>;
-      out << fmt::format("{} took {}seconds.",
+      fmt::print( out, "{} took {}seconds.",
           title, std::chrono::duration_cast<float_seconds>( diff ).count());
       out << std::endl;
     }

--- a/engine/sim/sc_option.hpp
+++ b/engine/sim/sc_option.hpp
@@ -40,14 +40,14 @@ public:
     _name( name )
 { }
   virtual ~option_t() { }
-  opts::parse_status parse_option( sim_t* sim , const std::string& n, const std::string& value ) const;
+  opts::parse_status parse( sim_t* sim , const std::string& n, const std::string& value ) const;
   std::string name() const
   { return _name; }
-  std::ostream& print_option( std::ostream& stream ) const
-  { return print( stream ); }
+  std::ostream& print( std::ostream& stream ) const
+  { return do_print( stream ); }
 protected:
-  virtual opts::parse_status parse( sim_t*, const std::string& name, const std::string& value ) const = 0;
-  virtual std::ostream& print( std::ostream& stream ) const = 0;
+  virtual opts::parse_status do_parse( sim_t*, const std::string& name, const std::string& value ) const = 0;
+  virtual std::ostream& do_print( std::ostream& stream ) const = 0;
 private:
   std::string _name;
 };
@@ -66,7 +66,7 @@ void parse( sim_t*, const std::string& context, const std::vector<std::unique_pt
 void parse( sim_t*, const std::string& context, const std::vector<std::unique_ptr<option_t>>&, const std::vector<std::string>& strings, const parse_status_fn_t& fn = nullptr );
 }
 inline std::ostream& operator<<( std::ostream& stream, const std::unique_ptr<option_t>& opt )
-{ return opt -> print_option( stream ); }
+{ return opt -> print( stream ); }
 
 std::unique_ptr<option_t> opt_string( const std::string& n, std::string& v );
 std::unique_ptr<option_t> opt_append( const std::string& n, std::string& v );

--- a/engine/sim/sc_raid_event.cpp
+++ b/engine/sim/sc_raid_event.cpp
@@ -1824,7 +1824,7 @@ double raid_event_t::evaluate_raid_event_expression( sim_t* s, std::string& type
 
 std::ostream& operator<<( std::ostream& os, const raid_event_t& r )
 {
-  os << fmt::format( "Raid event (type={} name={})", r.type, r.name );
+  fmt::print( os, "Raid event (type={} name={})", r.type, r.name );
   return os;
 }
 

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -601,7 +601,7 @@ bool parse_fight_style( sim_t*             sim,
   if ( it == FIGHT_STYLES.end() )
   {
     throw std::invalid_argument( fmt::format( "Unknown fight style {}, available values: {}",
-      value, util::string_join( FIGHT_STYLES ) ) );
+      value, fmt::join( FIGHT_STYLES, ", " ) ) );
   }
 
   sim->fight_style = *it;

--- a/engine/sim/sim_ostream.hpp
+++ b/engine/sim/sim_ostream.hpp
@@ -8,6 +8,7 @@
 #include "config.hpp"
 #include "fmt/core.h"
 #include "fmt/printf.h"
+#include "fmt/ostream.h"
 
 struct sim_t;
 
@@ -22,6 +23,13 @@ struct sc_raw_ostream_t {
   sc_raw_ostream_t& printf(Format&& format, Args&& ... args)
   {
     fmt::fprintf(*get_stream(), std::forward<Format>(format), std::forward<Args>(args)... );
+    return *this;
+  }
+
+  template <typename Format, typename... Args>
+  sc_raw_ostream_t& print(const Format& format, Args&& ... args)
+  {
+    fmt::print( *get_stream(), format, std::forward<Args>(args)... );
     return *this;
   }
 
@@ -79,10 +87,12 @@ struct sim_ostream_t
   /**
    * Print using fmt libraries python-like formatting syntax.
    */
-  template<typename Format, typename... Args>
-  sim_ostream_t& print(Format&& format, Args&& ... args)
+  template <typename Format, typename... Args>
+  sim_ostream_t& print(const Format& format, Args&& ... args)
   {
-    *this << fmt::format(std::forward<Format>(format), std::forward<Args>(args)... );
+    print_simulation_time();
+    fmt::print( *_raw.get_stream(), format, std::forward<Args>(args)... );
+    _raw << '\n';
     return *this;
   }
 private:

--- a/engine/util/io.hpp
+++ b/engine/util/io.hpp
@@ -8,6 +8,7 @@
 
 #include "config.hpp"
 #include "fmt/printf.h"
+#include "fmt/ostream.h"
 #include <string>
 #include <vector>
 #include <fstream>
@@ -63,20 +64,20 @@ public:
   /**
    * Output using printf formatting syntax.
    */
-  template<typename Format, typename... Args>
-  ofstream& printf(Format&& format, Args&& ... args)
+  template <typename Format, typename... Args>
+  ofstream& printf(const Format& format, Args&& ... args)
   {
-    *this << fmt::sprintf(std::forward<Format>(format), std::forward<Args>(args)... );;
+    fmt::fprintf( *this, format, std::forward<Args>(args)... );;
 
     return *this;
   }
   /**
    * Output using fmt::format formatting syntax.
    */
-  template<typename Format, typename... Args>
-  ofstream& format(Format&& format, Args&& ... args)
+  template <typename Format, typename... Args>
+  ofstream& format(const Format& format, Args&& ... args)
   {
-    *this << fmt::format(std::forward<Format>(format), std::forward<Args>(args)... );
+    fmt::print( *this, format, std::forward<Args>(args)... );
 
     return *this;
   }

--- a/engine/util/util.cpp
+++ b/engine/util/util.cpp
@@ -8,16 +8,10 @@
 #include "player/sc_player.hpp"
 #include "sim/scale_factor_control.hpp"
 #include "dbc/dbc.hpp"
+
 #include "lib/utf8-cpp/utf8.h"
-#include <iomanip>
+
 #include <cctype>
-
-#if !defined(SC_WINDOWS)
-#include <sys/time.h>
-#endif
-
-
-#include <cerrno>
 
 namespace { // anonymous namespace ==========================================
 

--- a/engine/util/util.cpp
+++ b/engine/util/util.cpp
@@ -2552,9 +2552,7 @@ std::string util::string_strip_quotes( std::string str )
 
 std::string util::to_string( double f, int precision )
 {
-  std::ostringstream ss;
-  ss << std::fixed << std::setprecision( precision ) << f;
-  return ss.str();
+  return fmt::format( "{:.{}f}", f, precision );
 }
 
 // to_string ================================================================

--- a/engine/util/util.cpp
+++ b/engine/util/util.cpp
@@ -2638,8 +2638,7 @@ void util::urlencode( std::string& str )
   {
     if ( c > 0x7F || c == ' ' || c == '\'' )
     {
-      temp += "%";
-      temp += uchar_to_hex( c );
+      fmt::format_to( std::back_inserter( temp ), "%{:02X}", c );
     }
     else if ( c == '+' )
       temp += "%20";
@@ -2889,19 +2888,6 @@ std::string util::encode_html( const std::string& s )
   replace_all( buffer, "<", "&lt;" );
   replace_all( buffer, ">", "&gt;" );
   return buffer;
-}
-
-/* Turn a unsigned char ( 0-255 ) into a hexadecimal string representation
- * with length 2 and upper case letters
- */
-std::string util::uchar_to_hex( unsigned char c )
-{
-  std::stringstream out;
-
-  out.width( 2 ); out.fill( '0' ); // Make sure we always fill out two spaces, so we get 00 not 0
-  out << std::fixed << std::uppercase << std::hex << static_cast<int>( c );
-
-  return out.str();
 }
 
 // floor ====================================================================

--- a/engine/util/util.hpp
+++ b/engine/util/util.hpp
@@ -225,7 +225,9 @@ void print_chained_exception( std::exception_ptr eptr, std::ostream& out, int le
 
 template <typename T>
 std::string util::to_string( const T& t )
-{ std::stringstream s; s << t; return s.str(); }
+{
+  return fmt::to_string( t );
+}
 
 template <typename T>
 std::string util::string_join( const T& container, const std::string& delim )

--- a/engine/util/util.hpp
+++ b/engine/util/util.hpp
@@ -230,17 +230,5 @@ std::string util::to_string( const T& t )
 template <typename T>
 std::string util::string_join( const T& container, const std::string& delim )
 {
-  std::stringstream s;
-
-  for ( auto i = container.cbegin(); i < container.cend(); ++i )
-  {
-    if ( i != container.cbegin() && ! delim.empty() )
-    {
-      s << delim;
-    }
-
-    s << util::to_string( *i );
-  }
-
-  return s.str();
+  return fmt::format( "{}", fmt::join( container, delim ) );
 }

--- a/engine/util/util.hpp
+++ b/engine/util/util.hpp
@@ -173,7 +173,6 @@ std::string decode_html( const std::string& );
 std::string remove_special_chars( const std::string& );
 void urlencode( std::string& str );
 void urldecode( std::string& str );
-std::string uchar_to_hex( unsigned char );
 std::string create_blizzard_talent_url( const player_t& p );
 std::string create_wowhead_artifact_url( const player_t& p );
 

--- a/engine/util/util.hpp
+++ b/engine/util/util.hpp
@@ -7,17 +7,19 @@
 
 #include "config.hpp"
 
+#include "dbc/data_enums.hh"
+#include "dbc/specialization.hpp"
+#include "sc_enums.hpp"
+#include "sc_timespan.hpp"
+
 #include "fmt/format.h"
 #include "fmt/ostream.h"
 #include "fmt/printf.h"
-#include "sc_enums.hpp"
-#include "dbc/data_enums.hh"
-#include "dbc/specialization.hpp"
-#include "sc_timespan.hpp"
 
-#include <sstream>
-#include <vector>
+#include <exception>
+#include <iosfwd>
 #include <string>
+#include <vector>
 
 // Forward declarations
 struct player_t;


### PR DESCRIPTION
Main idea was to cleanup its usage in `util`. Got sidetracked a bit with various other places.

Overall (apart from `util` cleanups):
* replace uses of `util::string_join()` with `fmt::join()` where already formatting with `libfmt`
* remove uses of `util:to_string()` where already formatting with `libfmt` (non-double only, as the output would be different)
* lessen the reliance on streams and prefer formatting to streams with `libfmt`