### PR TITLE
Remove runtime selection of rng engines

### DIFF
--- a/engine/sim/event.hpp
+++ b/engine/sim/event.hpp
@@ -62,7 +62,6 @@ struct event_t : private noncopyable
   const sim_t& sim() const
   { return _sim; }
   rng::rng_t& rng();
-  rng::rng_t& rng() const;
 
   virtual void execute() = 0; // MUST BE IMPLEMENTED IN SUB-CLASS!
   virtual const char* name() const

--- a/engine/sim/sc_event.cpp
+++ b/engine/sim/sc_event.cpp
@@ -40,9 +40,6 @@ timespan_t event_t::remains() const
 rng::rng_t& event_t::rng()
 { return sim().rng(); }
 
-rng::rng_t& event_t::rng() const
-{ return sim().rng(); }
-
 /// Placement-new operator for creating events. Do not use in user-code.
 void* event_t::operator new( std::size_t size, sim_t& sim )
 {

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -30,7 +30,6 @@
 #include "sim/sc_cooldown.hpp"
 #include "sim/x6_pantheon.hpp"
 #include "dbc/spell_query/spell_data_expr.hpp"
-#include "util/rng.hpp"
 #include "util/xml.hpp"
 #include <random>
 #ifdef SC_WINDOWS
@@ -1565,7 +1564,7 @@ sim_t::~sim_t()
 
 // sim_t::iteration_time_adjust =============================================
 
-double sim_t::iteration_time_adjust() const
+double sim_t::iteration_time_adjust()
 {
   if ( iterations <= 1 )
     return 1.0;
@@ -2539,8 +2538,7 @@ void sim_t::init()
       seed  = uint64_t(rd()) | (uint64_t(rd()) << 32);
     }
   }
-  _rng = rng::create( rng::parse_type( rng_str ) );
-  _rng -> seed( seed + thread_index );
+  _rng.seed( seed + thread_index );
 
   if (   queue_lag_stddev == timespan_t::zero() )   queue_lag_stddev =   queue_lag * 0.25;
   if (     gcd_lag_stddev == timespan_t::zero() )     gcd_lag_stddev =     gcd_lag * 0.25;
@@ -3467,7 +3465,7 @@ void sim_t::create_options()
   // Regen
   add_option( opt_timespan( "regen_periodicity", regen_periodicity ) );
   // RNG
-  add_option( opt_string( "rng", rng_str ) );
+  add_option( opt_obsoleted( "rng" ) );
   add_option( opt_bool( "deterministic", deterministic ) );
   add_option( opt_bool( "strict_work_queue", strict_work_queue ) );
   add_option( opt_float( "report_iteration_data", report_iteration_data ) );

--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -16,6 +16,8 @@
 #include "sc_profileset.hpp"
 #include "event_manager.hpp"
 #include "util/util.hpp"
+#include "util/rng.hpp"
+
 #include <map>
 #include <mutex>
 #include <memory>
@@ -33,9 +35,6 @@ struct option_t;
 struct plot_t;
 struct raid_event_t;
 struct reforge_plot_t;
-namespace rng {
-  struct rng_t;
-}
 struct scale_factor_control_t;
 struct sim_control_t;
 struct spell_data_expr_t;
@@ -181,8 +180,7 @@ struct sim_t : private sc_thread_t
   std::vector<std::string> item_db_sources;
 
   // Random Number Generation
-  std::unique_ptr<rng::rng_t> _rng;
-  std::string rng_str;
+  rng::rng_t _rng;
   uint64_t seed;
   int deterministic;
   int strict_work_queue;
@@ -568,7 +566,7 @@ struct sim_t : private sc_thread_t
 
   virtual void run() override;
   int       main( const std::vector<std::string>& args );
-  double    iteration_time_adjust() const;
+  double    iteration_time_adjust();
   double    expected_max_time() const;
   bool      is_canceled() const;
   void      cancel_iteration();
@@ -650,8 +648,10 @@ struct sim_t : private sc_thread_t
   { return s.confidence_estimator * sd.mean_std_dev; }
   void register_target_data_initializer(std::function<void(actor_target_data_t*)> cb)
   { target_data_initializer.push_back( cb ); }
-  rng::rng_t& rng() const
-  { return *_rng; }
+  const rng::rng_t& rng() const
+  { return _rng; }
+  rng::rng_t& rng()
+  { return _rng; }
   double averaged_range( double min, double max );
 
   // Thread id of this sim_t object

--- a/engine/util/rng.cpp
+++ b/engine/util/rng.cpp
@@ -3,9 +3,10 @@
 // Send questions to natehieter@gmail.com
 // ==========================================================================
 
+#include "rng.hpp"
+
 #include <cstdint>
 #include <algorithm>
-#include "rng.hpp"
 
 // Pseudo-Random Number Generation ==========================================
 
@@ -13,100 +14,51 @@ namespace rng {
 
 namespace {
 
-/// MAGIC! http://en.wikipedia.org/wiki/Double-precision_floating-point_format
-double convert_to_double_0_1( uint64_t ui64 )
-{
-  ui64 &= 0x000fffffffffffff;
-  ui64 |= 0x3ff0000000000000;
-  union { uint64_t ui64; double d; } u;
-  u.ui64 = ui64;
-  return u.d - 1.0;
-}
-
 /**
  * @brief SplitMix64 Random Number Generator
- * 
+ *
  * Used to seed other generators
  *
  * All credit goes to Sebastiano Vigna (vigna@acm.org) @2014
  * http://prng.di.unimi.it/
  */
-class rng_split_mix64_t : public rng_t
+struct split_mix64_t
 {
-private:
   uint64_t x; // The state can be seeded with any value.
 
-public:
-  uint64_t next() 
-  { 
+  uint64_t next() noexcept
+  {
     uint64_t z = (x += 0x9e3779b97f4a7c15);
     z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
     z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
     return z ^ (z >> 31);
   }
 
-  const char* name() const override { return "SplitMix64"; }
-
-  void seed( uint64_t start ) override
-  { 
+  void seed( uint64_t start ) noexcept
+  {
     x = start;
   }
 
-  double real() override
-  { 
-    return convert_to_double_0_1( next() );
+  const char* name() const noexcept
+  {
+    return "SplitMix64";
   }
 };
-
-void init_state_from_mix64(uint64_t& state, uint64_t start)
-{    
-  rng_split_mix64_t mix64;
-  mix64.seed( start );
-  state = mix64.next();
-}
 
 template <typename Range>
-void init_state_from_mix64(Range& range, uint64_t start)
+void init_state_from_mix64( Range& range, uint64_t start)
 {
-    rng_split_mix64_t mix64;
-    mix64.seed( start );
-    for(auto & elem : range)
-    {
-      elem=mix64.next();
-    } 
+  split_mix64_t mix64;
+  mix64.seed( start );
+  for (auto & elem : range)
+    elem = mix64.next();
 }
 
-/**
- * @brief XORSHIFT-64 Random Number Generator
- *
- * All credit goes to Sebastiano Vigna (vigna@acm.org) @2014
- * http://xorshift.di.unimi.it/
- */
-struct rng_xorshift64_t : public rng_t
-{
-  uint64_t x; /* The state must be seeded with a nonzero value. */
+constexpr uint64_t rotl( const uint64_t x, int k ) {
+  return (x << k) | (x >> (64 - k));
+}
 
-  uint64_t next() 
-  {
-    x ^= x >> 12; // a
-    x ^= x << 25; // b
-    x ^= x >> 27; // c
-    return x * 2685821657736338717LL;
-  }
-
-  const char* name() const override { return "xorshift64"; }
-
-  void seed( uint64_t start ) override
-  { 
-    init_state_from_mix64(x, start);
-  }
-
-  double real() override
-  { 
-    return convert_to_double_0_1( next() );
-  }
-};
-
+} // anon namespace
 
 /**
  * @brief XORSHIFT-128 Random Number Generator
@@ -114,82 +66,62 @@ struct rng_xorshift64_t : public rng_t
  * All credit goes to Sebastiano Vigna (vigna@acm.org) @2014
  * http://xorshift.di.unimi.it/
  */
-struct rng_xorshift128_t : public rng_t
+uint64_t xorshift128_t::next() noexcept
 {
-  uint64_t s[2];
+  uint64_t s1 = s[ 0 ];
+  const uint64_t s0 = s[ 1 ];
+  s[ 0 ] = s0;
+  s1 ^= s1 << 23; // a
+  return ( s[ 1 ] = ( s1 ^ s0 ^ ( s1 >> 17 ) ^ ( s0 >> 26 ) ) ) + s0; // b, c
+}
 
-  uint64_t next() 
-  { 
-    uint64_t s1 = s[ 0 ];
-    const uint64_t s0 = s[ 1 ];
-    s[ 0 ] = s0;
-    s1 ^= s1 << 23; // a
-    return ( s[ 1 ] = ( s1 ^ s0 ^ ( s1 >> 17 ) ^ ( s0 >> 26 ) ) ) + s0; // b, c
-  }
+void xorshift128_t::seed( uint64_t start ) noexcept
+{
+  init_state_from_mix64(s, start);
+}
 
-  const char* name() const override { return "xorshift128"; }
-
-  void seed( uint64_t start ) override
-  { 
-    init_state_from_mix64(s, start);
-  }
-
-  double real() override
-  { 
-    return convert_to_double_0_1( next() );
-  }
-};
+const char* xorshift128_t::name() const noexcept
+{
+  return "xorshift128";
+}
 
 /**
  * @brief xoshiro256+ Random Number Generator
  *
  * If, however, one has to generate only 64-bit floating-point numbers (by extracting the upper 53 bits) xoshiro256+
- * is a slightly (≈15%) faster [compared to xoshiro256** or xoshiro256++] generator with analogous statistical 
+ * is a slightly (≈15%) faster [compared to xoshiro256** or xoshiro256++] generator with analogous statistical
  * properties.
- * 
+ *
  * All credit goes to David Blackman and Sebastiano Vigna (vigna@acm.org) @2018
  * http://prng.di.unimi.it/
  */
-class rng_xoshiro256plus_t : public rng_t
+uint64_t xoshiro256plus_t::next() noexcept
 {
-private:
-  uint64_t s[4];
+  const uint64_t result = s[0] + s[3];
 
-  static inline uint64_t rotl(const uint64_t x, int k) {
-    return (x << k) | (x >> (64 - k));
-  }
+  const uint64_t t = s[1] << 17;
 
-  uint64_t next() 
-  { 
-    const uint64_t result = s[0] + s[3];
+  s[2] ^= s[0];
+  s[3] ^= s[1];
+  s[1] ^= s[2];
+  s[0] ^= s[3];
 
-    const uint64_t t = s[1] << 17;
+  s[2] ^= t;
 
-    s[2] ^= s[0];
-    s[3] ^= s[1];
-    s[1] ^= s[2];
-    s[0] ^= s[3];
+  s[3] = rotl(s[3], 45);
 
-    s[2] ^= t;
+  return result;
+}
 
-    s[3] = rotl(s[3], 45);
+void xoshiro256plus_t::seed( uint64_t start ) noexcept
+{
+  init_state_from_mix64(s, start);
+}
 
-    return result;
-  }
-
-  const char* name() const override { return "xoshiro256+"; }
-
-  void seed( uint64_t start ) override
-  { 
-    init_state_from_mix64(s, start);
-  }
-
-  double real() override
-  { 
-    return convert_to_double_0_1( next() );
-  }
-};
-
+const char* xoshiro256plus_t::name() const noexcept
+{
+  return "xoshiro256+";
+}
 
 /**
  * @brief XORSHIFT-1024 Random Number Generator
@@ -197,208 +129,24 @@ private:
  * All credit goes to Sebastiano Vigna (vigna@acm.org) @2014
  * http://xorshift.di.unimi.it/
  */
-struct rng_xorshift1024_t : public rng_t
+uint64_t xorshift1024_t::next() noexcept
 {
-  uint64_t s[16];
-  int p;
-
-  uint64_t next()
-  { 
-    uint64_t s0 = s[ p ];
-    uint64_t s1 = s[ p = ( p + 1 ) & 15 ];
-    s1 ^= s1 << 31; // a
-    s1 ^= s1 >> 11; // b
-    s0 ^= s0 >> 30; // c
-    return ( s[ p ] = s0 ^ s1 ) * 1181783497276652981LL; 
-  }
-
-  const char* name() const override { return "xorshift1024"; }
-
-  void seed( uint64_t start ) override
-  { 
-    init_state_from_mix64(s, start);
-  }
-
-  double real() override
-  { 
-    return convert_to_double_0_1( next() );
-  }
-};
-
-
-} // unnamed
-
-// ==========================================================================
-// Probability Distributions
-// ==========================================================================
-
-/// Bernoulli Distribution
-bool rng_t::roll( double chance )
-{
-  if ( chance <= 0 ) return false;
-  if ( chance >= 1 ) return true;
-  return real() < chance;
+  uint64_t s0 = s[ p ];
+  uint64_t s1 = s[ p = ( p + 1 ) & 15 ];
+  s1 ^= s1 << 31; // a
+  s1 ^= s1 >> 11; // b
+  s0 ^= s0 >> 30; // c
+  return ( s[ p ] = s0 ^ s1 ) * 1181783497276652981LL;
 }
 
-/// Uniform distribution in the range [min max]
-double rng_t::range( double min, double max )
+void xorshift1024_t::seed( uint64_t start ) noexcept
 {
-  assert( min <= max );
-  return min + real() * ( max - min );
+  init_state_from_mix64(s, start);
 }
 
-/**
- * @brief Gaussian Distribution
- *
- * This code adapted from ftp://ftp.taygeta.com/pub/c/boxmuller.c
- * Implements the Polar form of the Box-Muller Transformation
- *
- * (c) Copyright 1994, Everett F. Carter Jr.
- *     Permission is granted by the author to use
- *     this software for any application provided this
- *     copyright notice is preserved.
- */
-double rng_t::gauss( double mean, double stddev, bool truncate_low_end )
+const char* xorshift1024_t::name() const noexcept
 {
-  assert(stddev >= 0 && "Calling gauss with negative stddev");
-  
-  double z;
-
-  if ( stddev != 0 )
-  {
-    if ( gauss_pair_use )
-    {
-      z = gauss_pair_value;
-      gauss_pair_use = false;
-    }
-    else
-    {
-      double x1, x2, w, y1, y2;
-      do
-      {
-  x1 = 2.0 * real() - 1.0;
-  x2 = 2.0 * real() - 1.0;
-  w = x1 * x1 + x2 * x2;
-      }
-      while ( w >= 1.0 || w == 0.0 );
-
-      w = sqrt( ( -2.0 * log( w ) ) / w );
-      y1 = x1 * w;
-      y2 = x2 * w;
-      
-      z = y1;
-      gauss_pair_value = y2;
-      gauss_pair_use = true;
-    }
-  }
-  else
-    z = 0.0;
-
-  double result = mean + z * stddev;
-
-  // True gaussian distribution can of course yield any number at some probability.  So truncate on the low end.
-  if ( truncate_low_end && result < 0 )
-    result = 0;
-
-  return result;
-}
-
-/// Exponential Distribution
-double rng_t::exponential( double nu )
-{
-  double x;
-  do { x = real(); } while ( x >= 1.0 ); // avoid ln(0)
-  return - std::log( 1 - x ) * nu;
-}
-
-/// Exponentially Modified Gaussian Distribution
-double rng_t::exgauss( double gauss_mean, 
-           double gauss_stddev, 
-           double exp_nu )
-{ 
-  return std::max( 0.0, gauss( gauss_mean, gauss_stddev ) + exponential( exp_nu ) ); 
-}
-
-/// timespan uniform distribution in the range [min max]
-timespan_t rng_t::range( timespan_t min, timespan_t max )
-{
-  return timespan_t::from_native( range( static_cast<double>( timespan_t::to_native( min ) ),
-                                         static_cast<double>( timespan_t::to_native( max ) ) ) );
-}
-
-/// timespan Gaussian Distribution
-timespan_t rng_t::gauss( timespan_t mean, timespan_t stddev )
-{
-  return timespan_t::from_native( gauss( static_cast<double>( timespan_t::to_native( mean ) ),
-                                         static_cast<double>( timespan_t::to_native( stddev ) ) ) );
-}
-
-/// tiemspan exponentially Modified Gaussian Distribution
-timespan_t rng_t::exgauss( timespan_t mean, timespan_t stddev, timespan_t nu )
-{
-  return timespan_t::from_native( exgauss( static_cast<double>( timespan_t::to_native( mean   ) ),
-             static_cast<double>( timespan_t::to_native( stddev ) ),
-             static_cast<double>( timespan_t::to_native( nu ) ) ) );
-}
-
-/// Reseed using current state
-uint64_t rng_t::reseed()
-{
-  union { uint64_t s; double d; } w;
-  w.d = real();
-  seed( w.s );
-  reset();
-  return w.s;
-}
-
-/// reset any state
-void rng_t::reset()
-{
-  gauss_pair_value = 0;
-  gauss_pair_use = false;
-}
-
-rng_t::rng_t() :
-    gauss_pair_value( 0.0 ), gauss_pair_use( false )
-{
-}
-
-// ==========================================================================
-// RNG Engine Broker
-// ==========================================================================
-
-/// parse rng type from string
-engine_type parse_type( const std::string& n )
-{
-  if( n == "xorshift128"  ) return engine_type::XORSHIFT128;
-  if( n == "xoshiro256+"  ) return engine_type::XOSHIRO256PLUS;
-  if( n == "xorshift1024" ) return engine_type::XORSHIFT1024;
-
-  return engine_type::DEFAULT;
-}
-
-/**
- * Factory method to create a rng object with given rng-engine type
- */
-std::unique_ptr<rng_t> create( engine_type t )
-{
-  switch( t )
-  {
-  case engine_type::XORSHIFT128:
-    return std::make_unique<rng_xorshift128_t>();
-
-  case engine_type::XOSHIRO256PLUS:
-    return std::make_unique<rng_xoshiro256plus_t>();
-
-  case engine_type::XORSHIFT1024:
-    return std::make_unique<rng_xorshift1024_t>();
-
-  case engine_type::DEFAULT:
-  default:
-    break;
-  }
-
-  return create( engine_type::XOSHIRO256PLUS );
+  return "xorshift1024";
 }
 
 /**
@@ -580,18 +328,17 @@ double stdnormal_inv( double p )
 #ifdef UNIT_TEST
 // Code to test functionality and performance of our RNG implementations
 
-#include <iostream>
-#include <iomanip>
 #include <random>
+#include <tuple>
+
 #include "lib/fmt/format.h"
 #include "util/generic.hpp"
 #include "util/chrono.hpp"
 
-namespace rng {
-
 using test_clock = chrono::cpu_clock;
 
-static void test_one( rng_t& rng, uint64_t n )
+template <typename Engine>
+static void test_one( rng::basic_rng_t<Engine>& rng, uint64_t n )
 {
   auto start_time = test_clock::now();
 
@@ -606,13 +353,12 @@ static void test_one( rng_t& rng, uint64_t n )
   average /= n;
   auto elapsed_cpu = chrono::elapsed_fp_seconds(start_time);
 
-  std::cout << n << " calls to rng::" << rng.name() << "::real()"
-            << ", average = " << std::setprecision( 8 ) << average
-            << ", time = " << elapsed_cpu << " s"
-               ", numbers/sec = " << static_cast<uint64_t>( n * 1000.0 / elapsed_cpu ) << "\n\n";
+  fmt::print( "{} calls to rng::{}::real(), average = {:.8f}, time = {}s, numbers/sec = {}\n\n",
+              n, rng.name(), average, elapsed_cpu, static_cast<uint64_t>( n * 1000.0 / elapsed_cpu ) );
 }
 
-static void test_seed( rng_t& rng, uint64_t n )
+template <typename Engine>
+static void test_seed( rng::basic_rng_t<Engine>& rng, uint64_t n )
 {
   auto start_time = test_clock::now();
 
@@ -623,13 +369,13 @@ static void test_seed( rng_t& rng, uint64_t n )
 
   auto elapsed_cpu = chrono::elapsed_fp_seconds(start_time);
 
-  std::cout << n << " calls to rng::" << rng.name() << "::seed()"
-            << ", time = " << elapsed_cpu << " s"
-               ", numbers/sec = " << static_cast<uint64_t>( n * 1000.0 / elapsed_cpu ) << "\n\n";
+  fmt::print( "{} calls to rng::{}::seed(), time = {}s, numbers/sec = {}\n\n",
+              n, rng.name(), elapsed_cpu, static_cast<uint64_t>( n * 1000.0 / elapsed_cpu ) );
 }
 
 // Monte-Carlo PI calculation.
-static void monte_carlo( rng_t& rng, uint64_t n )
+template <typename Engine>
+static void monte_carlo( rng::basic_rng_t<Engine>& rng, uint64_t n )
 {
   auto start_time = test_clock::now();
 
@@ -643,14 +389,13 @@ static void monte_carlo( rng_t& rng, uint64_t n )
   }
   auto elapsed_cpu = chrono::elapsed_fp_seconds(start_time);
 
-  std::cout << n << " runs for pi-calculation with " << rng.name()
-            << ". count in sphere = " << count_in_sphere
-            << ", pi = " << std::setprecision( 21 ) << static_cast<double>( count_in_sphere ) * 4 / n
-            << ", time = " << elapsed_cpu << " s"
-               ", numbers/sec = " << static_cast<uint64_t>( n * 1000.0 / elapsed_cpu ) << "\n\n";
+  fmt::print( "{} runs for pi-calculation with {}. count in sphere = {}, pi = {:.21f}, time = {}s, numbers/sec = {}\n\n",
+              n, rng.name(), count_in_sphere, static_cast<double>( count_in_sphere ) * 4 / n,
+              elapsed_cpu, static_cast<uint64_t>( n * 1000.0 / elapsed_cpu ) );
 }
 
-static void test_uniform_int( rng_t& rng, uint64_t n, unsigned num_buckets )
+template <typename Engine>
+static void test_uniform_int( rng::basic_rng_t<Engine>& rng, uint64_t n, unsigned num_buckets )
 {
   auto start_time = test_clock::now();
 
@@ -676,45 +421,50 @@ static void test_uniform_int( rng_t& rng, uint64_t n, unsigned num_buckets )
   fmt::print("time = {} s\n\n", elapsed_cpu);
 }
 
-} // namespace rng
+namespace detail {
+template <typename Tuple, typename F, std::size_t... I>
+void for_each_impl(Tuple&& t, F&& f, std::index_sequence<I...>)
+{
+  int _[] = { ( range::invoke( std::forward<F>( f ), std::get<I>( std::forward<Tuple>(t) ) ), 0 )... };
+  (void)_;
+}
+}
+
+template <typename Tuple, typename F>
+void for_each(Tuple&& t, F&& f)
+{
+    return detail::for_each_impl( std::forward<Tuple>(t), std::forward<F>(f),
+            std::make_index_sequence<std::tuple_size<std::remove_reference_t<Tuple>>::value>{});
+}
 
 int main( int /*argc*/, char** /*argv*/ )
 {
-  using namespace rng;
-  auto generators = std::vector<std::unique_ptr<rng_t>>();
-  generators.push_back(std::make_unique<rng_xorshift128_t>());
-  generators.push_back(std::make_unique<rng_xoshiro256plus_t>());
-  generators.push_back(std::make_unique<rng_xorshift1024_t>());
+  auto generators = std::make_tuple(
+    rng::basic_rng_t<rng::xoshiro256plus_t>{},
+    rng::basic_rng_t<rng::xorshift128_t>{},
+    rng::basic_rng_t<rng::xorshift1024_t>{}
+  );
 
   std::random_device rd;
   uint64_t seed  = uint64_t(rd()) | (uint64_t(rd()) << 32);
-  std::cout << "Seed: " << seed << "\n\n";
+  fmt::print( "Seed: {}\n\n", seed );
 
-  range::for_each(generators, [&](auto& g) {g->seed(seed);});
+  for_each( generators, [seed]( auto& g ) { g.seed( seed ); } );
 
-  uint64_t n = 1000000000;
+  for_each( generators, []( auto& g ) { test_one( g, 1'000'000'000 ); } );
 
-  
-  range::for_each(generators, [&](auto& g) {test_one(*g, n);});
+  for_each( generators, []( auto& g ) { monte_carlo( g, 1'000'000'000 ); } );
 
-  range::for_each(generators, [&](auto& g) {monte_carlo(*g, n);});
+  for_each( generators, []( auto& g ) { test_seed( g, 10'000'000 ); } );
 
-  auto n_seed_test = 10000000;
-  range::for_each(generators, [&](auto& g) {test_seed(*g, n_seed_test);});
+  for_each( generators, []( auto& g ) { test_uniform_int( g, 10'000, 10 ); } );
 
+  fmt::print( "random device: min={} max={}\n\n", rd.min(), rd.max() );
 
+  auto& rng = std::get<0>( generators );
+  fmt::print( "Testing {}\n\n", rng.name() );
 
-  unsigned num_buckets = 10;
-  uint64_t k = 10000;
-  range::for_each(generators, [&](auto& g) {test_uniform_int(*g, k, num_buckets );});
-
-  std::cout << "random device: min=" << rd.min() << " max=" << rd.max() << "\n\n";
-
-  rng_t* rng = generators[0].get();
-
-  std::cout << "Testing " << rng -> name() << "\n\n";
-
-  n /= 10;
+  const uint64_t n = 100'000'000;
 
   // double gauss
   {
@@ -722,12 +472,11 @@ int main( int /*argc*/, char** /*argv*/ )
 
     double average = 0;
     for ( uint64_t i = 0; i < n; i++ )
-      average += rng -> gauss( 0, 1 );
+      average += rng.gauss( 0, 1 );
     average /= n;
-    auto elapsed_cpu = chrono::elapsed_fp_seconds(start_time);
 
-    std::cout << n << " calls to gauss(0,1): average = " << std::setprecision( 8 ) << average
-              << ", time = " << elapsed_cpu << " ms\n\n";
+    fmt::print( "{} calls to gauss(0, 1): average = {:.8f}, time = {}s\n\n",
+                n, average, chrono::elapsed_fp_seconds(start_time) );
   }
 
   // double exgauss
@@ -736,12 +485,11 @@ int main( int /*argc*/, char** /*argv*/ )
 
     double average = 0;
     for ( uint64_t i = 0; i < n; i++ )
-      average += 0.1 + rng -> exgauss( 0.3, 0.06, 0.25 );
+      average += 0.1 + rng.exgauss( 0.3, 0.06, 0.25 );
     average /= n;
-    auto elapsed_cpu = chrono::elapsed_fp_seconds(start_time);
 
-    std::cout << n << " calls to 0.1 + rng.exgauss( 0.3,0.06,0.25 );: average = " << std::setprecision( 8 ) << average
-              << ", time = " << elapsed_cpu << " s\n\n";
+    fmt::print( "{} calls to 0.1 + rng.exgauss( 0.3,0.06,0.25 );: average = {:.8f}, time = {}s\n\n",
+                n, average, chrono::elapsed_fp_seconds(start_time) );
   }
 
   // exponential
@@ -752,46 +500,32 @@ int main( int /*argc*/, char** /*argv*/ )
     double average = 0;
     for ( uint64_t i = 0; i < n; i++ )
     {
-      double result = rng -> exponential( nu );
+      double result = rng.exponential( nu );
       average += result;
     }
     average /= n;
-    auto elapsed_cpu = chrono::elapsed_fp_seconds(start_time);
 
-    std::cout << n << " calls exp nu=0.25: "
-              "average = " << average << " "
-              "time = " << elapsed_cpu << " s\n\n";
+    fmt::print( "{} calls exp nu=0.25: average = {}, time = {}s\n\n",
+                n, average, chrono::elapsed_fp_seconds(start_time) );
   }
 
-  std::cout << "\nreal:\n";
+  fmt::print( "\nreal:\n" );
   for ( unsigned i = 1; i <= 100; i++ )
-  {
-    std::cout << "  " << rng -> real();
-    if ( i % 10 == 0 )
-      std::cout << '\n';
-  }
+    fmt::print( "  {:>11.8f}{}", rng.real(), i % 10 == 0 ? "\n" : "" );
 
-  std::cout << "\ngauss mean=0, std_dev=1.0:\n";
+  fmt::print( "\ngauss mean=0, std_dev=1.0:\n" );
   for ( unsigned i = 1; i <= 100; i++ )
-  {
-    std::cout << "  " << rng -> gauss( 0.0, 1.0 );
-    if ( i % 10 == 0 )
-      std::cout << '\n';
-  }
+    fmt::print( "  {:>11.8f}{}", rng.gauss( 0.0, 1.0 ), i % 10 == 0 ? "\n" : "" );
 
-  std::cout << "\nroll 30%:\n";
+  fmt::print( "\nroll 30%:\n" );
   for ( unsigned i = 1; i <= 100; i++ )
-  {
-    std::cout << "  " << rng -> roll( 0.30 );
-    if ( i % 10 == 0 )
-      std::cout << '\n';
-  }
+    fmt::print( "  {:d}{}", rng.roll( 0.30 ), i % 10 == 0 ? "\n" : "" );
 
-  std::cout << "\n";
-  std::cout << "m_pi=" << m_pi << "\n";
-  std::cout << "calls to rng::stdnormal_inv( double x )\n";
-  std::cout << "x=0.975: " << rng::stdnormal_inv( 0.975 ) << " should be equal to 1.959964\n";
-  std::cout << "x=0.995: " << rng::stdnormal_inv( 0.995 ) << " should be equal to 2.5758293\n";
+  fmt::print( "\n" );
+  fmt::print( "m_pi={}\n", m_pi );
+  fmt::print( "calls to rng::stdnormal_inv( double x )\n" );
+  fmt::print( "x=0.975: {:.7} should be equal to 1.959964\n", rng::stdnormal_inv( 0.975 ) );
+  fmt::print( "x=0.995: {:.8} should be equal to 2.5758293\n", rng::stdnormal_inv( 0.995 ) );
 }
 
 #endif // UNIT_TEST

--- a/engine/util/rng.hpp
+++ b/engine/util/rng.hpp
@@ -9,8 +9,11 @@
 /*! \defgroup SC_RNG Random Number Generator */
 
 #include "config.hpp"
-#include <memory>
-#include <string>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+
 #include "sc_timespan.hpp"
 
 /** \ingroup SC_RNG
@@ -18,64 +21,285 @@
  */
 namespace rng {
 
-
-/// rng engines
-enum class engine_type {
-  DEFAULT, XORSHIFT128, XOSHIRO256PLUS, XORSHIFT1024
-};
-
 /**\ingroup SC_RNG
- * @brief Random number generator base class
+ * @brief Random number generator wrapper around an rng engine
  *
- * Implements different rng-engines, selectable through a factory,
- * as well as different distribution outputs ( uniform, gauss, etc. )
+ * Implements different distribution outputs ( uniform, gauss, etc. )
  */
-struct rng_t
+template <typename Engine>
+struct basic_rng_t
 {
+public:
+  explicit basic_rng_t() = default;
 
-  virtual ~rng_t() {}
-  /// name of rng engine
-  virtual const char* name() const = 0;
-  /// seed rng engine
-  virtual void seed( uint64_t start ) = 0;
-  /// uniform distribution in range [0,1]
-  virtual double real() = 0;
-  virtual uint64_t reseed();
-  virtual void reset();
+  basic_rng_t(const basic_rng_t&) = delete;
+  basic_rng_t& operator=(const basic_rng_t&) = delete;
 
+  /// Return engine name
+  const char* name() const {
+    return engine.name();
+  }
+
+  /// Seed rng engine
+  void seed( uint64_t s ) {
+    engine.seed( s );
+  }
+
+  /// Reseed using current state
+  uint64_t reseed();
+
+  /// Reset any state
+  void reset();
+
+  /// Uniform distribution in range [0,1]
+  double real();
+
+  /// Bernoulli Distribution
   bool roll( double chance );
+
+  /// Uniform distribution in the range [min max]
   double range( double min, double max );
 
-  template<class T, typename = typename std::enable_if<std::is_integral<T>::value>::type>
-  T range(T min, T max)
-  {
-	  return static_cast<T>(range(static_cast<double>(min), static_cast<double>(max)));
+  template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+  T range( T min, T max ) {
+    return static_cast<T>(range(static_cast<double>(min), static_cast<double>(max)));
   }
 
-  template<class T, typename = typename std::enable_if<std::is_integral<T>::value>::type>
-  T range(T max)
-  {
-	  return static_cast<T>(range(T{}, static_cast<double>(max)));
+  template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+  T range( T max ) {
+    return range<T>( T{}, max );
   }
 
-
+  /// Gaussian Distribution
   double gauss( double mean, double stddev, bool truncate_low_end = false );
-  double exponential( double nu );
-  double exgauss( double gauss_mean, double gauss_stddev, double exp_nu );
-  timespan_t range( timespan_t min, timespan_t max );
-  timespan_t gauss( timespan_t mean, timespan_t stddev );
-  timespan_t exgauss( timespan_t mean, timespan_t stddev, timespan_t nu );
-protected:
-  rng_t();
-private:
-  // Allow re-use of unused ( but necessary ) random number of a previous call to gauss()  
-  double gauss_pair_value; 
-  bool   gauss_pair_use;
 
+  /// Exponential Distribution
+  double exponential( double nu );
+
+  /// Exponentially Modified Gaussian Distribution
+  double exgauss( double gauss_mean, double gauss_stddev, double exp_nu );
+
+  /// Timespan uniform distribution in the range [min max]
+  timespan_t range( timespan_t min, timespan_t max );
+
+  /// Timespan Gaussian Distribution
+  timespan_t gauss( timespan_t mean, timespan_t stddev );
+
+  /// Timespan exponentially Modified Gaussian Distribution
+  timespan_t exgauss( timespan_t mean, timespan_t stddev, timespan_t nu );
+
+private:
+  Engine engine;
+  // Allow re-use of unused ( but necessary ) random number of a previous call to gauss()
+  double gauss_pair_value = 0.0;
+  bool   gauss_pair_use = false;
 };
 
-std::unique_ptr<rng_t> create( engine_type = engine_type::DEFAULT );
-engine_type parse_type( const std::string& name );
+/// Reseed using current state
+template <typename Engine>
+uint64_t basic_rng_t<Engine>::reseed()
+{
+  const uint64_t s = engine.next();
+  seed( s );
+  reset();
+  return s;
+}
+
+/// Reset state
+template <typename Engine>
+void basic_rng_t<Engine>::reset()
+{
+  gauss_pair_value = 0;
+  gauss_pair_use = false;
+}
+
+// ==========================================================================
+// Probability Distributions
+// ==========================================================================
+
+/// Uniform distribution in range [0,1]
+template <typename Engine>
+inline double basic_rng_t<Engine>::real()
+{
+  /// MAGIC! http://en.wikipedia.org/wiki/Double-precision_floating-point_format
+  uint64_t ui64 = engine.next();
+  ui64 &= 0x000fffffffffffff;
+  ui64 |= 0x3ff0000000000000;
+  union { uint64_t ui64; double d; } u;
+  u.ui64 = ui64;
+  return u.d - 1.0;
+}
+
+/// Bernoulli Distribution
+template <typename Engine>
+bool basic_rng_t<Engine>::roll( double chance )
+{
+  if ( chance <= 0 ) return false;
+  if ( chance >= 1 ) return true;
+  return real() < chance;
+}
+
+/// Uniform distribution in the range [min max]
+template <typename Engine>
+double basic_rng_t<Engine>::range( double min, double max )
+{
+  assert( min <= max );
+  return min + real() * ( max - min );
+}
+
+/**
+ * @brief Gaussian Distribution
+ *
+ * This code adapted from ftp://ftp.taygeta.com/pub/c/boxmuller.c
+ * Implements the Polar form of the Box-Muller Transformation
+ *
+ * (c) Copyright 1994, Everett F. Carter Jr.
+ *     Permission is granted by the author to use
+ *     this software for any application provided this
+ *     copyright notice is preserved.
+ */
+template <typename Engine>
+double basic_rng_t<Engine>::gauss( double mean, double stddev, bool truncate_low_end )
+{
+  assert(stddev >= 0 && "Calling gauss with negative stddev");
+
+  double z;
+
+  if ( stddev != 0 )
+  {
+    if ( gauss_pair_use )
+    {
+      z = gauss_pair_value;
+      gauss_pair_use = false;
+    }
+    else
+    {
+      double x1, x2, w, y1, y2;
+      do
+      {
+        x1 = 2.0 * real() - 1.0;
+        x2 = 2.0 * real() - 1.0;
+        w = x1 * x1 + x2 * x2;
+      }
+      while ( w >= 1.0 || w == 0.0 );
+
+      w = std::sqrt( ( -2.0 * std::log( w ) ) / w );
+      y1 = x1 * w;
+      y2 = x2 * w;
+
+      z = y1;
+      gauss_pair_value = y2;
+      gauss_pair_use = true;
+    }
+  }
+  else
+    z = 0.0;
+
+  double result = mean + z * stddev;
+
+  // True gaussian distribution can of course yield any number at some probability.  So truncate on the low end.
+  if ( truncate_low_end && result < 0 )
+    result = 0;
+
+  return result;
+}
+
+/// Exponential Distribution
+template <typename Engine>
+double basic_rng_t<Engine>::exponential( double nu )
+{
+  double x;
+  do { x = real(); } while ( x >= 1.0 ); // avoid ln(0)
+  return - std::log( 1 - x ) * nu;
+}
+
+/// Exponentially Modified Gaussian Distribution
+template <typename Engine>
+double basic_rng_t<Engine>::exgauss( double gauss_mean, double gauss_stddev, double exp_nu )
+{
+  double v = gauss( gauss_mean, gauss_stddev ) + exponential( exp_nu );
+  return v > 0.0 ? v : 0.0;
+}
+
+/// Timespan uniform distribution in the range [min max]
+template <typename Engine>
+timespan_t basic_rng_t<Engine>::range( timespan_t min, timespan_t max )
+{
+  return timespan_t::from_native( range( timespan_t::to_native( min ), timespan_t::to_native( max ) ) );
+}
+
+/// Timespan Gaussian Distribution
+template <typename Engine>
+timespan_t basic_rng_t<Engine>::gauss( timespan_t mean, timespan_t stddev )
+{
+  return timespan_t::from_native( gauss( static_cast<double>( timespan_t::to_native( mean ) ),
+                                         static_cast<double>( timespan_t::to_native( stddev ) ) ) );
+}
+
+/// Timespan exponentially Modified Gaussian Distribution
+template <typename Engine>
+timespan_t basic_rng_t<Engine>::exgauss( timespan_t mean, timespan_t stddev, timespan_t nu )
+{
+  return timespan_t::from_native( exgauss( static_cast<double>( timespan_t::to_native( mean   ) ),
+                                           static_cast<double>( timespan_t::to_native( stddev ) ),
+                                           static_cast<double>( timespan_t::to_native( nu ) ) ) );
+}
+
+/// RNG Engines
+
+/**
+ * @brief XORSHIFT-128 Random Number Generator
+ *
+ * All credit goes to Sebastiano Vigna (vigna@acm.org) @2014
+ * http://xorshift.di.unimi.it/
+ */
+struct xorshift128_t
+{
+  uint64_t next() noexcept;
+  void seed( uint64_t start ) noexcept;
+  const char* name() const noexcept;
+private:
+  uint64_t s[2];
+};
+
+/**
+ * @brief xoshiro256+ Random Number Generator
+ *
+ * If, however, one has to generate only 64-bit floating-point numbers (by extracting the upper 53 bits) xoshiro256+
+ * is a slightly (≈15%) faster [compared to xoshiro256** or xoshiro256++] generator with analogous statistical
+ * properties.
+ *
+ * All credit goes to David Blackman and Sebastiano Vigna (vigna@acm.org) @2018
+ * http://prng.di.unimi.it/
+ */
+struct xoshiro256plus_t
+{
+  uint64_t next() noexcept;
+  void seed( uint64_t start ) noexcept;
+  const char* name() const noexcept;
+private:
+  uint64_t s[4];
+};
+
+/**
+ * @brief XORSHIFT-1024 Random Number Generator
+ *
+ * All credit goes to Sebastiano Vigna (vigna@acm.org) @2014
+ * http://xorshift.di.unimi.it/
+ */
+struct xorshift1024_t
+{
+  uint64_t next() noexcept;
+  void seed( uint64_t start ) noexcept;
+  const char* name() const noexcept;
+private:
+  uint64_t s[16];
+  int p;
+};
+
+// "Default" rng
+// Explicitly *NOT* a type alias to allow forward declaraions
+struct rng_t : public basic_rng_t<xoshiro256plus_t> {};
 
 double stdnormal_cdf( double );
 double stdnormal_inv( double );


### PR DESCRIPTION
This feature has in my opinion questionable user value. I'd be surprised if
anyone actually uses it on a regular basis.

This lets us devirtualize the engine with all the related benefits:
* no pointer inderiction on access (we can embed it right into the sim object)
* no virtual dispatch

The setup with `basic_rng_t` template is somewhat overengineered to handle
compile-time selection of rng engines and to actually let us test & compare the
engines in the "unit test". It can also be extended to bring back support for
runtime engine selection if the need arises.

Unsuprisingly it speeds up the sim a bit (with all of the usual caveats of
machine/compiler/etc.):
```
  nuohep@r2d2:~/dev/simc> for i in `seq 1 500`; do \
  > for exec in 'rng' 'bfa-dev'; do \
  > ./build-release/simc.$exec profiles/Tier25/T25_Hunter_Beast_Mastery.simc | \
  >   rg -o -r '$1' -e 'WallSeconds\s*=\s*([0-9.]+)' >> $exec-patchwerk.csv ; \
  > done; done
  nuohep@r2d2:~/dev/simc> ministat -q bfa-dev-patchwerk.csv rng-patchwerk.csv
  x bfa-dev-patchwerk.csv
  + rng-patchwerk.csv
      N           Min           Max        Median           Avg        Stddev
  x 500     1.3750636      2.145222     1.5516013     1.5675446   0.071085515
  + 500     1.3329705     2.2513635     1.5070543     1.5233121   0.074769679
  Difference at 95.0% confidence
	  -0.0442325 +/- 0.00904308
	  -2.82177% +/- 0.576895%
	  (Student's t, pooled s = 0.0729509)
```
While at it, further cleanup test code.

---

Not sure if it's in any way simpler, but at least it's a bit faster.

Regarding runtime engine selection - it can be implemented with this "design" too with a bit more code: https://github.com/nuoHep/simc/commit/80ab0e5b2952b6b0a69b1ea7915c8fa9c40ed61e
The unit test shows that the virtual version (which should be basically what we have now) is ~2x slower though.