### PR TITLE
Include ostream required by VS2019

### DIFF
--- a/engine/player/player_talent_points.hpp
+++ b/engine/player/player_talent_points.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <functional>
 #include <string>
+#include <ostream>
 
 struct spell_data_t;
 


### PR DESCRIPTION
Problem in VS2019:
> error C2027: use of undefined type 'std::basic_ostream<char,std::char_traits<char>>'

More info in answer:
https://developercommunity.visualstudio.com/content/problem/503648/simple-code-no-longer-compiles-when-using-and-stdo.html

Mainly:
> This behavior change is by design. The previous arrangement of <xstring> created a number of problems:
> * Programs that only wanted to use std::string facilities were including all of the iostreams machinery. The consequence of this was that a program that used only <string> took ~40% longer to compile than it should have.