### PR TITLE
Switch a bunch of stuff to string_views

### DIFF
--- a/engine/action/absorb.cpp
+++ b/engine/action/absorb.cpp
@@ -10,7 +10,7 @@
 #include "player/sc_player.hpp"
 #include "sim/sc_sim.hpp"
 
-absorb_t::absorb_t(const std::string& token,
+absorb_t::absorb_t(util::string_view token,
   player_t* p,
   const spell_data_t* s) :
   spell_base_t(ACTION_ABSORB, token, p, s),

--- a/engine/action/absorb.hpp
+++ b/engine/action/absorb.hpp
@@ -16,7 +16,7 @@ struct absorb_t : public spell_base_t
 {
   target_specific_t<absorb_buff_t> target_specific;
 
-  absorb_t(const std::string& name, player_t* p, const spell_data_t* s);
+  absorb_t(util::string_view name, player_t* p, const spell_data_t* s);
 
   // Allows customization of the absorb_buff_t that we are creating.
   virtual absorb_buff_t* create_buff(const action_state_t* s);

--- a/engine/action/attack.hpp
+++ b/engine/action/attack.hpp
@@ -12,8 +12,8 @@ struct attack_t : public action_t
 {
   double base_attack_expertise;
 
-  attack_t(const std::string& token, player_t* p);
-  attack_t( const std::string& token, player_t* p, const spell_data_t* s );
+  attack_t( util::string_view token, player_t* p );
+  attack_t( util::string_view token, player_t* p, const spell_data_t* s );
 
   // Attack Overrides
   virtual timespan_t execute_time() const override;
@@ -78,8 +78,8 @@ private:
 
 struct melee_attack_t : public attack_t
 {
-  melee_attack_t(const std::string& token, player_t* p);
-  melee_attack_t( const std::string& token, player_t* p, const spell_data_t* s );
+  melee_attack_t( util::string_view token, player_t* p );
+  melee_attack_t( util::string_view token, player_t* p, const spell_data_t* s );
 
   // Melee Attack Overrides
   virtual void init() override;
@@ -93,8 +93,8 @@ struct melee_attack_t : public attack_t
 
 struct ranged_attack_t : public attack_t
 {
-  ranged_attack_t(const std::string& token, player_t* p);
-  ranged_attack_t( const std::string& token, player_t* p, const spell_data_t* s );
+  ranged_attack_t( util::string_view token, player_t* p );
+  ranged_attack_t( util::string_view token, player_t* p, const spell_data_t* s );
 
   // Ranged Attack Overrides
   virtual double composite_target_multiplier( player_t* ) const override;

--- a/engine/action/dot.hpp
+++ b/engine/action/dot.hpp
@@ -9,6 +9,8 @@
 #include "sc_timespan.hpp"
 #include "sc_enums.hpp"
 #include "util/generic.hpp"
+#include "util/string_view.hpp"
+
 #include <string>
 #include <memory>
 #include <cstdint>
@@ -47,7 +49,7 @@ public:
   timespan_t time_to_tick;
   std::string name_str;
 
-  dot_t(const std::string& n, player_t* target, player_t* source);
+  dot_t(util::string_view n, player_t* target, player_t* source);
 
   void   extend_duration(timespan_t extra_seconds, timespan_t max_total_time = timespan_t::min(), uint32_t state_flags = -1);
   void   extend_duration(timespan_t extra_seconds, uint32_t state_flags)

--- a/engine/action/heal.cpp
+++ b/engine/action/heal.cpp
@@ -14,14 +14,14 @@
 #include "sim/sc_sim.hpp"
 #include "util/rng.hpp"
 
-heal_t::heal_t(const std::string& token,
+heal_t::heal_t(util::string_view token,
   player_t* p) :
   heal_t(token, p, spell_data_t::nil())
 {
 
 }
 
-heal_t::heal_t(const std::string& token,
+heal_t::heal_t(util::string_view token,
   player_t* p,
   const spell_data_t* s) :
   spell_base_t(ACTION_HEAL, token, p, s),

--- a/engine/action/heal.hpp
+++ b/engine/action/heal.hpp
@@ -17,8 +17,8 @@ public:
   double tick_pct_heal;
   gain_t* heal_gain;
 
-  heal_t(const std::string& name, player_t* p);
-  heal_t( const std::string& name, player_t* p, const spell_data_t* s );
+  heal_t( util::string_view name, player_t* p );
+  heal_t( util::string_view name, player_t* p, const spell_data_t* s );
 
   virtual double composite_pct_heal( const action_state_t* ) const;
   virtual void assess_damage( result_amount_type, action_state_t* ) override;

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -2668,7 +2668,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
   public:
     action_t& action;
 
-    action_expr_t( const std::string& name, action_t& a ) : expr_t( name ), action( a )
+    action_expr_t( util::string_view name, action_t& a ) : expr_t( name ), action( a )
     {
     }
   };
@@ -2677,7 +2677,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
   {
   public:
     action_state_t* state;
-    action_state_expr_t( const std::string& name, action_t& a ) : action_expr_t( name, a ), state( a.get_state() )
+    action_state_expr_t( util::string_view name, action_t& a ) : action_expr_t( name, a ), state( a.get_state() )
     {
     }
 
@@ -2694,7 +2694,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
     result_e result_type;
     bool average_crit;
 
-    amount_expr_t( const std::string& name, result_amount_type at, action_t& a, result_e rt = RESULT_NONE )
+    amount_expr_t( util::string_view name, result_amount_type at, action_t& a, result_e rt = RESULT_NONE )
       : action_state_expr_t( name, a ), amount_type( at ), result_type( rt ), average_crit( false )
     {
       if ( result_type == RESULT_NONE )
@@ -3110,7 +3110,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
       struct prev_expr_t : public action_expr_t
       {
         action_t* prev;
-        prev_expr_t( action_t& a, const std::string& prev_action )
+        prev_expr_t( action_t& a, util::string_view prev_action )
           : action_expr_t( "prev", a ), prev( a.player->find_action( prev_action ) )
         {
         }
@@ -3128,7 +3128,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
       struct prev_gcd_expr_t : public action_expr_t
       {
         action_t* previously_off_gcd;
-        prev_gcd_expr_t( action_t& a, const std::string& offgcdaction )
+        prev_gcd_expr_t( action_t& a, util::string_view offgcdaction )
           : action_expr_t( "prev_off_gcd", a ), previously_off_gcd( a.player->find_action( offgcdaction ) )
         {
         }
@@ -3210,7 +3210,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
         action_t& original_spell;
         const std::string name_of_spell;
         bool second_attempt;
-        spell_targets_t( action_t& a, const std::string spell_name )
+        spell_targets_t( action_t& a, util::string_view spell_name )
           : expr_t( "spell_targets" ), original_spell( a ), name_of_spell( spell_name ), second_attempt( false )
         {
           spell = a.player->find_action( spell_name );
@@ -3285,7 +3285,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
       int gcd;
       action_t* previously_used;
 
-      prevgcd_expr_t( action_t& a, int gcd, const std::string& prev_action )
+      prevgcd_expr_t( action_t& a, int gcd, util::string_view prev_action )
         : action_expr_t( "prev_gcd", a ),
           gcd( gcd ),  // prevgcd.1.action will mean 1 gcd ago, prevgcd.2.action will mean 2 gcds ago, etc.
           previously_used( a.player->find_action( prev_action ) )
@@ -3426,7 +3426,7 @@ std::unique_ptr<expr_t> action_t::create_expression( const std::string& name_str
       std::vector<std::unique_ptr<expr_t>> proxy_expr;
       std::string suffix_expr_str;
 
-      target_proxy_expr_t( action_t& a, const std::string& expr_str )
+      target_proxy_expr_t( action_t& a, util::string_view expr_str )
         : action_expr_t( "target_proxy_expr", a ), suffix_expr_str( expr_str )
       {
       }

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -263,13 +263,13 @@ action_t::options_t::options_t()
     target_str()
 {
 }
-action_t::action_t(action_e ty, const std::string& token, player_t* p)
+action_t::action_t( action_e ty, util::string_view token, player_t* p )
   : action_t(ty, token, p, spell_data_t::nil())
 {
 
 }
 
-action_t::action_t( action_e ty, const std::string& token, player_t* p, const spell_data_t* s )
+action_t::action_t( action_e ty, util::string_view token, player_t* p, const spell_data_t* s )
   : s_data( s ? s : spell_data_t::nil() ),
     s_data_reporting(spell_data_t::nil()),
     sim( p->sim ),
@@ -3886,7 +3886,7 @@ call_action_list_t::call_action_list_t( player_t* player, const std::string& opt
 }
 
 swap_action_list_t::swap_action_list_t( player_t* player, const std::string& options_str,
-                                        const std::string& name ) :
+                                        util::string_view name ) :
     action_t( ACTION_OTHER, name, player ),
     alist( nullptr )
 {
@@ -3898,7 +3898,7 @@ swap_action_list_t::swap_action_list_t( player_t* player, const std::string& opt
   ignore_false_positive = true;
   if ( alist_name.empty() )
   {
-    sim->errorf( "Player %s uses %s without specifying the name of the action list\n", player->name(), name.c_str() );
+    sim->error( "Player {} uses {} without specifying the name of the action list\n", player->name(), name );
     sim->cancel();
   }
 
@@ -3906,8 +3906,7 @@ swap_action_list_t::swap_action_list_t( player_t* player, const std::string& opt
 
   if ( !alist )
   {
-    sim->errorf( "Player %s uses %s with unknown action list %s\n", player->name(), name.c_str(),
-                 alist_name.c_str() );
+    sim->error( "Player {} uses {} with unknown action list {}\n", player->name(), name, alist_name );
     sim->cancel();
   }
   else if ( randomtoggle == 1 )

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -6,11 +6,12 @@
 #pragma once
 
 #include "config.hpp"
-#include "util/generic.hpp"
+#include "dbc/data_definitions.hh"
+#include "player/target_specific.hpp"
 #include "sc_enums.hpp"
 #include "sc_timespan.hpp"
-#include "player/target_specific.hpp"
-#include "dbc/data_definitions.hh"
+#include "util/generic.hpp"
+#include "util/string_view.hpp"
 
 #include <array>
 #include <vector>
@@ -511,8 +512,8 @@ private:
   action_state_t* state_cache;
   std::vector<travel_event_t*> travel_events;
 public:
-  action_t(action_e type, const std::string& token, player_t* p);
-  action_t( action_e type, const std::string& token, player_t* p, const spell_data_t* s );
+  action_t( action_e type, util::string_view token, player_t* p );
+  action_t( action_e type, util::string_view token, player_t* p, const spell_data_t* s );
 
   virtual ~action_t();
 
@@ -975,7 +976,7 @@ struct swap_action_list_t : public action_t
   action_priority_list_t* alist;
 
   swap_action_list_t( player_t* player, const std::string& options_str,
-    const std::string& name = "swap_action_list" );
+    util::string_view name = "swap_action_list" );
 
   void execute() override;
   bool ready() override;

--- a/engine/action/sc_attack.cpp
+++ b/engine/action/sc_attack.cpp
@@ -16,13 +16,13 @@
 // Attack
 // ==========================================================================
 
-attack_t::attack_t(const std::string& n, player_t* p)
+attack_t::attack_t( util::string_view n, player_t* p )
   : attack_t(n, p, spell_data_t::nil())
 {
 
 }
 
-attack_t::attack_t( const std::string& n, player_t* p, const spell_data_t* s )
+attack_t::attack_t( util::string_view n, player_t* p, const spell_data_t* s )
   : action_t( ACTION_ATTACK, n, p, s ),
     base_attack_expertise( 0 ),
     attack_table()
@@ -407,13 +407,13 @@ void attack_t::reset()
 // Melee Attack
 // ==========================================================================
 
-melee_attack_t::melee_attack_t(const std::string& n, player_t* p)
+melee_attack_t::melee_attack_t( util::string_view n, player_t* p )
   : melee_attack_t(n, p, spell_data_t::nil())
 {
 
 }
 
-melee_attack_t::melee_attack_t( const std::string& n, player_t* p, const spell_data_t* s )
+melee_attack_t::melee_attack_t( util::string_view n, player_t* p, const spell_data_t* s )
   : attack_t( n, p, s )
 {
   may_miss = may_dodge = may_parry = may_glance = may_block = true;
@@ -492,12 +492,12 @@ proc_types melee_attack_t::proc_type() const
 // Ranged Attack
 // ==========================================================================
 
-ranged_attack_t::ranged_attack_t(const std::string& token, player_t* p)
+ranged_attack_t::ranged_attack_t( util::string_view token, player_t* p )
   : ranged_attack_t(token, p, spell_data_t::nil())
 {
 }
 
-ranged_attack_t::ranged_attack_t( const std::string& token, player_t* p, const spell_data_t* s )
+ranged_attack_t::ranged_attack_t( util::string_view token, player_t* p, const spell_data_t* s )
   : attack_t( token, p, s )
 {
   may_miss  = true;

--- a/engine/action/sc_dot.cpp
+++ b/engine/action/sc_dot.cpp
@@ -50,7 +50,7 @@ private:
 // Dot
 // ==========================================================================
 
-dot_t::dot_t( const std::string& n, player_t* t, player_t* s )
+dot_t::dot_t( util::string_view n, player_t* t, player_t* s )
   : sim( *( t->sim ) ),
     ticking( false ),
     current_duration( timespan_t::zero() ),

--- a/engine/action/sc_spell.cpp
+++ b/engine/action/sc_spell.cpp
@@ -19,7 +19,7 @@
 // ==========================================================================
 
 spell_base_t::spell_base_t(action_e at,
-  const std::string& token,
+  util::string_view token,
   player_t* p) :
   spell_base_t(at, token, p, spell_data_t::nil())
 {
@@ -27,7 +27,7 @@ spell_base_t::spell_base_t(action_e at,
 }
 
 spell_base_t::spell_base_t( action_e at,
-                            const std::string& token,
+                            util::string_view token,
                             player_t* p,
                             const spell_data_t* s ) :
   action_t( at, token, p, s ),
@@ -164,13 +164,13 @@ proc_types spell_base_t::proc_type() const
 // Harmful Spell
 // ==========================================================================
 
-spell_t::spell_t(const std::string& token,
+spell_t::spell_t(util::string_view token,
   player_t* p) :
   spell_t(token, p, spell_data_t::nil())
 {
 }
 
-spell_t::spell_t( const std::string&  token,
+spell_t::spell_t( util::string_view   token,
                   player_t*           p,
                   const spell_data_t* s ) :
   spell_base_t( ACTION_SPELL, token, p, s )

--- a/engine/action/sc_stats.cpp
+++ b/engine/action/sc_stats.cpp
@@ -12,7 +12,7 @@
 
 // stats_t::stats_t =========================================================
 
-stats_t::stats_t( const std::string& n, player_t* p ) :
+stats_t::stats_t( util::string_view n, player_t* p ) :
   sim( *( p -> sim ) ),
   name_str( n ),
   player( p ),

--- a/engine/action/spell.hpp
+++ b/engine/action/spell.hpp
@@ -11,8 +11,8 @@
 struct spell_t : public spell_base_t
 {
 public:
-  spell_t(const std::string& token, player_t* p);
-  spell_t( const std::string& token, player_t* p, const spell_data_t* s );
+  spell_t( util::string_view token, player_t* p );
+  spell_t( util::string_view token, player_t* p, const spell_data_t* s );
 
   // Harmful Spell Overrides
   virtual result_amount_type amount_type( const action_state_t* /* state */, bool /* periodic */ = false ) const override;

--- a/engine/action/spell_base.hpp
+++ b/engine/action/spell_base.hpp
@@ -13,8 +13,8 @@ struct spell_base_t : public action_t
   // special item flags
   bool procs_courageous_primal_diamond;
 
-  spell_base_t(action_e at, const std::string& token, player_t* p);
-  spell_base_t( action_e at, const std::string& token, player_t* p, const spell_data_t* s );
+  spell_base_t( action_e at, util::string_view token, player_t* p);
+  spell_base_t( action_e at, util::string_view token, player_t* p, const spell_data_t* s );
 
   // Spell Base Overrides
   virtual timespan_t execute_time() const override;

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -30,7 +30,7 @@ struct buff_expr_t : public expr_t
   target_specific_t<buff_t> specific_buff;
   double default_value;
 
-  buff_expr_t( const std::string& n, const std::string& bn, action_t* a, buff_t* b, double default_ = 0 )
+  buff_expr_t( util::string_view n, util::string_view bn, action_t* a, buff_t* b, double default_ = 0 )
     : expr_t( n ), buff_name( bn ), action( a ), static_buff( b ), specific_buff( false ),
       default_value( default_ )
   { }
@@ -278,7 +278,7 @@ struct expiration_delay_t : public buff_event_t
   }
 };
 
-std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std::string& type, action_t* action, buff_t* static_buff )
+std::unique_ptr<expr_t> create_buff_expression( util::string_view buff_name, util::string_view type, action_t* action, buff_t* static_buff )
 {
   if ( !static_buff && !action )
   {
@@ -290,7 +290,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct duration_expr_t : public buff_expr_t
     {
-      duration_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      duration_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_duration", bn, a, b )
       { }
 
@@ -304,7 +304,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct remains_expr_t : public buff_expr_t
     {
-      remains_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      remains_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_remains", bn, a, b )
       { }
 
@@ -318,7 +318,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct cooldown_remains_expr_t : public buff_expr_t
     {
-      cooldown_remains_expr_t( std::string bn, action_t* a, buff_t* b )
+      cooldown_remains_expr_t( util::string_view bn, action_t* a, buff_t* b )
         : buff_expr_t( "buff_cooldown_remains", bn, a, b )
       { }
 
@@ -332,7 +332,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct up_expr_t : public buff_expr_t
     {
-      up_expr_t( std::string bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_up", bn, a, b )
+      up_expr_t( util::string_view bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_up", bn, a, b )
       { }
 
       double evaluate() override
@@ -345,7 +345,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct down_expr_t : public buff_expr_t
     {
-      down_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      down_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_down", bn, a, b, 1.0 )
       { }
 
@@ -359,7 +359,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct stack_expr_t : public buff_expr_t
     {
-      stack_expr_t( std::string bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_stack", bn, a, b )
+      stack_expr_t( util::string_view bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_stack", bn, a, b )
       { }
 
       double evaluate() override
@@ -372,7 +372,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct stack_pct_expr_t : public buff_expr_t
     {
-      stack_pct_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      stack_pct_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_stack_pct", bn, a, b )
       { }
 
@@ -386,7 +386,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct max_stack_expr_t : public buff_expr_t
     {
-      max_stack_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      max_stack_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_max_stack", bn, a, b, 1.0 )
       { }
 
@@ -400,7 +400,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct value_expr_t : public buff_expr_t
     {
-      value_expr_t( std::string bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_value", bn, a, b )
+      value_expr_t( util::string_view bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_value", bn, a, b )
       { }
 
       double evaluate() override
@@ -413,7 +413,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct react_expr_t : public buff_expr_t
     {
-      react_expr_t( std::string bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_react", bn, a, b )
+      react_expr_t( util::string_view bn, action_t* a, buff_t* b ) : buff_expr_t( "buff_react", bn, a, b )
       {
         if ( b )
           b->reactable = true;
@@ -436,7 +436,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct react_pct_expr_t : public buff_expr_t
     {
-      react_pct_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      react_pct_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_react_pct", bn, a, b )
       {
         if ( b )
@@ -460,7 +460,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct cooldown_react_expr_t : public buff_expr_t
     {
-      cooldown_react_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      cooldown_react_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_cooldown_react", bn, a, b )
       { }
 
@@ -479,7 +479,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct last_trigger_expr_t : public buff_expr_t
     {
-      last_trigger_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      last_trigger_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_last_trigger", bn, a, b )
       { }
 
@@ -493,7 +493,7 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
   {
     struct last_expire_expr_t : public buff_expr_t
     {
-      last_expire_expr_t( std::string bn, action_t* a, buff_t* b ) :
+      last_expire_expr_t( util::string_view bn, action_t* a, buff_t* b ) :
         buff_expr_t( "buff_last_expire", bn, a, b )
       { }
 
@@ -510,28 +510,28 @@ std::unique_ptr<expr_t> create_buff_expression( std::string buff_name, const std
 }  // namespace
 
 
-buff_t::buff_t(actor_pair_t q, const std::string& name)
+buff_t::buff_t(actor_pair_t q, util::string_view name)
   : buff_t(q, name, spell_data_t::nil(), nullptr)
 {
 
 }
 
-buff_t::buff_t( actor_pair_t q, const std::string& name, const spell_data_t* spell_data, const item_t* item )
+buff_t::buff_t( actor_pair_t q, util::string_view name, const spell_data_t* spell_data, const item_t* item )
   : buff_t( q.source->sim, q.target, q.source, name, spell_data, item )
 {
 }
 
-buff_t::buff_t(sim_t* sim, const std::string& name)
+buff_t::buff_t(sim_t* sim, util::string_view name)
   : buff_t(sim, nullptr, nullptr, name, spell_data_t::nil(), nullptr)
 {
 }
 
-buff_t::buff_t( sim_t* sim, const std::string& name, const spell_data_t* spell_data, const item_t* item )
+buff_t::buff_t( sim_t* sim, util::string_view name, const spell_data_t* spell_data, const item_t* item )
   : buff_t( sim, nullptr, nullptr, name, spell_data, item )
 {
 }
 
-buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, const std::string& name, const spell_data_t* spell_data, const item_t* item )
+buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_view name, const spell_data_t* spell_data, const item_t* item )
   : sim( sim ),
     player( target ),
     item( item ),
@@ -1980,7 +1980,7 @@ void buff_t::analyze()
   }
 }
 
-buff_t* buff_t::find( const std::vector<buff_t*>& buffs, const std::string& name_str, player_t* source )
+buff_t* buff_t::find( util::span<buff_t* const> buffs, util::string_view name_str, player_t* source )
 {
   for ( buff_t* buff : buffs )
   {
@@ -2015,7 +2015,7 @@ struct potion_spell_filter
 };
 }  // namespace
 
-static buff_t* find_potion_buff( const std::vector<buff_t*>& buffs, player_t* source )
+static buff_t* find_potion_buff( util::span<buff_t* const> buffs, player_t* source )
 {
   for ( auto b : buffs )
   {
@@ -2040,7 +2040,7 @@ static buff_t* find_potion_buff( const std::vector<buff_t*>& buffs, player_t* so
   return nullptr;
 }
 
-buff_t* buff_t::find_expressable( const std::vector<buff_t*>& buffs, const std::string& name, player_t* source )
+buff_t* buff_t::find_expressable( util::span<buff_t* const> buffs, util::string_view name, player_t* source )
 {
   if ( util::str_compare_ci( "potion", name ) )
     return find_potion_buff( buffs, source );
@@ -2062,12 +2062,12 @@ std::string buff_t::to_str() const
   return s.str();
 }
 
-std::unique_ptr<expr_t> buff_t::create_expression( std::string buff_name, const std::string& type, action_t& action )
+std::unique_ptr<expr_t> buff_t::create_expression( util::string_view buff_name, util::string_view type, action_t& action )
 {
   return create_buff_expression( buff_name, type, &action, nullptr );
 }
 
-std::unique_ptr<expr_t> buff_t::create_expression( std::string buff_name, const std::string& type, buff_t& static_buff )
+std::unique_ptr<expr_t> buff_t::create_expression( util::string_view buff_name, util::string_view type, buff_t& static_buff )
 {
   return create_buff_expression( buff_name, type, nullptr, &static_buff );
 }
@@ -2096,17 +2096,17 @@ void buff_t::invalidate_cache()
 
 #endif
 
-buff_t* buff_t::find( sim_t* s, const std::string& name )
+buff_t* buff_t::find( sim_t* s, util::string_view name )
 {
   return find( s->buff_list, name );
 }
 
-buff_t* buff_t::find( player_t* p, const std::string& name, player_t* source )
+buff_t* buff_t::find( player_t* p, util::string_view name, player_t* source )
 {
   return find( p->buff_list, name, source );
 }
 
-std::string buff_t::source_name() const
+util::string_view buff_t::source_name() const
 {
   if ( source )
     return source->name_str;
@@ -2212,15 +2212,15 @@ std::ostream& operator<<(std::ostream &os, const buff_t& b)
 // STAT_BUFF
 // ==========================================================================
 
-stat_buff_t::stat_buff_t(actor_pair_t q, const std::string& name)
+stat_buff_t::stat_buff_t(actor_pair_t q, util::string_view name)
   : stat_buff_t(q, name, spell_data_t::nil(), nullptr)
 {
 
 }
 
-stat_buff_t::stat_buff_t( actor_pair_t q, const std::string& name, const spell_data_t* spell, const item_t* item )
+stat_buff_t::stat_buff_t( actor_pair_t q, util::string_view name, const spell_data_t* spell, const item_t* item )
   : buff_t( q, name, spell, item ),
-    stat_gain( player->get_gain( name + "_buff" ) ),  // append _buff for now to check usage
+    stat_gain( player->get_gain( std::string( name ) + "_buff" ) ),  // append _buff for now to check usage
     manual_stats_added( false )
 {
   bool has_ap = false;
@@ -2407,13 +2407,13 @@ void stat_buff_t::expire_override( int expiration_stacks, timespan_t remaining_d
 // COST_REDUCTION_BUFF
 // ==========================================================================
 
-cost_reduction_buff_t::cost_reduction_buff_t(actor_pair_t q, const std::string& name)
+cost_reduction_buff_t::cost_reduction_buff_t(actor_pair_t q, util::string_view name)
   : cost_reduction_buff_t(q, name, spell_data_t::nil(), nullptr)
 {
 
 }
 
-cost_reduction_buff_t::cost_reduction_buff_t( actor_pair_t q, const std::string& name, const spell_data_t* spell,
+cost_reduction_buff_t::cost_reduction_buff_t( actor_pair_t q, util::string_view name, const spell_data_t* spell,
                                               const item_t* item )
   : buff_t( q, name, spell, item ), amount(), school( SCHOOL_NONE )
 {
@@ -2482,13 +2482,13 @@ cost_reduction_buff_t* cost_reduction_buff_t::set_reduction( school_e school, do
   return this;
 }
 
-absorb_buff_t::absorb_buff_t(actor_pair_t q, const std::string& name)
+absorb_buff_t::absorb_buff_t(actor_pair_t q, util::string_view name)
   : absorb_buff_t(q, name, spell_data_t::nil(), nullptr)
 {
 
 }
 
-absorb_buff_t::absorb_buff_t( actor_pair_t q, const std::string& name, const spell_data_t* spell, const item_t* item )
+absorb_buff_t::absorb_buff_t( actor_pair_t q, util::string_view name, const spell_data_t* spell, const item_t* item )
   : buff_t( q, name, spell, item ),
     absorb_school( SCHOOL_CHAOS ),
     absorb_source(),

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -10,10 +10,13 @@
 #include <string>
 #include <vector>
 #include <memory>
+
 #include "sc_timespan.hpp"
 #include "sc_enums.hpp"
 #include "player/sc_actor_pair.hpp"
 #include "util/sample_data.hpp"
+#include "util/span.hpp"
+#include "util/string_view.hpp"
 #include "util/timeline.hpp"
 #include "sim/uptime.hpp"
 
@@ -132,12 +135,12 @@ public:
 
   virtual ~buff_t() {}
 
-  buff_t(actor_pair_t q, const std::string& name);
-  buff_t( actor_pair_t q, const std::string& name, const spell_data_t*, const item_t* item = nullptr );
-  buff_t(sim_t* sim, const std::string& name);
-  buff_t( sim_t* sim, const std::string& name, const spell_data_t*, const item_t* item = nullptr );
+  buff_t(actor_pair_t q, util::string_view name);
+  buff_t( actor_pair_t q, util::string_view name, const spell_data_t*, const item_t* item = nullptr );
+  buff_t(sim_t* sim, util::string_view name);
+  buff_t( sim_t* sim, util::string_view name, const spell_data_t*, const item_t* item = nullptr );
 protected:
-  buff_t( sim_t* sim, player_t* target, player_t* source, const std::string& name, const spell_data_t*, const item_t* item );
+  buff_t( sim_t* sim, player_t* target, player_t* source, util::string_view name, const spell_data_t*, const item_t* item );
 public:
   const spell_data_t& data() const { return *s_data; }
   const spell_data_t& data_reporting() const;
@@ -256,22 +259,22 @@ public:
 
   virtual int total_stack();
 
-  static std::unique_ptr<expr_t> create_expression( std::string buff_name,
-                                    const std::string& type,
+  static std::unique_ptr<expr_t> create_expression( util::string_view buff_name,
+                                    util::string_view type,
                                     action_t& action );
-  static std::unique_ptr<expr_t> create_expression( std::string buff_name,
-                                    const std::string& type,
+  static std::unique_ptr<expr_t> create_expression( util::string_view buff_name,
+                                    util::string_view type,
                                     buff_t& static_buff );
   std::string to_str() const;
 
   static double DEFAULT_VALUE() { return -std::numeric_limits< double >::min(); }
-  static buff_t* find( const std::vector<buff_t*>&, const std::string& name, player_t* source = nullptr );
-  static buff_t* find(    sim_t*, const std::string& name );
-  static buff_t* find( player_t*, const std::string& name, player_t* source = nullptr );
-  static buff_t* find_expressable( const std::vector<buff_t*>&, const std::string& name, player_t* source = nullptr );
+  static buff_t* find( util::span<buff_t* const>, util::string_view name, player_t* source = nullptr );
+  static buff_t* find(    sim_t*, util::string_view name );
+  static buff_t* find( player_t*, util::string_view name, player_t* source = nullptr );
+  static buff_t* find_expressable( util::span<buff_t* const>, util::string_view name, player_t* source = nullptr );
 
   const char* name() const { return name_str.c_str(); }
-  std::string source_name() const;
+  util::string_view source_name() const;
   int max_stack() const { return _max_stack; }
   const spell_data_t* get_trigger_data() const
   { return trigger_data; }
@@ -346,8 +349,8 @@ struct stat_buff_t : public buff_t
 
   stat_buff_t* add_stat( stat_e s, double a, std::function<bool(const stat_buff_t&)> c = std::function<bool(const stat_buff_t&)>() );
 
-  stat_buff_t(actor_pair_t q, const std::string& name);
-  stat_buff_t( actor_pair_t q, const std::string& name, const spell_data_t*, const item_t* item = nullptr );
+  stat_buff_t(actor_pair_t q, util::string_view name);
+  stat_buff_t( actor_pair_t q, util::string_view name, const spell_data_t*, const item_t* item = nullptr );
 };
 
 struct absorb_buff_t : public buff_t
@@ -359,8 +362,8 @@ struct absorb_buff_t : public buff_t
   bool     high_priority; // For tank absorbs that should explicitly "go first"
   absorb_eligibility eligibility; // A custom function whose result determines if the attack is eligible to be absorbed.
 
-  absorb_buff_t(actor_pair_t q, const std::string& name);
-  absorb_buff_t( actor_pair_t q, const std::string& name, const spell_data_t* spell, const item_t* item = nullptr );
+  absorb_buff_t(actor_pair_t q, util::string_view name);
+  absorb_buff_t( actor_pair_t q, util::string_view name, const spell_data_t* spell, const item_t* item = nullptr );
 protected:
 
   // Hook for derived classes to recieve notification when some of the absorb is consumed.
@@ -384,8 +387,8 @@ struct cost_reduction_buff_t : public buff_t
   double amount;
   school_e school;
 
-  cost_reduction_buff_t(actor_pair_t q, const std::string& name);
-  cost_reduction_buff_t( actor_pair_t q, const std::string& name, const spell_data_t* spell, const item_t* item = nullptr );
+  cost_reduction_buff_t(actor_pair_t q, util::string_view name);
+  cost_reduction_buff_t( actor_pair_t q, util::string_view name, const spell_data_t* spell, const item_t* item = nullptr );
   virtual void bump     ( int stacks = 1, double value = -1.0 ) override;
   virtual void decrement( int stacks = 1, double value = -1.0 ) override;
   virtual void expire_override( int expiration_stacks, timespan_t remaining_duration ) override;

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1440,11 +1440,6 @@ void priest_t::target_mitigation( school_e school, result_amount_type dt, action
   }
 }
 
-action_t* priest_t::create_proc_action( const std::string& /*name*/, const special_effect_t& /*effect*/ )
-{
-  return nullptr;
-}
-
 void priest_t::create_options()
 {
   base_t::create_options();

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -433,7 +433,6 @@ public:
   void create_options() override;
   std::string create_profile( save_e ) override;
   action_t* create_action( const std::string& name, const std::string& options ) override;
-  virtual action_t* create_proc_action( const std::string& name, const special_effect_t& effect ) override;
   pet_t* create_pet( const std::string& name, const std::string& type = std::string() ) override;
   void create_pets() override;
   void copy_from( player_t* source ) override;

--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -1618,7 +1618,7 @@ std::unique_ptr<expr_t> enemy_t::create_expression( const std::string& name_str 
         enemy_t* boss;
         std::string debuff_str;
 
-        current_target_debuff_expr_t( enemy_t* e, const std::string& debuff_str ) :
+        current_target_debuff_expr_t( enemy_t* e, util::string_view debuff_str ) :
           expr_t( "current_target_debuff" ), boss( e ), debuff_str( debuff_str )
         {}
 

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -4602,7 +4602,7 @@ std::unique_ptr<expr_t> hunter_t::create_expression( const std::string& expressi
         hunter_t* hunter;
         cooldown_t* cooldown;
 
-        cooldown_remains_guess_t( hunter_t* h, const std::string& str, cooldown_t* cd ) :
+        cooldown_remains_guess_t( hunter_t* h, util::string_view str, cooldown_t* cd ) :
           expr_t( str ), hunter( h ), cooldown( cd )
         { }
 
@@ -4629,7 +4629,7 @@ std::unique_ptr<expr_t> hunter_t::create_expression( const std::string& expressi
         hunter_t* hunter;
         cooldown_t* cooldown;
 
-        cooldown_duration_guess_t( hunter_t* h, const std::string& str, cooldown_t* cd ) :
+        cooldown_duration_guess_t( hunter_t* h, util::string_view str, cooldown_t* cd ) :
           expr_t( str ), hunter( h ), cooldown( cd )
         { }
 

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -612,8 +612,6 @@ public:
   std::string default_food() const override;
   std::string default_rune() const override;
 
-  std::string special_use_item_action( const std::string& item_name, const std::string& condition = std::string() ) const;
-
   target_specific_t<hunter_td_t> target_data;
 
   hunter_td_t* get_target_data( player_t* target ) const override
@@ -631,7 +629,7 @@ public:
   std::vector<action_t*> background_actions;
 
   template <typename T, typename... Ts>
-  T* get_background_action( const std::string& n, Ts&&... args )
+  T* get_background_action( util::string_view n, Ts&&... args )
   {
     auto it = range::find( background_actions, n, &action_t::name_str );
     if ( it != background_actions.cend() )
@@ -671,7 +669,7 @@ public:
     bool coordinated_assault;
   } affected_by;
 
-  hunter_action_t( const std::string& n, hunter_t* player, const spell_data_t* s = spell_data_t::nil() ):
+  hunter_action_t( util::string_view n, hunter_t* player, const spell_data_t* s = spell_data_t::nil() ):
     ab( n, player, s ),
     track_cd_waste( s -> cooldown() > 0_ms || s -> charge_cooldown() > 0_ms ),
     cd_waste( nullptr ),
@@ -875,7 +873,7 @@ public:
       p() -> buffs.steady_focus -> expire();
   }
 
-  void add_pet_stats( pet_t* pet, std::initializer_list<std::string> names )
+  void add_pet_stats( pet_t* pet, std::initializer_list<util::string_view> names )
   {
     if ( ! pet )
       return;
@@ -912,7 +910,7 @@ void trigger_bloodseeker_update( hunter_t* );
 
 struct hunter_ranged_attack_t: public hunter_action_t < ranged_attack_t >
 {
-  hunter_ranged_attack_t( const std::string& n, hunter_t* player,
+  hunter_ranged_attack_t( util::string_view n, hunter_t* player,
                           const spell_data_t* s = spell_data_t::nil() ):
                           hunter_action_t( n, player, s )
   {}
@@ -929,9 +927,9 @@ struct hunter_ranged_attack_t: public hunter_action_t < ranged_attack_t >
 
 struct hunter_melee_attack_t: public hunter_action_t < melee_attack_t >
 {
-  hunter_melee_attack_t( const std::string& n, hunter_t* p,
-                          const spell_data_t* s = spell_data_t::nil() ):
-                          hunter_action_t( n, p, s )
+  hunter_melee_attack_t( util::string_view n, hunter_t* p,
+                         const spell_data_t* s = spell_data_t::nil() ):
+                         hunter_action_t( n, p, s )
   {}
 
   void init() override
@@ -946,7 +944,7 @@ struct hunter_melee_attack_t: public hunter_action_t < melee_attack_t >
 struct hunter_spell_t: public hunter_action_t < spell_t >
 {
 public:
-  hunter_spell_t( const std::string& n, hunter_t* player,
+  hunter_spell_t( util::string_view n, hunter_t* player,
                   const spell_data_t* s = spell_data_t::nil() ):
                   hunter_action_t( n, player, s )
   {}
@@ -1006,7 +1004,7 @@ private:
   using ab = Base;
 public:
 
-  hunter_pet_action_t( const std::string& n, T_PET* p, const spell_data_t* s = spell_data_t::nil() ):
+  hunter_pet_action_t( util::string_view n, T_PET* p, const spell_data_t* s = spell_data_t::nil() ):
     ab( n, p, s )
   {
     ab::may_crit = true;
@@ -1056,7 +1054,7 @@ private:
   using ab = hunter_pet_action_t<Pet, melee_attack_t>;
 public:
 
-  hunter_pet_melee_t( const std::string &n, Pet* p ):
+  hunter_pet_melee_t( util::string_view n, Pet* p ):
     ab( n, p )
   {
     ab::background = ab::repeating = true;
@@ -1503,7 +1501,7 @@ public:
     bool spirit_bond;
   } affected_by;
 
-  hunter_main_pet_action_t( const std::string& n, hunter_main_pet_t* p, const spell_data_t* s = spell_data_t::nil() ):
+  hunter_main_pet_action_t( util::string_view n, hunter_main_pet_t* p, const spell_data_t* s = spell_data_t::nil() ):
                             ab( n, p, s ), affected_by()
   {
     affected_by.aspect_of_the_beast = ab::data().affected_by( ab::o() -> talents.aspect_of_the_beast -> effectN( 1 ) );
@@ -1726,7 +1724,7 @@ static void trigger_beast_cleave( action_state_t* s )
 
 struct pet_melee_t : public hunter_pet_melee_t<hunter_main_pet_base_t>
 {
-  pet_melee_t( const std::string& n, hunter_main_pet_base_t* p ):
+  pet_melee_t( util::string_view n, hunter_main_pet_base_t* p ):
     hunter_pet_melee_t( n, p )
   {
   }
@@ -1776,7 +1774,7 @@ struct basic_attack_t : public hunter_main_pet_attack_t
   } wild_hunt;
   const double venomous_fangs_bonus_da;
 
-  basic_attack_t( hunter_main_pet_t* p, const std::string& n, const std::string& options_str ):
+  basic_attack_t( hunter_main_pet_t* p, util::string_view n, const std::string& options_str ):
     hunter_main_pet_attack_t( n, p, p -> find_pet_spell( n ) ),
     venomous_fangs_bonus_da( p -> o() -> azerite.venomous_fangs.value( 1 ) )
   {
@@ -2041,7 +2039,7 @@ private:
 public:
   bool first = true;
 
-  auto_attack_base_t( const std::string& n, hunter_t* p, const spell_data_t* s = spell_data_t::nil() ) :
+  auto_attack_base_t( util::string_view n, hunter_t* p, const spell_data_t* s = spell_data_t::nil() ) :
     ab( n, p, s )
   {
     ab::background = ab::repeating = true;
@@ -2083,7 +2081,7 @@ public:
 
 struct volley_t: hunter_ranged_attack_t
 {
-  volley_t( const std::string& n, hunter_t* p ):
+  volley_t( util::string_view n, hunter_t* p ):
     hunter_ranged_attack_t( n, p, p -> talents.volley -> effectN( 1 ).trigger() )
   {
     background = true;
@@ -2161,7 +2159,7 @@ struct barrage_t: public hunter_spell_t
 {
   struct barrage_damage_t: public hunter_ranged_attack_t
   {
-    barrage_damage_t( const std::string& n, hunter_t* p ):
+    barrage_damage_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> talents.barrage -> effectN( 1 ).trigger() )
     {
       aoe = -1;
@@ -2201,7 +2199,7 @@ struct multi_shot_t: public hunter_ranged_attack_t
 {
   struct rapid_reload_t: public hunter_ranged_attack_t
   {
-    rapid_reload_t( const std::string& n, hunter_t* p ):
+    rapid_reload_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> find_spell( 278565 ) )
     {
       aoe = -1;
@@ -2288,7 +2286,7 @@ struct chimaera_shot_t: public hunter_ranged_attack_t
 {
   struct chimaera_shot_impact_t: public hunter_ranged_attack_t
   {
-    chimaera_shot_impact_t( const std::string& n, hunter_t* p, const spell_data_t* s ):
+    chimaera_shot_impact_t( util::string_view n, hunter_t* p, const spell_data_t* s ):
       hunter_ranged_attack_t( n, p, s )
     {
       dual = true;
@@ -2448,7 +2446,7 @@ struct aimed_shot_base_t: public hunter_ranged_attack_t
   } careful_aim;
   const int trick_shots_targets;
 
-  aimed_shot_base_t( const std::string& name, hunter_t* p ):
+  aimed_shot_base_t( util::string_view name, hunter_t* p ):
     hunter_ranged_attack_t( name, p, p -> specs.aimed_shot ),
     trick_shots_targets( static_cast<int>( p -> specs.trick_shots -> effectN( 1 ).base_value() ) )
   {
@@ -2513,7 +2511,7 @@ struct aimed_shot_t : public aimed_shot_base_t
   // class for 'secondary' aimed shots
   struct aimed_shot_secondary_t: public aimed_shot_base_t
   {
-    aimed_shot_secondary_t( const std::string& n, hunter_t* p ):
+    aimed_shot_secondary_t( util::string_view n, hunter_t* p ):
       aimed_shot_base_t( n, p )
     {
       background = true;
@@ -2783,7 +2781,7 @@ struct rapid_fire_t: public hunter_spell_t
       int max_num_ticks = 0;
     } surging_shots;
 
-    rapid_fire_damage_t( const std::string& n, hunter_t* p ):
+    rapid_fire_damage_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> find_spell( 257045 ) ),
       trick_shots_targets( as<int>( p -> specs.trick_shots -> effectN( 3 ).base_value() ) )
     {
@@ -2967,7 +2965,7 @@ struct explosive_shot_t: public hunter_ranged_attack_t
 {
   struct explosive_shot_aoe_t: hunter_ranged_attack_t
   {
-    explosive_shot_aoe_t( const std::string& n, hunter_t* p ):
+    explosive_shot_aoe_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> find_spell( 212680 ) )
     {
       background = true;
@@ -3028,7 +3026,7 @@ struct internal_bleeding_t
 {
   struct internal_bleeding_action_t: hunter_ranged_attack_t
   {
-    internal_bleeding_action_t( const std::string& n, hunter_t* p ):
+    internal_bleeding_action_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> find_spell( 270343 ) )
     {
       dual = true;
@@ -3065,7 +3063,7 @@ struct melee_focus_spender_t: hunter_melee_attack_t
 {
   struct latent_poison_t: hunter_spell_t
   {
-    latent_poison_t( const std::string& n, hunter_t* p ):
+    latent_poison_t( util::string_view n, hunter_t* p ):
       hunter_spell_t( n, p, p -> find_spell( 273289 ) )
     {}
 
@@ -3087,7 +3085,7 @@ struct melee_focus_spender_t: hunter_melee_attack_t
   latent_poison_t* latent_poison = nullptr;
   timespan_t wilderness_survival_reduction;
 
-  melee_focus_spender_t( const std::string& n, hunter_t* p, const spell_data_t* s ):
+  melee_focus_spender_t( util::string_view n, hunter_t* p, const spell_data_t* s ):
     hunter_melee_attack_t( n, p, s ),
     internal_bleeding( p ),
     wilderness_survival_reduction( p -> azerite.wilderness_survival.spell() -> effectN( 1 ).time_value() )
@@ -3154,7 +3152,7 @@ struct mongoose_bite_base_t: melee_focus_spender_t
     std::array<proc_t*, 7> at_fury;
   } stats_;
 
-  mongoose_bite_base_t( const std::string& n, hunter_t* p, spell_data_ptr_t s ):
+  mongoose_bite_base_t( util::string_view n, hunter_t* p, spell_data_ptr_t s ):
     melee_focus_spender_t( n, p, s )
   {
     base_dd_adder += p -> azerite.wilderness_survival.value( 2 );
@@ -3209,7 +3207,7 @@ struct flanking_strike_t: hunter_melee_attack_t
 {
   struct flanking_strike_damage_t : hunter_melee_attack_t
   {
-    flanking_strike_damage_t( const std::string& n, hunter_t* p ):
+    flanking_strike_damage_t( util::string_view n, hunter_t* p ):
       hunter_melee_attack_t( n, p, p -> find_spell( 269752 ) )
     {
       background = true;
@@ -3271,7 +3269,7 @@ struct carve_base_t: public hunter_melee_attack_t
   const int wfb_reduction_target_cap;
   internal_bleeding_t internal_bleeding;
 
-  carve_base_t( const std::string& n, hunter_t* p, const spell_data_t* s,
+  carve_base_t( util::string_view n, hunter_t* p, const spell_data_t* s,
                 timespan_t wfb_reduction, int wfb_reduction_target_cap ):
     hunter_melee_attack_t( n, p, s ),
     wfb_reduction( wfb_reduction ),
@@ -3331,7 +3329,7 @@ struct butchery_t: public carve_base_t
 
 struct raptor_strike_base_t: public melee_focus_spender_t
 {
-  raptor_strike_base_t( const std::string& n, hunter_t* p, spell_data_ptr_t s ):
+  raptor_strike_base_t( util::string_view n, hunter_t* p, spell_data_ptr_t s ):
     melee_focus_spender_t( n, p, s )
   {
     base_dd_adder += p -> azerite.wilderness_survival.value( 3 );
@@ -3381,7 +3379,7 @@ struct harpoon_t: public hunter_melee_attack_t
 {
   struct terms_of_engagement_t : hunter_ranged_attack_t
   {
-    terms_of_engagement_t( const std::string& n, hunter_t* p ):
+    terms_of_engagement_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> find_spell( 271625 ) )
     {
       dual = true;
@@ -3555,7 +3553,7 @@ struct chakrams_t : public hunter_ranged_attack_t
 
   struct chakrams_damage_t : public hunter_ranged_attack_t
   {
-    chakrams_damage_t( const std::string& n, hunter_t* p ):
+    chakrams_damage_t( util::string_view n, hunter_t* p ):
       hunter_ranged_attack_t( n, p, p -> talents.chakrams -> effectN( 1 ).trigger() )
     {
       dual = true;
@@ -3603,7 +3601,7 @@ namespace spells
 
 struct interrupt_base_t: public hunter_spell_t
 {
-  interrupt_base_t( const std::string &n, hunter_t* p, const spell_data_t* s ):
+  interrupt_base_t( util::string_view n, hunter_t* p, const spell_data_t* s ):
     hunter_spell_t( n, p, s )
   {
     may_miss = may_block = may_dodge = may_parry = false;
@@ -3622,7 +3620,7 @@ struct moc_t : public hunter_spell_t
 {
   struct peck_t : public hunter_ranged_attack_t
   {
-    peck_t( const std::string& n, hunter_t* p ) :
+    peck_t( util::string_view n, hunter_t* p ) :
       hunter_ranged_attack_t( n, p, p -> find_spell( 131900 ) )
     {
       may_parry = may_block = may_dodge = false;
@@ -4153,7 +4151,7 @@ struct steel_trap_t: public hunter_spell_t
 {
   struct steel_trap_impact_t : public hunter_spell_t
   {
-    steel_trap_impact_t( const std::string& n, hunter_t* p ):
+    steel_trap_impact_t( util::string_view n, hunter_t* p ):
       hunter_spell_t( n, p, p -> find_spell( 162487 ) )
     {
       background = true;
@@ -4179,7 +4177,7 @@ struct wildfire_bomb_t: public hunter_spell_t
 {
   struct wildfire_cluster_t : public hunter_spell_t
   {
-    wildfire_cluster_t( const std::string& n, hunter_t* p ):
+    wildfire_cluster_t( util::string_view n, hunter_t* p ):
       hunter_spell_t( n, p, p -> find_spell( 272745 ) )
     {
       aoe = -1;
@@ -4191,7 +4189,7 @@ struct wildfire_bomb_t: public hunter_spell_t
   {
     struct dot_action_t : public hunter_spell_t
     {
-      dot_action_t( const std::string& n, hunter_t* p, const spell_data_t* s ):
+      dot_action_t( util::string_view n, hunter_t* p, const spell_data_t* s ):
         hunter_spell_t( n, p, s )
       {
         dual = true;
@@ -4206,7 +4204,7 @@ struct wildfire_bomb_t: public hunter_spell_t
     };
     dot_action_t* dot_action;
 
-    bomb_base_t( const std::string& n, wildfire_bomb_t* a, const spell_data_t* s, const std::string& dot_n, const spell_data_t* dot_s ):
+    bomb_base_t( util::string_view n, wildfire_bomb_t* a, const spell_data_t* s, util::string_view dot_n, const spell_data_t* dot_s ):
       hunter_spell_t( n, a -> p(), s ),
       dot_action( a -> p() -> get_background_action<dot_action_t>( dot_n, dot_s ) )
     {
@@ -4231,14 +4229,14 @@ struct wildfire_bomb_t: public hunter_spell_t
 
   struct wildfire_bomb_damage_t : public bomb_base_t
   {
-    wildfire_bomb_damage_t( const std::string& n, hunter_t* p, wildfire_bomb_t* a ):
+    wildfire_bomb_damage_t( util::string_view n, hunter_t* p, wildfire_bomb_t* a ):
       bomb_base_t( n, a, p -> find_spell( 265157 ), "wildfire_bomb_dot", p -> find_spell( 269747 ) )
     {}
   };
 
   struct shrapnel_bomb_t : public bomb_base_t
   {
-    shrapnel_bomb_t( const std::string& n, hunter_t* p, wildfire_bomb_t* a ):
+    shrapnel_bomb_t( util::string_view n, hunter_t* p, wildfire_bomb_t* a ):
       bomb_base_t( n, a, p -> find_spell( 270338 ), "shrapnel_bomb", p -> find_spell( 270339 ) )
     {
       attacks::internal_bleeding_t internal_bleeding( p );
@@ -4248,7 +4246,7 @@ struct wildfire_bomb_t: public hunter_spell_t
 
   struct pheromone_bomb_t : public bomb_base_t
   {
-    pheromone_bomb_t( const std::string& n, hunter_t* p, wildfire_bomb_t* a ):
+    pheromone_bomb_t( util::string_view n, hunter_t* p, wildfire_bomb_t* a ):
       bomb_base_t( n, a, p -> find_spell( 270329 ), "pheromone_bomb", p -> find_spell( 270332 ) )
     {}
   };
@@ -4257,7 +4255,7 @@ struct wildfire_bomb_t: public hunter_spell_t
   {
     struct violent_reaction_t : public hunter_spell_t
     {
-      violent_reaction_t( const std::string& n, hunter_t* p ):
+      violent_reaction_t( util::string_view n, hunter_t* p ):
         hunter_spell_t( n, p, p -> find_spell( 260231 ) )
       {
         dual = true;
@@ -4266,7 +4264,7 @@ struct wildfire_bomb_t: public hunter_spell_t
     };
     violent_reaction_t* violent_reaction;
 
-    volatile_bomb_t( const std::string& n, hunter_t* p, wildfire_bomb_t* a ):
+    volatile_bomb_t( util::string_view n, hunter_t* p, wildfire_bomb_t* a ):
       bomb_base_t( n, a, p -> find_spell( 271048 ), "volatile_bomb", p -> find_spell( 271049 ) ),
       violent_reaction( p -> get_background_action<violent_reaction_t>( "violent_reaction" ) )
     {
@@ -5362,22 +5360,6 @@ void hunter_t::init_action_list()
     use_default_action_list = true;
     player_t::init_action_list();
   }
-}
-
-// Item Actions =======================================================================
-
-std::string hunter_t::special_use_item_action( const std::string& item_name, const std::string& condition ) const
-{
-  auto item = range::find_if( items, [ &item_name ]( const item_t& item ) {
-    return item.has_special_effect( SPECIAL_EFFECT_SOURCE_ITEM, SPECIAL_EFFECT_USE ) && item.name_str == item_name;
-  });
-  if ( item == items.end() )
-    return std::string();
-
-  std::string action = "use_item,name=" + item -> name_str;
-  if ( !condition.empty() )
-    action += "," + condition;
-  return action;
 }
 
 // Beastmastery Action List =============================================================

--- a/engine/item/enchants.cpp
+++ b/engine/item/enchants.cpp
@@ -39,7 +39,7 @@ thread_local std::unordered_map<size_t, std::string> cached_enchant_names;
 
 } /* ANONYMOUS NAMESPACE */
 
-unsigned enchant::find_enchant_id( const std::string& name )
+unsigned enchant::find_enchant_id( util::string_view name )
 {
   for ( auto& enchant_entry : __enchant_db )
   {
@@ -192,7 +192,7 @@ std::string enchant::encoded_enchant_name( const dbc_t& dbc, const item_enchantm
  * Tailoring enchant mappings in the array above.
  */
 const item_enchantment_data_t& enchant::find_item_enchant( const item_t& item,
-                                                           const std::string& name )
+                                                           util::string_view name )
 {
   auto enchant_id = find_enchant_id( name );
   // Check additional mapping table first
@@ -420,8 +420,8 @@ bool enchant::passive_enchant( item_t& item, unsigned spell_id )
  * (capacitive_primal_diamond), and the "short" form of the tokenized name
  * (capacitive_primal).
  */
-const item_enchantment_data_t& enchant::find_meta_gem( const dbc_t&       dbc,
-                                                       const std::string& encoding )
+const item_enchantment_data_t& enchant::find_meta_gem( const dbc_t&      dbc,
+                                                       util::string_view encoding )
 {
   for ( const auto& gem_property : gem_property_data_t::data( dbc.ptr ) )
   {
@@ -445,10 +445,10 @@ const item_enchantment_data_t& enchant::find_meta_gem( const dbc_t&       dbc,
 
     std::string tokenized_name = gem.name;
     util::tokenize( tokenized_name );
-    std::string shortname;
+    util::string_view shortname;
     std::string::size_type offset = tokenized_name.find( "_diamond" );
     if ( offset != std::string::npos )
-      shortname = tokenized_name.substr( 0, offset );
+      shortname = util::string_view( tokenized_name ).substr( 0, offset );
 
     if ( util::str_in_str_ci( encoding, tokenized_name ) ||
          ( ! shortname.empty() && util::str_in_str_ci( encoding, shortname ) ) )

--- a/engine/item/enchants.hpp
+++ b/engine/item/enchants.hpp
@@ -9,6 +9,7 @@
 #include "sc_enums.hpp"
 #include "item.hpp"
 #include "dbc/gem_data.hpp"
+#include "util/string_view.hpp"
 
 #include <string>
 
@@ -23,12 +24,12 @@ namespace enchant
     unsigned    enchant_id;
   };
 
-  unsigned find_enchant_id( const std::string& name );
+  unsigned find_enchant_id( util::string_view name );
   std::string find_enchant_name( unsigned enchant_id );
   std::string encoded_enchant_name( const dbc_t&, const item_enchantment_data_t& );
 
-  const item_enchantment_data_t& find_item_enchant( const item_t& item, const std::string& name );
-  const item_enchantment_data_t& find_meta_gem( const dbc_t& dbc, const std::string& encoding );
+  const item_enchantment_data_t& find_item_enchant( const item_t& item, util::string_view name );
+  const item_enchantment_data_t& find_meta_gem( const dbc_t& dbc, util::string_view encoding );
   meta_gem_e meta_gem_type( const dbc_t& dbc, const item_enchantment_data_t& );
   bool passive_enchant( item_t& item, unsigned spell_id );
 

--- a/engine/item/item.cpp
+++ b/engine/item/item.cpp
@@ -147,7 +147,7 @@ const special_effect_t* item_t::special_effect( special_effect_source_e source, 
 
 // item_t::special_effect_with_name =========================================
 
-const special_effect_t* item_t::special_effect_with_name( const std::string& name, special_effect_source_e source, special_effect_e type ) const
+const special_effect_t* item_t::special_effect_with_name( util::string_view name, special_effect_source_e source, special_effect_e type ) const
 {
   for ( size_t i = 0; i < parsed.special_effects.size(); i++ )
   {

--- a/engine/item/item.hpp
+++ b/engine/item/item.hpp
@@ -6,11 +6,13 @@
 #pragma once
 
 #include "config.hpp"
-#include "util/generic.hpp"
-#include "sc_enums.hpp"
-#include "player/gear_stats.hpp"
-#include "sc_timespan.hpp"
 #include "dbc/item_data.hpp"
+#include "player/gear_stats.hpp"
+#include "sc_enums.hpp"
+#include "sc_timespan.hpp"
+#include "util/generic.hpp"
+#include "util/string_view.hpp"
+
 #include <array>
 #include <vector>
 #include <memory>
@@ -188,6 +190,6 @@ struct item_t
   bool has_scaling_stat_bonus_id() const;
 
   const special_effect_t* special_effect( special_effect_source_e source = SPECIAL_EFFECT_SOURCE_NONE, special_effect_e type = SPECIAL_EFFECT_NONE ) const;
-  const special_effect_t* special_effect_with_name( const std::string& name, special_effect_source_e source = SPECIAL_EFFECT_SOURCE_NONE, special_effect_e type = SPECIAL_EFFECT_NONE ) const;
+  const special_effect_t* special_effect_with_name( util::string_view name, special_effect_source_e source = SPECIAL_EFFECT_SOURCE_NONE, special_effect_e type = SPECIAL_EFFECT_NONE ) const;
 };
 std::ostream& operator<<(std::ostream&, const item_t&);

--- a/engine/player/action_priority_list.cpp
+++ b/engine/player/action_priority_list.cpp
@@ -4,6 +4,7 @@
 // ==========================================================================
 
 #include "action_priority_list.hpp"
+
 #include "util/util.hpp"
 #include "action/sc_action.hpp"
 #include "player/sc_player.hpp"
@@ -15,8 +16,8 @@
  *
  * Anything goes to action priority list.
  */
-action_priority_t* action_priority_list_t::add_action(const std::string& action_priority_str,
-  const std::string& comment)
+action_priority_t* action_priority_list_t::add_action(util::string_view action_priority_str,
+  util::string_view comment)
 {
   if (action_priority_str.empty())
     return nullptr;
@@ -30,17 +31,16 @@ action_priority_t* action_priority_list_t::add_action(const std::string& action_
  * Check the validity of spell data before anything goes to action priority list
  */
 action_priority_t* action_priority_list_t::add_action(const player_t* p, const spell_data_t* s,
-  const std::string& action_name,
-  const std::string& action_options, const std::string& comment)
+  util::string_view action_name,
+  util::string_view action_options, util::string_view comment)
 {
   if (!s || !s->ok() || !s->is_level(p->true_level))
     return nullptr;
 
-  std::string str = action_name;
-  if (!action_options.empty())
-    str += "," + action_options;
+  if (action_options.empty())
+    return add_action(action_name, comment);
 
-  return add_action(str, comment);
+  return add_action(fmt::format("{},{}", action_name, action_options), comment);
 }
 
 /**
@@ -49,15 +49,13 @@ action_priority_t* action_priority_list_t::add_action(const player_t* p, const s
  * Check the availability of a class spell of "name" and the validity of it's
  * spell data before anything goes to action priority list
  */
-action_priority_t* action_priority_list_t::add_action(const player_t* p, const std::string& name,
-  const std::string& action_options, const std::string& comment)
+action_priority_t* action_priority_list_t::add_action(const player_t* p, util::string_view name,
+  util::string_view action_options, util::string_view comment)
 {
   const spell_data_t* s = p->find_class_spell(name);
   if (s == spell_data_t::not_found())
     s = p->find_specialization_spell(name);
-  std::string tokenized_name = s->name_cstr();
-  util::tokenize(tokenized_name);
-  return add_action(p, s, tokenized_name, action_options, comment);
+  return add_action(p, s, util::tokenize_fn( s->name_cstr() ), action_options, comment);
 }
 
 /**
@@ -73,11 +71,9 @@ action_priority_t* action_priority_list_t::add_action(const player_t* p, const s
  * If omitted, it will be automatically added to the if expression (or
  * if expression will be created if it is missing).
  */
-action_priority_t* action_priority_list_t::add_talent(const player_t* p, const std::string& name,
-  const std::string& action_options, const std::string& comment)
+action_priority_t* action_priority_list_t::add_talent(const player_t* p, util::string_view name,
+  util::string_view action_options, util::string_view comment)
 {
   const spell_data_t* s = p->find_talent_spell(name, SPEC_NONE, false, false);
-  std::string tokenized_name = s->name_cstr();
-  util::tokenize(tokenized_name);
-  return add_action(p, s, tokenized_name, action_options, comment);
+  return add_action(p, s, util::tokenize_fn( s->name_cstr() ), action_options, comment);
 }

--- a/engine/player/action_priority_list.hpp
+++ b/engine/player/action_priority_list.hpp
@@ -6,6 +6,9 @@
 #pragma once
 
 #include "config.hpp"
+
+#include "util/string_view.hpp"
+
 #include <string>
 #include <cstdint>
 #include <vector>
@@ -19,13 +22,13 @@ struct action_priority_t
   std::string action_;
   std::string comment_;
 
-  action_priority_t(const std::string& a, const std::string& c) :
+  action_priority_t(util::string_view a, util::string_view c) :
     action_(a), comment_(c)
   { }
 
-  action_priority_t* comment(const std::string& c)
+  action_priority_t* comment(util::string_view c)
   {
-    comment_ = c; return this;
+    comment_.assign(c.data(), c.size()); return this;
   }
 };
 
@@ -46,16 +49,16 @@ struct action_priority_list_t
   std::vector<action_t*> off_gcd_actions;
   std::vector<action_t*> cast_while_casting_actions;
   int random; // Used to determine how faceroll something actually is. :D
-  action_priority_list_t(std::string name, player_t* p, const std::string& list_comment = std::string()) :
+  action_priority_list_t(util::string_view name, player_t* p, util::string_view list_comment = {}) :
     internal_id(0), internal_id_mask(0), name_str(name), action_list_comment_str(list_comment), player(p), used(false),
     foreground_action_list(), off_gcd_actions(), cast_while_casting_actions(), random(0)
   { }
 
-  action_priority_t* add_action(const std::string& action_priority_str, const std::string& comment = std::string());
-  action_priority_t* add_action(const player_t* p, const spell_data_t* s, const std::string& action_name,
-    const std::string& action_options = std::string(), const std::string& comment = std::string());
-  action_priority_t* add_action(const player_t* p, const std::string& name, const std::string& action_options = std::string(),
-    const std::string& comment = std::string());
-  action_priority_t* add_talent(const player_t* p, const std::string& name, const std::string& action_options = std::string(),
-    const std::string& comment = std::string());
+  action_priority_t* add_action(util::string_view action_priority_str, util::string_view comment = {});
+  action_priority_t* add_action(const player_t* p, const spell_data_t* s, util::string_view action_name,
+    util::string_view action_options = {}, util::string_view comment = {});
+  action_priority_t* add_action(const player_t* p, util::string_view name, util::string_view action_options = {},
+    util::string_view comment = {});
+  action_priority_t* add_talent(const player_t* p, util::string_view name, util::string_view action_options = {},
+    util::string_view comment = {});
 };

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -2155,7 +2155,7 @@ struct reorigination_array_buff_t : public buff_t
     current_stat = highest_stat;
   }
 
-  reorigination_array_buff_t( player_t* p, const std::string& name, const special_effect_t& effect ) :
+  reorigination_array_buff_t( player_t* p, util::string_view name, const special_effect_t& effect ) :
     buff_t( p, name, effect.player->find_spell( 280573 ), effect.item ),
     proc_crit( p->get_proc( "Reorigination Array: Critical Strike" ) ),
     proc_haste( p->get_proc( "Reorigination Array: Haste" ) ),

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -488,7 +488,7 @@ azerite_power_t azerite_state_t::get_power( unsigned id )
   }
 }
 
-azerite_power_t azerite_state_t::get_power( const std::string& name, bool tokenized )
+azerite_power_t azerite_state_t::get_power( util::string_view name, bool tokenized )
 {
   const auto& power = m_player -> dbc->azerite_power( name, tokenized );
 
@@ -658,7 +658,7 @@ size_t azerite_state_t::rank( unsigned id ) const
   return 0u;
 }
 
-size_t azerite_state_t::rank( const std::string& name, bool tokenized ) const
+size_t azerite_state_t::rank( util::string_view name, bool tokenized ) const
 {
   const auto& power = m_player -> dbc->azerite_power( name, tokenized );
   if ( power.id == 0 )
@@ -674,7 +674,7 @@ bool azerite_state_t::is_enabled( unsigned id ) const
   return rank( id ) > 0;
 }
 
-bool azerite_state_t::is_enabled( const std::string& name, bool tokenized ) const
+bool azerite_state_t::is_enabled( util::string_view name, bool tokenized ) const
 {
   const auto& power = m_player -> dbc->azerite_power( name, tokenized );
   if ( power.id == 0 )
@@ -955,7 +955,7 @@ azerite_essence_state_t::azerite_essence_state_t( const player_t* player ) : m_p
 { }
 
 // Get an azerite essence object by name
-azerite_essence_t azerite_essence_state_t::get_essence( const std::string& name, bool tokenized ) const
+azerite_essence_t azerite_essence_state_t::get_essence( util::string_view name, bool tokenized ) const
 {
   const auto& essence = azerite_essence_entry_t::find( name, tokenized, m_player->dbc->ptr );
   // Could also be a passive spell, so check if the passives logged for the player match this

--- a/engine/player/azerite_data.hpp
+++ b/engine/player/azerite_data.hpp
@@ -204,16 +204,16 @@ public:
   /// Get an azerite_power_t object for a given power identifier
   azerite_power_t get_power( unsigned id );
   /// Get an azerite_power_t object for a given power name, potentially tokenized
-  azerite_power_t get_power( const std::string& name, bool tokenized = false );
+  azerite_power_t get_power( util::string_view name, bool tokenized = false );
 
   /// Check the enable status of an azerite power
   bool is_enabled( unsigned id ) const;
   /// Check the enable status of an azerite power
-  bool is_enabled( const std::string& name, bool tokenized = false ) const;
+  bool is_enabled( util::string_view name, bool tokenized = false ) const;
   /// Rank of the azrerite power (how many items have the selected power)
   size_t rank( unsigned id ) const;
   /// Rank of the azrerite power (how many items have the selected power)
-  size_t rank( const std::string& name, bool tokenized = false ) const;
+  size_t rank( util::string_view name, bool tokenized = false ) const;
 
   /// Parse and sanitize azerite_override option
   bool parse_override( sim_t*, const std::string& /*name*/, const std::string& /*value*/ );
@@ -276,7 +276,7 @@ public:
   azerite_essence_state_t( const player_t* player );
 
   azerite_essence_t get_essence( unsigned id ) const;
-  azerite_essence_t get_essence( const std::string& name, bool tokenized = false ) const;
+  azerite_essence_t get_essence( util::string_view name, bool tokenized = false ) const;
 
   /// Add an azerite essence
   bool add_essence( essence_type type, unsigned id, unsigned rank );

--- a/engine/player/pet.hpp
+++ b/engine/player/pet.hpp
@@ -59,7 +59,7 @@ public:
   const player_t* get_owner_or_self() const override
   { return owner; }
 
-  const spell_data_t* find_pet_spell( const std::string& name );
+  const spell_data_t* find_pet_spell( util::string_view name );
 
   double composite_attribute( attribute_e attr ) const override;
   double composite_player_multiplier( school_e ) const override;

--- a/engine/player/pet_spawner.hpp
+++ b/engine/player/pet_spawner.hpp
@@ -108,12 +108,12 @@ private:
   /// Recreate m_active pets, m_inactive pets if m_dirty == 1
   void update_state();
 public:
-  pet_spawner_t( const std::string& id, O* p, pet_spawn_type st = PET_SPAWN_DYNAMIC );
-  pet_spawner_t( const std::string& id, O* p, unsigned max_pets,
+  pet_spawner_t( util::string_view id, O* p, pet_spawn_type st = PET_SPAWN_DYNAMIC );
+  pet_spawner_t( util::string_view id, O* p, unsigned max_pets,
                    pet_spawn_type st = PET_SPAWN_DYNAMIC );
-  pet_spawner_t( const std::string& id, O* p, unsigned max_pets, const create_fn_t& creator,
+  pet_spawner_t( util::string_view id, O* p, unsigned max_pets, const create_fn_t& creator,
                    pet_spawn_type st = PET_SPAWN_DYNAMIC );
-  pet_spawner_t( const std::string& id, O* p, const create_fn_t& creator,
+  pet_spawner_t( util::string_view id, O* p, const create_fn_t& creator,
                    pet_spawn_type st = PET_SPAWN_DYNAMIC );
 
   /// Spawn n new pets (defaults, 1 for dynamic, max_pets for persistent),

--- a/engine/player/pet_spawner_impl.hpp
+++ b/engine/player/pet_spawner_impl.hpp
@@ -27,7 +27,7 @@ namespace spawner
 // Constructors
 
 template<typename T, typename O>
-pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, pet_spawn_type st ) :
+pet_spawner_t<T, O>::pet_spawner_t( util::string_view id, O* p, pet_spawn_type st ) :
   base_actor_spawner_t( id, p ), m_max_pets( st == PET_SPAWN_DYNAMIC ? 0 : 1 ),
   m_creator( []( O* p ) { return new T( p ); } ),
   m_duration( timespan_t::zero() ), m_type( st ),
@@ -36,7 +36,7 @@ pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, pet_spawn_type 
 { }
 
 template<typename T, typename O>
-pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, unsigned max_pets,
+pet_spawner_t<T, O>::pet_spawner_t( util::string_view id, O* p, unsigned max_pets,
                                         pet_spawn_type st ) :
   base_actor_spawner_t( id, p ), m_max_pets( max_pets ),
   m_creator( []( O* p ) { return new T( p ); } ),
@@ -46,7 +46,7 @@ pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, unsigned max_pe
 { }
 
 template<typename T, typename O>
-pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, unsigned max_pets,
+pet_spawner_t<T, O>::pet_spawner_t( util::string_view id, O* p, unsigned max_pets,
                                      const create_fn_t& creator, pet_spawn_type st ) :
   base_actor_spawner_t( id, p ), m_max_pets( max_pets ), m_creator( creator ),
   m_duration( timespan_t::zero() ), m_type( st ),
@@ -55,7 +55,7 @@ pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, unsigned max_pe
 { }
 
 template<typename T, typename O>
-pet_spawner_t<T, O>::pet_spawner_t( const std::string& id, O* p, const create_fn_t& creator,
+pet_spawner_t<T, O>::pet_spawner_t( util::string_view id, O* p, const create_fn_t& creator,
                                         pet_spawn_type st ) :
   base_actor_spawner_t( id, p ), m_max_pets( st == PET_SPAWN_DYNAMIC ? 0 : 1 ), m_creator( creator ),
   m_duration( timespan_t::zero() ), m_type( st ),

--- a/engine/player/sample_data_helper.hpp
+++ b/engine/player/sample_data_helper.hpp
@@ -15,7 +15,7 @@
  */
 struct sample_data_helper_t : public extended_sample_data_t, private noncopyable
 {
-  sample_data_helper_t(std::string n, bool simple) :
+  sample_data_helper_t(util::string_view n, bool simple) :
     extended_sample_data_t(n, simple),
     buffer_value(0.0)
   {

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -303,9 +303,9 @@ void pet_t::init_finished()
     quiet = ! sim -> report_pets_separately;
 }
 
-const spell_data_t* pet_t::find_pet_spell( const std::string& name )
+const spell_data_t* pet_t::find_pet_spell( util::string_view name )
 {
-  unsigned spell_id = dbc->pet_ability_id( type, name.c_str() );
+  unsigned spell_id = dbc->pet_ability_id( type, name );
 
   if ( ! spell_id || ! dbc->spell( spell_id ) )
   {

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -2261,7 +2261,7 @@ std::vector<std::string> player_t::get_racial_actions()
  * and check if that spell data is ok()
  * returns true if spell data is ok(), false otherwise
  */
-bool player_t::add_action( std::string action, std::string options, std::string alist )
+bool player_t::add_action( util::string_view action, util::string_view options, util::string_view alist )
 {
   return add_action( find_class_spell( action ), options, alist );
 }
@@ -2272,7 +2272,7 @@ bool player_t::add_action( std::string action, std::string options, std::string 
  * Helper function to add actions to the action list if given spell data is ok()
  * returns true if spell data is ok(), false otherwise
  */
-bool player_t::add_action( const spell_data_t* s, std::string options, std::string alist )
+bool player_t::add_action( const spell_data_t* s, util::string_view options, util::string_view alist )
 {
   if ( s->ok() )
   {
@@ -2283,7 +2283,8 @@ bool player_t::add_action( const spell_data_t* s, std::string options, std::stri
     str += "/" + name;
     if ( !options.empty() )
     {
-      str += "," + options;
+      str += ",";
+      str.append( options.data(), options.size() );
     }
     return true;
   }
@@ -7139,7 +7140,7 @@ uptime_t* player_t::get_uptime( const std::string& name )
   return u;
 }
 
-action_priority_list_t* player_t::get_action_priority_list( const std::string& name, const std::string& comment )
+action_priority_list_t* player_t::get_action_priority_list( util::string_view name, util::string_view comment )
 {
   action_priority_list_t* a = find_action_priority_list( name );
   if ( !a )
@@ -7149,10 +7150,9 @@ action_priority_list_t* player_t::get_action_priority_list( const std::string& n
       throw std::invalid_argument("Maximum number of action lists is 64");
     }
 
-    a                          = new action_priority_list_t( name, this );
-    a->action_list_comment_str = comment;
-    a->internal_id             = action_list_id_++;
-    a->internal_id_mask        = 1ULL << ( a->internal_id );
+    a                   = new action_priority_list_t( name, this, comment );
+    a->internal_id      = action_list_id_++;
+    a->internal_id_mask = 1ULL << ( a->internal_id );
 
     action_priority_list.push_back( a );
   }

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -3332,9 +3332,9 @@ void player_t::create_buffs()
   }
 }
 
-item_t* player_t::find_item_by_name( const std::string& item_name )
+item_t* player_t::find_item_by_name( util::string_view item_name )
 {
-  auto it = range::find_if(items, [item_name](const item_t& item) { return item_name == item.name();});
+  auto it = range::find(items, item_name, &item_t::name );
 
   if ( it != items.end())
   {
@@ -3356,7 +3356,7 @@ item_t* player_t::find_item_by_id( unsigned item_id )
   return nullptr;
 }
 
-item_t* player_t::find_item_by_use_effect_name( const std::string& effect_name )
+item_t* player_t::find_item_by_use_effect_name( util::string_view effect_name )
 {
   auto it = range::find_if(items, [effect_name](const item_t& item) {
     return item.has_use_special_effect() && effect_name == item.special_effect( SPECIAL_EFFECT_SOURCE_NONE, SPECIAL_EFFECT_USE )->name();
@@ -6840,20 +6840,20 @@ void player_t::assess_heal( school_e, result_amount_type, action_state_t* s )
   iteration_heal_taken += s->result_amount;
 }
 
-void player_t::summon_pet( const std::string& pet_name, const timespan_t duration )
+void player_t::summon_pet( util::string_view pet_name, const timespan_t duration )
 {
   if ( pet_t* p = find_pet( pet_name ) )
     p->summon( duration );
   else
-    sim->errorf( "Player %s is unable to summon pet '%s'\n", name(), pet_name.c_str() );
+    sim->error( "Player {} is unable to summon pet '{}'\n", name(), pet_name );
 }
 
-void player_t::dismiss_pet( const std::string& pet_name )
+void player_t::dismiss_pet( util::string_view pet_name )
 {
   pet_t* p = find_pet( pet_name );
   if ( !p )
   {
-    sim->errorf( "Player %s: Could not find pet with name '%s' to dismiss.", name(), pet_name.c_str() );
+    sim->error( "Player {}: Could not find pet with name '{}' to dismiss.", name(), pet_name );
     return;
   }
   p->dismiss();
@@ -6865,11 +6865,10 @@ bool player_t::recent_cast() const
          ( ( last_cast + timespan_t::from_seconds( 5.0 ) ) > sim->current_time() );
 }
 
-dot_t* player_t::find_dot( const std::string& name, player_t* source ) const
+dot_t* player_t::find_dot( util::string_view name, player_t* source ) const
 {
-  for ( size_t i = 0; i < dot_list.size(); ++i )
+  for ( dot_t* d : dot_list )
   {
-    dot_t* d = dot_list[ i ];
     if ( d->source == source && d->name_str == name )
       return d;
   }
@@ -6889,7 +6888,7 @@ void player_t::clear_action_priority_lists() const
 /**
  * Replaces "old_list" action_priority_list data with "new_list" action_priority_list data
  */
-void player_t::copy_action_priority_list( const std::string& old_list, const std::string& new_list )
+void player_t::copy_action_priority_list( util::string_view old_list, util::string_view new_list )
 {
   action_priority_list_t* ol = find_action_priority_list( old_list );
   action_priority_list_t* nl = find_action_priority_list( new_list );
@@ -6905,7 +6904,7 @@ void player_t::copy_action_priority_list( const std::string& old_list, const std
 }
 
 template <typename T>
-T* find_vector_member( const std::vector<T*>& list, const std::string& name )
+T* find_vector_member( const std::vector<T*>& list, util::string_view name )
 {
   for ( auto t : list )
   {
@@ -6917,52 +6916,52 @@ T* find_vector_member( const std::vector<T*>& list, const std::string& name )
 
 // player_t::find_action_priority_list( const std::string& name ) ===========
 
-action_priority_list_t* player_t::find_action_priority_list( const std::string& name ) const
+action_priority_list_t* player_t::find_action_priority_list( util::string_view name ) const
 {
   return find_vector_member( action_priority_list, name );
 }
 
-pet_t* player_t::find_pet( const std::string& name ) const
+pet_t* player_t::find_pet( util::string_view name ) const
 {
   return find_vector_member( pet_list, name );
 }
 
-stats_t* player_t::find_stats( const std::string& name ) const
+stats_t* player_t::find_stats( util::string_view name ) const
 {
   return find_vector_member( stats_list, name );
 }
 
-gain_t* player_t::find_gain( const std::string& name ) const
+gain_t* player_t::find_gain( util::string_view name ) const
 {
   return find_vector_member( gain_list, name );
 }
 
-proc_t* player_t::find_proc( const std::string& name ) const
+proc_t* player_t::find_proc( util::string_view name ) const
 {
   return find_vector_member( proc_list, name );
 }
 
-sample_data_helper_t* player_t::find_sample_data( const std::string& name ) const
+sample_data_helper_t* player_t::find_sample_data( util::string_view name ) const
 {
   return find_vector_member( sample_data_list, name );
 }
 
-benefit_t* player_t::find_benefit( const std::string& name ) const
+benefit_t* player_t::find_benefit( util::string_view name ) const
 {
   return find_vector_member( benefit_list, name );
 }
 
-uptime_t* player_t::find_uptime( const std::string& name ) const
+uptime_t* player_t::find_uptime( util::string_view name ) const
 {
   return find_vector_member( uptime_list, name );
 }
 
-cooldown_t* player_t::find_cooldown( const std::string& name ) const
+cooldown_t* player_t::find_cooldown( util::string_view name ) const
 {
   return find_vector_member( cooldown_list, name );
 }
 
-action_t* player_t::find_action( const std::string& name ) const
+action_t* player_t::find_action( util::string_view name ) const
 {
   return find_vector_member( action_list, name );
 }
@@ -7160,7 +7159,7 @@ action_priority_list_t* player_t::get_action_priority_list( const std::string& n
   return a;
 }
 
-int player_t::find_action_id( const std::string& name ) const
+int player_t::find_action_id( util::string_view name ) const
 {
   for ( size_t i = 0; i < action_map.size(); i++ )
   {
@@ -7171,7 +7170,7 @@ int player_t::find_action_id( const std::string& name ) const
   return -1;
 }
 
-int player_t::get_action_id( const std::string& name )
+int player_t::get_action_id( util::string_view name )
 {
   auto id = find_action_id( name );
   if ( id != -1 )
@@ -7179,7 +7178,7 @@ int player_t::get_action_id( const std::string& name )
     return id;
   }
 
-  action_map.push_back( name );
+  action_map.emplace_back( name );
   return static_cast<int>(action_map.size() - 1);
 }
 
@@ -9248,7 +9247,7 @@ void player_t::replace_spells()
  * spell_data_t::not_found() is returned.
  * The talent search by name is case sensitive, including all special characters!
  */
-const spell_data_t* player_t::find_talent_spell( const std::string& n, specialization_e s, bool name_tokenized,
+const spell_data_t* player_t::find_talent_spell( util::string_view n, specialization_e s, bool name_tokenized,
                                                  bool check_validity ) const
 {
   if ( s == SPEC_NONE )
@@ -9257,7 +9256,7 @@ const spell_data_t* player_t::find_talent_spell( const std::string& n, specializ
   }
 
   // Get a talent's spell id for a given talent name
-  unsigned spell_id = dbc->talent_ability_id( type, s, n.c_str(), name_tokenized );
+  unsigned spell_id = dbc->talent_ability_id( type, s, n, name_tokenized );
 
   if ( !spell_id )
   {
@@ -9293,11 +9292,11 @@ const spell_data_t* player_t::find_talent_spell( const std::string& n, specializ
   return spell_data_t::not_found();
 }
 
-const spell_data_t* player_t::find_specialization_spell( const std::string& name, specialization_e s ) const
+const spell_data_t* player_t::find_specialization_spell( util::string_view name, specialization_e s ) const
 {
   if ( s == SPEC_NONE || s == _spec )
   {
-    if ( unsigned spell_id = dbc->specialization_ability_id( _spec, name.c_str() ) )
+    if ( unsigned spell_id = dbc->specialization_ability_id( _spec, name ) )
     {
       auto spell = dbc::find_spell( this, spell_id );
 
@@ -9352,7 +9351,7 @@ azerite_power_t player_t::find_azerite_spell( unsigned id ) const
   return azerite -> get_power( id );
 }
 
-azerite_power_t player_t::find_azerite_spell( const std::string& name, bool tokenized ) const
+azerite_power_t player_t::find_azerite_spell( util::string_view name, bool tokenized ) const
 {
   if ( ! azerite )
   {
@@ -9373,7 +9372,7 @@ azerite_essence_t player_t::find_azerite_essence( unsigned id ) const
   return azerite_essence->get_essence( id );
 }
 
-azerite_essence_t player_t::find_azerite_essence( const std::string& name, bool tokenized ) const
+azerite_essence_t player_t::find_azerite_essence( util::string_view name, bool tokenized ) const
 {
   if ( !azerite_essence )
   {
@@ -9400,7 +9399,7 @@ void player_t::vision_of_perfection_proc()
  * It does this by going through various spell lists in following order:
  * class spell, specialization spell, mastery spell, talent spell, racial spell, pet_spell
  */
-const spell_data_t* player_t::find_spell( const std::string& name, specialization_e s ) const
+const spell_data_t* player_t::find_spell( util::string_view name, specialization_e s ) const
 {
   const spell_data_t* sp = find_class_spell( name, s );
   assert( sp );
@@ -9438,9 +9437,9 @@ const spell_data_t* player_t::find_spell( const std::string& name, specializatio
   return spell_data_t::not_found();
 }
 
-const spell_data_t* player_t::find_racial_spell( const std::string& name, race_e r ) const
+const spell_data_t* player_t::find_racial_spell( util::string_view name, race_e r ) const
 {
-  if ( unsigned spell_id = dbc->race_ability_id( type, ( r != RACE_NONE ) ? r : race, name.c_str() ) )
+  if ( unsigned spell_id = dbc->race_ability_id( type, ( r != RACE_NONE ) ? r : race, name ) )
   {
     const spell_data_t* s = dbc->spell( spell_id );
     if ( s->id() == spell_id )
@@ -9452,11 +9451,11 @@ const spell_data_t* player_t::find_racial_spell( const std::string& name, race_e
   return spell_data_t::not_found();
 }
 
-const spell_data_t* player_t::find_class_spell( const std::string& name, specialization_e s ) const
+const spell_data_t* player_t::find_class_spell( util::string_view name, specialization_e s ) const
 {
   if ( s == SPEC_NONE || s == _spec )
   {
-    if ( unsigned spell_id = dbc->class_ability_id( type, _spec, name.c_str() ) )
+    if ( unsigned spell_id = dbc->class_ability_id( type, _spec, name ) )
     {
       const spell_data_t* spell = dbc->spell( spell_id );
       if ( spell->id() == spell_id && as<int>( spell->level() ) <= true_level )
@@ -9469,7 +9468,7 @@ const spell_data_t* player_t::find_class_spell( const std::string& name, special
   return spell_data_t::not_found();
 }
 
-const spell_data_t* player_t::find_pet_spell( const std::string& name ) const
+const spell_data_t* player_t::find_pet_spell( util::string_view name ) const
 {
   if ( unsigned spell_id = dbc->pet_ability_id( type, name ) )
   {
@@ -12075,7 +12074,7 @@ action_t* player_t::select_action( const action_priority_list_t& list,
   return nullptr;
 }
 
-player_t* player_t::actor_by_name_str( const std::string& name ) const
+player_t* player_t::actor_by_name_str( util::string_view name ) const
 {
   // Check player pets first
   for ( size_t i = 0; i < pet_list.size(); i++ )
@@ -12582,9 +12581,9 @@ std::ostream& operator<<(std::ostream &os, const player_t& p)
   return os;
 }
 
-spawner::base_actor_spawner_t* player_t::find_spawner( const std::string& id ) const
+spawner::base_actor_spawner_t* player_t::find_spawner( util::string_view id ) const
 {
-  auto it = range::find_if( spawners, [ &id ]( spawner::base_actor_spawner_t* o ) {
+  auto it = range::find_if( spawners, [ id ]( spawner::base_actor_spawner_t* o ) {
     return util::str_compare_ci( id, o -> name() );
   } );
 

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -9520,7 +9520,7 @@ struct player_expr_t : public expr_t
 {
   player_t& player;
 
-  player_expr_t( const std::string& n, player_t& p ) : expr_t( n ), player( p )
+  player_expr_t( util::string_view n, player_t& p ) : expr_t( n ), player( p )
   {
   }
 };
@@ -9528,7 +9528,7 @@ struct player_expr_t : public expr_t
 struct position_expr_t : public player_expr_t
 {
   int mask;
-  position_expr_t( const std::string& n, player_t& p, int m ) : player_expr_t( n, p ), mask( m )
+  position_expr_t( util::string_view n, player_t& p, int m ) : player_expr_t( n, p ), mask( m )
   {
   }
   double evaluate() override
@@ -9724,7 +9724,7 @@ std::unique_ptr<expr_t> player_t::create_expression( const std::string& expressi
       {
         const action_variable_t* var_;
 
-        variable_expr_t( player_t* p, const std::string& name ) : expr_t( "variable" ),
+        variable_expr_t( player_t* p, util::string_view name ) : expr_t( "variable" ),
           var_( nullptr )
         {
           auto it = range::find_if( p->variables, [&name]( const action_variable_t* var ) {

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -6967,7 +6967,7 @@ action_t* player_t::find_action( util::string_view name ) const
   return find_vector_member( action_list, name );
 }
 
-cooldown_t* player_t::get_cooldown( const std::string& name, action_t* a )
+cooldown_t* player_t::get_cooldown( util::string_view name, action_t* a )
 {
   cooldown_t* c = find_cooldown( name );
 
@@ -6984,12 +6984,12 @@ cooldown_t* player_t::get_cooldown( const std::string& name, action_t* a )
   return c;
 }
 
-real_ppm_t* player_t::get_rppm(const std::string& name)
+real_ppm_t* player_t::get_rppm( util::string_view name )
 {
   return get_rppm(name, spell_data_t::nil(), nullptr);
 }
 
-real_ppm_t* player_t::get_rppm( const std::string& name, const spell_data_t* data, const item_t* item )
+real_ppm_t* player_t::get_rppm( util::string_view name, const spell_data_t* data, const item_t* item )
 {
   auto it = range::find_if( rppm_list,
                             [&name]( const real_ppm_t* rppm ) { return util::str_compare_ci( rppm->name(), name ); } );
@@ -7005,7 +7005,7 @@ real_ppm_t* player_t::get_rppm( const std::string& name, const spell_data_t* dat
   return new_rppm;
 }
 
-real_ppm_t* player_t::get_rppm( const std::string& name, double freq, double mod, unsigned s )
+real_ppm_t* player_t::get_rppm( util::string_view name, double freq, double mod, unsigned s )
 {
   auto it = range::find_if( rppm_list,
                             [&name]( const real_ppm_t* rppm ) { return util::str_compare_ci( rppm->name(), name ); } );
@@ -7021,7 +7021,7 @@ real_ppm_t* player_t::get_rppm( const std::string& name, double freq, double mod
   return new_rppm;
 }
 
-shuffled_rng_t* player_t::get_shuffled_rng( const std::string& name, int success_entries, int total_entries )
+shuffled_rng_t* player_t::get_shuffled_rng( util::string_view name, int success_entries, int total_entries )
 {
   auto it = range::find_if( shuffled_rng_list, [&name]( const shuffled_rng_t* shuffled_rng ) {
     return util::str_compare_ci( shuffled_rng->name(), name );
@@ -7038,7 +7038,7 @@ shuffled_rng_t* player_t::get_shuffled_rng( const std::string& name, int success
   return new_shuffled_rng;
 }
 
-dot_t* player_t::get_dot( const std::string& name, player_t* source )
+dot_t* player_t::get_dot( util::string_view name, player_t* source )
 {
   dot_t* d = find_dot( name, source );
 
@@ -7051,7 +7051,7 @@ dot_t* player_t::get_dot( const std::string& name, player_t* source )
   return d;
 }
 
-gain_t* player_t::get_gain( const std::string& name )
+gain_t* player_t::get_gain( util::string_view name )
 {
   gain_t* g = find_gain( name );
 
@@ -7065,7 +7065,7 @@ gain_t* player_t::get_gain( const std::string& name )
   return g;
 }
 
-proc_t* player_t::get_proc( const std::string& name )
+proc_t* player_t::get_proc( util::string_view name )
 {
   proc_t* p = find_proc( name );
 
@@ -7079,7 +7079,7 @@ proc_t* player_t::get_proc( const std::string& name )
   return p;
 }
 
-sample_data_helper_t* player_t::get_sample_data( const std::string& name )
+sample_data_helper_t* player_t::get_sample_data( util::string_view name )
 {
   sample_data_helper_t* sd = find_sample_data( name );
 
@@ -7093,7 +7093,7 @@ sample_data_helper_t* player_t::get_sample_data( const std::string& name )
   return sd;
 }
 
-stats_t* player_t::get_stats( const std::string& n, action_t* a )
+stats_t* player_t::get_stats( util::string_view n, action_t* a )
 {
   stats_t* stats = find_stats( n );
 
@@ -7112,7 +7112,7 @@ stats_t* player_t::get_stats( const std::string& n, action_t* a )
   return stats;
 }
 
-benefit_t* player_t::get_benefit( const std::string& name )
+benefit_t* player_t::get_benefit( util::string_view name )
 {
   benefit_t* u = find_benefit( name );
 
@@ -7126,7 +7126,7 @@ benefit_t* player_t::get_benefit( const std::string& name )
   return u;
 }
 
-uptime_t* player_t::get_uptime( const std::string& name )
+uptime_t* player_t::get_uptime( util::string_view name )
 {
   uptime_t* u = find_uptime( name );
 

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -653,8 +653,8 @@ public:
   void change_position( position_e );
   void register_resource_callback(resource_e resource, double value, resource_callback_function_t callback,
       bool use_pct, bool fire_once = true);
-  bool add_action( std::string action, std::string options = "", std::string alist = "default" );
-  bool add_action( const spell_data_t* s, std::string options = "", std::string alist = "default" );
+  bool add_action( util::string_view action, util::string_view options = "", util::string_view alist = "default" );
+  bool add_action( const spell_data_t* s, util::string_view options = "", util::string_view alist = "default" );
   void add_option( std::unique_ptr<option_t> o );
   void parse_talents_numbers( const std::string& talent_string );
   bool parse_talents_armory( const std::string& talent_string );
@@ -753,7 +753,7 @@ public:
   benefit_t*  get_benefit ( const std::string& name );
   uptime_t*   get_uptime  ( const std::string& name );
   sample_data_helper_t* get_sample_data( const std::string& name );
-  action_priority_list_t* get_action_priority_list( const std::string& name, const std::string& comment = std::string() );
+  action_priority_list_t* get_action_priority_list( util::string_view name, util::string_view comment = {} );
   int get_action_id( util::string_view name );
 
 

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -1025,7 +1025,7 @@ public:
 
   scaling_metric_data_t scaling_for_metric( scale_metric_e metric ) const;
 
-  virtual action_t* create_proc_action( const std::string& /* name */, const special_effect_t& /* effect */ )
+  virtual action_t* create_proc_action( util::string_view /* name */, const special_effect_t& /* effect */ )
   { return nullptr; }
   virtual bool requires_data_collection() const
   { return active_during_iteration; }

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -649,7 +649,7 @@ public:
   void create_talents_armory();
   void create_talents_wowhead();
   void clear_action_priority_lists() const;
-  void copy_action_priority_list( const std::string& old_list, const std::string& new_list );
+  void copy_action_priority_list( util::string_view old_list, util::string_view new_list );
   void change_position( position_e );
   void register_resource_callback(resource_e resource, double value, resource_callback_function_t callback,
       bool use_pct, bool fire_once = true);
@@ -710,36 +710,36 @@ public:
   pet_t* cast_pet();
   const pet_t* cast_pet() const;
 
-  azerite_power_t find_azerite_spell( const std::string& name, bool tokenized = false ) const;
+  azerite_power_t find_azerite_spell( util::string_view name, bool tokenized = false ) const;
   azerite_power_t find_azerite_spell( unsigned power_id ) const;
-  azerite_essence_t find_azerite_essence( const std::string& name, bool tokenized = false ) const;
+  azerite_essence_t find_azerite_essence( util::string_view name, bool tokenized = false ) const;
   azerite_essence_t find_azerite_essence( unsigned power_id ) const;
-  const spell_data_t* find_racial_spell( const std::string& name, race_e s = RACE_NONE ) const;
-  const spell_data_t* find_class_spell( const std::string& name, specialization_e s = SPEC_NONE ) const;
-  const spell_data_t* find_pet_spell( const std::string& name ) const;
-  const spell_data_t* find_talent_spell( const std::string& name, specialization_e s = SPEC_NONE, bool name_tokenized = false, bool check_validity = true ) const;
-  const spell_data_t* find_specialization_spell( const std::string& name, specialization_e s = SPEC_NONE ) const;
+  const spell_data_t* find_racial_spell( util::string_view name, race_e s = RACE_NONE ) const;
+  const spell_data_t* find_class_spell( util::string_view name, specialization_e s = SPEC_NONE ) const;
+  const spell_data_t* find_pet_spell( util::string_view name ) const;
+  const spell_data_t* find_talent_spell( util::string_view name, specialization_e s = SPEC_NONE, bool name_tokenized = false, bool check_validity = true ) const;
+  const spell_data_t* find_specialization_spell( util::string_view name, specialization_e s = SPEC_NONE ) const;
   const spell_data_t* find_specialization_spell( unsigned spell_id, specialization_e s = SPEC_NONE ) const;
   const spell_data_t* find_mastery_spell( specialization_e s, uint32_t idx = 0 ) const;
-  const spell_data_t* find_spell( const std::string& name, specialization_e s = SPEC_NONE ) const;
+  const spell_data_t* find_spell( util::string_view name, specialization_e s = SPEC_NONE ) const;
   const spell_data_t* find_spell( unsigned int id, specialization_e s ) const;
   const spell_data_t* find_spell( unsigned int id ) const;
 
-  pet_t*      find_pet( const std::string& name ) const;
-  item_t*     find_item_by_name( const std::string& name );
+  pet_t*      find_pet( util::string_view name ) const;
+  item_t*     find_item_by_name( util::string_view name );
   item_t*     find_item_by_id( unsigned id );
-  item_t*     find_item_by_use_effect_name( const std::string& name );
-  action_t*   find_action( const std::string& ) const;
-  cooldown_t* find_cooldown( const std::string& name ) const;
-  dot_t*      find_dot     ( const std::string& name, player_t* source ) const;
-  stats_t*    find_stats   ( const std::string& name ) const;
-  gain_t*     find_gain    ( const std::string& name ) const;
-  proc_t*     find_proc    ( const std::string& name ) const;
-  benefit_t*  find_benefit ( const std::string& name ) const;
-  uptime_t*   find_uptime  ( const std::string& name ) const;
-  sample_data_helper_t* find_sample_data( const std::string& name ) const;
-  action_priority_list_t* find_action_priority_list( const std::string& name ) const;
-  int find_action_id( const std::string& name ) const;
+  item_t*     find_item_by_use_effect_name( util::string_view name );
+  action_t*   find_action( util::string_view ) const;
+  cooldown_t* find_cooldown( util::string_view name ) const;
+  dot_t*      find_dot     ( util::string_view name, player_t* source ) const;
+  stats_t*    find_stats   ( util::string_view name ) const;
+  gain_t*     find_gain    ( util::string_view name ) const;
+  proc_t*     find_proc    ( util::string_view name ) const;
+  benefit_t*  find_benefit ( util::string_view name ) const;
+  uptime_t*   find_uptime  ( util::string_view name ) const;
+  sample_data_helper_t* find_sample_data( util::string_view name ) const;
+  action_priority_list_t* find_action_priority_list( util::string_view name ) const;
+  int find_action_id( util::string_view name ) const;
 
   cooldown_t* get_cooldown( const std::string& name, action_t* action = nullptr );
   real_ppm_t* get_rppm(const std::string& name);
@@ -754,7 +754,7 @@ public:
   uptime_t*   get_uptime  ( const std::string& name );
   sample_data_helper_t* get_sample_data( const std::string& name );
   action_priority_list_t* get_action_priority_list( const std::string& name, const std::string& comment = std::string() );
-  int get_action_id( const std::string& name );
+  int get_action_id( util::string_view name );
 
 
   // Virtual methods
@@ -974,8 +974,8 @@ public:
 
   virtual bool taunt( player_t* /* source */ ) { return false; }
 
-  virtual void  summon_pet( const std::string& name, timespan_t duration = timespan_t::zero() );
-  virtual void dismiss_pet( const std::string& name );
+  virtual void  summon_pet( util::string_view name, timespan_t duration = timespan_t::zero() );
+  virtual void dismiss_pet( util::string_view name );
 
   virtual std::unique_ptr<expr_t> create_expression( const std::string& name );
   virtual std::unique_ptr<expr_t> create_action_expression( action_t&, const std::string& name );
@@ -1091,7 +1091,7 @@ public:
 
   // Figure out another actor, by name. Prioritizes pets > harmful targets >
   // other players. Used by "actor.<name>" expression currently.
-  virtual player_t* actor_by_name_str( const std::string& ) const;
+  virtual player_t* actor_by_name_str( util::string_view ) const;
 
   // Wicked resource threshold trigger-ready stuff .. work in progress
   event_t* resource_threshold_trigger;
@@ -1123,7 +1123,7 @@ public:
   // Stuff, testing
   std::vector<spawner::base_actor_spawner_t*> spawners;
 
-  spawner::base_actor_spawner_t* find_spawner( const std::string& id ) const;
+  spawner::base_actor_spawner_t* find_spawner( util::string_view id ) const;
   int nth_iteration() const;
 };
 

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -741,18 +741,18 @@ public:
   action_priority_list_t* find_action_priority_list( util::string_view name ) const;
   int find_action_id( util::string_view name ) const;
 
-  cooldown_t* get_cooldown( const std::string& name, action_t* action = nullptr );
-  real_ppm_t* get_rppm(const std::string& name);
-  real_ppm_t* get_rppm    ( const std::string& name, const spell_data_t* data, const item_t* item = nullptr );
-  real_ppm_t* get_rppm    ( const std::string& name, double freq, double mod = 1.0, unsigned s = RPPM_NONE );
-  shuffled_rng_t* get_shuffled_rng(const std::string& name, int success_entries = 0, int total_entries = 0);
-  dot_t*      get_dot     ( const std::string& name, player_t* source );
-  gain_t*     get_gain    ( const std::string& name );
-  proc_t*     get_proc    ( const std::string& name );
-  stats_t*    get_stats   ( const std::string& name, action_t* action = nullptr );
-  benefit_t*  get_benefit ( const std::string& name );
-  uptime_t*   get_uptime  ( const std::string& name );
-  sample_data_helper_t* get_sample_data( const std::string& name );
+  cooldown_t* get_cooldown( util::string_view name, action_t* action = nullptr );
+  real_ppm_t* get_rppm    ( util::string_view );
+  real_ppm_t* get_rppm    ( util::string_view, const spell_data_t* data, const item_t* item = nullptr );
+  real_ppm_t* get_rppm    ( util::string_view, double freq, double mod = 1.0, unsigned s = RPPM_NONE );
+  shuffled_rng_t* get_shuffled_rng( util::string_view name, int success_entries = 0, int total_entries = 0);
+  dot_t*      get_dot     ( util::string_view name, player_t* source );
+  gain_t*     get_gain    ( util::string_view name );
+  proc_t*     get_proc    ( util::string_view name );
+  stats_t*    get_stats   ( util::string_view name, action_t* action = nullptr );
+  benefit_t*  get_benefit ( util::string_view name );
+  uptime_t*   get_uptime  ( util::string_view name );
+  sample_data_helper_t* get_sample_data( util::string_view name );
   action_priority_list_t* get_action_priority_list( util::string_view name, util::string_view comment = {} );
   int get_action_id( util::string_view name );
 

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -4474,7 +4474,7 @@ std::unique_ptr<expr_t> unique_gear::create_expression( player_t& player, const 
 // Find a consumable of a given subtype, see data_enum.hh for type values.
 // Returns 0 if not found.
 const item_data_t* unique_gear::find_consumable( const dbc_t& dbc,
-                                                 const std::string& name,
+                                                 util::string_view name,
                                                  item_subclass_consumable type )
 {
   if ( name.empty() )
@@ -4483,7 +4483,7 @@ const item_data_t* unique_gear::find_consumable( const dbc_t& dbc,
   }
 
   // Poor man's longest matching prefix!
-  const auto& item = dbc::find_consumable( type, dbc.ptr, [&name]( const item_data_t* i ) {
+  const auto& item = dbc::find_consumable( type, dbc.ptr, [name]( const item_data_t* i ) {
     std::string n = i -> name ? i -> name : "unknown";
     util::tokenize( n );
     return util::str_in_str_ci( n, name );

--- a/engine/player/scaling_metric_data.hpp
+++ b/engine/player/scaling_metric_data.hpp
@@ -7,16 +7,18 @@
 
 #include "config.hpp"
 #include "sc_enums.hpp"
+#include "util/string_view.hpp"
+
 #include <string>
 
 struct scaling_metric_data_t {
   std::string name;
   double value, stddev;
   scale_metric_e metric;
-  scaling_metric_data_t( scale_metric_e m, const std::string& n, double v, double dev ) :
+  scaling_metric_data_t( scale_metric_e m, util::string_view n, double v, double dev ) :
     name( n ), value( v ), stddev( dev ), metric( m ) {}
   scaling_metric_data_t( scale_metric_e m, const extended_sample_data_t& sd ) :
     name( sd.name_str ), value( sd.mean() ), stddev( sd.mean_std_dev ), metric( m ) {}
-  scaling_metric_data_t( scale_metric_e m, const sc_timeline_t& tl, const std::string& name ) :
+  scaling_metric_data_t( scale_metric_e m, const sc_timeline_t& tl, util::string_view name ) :
     name( name ), value( tl.mean() ), stddev( tl.mean_stddev() ), metric( m ) {}
 };

--- a/engine/player/spawner_base.hpp
+++ b/engine/player/spawner_base.hpp
@@ -8,6 +8,8 @@
 #include "config.hpp"
 #include "sc_timespan.hpp"
 #include "util/span.hpp"
+#include "util/string_view.hpp"
+
 #include <string>
 #include <memory>
 
@@ -31,7 +33,7 @@ namespace spawner
     player_t* m_owner;
 
   public:
-    base_actor_spawner_t(const std::string& id, player_t* o) :
+    base_actor_spawner_t(util::string_view id, player_t* o) :
       m_name(id), m_owner(o)
     {
       register_object();

--- a/engine/player/stats.hpp
+++ b/engine/player/stats.hpp
@@ -9,8 +9,10 @@
 #include "sc_enums.hpp"
 #include "sc_timespan.hpp"
 #include "util/sample_data.hpp"
+#include "util/string_view.hpp"
 #include "sim/gain.hpp"
 #include "player/gear_stats.hpp"
+
 #include <vector>
 #include <string>
 
@@ -87,7 +89,7 @@ public:
   std::unique_ptr<stats_scaling_t> scaling;
   std::unique_ptr<sc_timeline_t> timeline_amount;
 
-  stats_t( const std::string& name, player_t* );
+  stats_t( util::string_view name, player_t* );
 
   void add_child( stats_t* child );
   void consume_resource( resource_e resource_type, double resource_amount );

--- a/engine/player/unique_gear.hpp
+++ b/engine/player/unique_gear.hpp
@@ -17,6 +17,8 @@
 #include "action/spell.hpp"
 #include "action/heal.hpp"
 #include "action/attack.hpp"
+#include "util/string_view.hpp"
+
 #include <vector>
 #include <functional>
 #include <cassert>
@@ -88,11 +90,11 @@ namespace unique_gear
     // behavior is required and the method is not overridden, must be provided.
     const std::string buff_name;
 
-    class_buff_cb_t( specialization_e spec, const std::string& name = std::string() ) :
+    class_buff_cb_t( specialization_e spec, util::string_view name = {} ) :
       class_scoped_callback_t( spec ), __dummy( nullptr ), buff_name( name )
     { }
 
-    class_buff_cb_t( player_e class_, const std::string& name = std::string() ) :
+    class_buff_cb_t( player_e class_, util::string_view name = {} ) :
       class_scoped_callback_t( class_ ), __dummy( nullptr ), buff_name( name )
     { }
 
@@ -188,11 +190,11 @@ namespace unique_gear
     const std::string name;
     const int spell_id;
 
-    scoped_action_callback_t( player_e c, const std::string& n ) :
+    scoped_action_callback_t( player_e c, util::string_view n ) :
       class_scoped_callback_t( c ), name( n ), spell_id( -1 )
     { }
 
-    scoped_action_callback_t( specialization_e s, const std::string& n ) :
+    scoped_action_callback_t( specialization_e s, util::string_view n ) :
       class_scoped_callback_t( s ), name( n ), spell_id( -1 )
     { }
 
@@ -240,11 +242,11 @@ namespace unique_gear
     const std::string name;
     const int spell_id;
 
-    scoped_buff_callback_t( player_e c, const std::string& n ) :
+    scoped_buff_callback_t( player_e c, util::string_view n ) :
       class_scoped_callback_t( c ), name( n ), spell_id( -1 )
     { }
 
-    scoped_buff_callback_t( specialization_e s, const std::string& n ) :
+    scoped_buff_callback_t( specialization_e s, util::string_view n ) :
       class_scoped_callback_t( s ), name( n ), spell_id( -1 )
     { }
 
@@ -346,7 +348,7 @@ void initialize_special_effect_2( special_effect_t* effect );
 // Initialize special effects related to various race spells
 void initialize_racial_effects( player_t* );
 
-const item_data_t* find_consumable( const dbc_t& dbc, const std::string& name, item_subclass_consumable type );
+const item_data_t* find_consumable( const dbc_t& dbc, util::string_view name, item_subclass_consumable type );
 
 std::unique_ptr<expr_t> create_expression( player_t& player, const std::string& name_str );
 
@@ -611,7 +613,7 @@ action_t* create_proc_action( util::string_view name, const special_effect_t& ef
 }
 
 template <typename BUFF, typename ...ARGS>
-BUFF* create_buff( player_t* p, const std::string& name, ARGS&&... args )
+BUFF* create_buff( player_t* p, util::string_view name, ARGS&&... args )
 {
   auto b = buff_t::find( p, name );
   if ( b != nullptr )

--- a/engine/player/unique_gear.hpp
+++ b/engine/player/unique_gear.hpp
@@ -420,7 +420,7 @@ struct proc_action_t : public T_ACTION
     }
   }
 
-  proc_action_t( const std::string& token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
+  proc_action_t( util::string_view token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
     super( token, p, s ),
     effect(nullptr)
   {
@@ -509,7 +509,7 @@ struct proc_spell_t : public proc_action_t<spell_t>
     super( e )
   { }
 
-  proc_spell_t( const std::string& token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
+  proc_spell_t( util::string_view token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
     super( token, p, s, i )
   { }
 };
@@ -518,7 +518,7 @@ struct proc_heal_t : public proc_action_t<heal_t>
 {
   using super = proc_action_t<heal_t>;
 
-  proc_heal_t( const std::string& token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
+  proc_heal_t( util::string_view token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
     super( token, p, s, i )
   { }
 
@@ -536,7 +536,7 @@ struct proc_attack_t : public proc_action_t<attack_t>
   {
   }
 
-  proc_attack_t( const std::string& token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
+  proc_attack_t( util::string_view token, player_t* p, const spell_data_t* s, const item_t* i = nullptr ) :
     super( token, p, s, i )
   { }
 
@@ -560,7 +560,7 @@ struct proc_resource_t : public proc_action_t<spell_t>
     __initialize();
   }
 
-  proc_resource_t( const std::string& token, player_t* p, const spell_data_t* s, const item_t* item_ = nullptr ) :
+  proc_resource_t( util::string_view token, player_t* p, const spell_data_t* s, const item_t* item_ = nullptr ) :
     super( token, p, s, item_ ), gain_da( 0 ), gain_ta( 0 ), gain_resource( RESOURCE_NONE )
   {
     __initialize();
@@ -592,7 +592,7 @@ struct proc_resource_t : public proc_action_t<spell_t>
 };
 
 template <typename CLASS, typename ...ARGS>
-action_t* create_proc_action( const std::string& name, const special_effect_t& effect, ARGS&&... args )
+action_t* create_proc_action( util::string_view name, const special_effect_t& effect, ARGS&&... args )
 {
   auto player = effect.player;
   auto a = player -> find_action( name );

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -2591,7 +2591,7 @@ void items::variable_intensity_gigavolt_oscillating_reactor_onuse( special_effec
   {
     vigor_engaged_t* driver;
 
-    oscillating_overload_t( player_t* p, const std::string& name, const spell_data_t* spell, const item_t* item )
+    oscillating_overload_t( player_t* p, ::util::string_view name, const spell_data_t* spell, const item_t* item )
       : buff_t( p, name, spell, item ), driver( nullptr )
     {
     }

--- a/engine/sim/benefit.hpp
+++ b/engine/sim/benefit.hpp
@@ -9,6 +9,7 @@
 
 #include "config.hpp"
 #include "util/sample_data.hpp"
+#include "util/string_view.hpp"
 
 struct sim_t;
 
@@ -23,7 +24,7 @@ public:
   const std::string name_str;
   sim_t& sim;
 
-  explicit benefit_t( sim_t& s, const std::string& n )
+  explicit benefit_t( sim_t& s, util::string_view n )
     : up( 0 ), down( 0 ), ratio( "Ratio", true ), name_str( n ), sim( s )
   {
   }

--- a/engine/sim/gain.hpp
+++ b/engine/sim/gain.hpp
@@ -7,6 +7,8 @@
 
 #include "config.hpp"
 #include "sc_enums.hpp"
+#include "util/string_view.hpp"
+
 #include <array>
 #include <string>
 
@@ -17,7 +19,7 @@ public:
   std::array<double, RESOURCE_MAX> actual, overflow, count;
   const std::string name_str;
 
-  gain_t( const std::string& n ) :
+  gain_t( util::string_view n ) :
     actual(),
     overflow(),
     count(),

--- a/engine/sim/proc.cpp
+++ b/engine/sim/proc.cpp
@@ -6,7 +6,7 @@
 
 #include "sim/sc_sim.hpp"
 
-proc_t::proc_t( sim_t& s, const std::string& n )
+proc_t::proc_t( sim_t& s, util::string_view n )
   : sim( s ),
     iteration_count(),
     last_proc( timespan_t::min() ),

--- a/engine/sim/proc.hpp
+++ b/engine/sim/proc.hpp
@@ -6,7 +6,9 @@
 
 #include "config.hpp"
 #include "util/sample_data.hpp"
+#include "util/string_view.hpp"
 #include "sc_timespan.hpp"
+
 #include <string>
 
 struct sim_t;
@@ -25,7 +27,7 @@ public:
   extended_sample_data_t interval_sum;
   extended_sample_data_t count;
 
-  proc_t(sim_t& s, const std::string& n);
+  proc_t(sim_t& s, util::string_view n);
 
   void occur();
 

--- a/engine/sim/real_ppm.cpp
+++ b/engine/sim/real_ppm.cpp
@@ -10,7 +10,7 @@
 #include "util/rng.hpp"
 #include "item/item.hpp"
 
-real_ppm_t::real_ppm_t( const std::string& name, player_t* p, const spell_data_t* data, const item_t* item )
+real_ppm_t::real_ppm_t( util::string_view name, player_t* p, const spell_data_t* data, const item_t* item )
   : player( p ),
     name_str( name ),
     freq( data->real_ppm() ),

--- a/engine/sim/real_ppm.hpp
+++ b/engine/sim/real_ppm.hpp
@@ -8,6 +8,8 @@
 #include "config.hpp"
 #include "sc_enums.hpp"
 #include "sc_timespan.hpp"
+#include "util/string_view.hpp"
+
 #include <string>
 
 struct item_t;
@@ -48,7 +50,7 @@ public:
                              unsigned   scales_with,
                              blp        blp_state );
 
-  real_ppm_t( const std::string& name, player_t* p, double frequency = 0, double mod = 1.0, unsigned s = RPPM_NONE, blp b = BLP_ENABLED ) :
+  real_ppm_t( util::string_view name, player_t* p, double frequency = 0, double mod = 1.0, unsigned s = RPPM_NONE, blp b = BLP_ENABLED ) :
     player( p ),
     name_str( name ),
     freq( frequency ),
@@ -60,7 +62,7 @@ public:
     blp_state( b )
   { }
 
-  real_ppm_t( const std::string& name, player_t* p, const spell_data_t* data, const item_t* item = nullptr );
+  real_ppm_t( util::string_view name, player_t* p, const spell_data_t* data, const item_t* item = nullptr );
 
   void set_scaling( unsigned s )
   { scales_with = s; }

--- a/engine/sim/sc_cooldown.cpp
+++ b/engine/sim/sc_cooldown.cpp
@@ -90,7 +90,7 @@ struct ready_trigger_event_t : public event_t
 
 } // UNNAMED NAMESPACE
 
-cooldown_t::cooldown_t( const std::string& n, player_t& p ) :
+cooldown_t::cooldown_t( util::string_view n, player_t& p ) :
   sim( *p.sim ),
   player( &p ),
   name_str( n ),
@@ -110,7 +110,7 @@ cooldown_t::cooldown_t( const std::string& n, player_t& p ) :
   base_duration( 0_ms )
 { }
 
-cooldown_t::cooldown_t( const std::string& n, sim_t& s ) :
+cooldown_t::cooldown_t( util::string_view n, sim_t& s ) :
   sim( s ),
   player( nullptr ),
   name_str( n ),

--- a/engine/sim/sc_cooldown.hpp
+++ b/engine/sim/sc_cooldown.hpp
@@ -8,6 +8,8 @@
 #include "config.hpp"
 #include "sc_timespan.hpp"
 #include "sc_enums.hpp"
+#include "util/string_view.hpp"
+
 #include <string>
 #include <memory>
 
@@ -43,8 +45,8 @@ struct cooldown_t
   double recharge_multiplier;
   timespan_t base_duration;
 
-  cooldown_t( const std::string& name, player_t& );
-  cooldown_t( const std::string& name, sim_t& );
+  cooldown_t( util::string_view name, player_t& );
+  cooldown_t( util::string_view name, sim_t& );
 
   // Adjust the CD. If "requires_reaction" is true (or not provided), then the CD change is something
   // the user would react to rather than plan ahead for.

--- a/engine/sim/sc_expressions.cpp
+++ b/engine/sim/sc_expressions.cpp
@@ -24,7 +24,7 @@ class expr_unary_t : public expr_t
   std::unique_ptr<expr_t> input;
 
 public:
-  expr_unary_t( const std::string& n, token_e o, std::unique_ptr<expr_t> i )
+  expr_unary_t( util::string_view n, token_e o, std::unique_ptr<expr_t> i )
     : expr_t( n, o ), input( std::move(i) )
   {
     assert(input);
@@ -83,7 +83,7 @@ namespace binary
 
 }
 
-std::unique_ptr<expr_t> select_unary( const std::string& name, token_e op, std::unique_ptr<expr_t> input )
+std::unique_ptr<expr_t> select_unary( util::string_view name, token_e op, std::unique_ptr<expr_t> input )
 {
   switch ( op )
   {
@@ -114,7 +114,7 @@ public:
   std::unique_ptr<expr_t> left;
   std::unique_ptr<expr_t> right;
 
-  binary_base_t( const std::string& n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  binary_base_t( util::string_view n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : expr_t( n, o ), left( std::move(l) ), right( std::move(r) )
   {
     assert(left);
@@ -125,7 +125,7 @@ public:
 class logical_and_t : public binary_base_t
 {
 public:
-  logical_and_t( const std::string& n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  logical_and_t( util::string_view n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : binary_base_t( n, TOK_AND, std::move(l), std::move(r) )
   {
   }
@@ -139,7 +139,7 @@ public:
 class logical_or_t : public binary_base_t
 {
 public:
-  logical_or_t( const std::string& n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  logical_or_t( util::string_view n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : binary_base_t( n, TOK_OR, std::move(l), std::move(r) )
   {
   }
@@ -153,7 +153,7 @@ public:
 class logical_xor_t : public binary_base_t
 {
 public:
-  logical_xor_t( const std::string& n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  logical_xor_t( util::string_view n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : binary_base_t( n, TOK_XOR, std::move(l), std::move(r) )
   {
   }
@@ -168,7 +168,7 @@ template <template <typename> class F>
 class expr_binary_t : public binary_base_t
 {
 public:
-  expr_binary_t( const std::string& n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  expr_binary_t( util::string_view n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : binary_base_t( n, o, std::move(l), std::move(r) )
   {
   }
@@ -179,7 +179,7 @@ public:
   }
 };
 
-std::unique_ptr<expr_t> select_binary( const std::string& name, token_e op, std::unique_ptr<expr_t> left,
+std::unique_ptr<expr_t> select_binary( util::string_view name, token_e op, std::unique_ptr<expr_t> left,
                        std::unique_ptr<expr_t> right )
 {
   switch ( op )
@@ -232,7 +232,7 @@ class expr_analyze_unary_t : public expr_t
   std::unique_ptr<expr_t> input;
 
 public:
-  expr_analyze_unary_t( const std::string& n, token_e o, std::unique_ptr<expr_t> i )
+  expr_analyze_unary_t( util::string_view n, token_e o, std::unique_ptr<expr_t> i )
     : expr_t( n, o ), input( std::move(i) )
   {
     assert( input );
@@ -269,7 +269,7 @@ public:
   }
 };
 
-std::unique_ptr<expr_t> select_analyze_unary( const std::string& name, token_e op,
+std::unique_ptr<expr_t> select_analyze_unary( util::string_view name, token_e op,
                               std::unique_ptr<expr_t> input )
 {
   switch ( op )
@@ -308,7 +308,7 @@ protected:
   uint64_t left_false, right_false;
 
 public:
-  analyze_binary_base_t( const std::string& n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  analyze_binary_base_t( util::string_view n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : expr_t( n, o ),
       op(),
       left( std::move(l) ),
@@ -342,7 +342,7 @@ public:
 class analyze_logical_and_t : public analyze_binary_base_t
 {
 public:
-  analyze_logical_and_t( const std::string& n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  analyze_logical_and_t( util::string_view n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : analyze_binary_base_t( n, TOK_AND, std::move(l), std::move(r) )
   {
   }
@@ -449,7 +449,7 @@ public:
 class analyze_logical_or_t : public analyze_binary_base_t
 {
 public:
-  analyze_logical_or_t( const std::string& n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  analyze_logical_or_t( util::string_view n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : analyze_binary_base_t( n, TOK_OR, std::move(l), std::move(r) )
   {
   }
@@ -554,7 +554,7 @@ public:
 class analyze_logical_xor_t : public analyze_binary_base_t
 {
 public:
-  analyze_logical_xor_t( const std::string& n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  analyze_logical_xor_t( util::string_view n, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : analyze_binary_base_t( n, TOK_XOR, std::move(l), std::move(r) )
   {
   }
@@ -636,7 +636,7 @@ template <template <typename> class F>
 class expr_analyze_binary_t : public analyze_binary_base_t
 {
 public:
-  expr_analyze_binary_t( const std::string& n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
+  expr_analyze_binary_t( util::string_view n, token_e o, std::unique_ptr<expr_t> l, std::unique_ptr<expr_t> r )
     : analyze_binary_base_t( n, o, std::move(l), std::move(r) )
   {
   }
@@ -680,7 +680,7 @@ public:
       {
         double left;
         std::unique_ptr<expr_t> right;
-        left_reduced_t( const std::string& n, token_e o, double l, std::unique_ptr<expr_t> r )
+        left_reduced_t( util::string_view n, token_e o, double l, std::unique_ptr<expr_t> r )
           : expr_t( n, o ), left( l ), right( std::move(r) )
         {
         }
@@ -702,7 +702,7 @@ public:
       {
         std::unique_ptr<expr_t> left;
         double right;
-        right_reduced_t( const std::string& n, token_e o, std::unique_ptr<expr_t> l, double r )
+        right_reduced_t( util::string_view n, token_e o, std::unique_ptr<expr_t> l, double r )
           : expr_t( n, o ), left( std::move(l) ), right( r )
         {
         }
@@ -719,7 +719,7 @@ public:
   }
 };
 
-std::unique_ptr<expr_t> select_analyze_binary( const std::string& name, token_e op,
+std::unique_ptr<expr_t> select_analyze_binary( util::string_view name, token_e op,
                                std::unique_ptr<expr_t> left, std::unique_ptr<expr_t> right )
 {
   switch ( op )
@@ -1336,7 +1336,7 @@ std::unique_ptr<expr_t> expr_t::parse( action_t* action, const std::string& expr
   }
 }
 
-target_wrapper_expr_t::target_wrapper_expr_t(action_t& a, const std::string& name_str, const std::string& expr_str) :
+target_wrapper_expr_t::target_wrapper_expr_t(action_t& a, util::string_view name_str, util::string_view expr_str) :
   expr_t(name_str), action(a), suffix_expr_str(expr_str)
 {
   std::generate_n(std::back_inserter(proxy_expr), action.sim->actor_list.size(), [] { return std::unique_ptr<expr_t>(); });

--- a/engine/sim/sc_expressions.hpp
+++ b/engine/sim/sc_expressions.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "sc_timespan.hpp"
+#include "util/string_view.hpp"
 
 struct action_t;
 struct sim_t;
@@ -81,7 +82,7 @@ std::unique_ptr<expr_t> build_player_expression_tree(
 struct expr_t
 {
 protected:
-  expr_t( const std::string& name, expression::token_e op = expression::TOK_UNKNOWN )
+  expr_t( util::string_view name, expression::token_e op = expression::TOK_UNKNOWN )
     : op_( op )
 #if !defined( NDEBUG )
       ,
@@ -146,7 +147,7 @@ public:
   static std::unique_ptr<expr_t> parse( action_t*, const std::string& expr_str,
                         bool optimize = false );
   template<class T>
-  static std::unique_ptr<expr_t> create_constant( const std::string& name, T value );
+  static std::unique_ptr<expr_t> create_constant( util::string_view name, T value );
 
   static void optimize_expression(std::unique_ptr<expr_t>& expression, int spacing = 0)
   {
@@ -190,7 +191,7 @@ class const_expr_t : public expr_t
   double value;
 
 public:
-  const_expr_t( const std::string& name, double value_ )
+  const_expr_t( util::string_view name, double value_ )
     : expr_t( name, expression::TOK_NUM ), value( value_ )
   {
   }
@@ -214,7 +215,7 @@ template <typename T>
 struct ref_expr_t : public expr_t
 {
 public:
-  ref_expr_t( const std::string& name, const T& t_ ) : expr_t( name ), t( t_ )
+  ref_expr_t( util::string_view name, const T& t_ ) : expr_t( name ), t( t_ )
   {
   }
 
@@ -228,7 +229,7 @@ private:
 
 // Template to return a reference expression
 template <typename T>
-inline std::unique_ptr<expr_t> make_ref_expr( const std::string& name, T& t )
+inline std::unique_ptr<expr_t> make_ref_expr( util::string_view name, T& t )
 {
   return std::make_unique<ref_expr_t<T>>( name, const_cast<const T&>( t ) );
 }
@@ -240,7 +241,7 @@ template <typename F>
 struct fn_expr_t : public expr_t
 {
 public:
-  fn_expr_t( const std::string& name, F&& f_ ) : expr_t( name ), f( f_ )
+  fn_expr_t( util::string_view name, F&& f_ ) : expr_t( name ), f( f_ )
   {
   }
 
@@ -260,15 +261,15 @@ struct target_wrapper_expr_t : public expr_t
   std::string suffix_expr_str;
 
   // Inlined
-  target_wrapper_expr_t( action_t& a, const std::string& name_str,
-                         const std::string& expr_str );
+  target_wrapper_expr_t( action_t& a, util::string_view name_str,
+                         util::string_view expr_str );
   virtual player_t* target() const;
   double evaluate() override;
 };
 
 // Template to return a function expression
 template <typename F>
-inline std::unique_ptr<expr_t> make_fn_expr( const std::string& name, F&& f )
+inline std::unique_ptr<expr_t> make_fn_expr( util::string_view name, F&& f )
 {
   return std::make_unique<fn_expr_t<F>>( name, std::forward<F>( f ) );
 }
@@ -277,13 +278,13 @@ inline std::unique_ptr<expr_t> make_fn_expr( const std::string& name, F&& f )
 // Template to return function expression that calls a member ( mem ) function (
 // fn ) f on reference t.
 template <typename F, typename T>
-inline std::unique_ptr<expr_t> make_mem_fn_expr( const std::string& name, T& t, F f )
+inline std::unique_ptr<expr_t> make_mem_fn_expr( util::string_view name, T& t, F f )
 {
   return make_fn_expr( name, std::bind( std::mem_fn( f ), &t ) );
 }
 
 template<class T>
-inline std::unique_ptr<expr_t> expr_t::create_constant( const std::string& name, T value )
+inline std::unique_ptr<expr_t> expr_t::create_constant( util::string_view name, T value )
 {
   return std::make_unique<const_expr_t>( name, coerce(value) );
 }

--- a/engine/sim/sc_option.cpp
+++ b/engine/sim/sc_option.cpp
@@ -167,7 +167,7 @@ struct opts_helper_t : public option_t
 {
   using base_t = opts_helper_t<T>;
 
-  opts_helper_t( const std::string& name, T& ref ) :
+  opts_helper_t( util::string_view name, T& ref ) :
     option_t( name ),
     _ref( ref )
   { }
@@ -177,7 +177,7 @@ protected:
 
 struct opt_string_t : public option_t
 {
-  opt_string_t( const std::string& name, std::string& addr ) :
+  opt_string_t( util::string_view name, std::string& addr ) :
     option_t( name ),
     _ref( addr )
   { }
@@ -202,7 +202,7 @@ private:
 
 struct opt_append_t : public option_t
 {
-  opt_append_t( const std::string& name, std::string& addr ) :
+  opt_append_t( util::string_view name, std::string& addr ) :
     option_t( name ),
     _ref( addr )
   { }
@@ -234,7 +234,7 @@ private:
 template<typename T, typename Converter>
 struct opt_numeric_t : public option_t
 {
-  opt_numeric_t( const std::string& name, T& addr ) :
+  opt_numeric_t( util::string_view name, T& addr ) :
     option_t( name ),
     _ref( addr )
   { }
@@ -271,7 +271,7 @@ private:
 template<typename T, typename Converter>
 struct opt_numeric_mm_t : public option_t
 {
-  opt_numeric_mm_t( const std::string& name, T& addr, T min, T max ) :
+  opt_numeric_mm_t( util::string_view name, T& addr, T min, T max ) :
     option_t( name ),
     _ref( addr ),
     _min( min ),
@@ -311,7 +311,7 @@ private:
 
 struct opt_bool_t : public option_t
 {
-  opt_bool_t( const std::string& name, bool& addr ) :
+  opt_bool_t( util::string_view name, bool& addr ) :
     option_t( name ),
     _ref( addr )
   { }
@@ -340,7 +340,7 @@ private:
 
 struct opt_bool_int_t : public option_t
 {
-  opt_bool_int_t( const std::string& name, int& addr ) :
+  opt_bool_int_t( util::string_view name, int& addr ) :
     option_t( name ),
     _ref( addr )
   { }
@@ -369,7 +369,7 @@ private:
 
 struct opts_sim_func_t : public option_t
 {
-  opts_sim_func_t( const std::string& name, const opts::function_t& ref ) :
+  opts_sim_func_t( util::string_view name, const opts::function_t& ref ) :
     option_t( name ),
     _fun( ref )
   { }
@@ -392,7 +392,7 @@ private:
 
 struct opts_map_t : public option_t
 {
-  opts_map_t( const std::string& name, opts::map_t& ref ) :
+  opts_map_t( util::string_view name, opts::map_t& ref ) :
     option_t( name ),
     _ref( ref )
   { }
@@ -437,7 +437,7 @@ protected:
 
 struct opts_map_list_t : public option_t
 {
-  opts_map_list_t( const std::string& name, opts::map_list_t& ref ) :
+  opts_map_list_t( util::string_view name, opts::map_list_t& ref ) :
     option_t( name ), _ref( ref )
   { }
 
@@ -494,7 +494,7 @@ protected:
 
 struct opts_list_t : public option_t
 {
-  opts_list_t( const std::string& name, opts::list_t& ref ) :
+  opts_list_t( util::string_view name, opts::list_t& ref ) :
     option_t( name ),
     _ref( ref )
   { }
@@ -522,7 +522,7 @@ private:
 
 struct opts_deperecated_t : public option_t
 {
-  opts_deperecated_t( const std::string& name, const std::string& new_option ) :
+  opts_deperecated_t( util::string_view name, util::string_view new_option ) :
     option_t( name ),
     _new_option( new_option )
   { }
@@ -546,7 +546,7 @@ private:
 
 struct opts_obsoleted_t : public option_t
 {
-  opts_obsoleted_t( const std::string& name ) :
+  opts_obsoleted_t( util::string_view name ) :
     option_t( name )
   { }
 protected:
@@ -913,59 +913,59 @@ option_db_t::option_db_t()
   auto_path.resize( std::distance(auto_path.begin(), it) );
 }
 
-std::unique_ptr<option_t> opt_string( const std::string& n, std::string& v )
+std::unique_ptr<option_t> opt_string( util::string_view n, std::string& v )
 { return std::unique_ptr<option_t>(new opt_string_t( n, v )); }
 
-std::unique_ptr<option_t> opt_append( const std::string& n, std::string& v )
+std::unique_ptr<option_t> opt_append( util::string_view n, std::string& v )
 { return std::unique_ptr<option_t>(new opt_append_t( n, v )); }
 
-std::unique_ptr<option_t> opt_bool( const std::string& n, int& v )
+std::unique_ptr<option_t> opt_bool( util::string_view n, int& v )
 { return std::unique_ptr<option_t>(new opt_bool_int_t( n, v )); }
 
-std::unique_ptr<option_t> opt_bool( const std::string& n, bool& v )
+std::unique_ptr<option_t> opt_bool( util::string_view n, bool& v )
 { return std::unique_ptr<option_t>(new opt_bool_t( n, v )); }
 
-std::unique_ptr<option_t> opt_uint64( const std::string& n, uint64_t& v )
+std::unique_ptr<option_t> opt_uint64( util::string_view n, uint64_t& v )
 { return std::unique_ptr<option_t>(new opt_numeric_t<uint64_t, converter_uint64_t>( n, v )); }
 
-std::unique_ptr<option_t> opt_int( const std::string& n, int& v )
+std::unique_ptr<option_t> opt_int( util::string_view n, int& v )
 { return std::unique_ptr<option_t>(new opt_numeric_t<int, converter_int_t>( n, v )); }
 
-std::unique_ptr<option_t> opt_int( const std::string& n, int& v, int min, int max )
+std::unique_ptr<option_t> opt_int( util::string_view n, int& v, int min, int max )
 { return std::unique_ptr<option_t>(new opt_numeric_mm_t<int, converter_int_t>( n, v, min, max )); }
 
-std::unique_ptr<option_t> opt_uint( const std::string& n, unsigned& v )
+std::unique_ptr<option_t> opt_uint( util::string_view n, unsigned& v )
 { return std::unique_ptr<option_t>(new opt_numeric_t<unsigned, converter_uint_t>( n, v )); }
 
-std::unique_ptr<option_t> opt_uint( const std::string& n, unsigned& v, unsigned min, unsigned max )
+std::unique_ptr<option_t> opt_uint( util::string_view n, unsigned& v, unsigned min, unsigned max )
 { return std::unique_ptr<option_t>(new opt_numeric_mm_t<unsigned, converter_uint_t>( n, v, min, max )); }
 
-std::unique_ptr<option_t> opt_float( const std::string& n, double& v )
+std::unique_ptr<option_t> opt_float( util::string_view n, double& v )
 { return std::unique_ptr<option_t>(new opt_numeric_t<double, converter_double_t>( n, v )); }
 
-std::unique_ptr<option_t> opt_float( const std::string& n, double& v, double min, double max )
+std::unique_ptr<option_t> opt_float( util::string_view n, double& v, double min, double max )
 { return std::unique_ptr<option_t>(new opt_numeric_mm_t<double, converter_double_t>( n, v, min, max )); }
 
-std::unique_ptr<option_t> opt_timespan( const std::string& n, timespan_t& v )
+std::unique_ptr<option_t> opt_timespan( util::string_view n, timespan_t& v )
 { return std::unique_ptr<option_t>(new opt_numeric_t<timespan_t, converter_timespan_t>( n, v )); }
 
-std::unique_ptr<option_t> opt_timespan( const std::string& n, timespan_t& v, timespan_t min, timespan_t max )
+std::unique_ptr<option_t> opt_timespan( util::string_view n, timespan_t& v, timespan_t min, timespan_t max )
 { return std::unique_ptr<option_t>(new opt_numeric_mm_t<timespan_t, converter_timespan_t>( n, v, min, max )); }
 
-std::unique_ptr<option_t> opt_list( const std::string& n, opts::list_t& v )
+std::unique_ptr<option_t> opt_list( util::string_view n, opts::list_t& v )
 { return std::unique_ptr<option_t>(new opts_list_t( n, v )); }
 
-std::unique_ptr<option_t> opt_map( const std::string& n, opts::map_t& v )
+std::unique_ptr<option_t> opt_map( util::string_view n, opts::map_t& v )
 { return std::unique_ptr<option_t>(new opts_map_t( n, v )); }
 
-std::unique_ptr<option_t> opt_map_list( const std::string& n, opts::map_list_t& v )
+std::unique_ptr<option_t> opt_map_list( util::string_view n, opts::map_list_t& v )
 { return std::unique_ptr<option_t>(new opts_map_list_t( n, v )); }
 
-std::unique_ptr<option_t> opt_func( const std::string& n, const opts::function_t& f )
+std::unique_ptr<option_t> opt_func( util::string_view n, const opts::function_t& f )
 { return std::unique_ptr<option_t>(new opts_sim_func_t( n, f )); }
 
-std::unique_ptr<option_t> opt_deprecated( const std::string& n, const std::string& new_option )
+std::unique_ptr<option_t> opt_deprecated( util::string_view n, util::string_view new_option )
 { return std::unique_ptr<option_t>(new opts_deperecated_t( n, new_option )); }
 
-std::unique_ptr<option_t> opt_obsoleted( const std::string& n )
+std::unique_ptr<option_t> opt_obsoleted( util::string_view n )
 { return std::unique_ptr<option_t>(new opts_obsoleted_t( n )); }

--- a/engine/sim/sc_option.hpp
+++ b/engine/sim/sc_option.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include "sc_timespan.hpp"
+#include "util/string_view.hpp"
 
 struct sim_t;
 
@@ -36,12 +37,12 @@ enum class parse_status : unsigned
 struct option_t
 {
 public:
-  option_t( const std::string& name ) :
+  option_t( util::string_view name ) :
     _name( name )
 { }
   virtual ~option_t() { }
   opts::parse_status parse( sim_t* sim , const std::string& n, const std::string& value ) const;
-  std::string name() const
+  const std::string& name() const
   { return _name; }
   std::ostream& print( std::ostream& stream ) const
   { return do_print( stream ); }
@@ -68,30 +69,30 @@ void parse( sim_t*, const std::string& context, const std::vector<std::unique_pt
 inline std::ostream& operator<<( std::ostream& stream, const std::unique_ptr<option_t>& opt )
 { return opt -> print( stream ); }
 
-std::unique_ptr<option_t> opt_string( const std::string& n, std::string& v );
-std::unique_ptr<option_t> opt_append( const std::string& n, std::string& v );
-std::unique_ptr<option_t> opt_bool( const std::string& n, int& v );
-std::unique_ptr<option_t> opt_bool( const std::string& n, bool& v );
-std::unique_ptr<option_t> opt_uint64( const std::string& n, uint64_t& v );
-std::unique_ptr<option_t> opt_int( const std::string& n, int& v );
-std::unique_ptr<option_t> opt_int( const std::string& n, int& v, int , int );
-std::unique_ptr<option_t> opt_uint( const std::string& n, unsigned& v );
-std::unique_ptr<option_t> opt_uint( const std::string& n, unsigned& v, unsigned , unsigned  );
-std::unique_ptr<option_t> opt_float( const std::string& n, double& v );
-std::unique_ptr<option_t> opt_float( const std::string& n, double& v, double , double  );
-std::unique_ptr<option_t> opt_timespan( const std::string& n, timespan_t& v );
-std::unique_ptr<option_t> opt_timespan( const std::string& n, timespan_t& v, timespan_t , timespan_t  );
-std::unique_ptr<option_t> opt_list( const std::string& n, opts::list_t& v );
-std::unique_ptr<option_t> opt_map( const std::string& n, opts::map_t& v );
-std::unique_ptr<option_t> opt_map_list( const std::string& n, opts::map_list_t& v );
-std::unique_ptr<option_t> opt_func( const std::string& n, const opts::function_t& f );
-std::unique_ptr<option_t> opt_deprecated( const std::string& n, const std::string& new_option );
-std::unique_ptr<option_t> opt_obsoleted( const std::string& n );
+std::unique_ptr<option_t> opt_string( util::string_view n, std::string& v );
+std::unique_ptr<option_t> opt_append( util::string_view n, std::string& v );
+std::unique_ptr<option_t> opt_bool( util::string_view n, int& v );
+std::unique_ptr<option_t> opt_bool( util::string_view n, bool& v );
+std::unique_ptr<option_t> opt_uint64( util::string_view n, uint64_t& v );
+std::unique_ptr<option_t> opt_int( util::string_view n, int& v );
+std::unique_ptr<option_t> opt_int( util::string_view n, int& v, int , int );
+std::unique_ptr<option_t> opt_uint( util::string_view n, unsigned& v );
+std::unique_ptr<option_t> opt_uint( util::string_view n, unsigned& v, unsigned , unsigned  );
+std::unique_ptr<option_t> opt_float( util::string_view n, double& v );
+std::unique_ptr<option_t> opt_float( util::string_view n, double& v, double , double  );
+std::unique_ptr<option_t> opt_timespan( util::string_view n, timespan_t& v );
+std::unique_ptr<option_t> opt_timespan( util::string_view n, timespan_t& v, timespan_t , timespan_t  );
+std::unique_ptr<option_t> opt_list( util::string_view n, opts::list_t& v );
+std::unique_ptr<option_t> opt_map( util::string_view n, opts::map_t& v );
+std::unique_ptr<option_t> opt_map_list( util::string_view n, opts::map_list_t& v );
+std::unique_ptr<option_t> opt_func( util::string_view n, const opts::function_t& f );
+std::unique_ptr<option_t> opt_deprecated( util::string_view n, util::string_view new_option );
+std::unique_ptr<option_t> opt_obsoleted( util::string_view n );
 
 struct option_tuple_t
 {
   std::string scope, name, value;
-  option_tuple_t( const std::string& s, const std::string& n, const std::string& v ) : scope( s ), name( n ), value( v ) {}
+  option_tuple_t( util::string_view s, util::string_view n, util::string_view v ) : scope( s ), name( n ), value( v ) {}
 };
 
 struct option_db_t : public std::vector<option_tuple_t>
@@ -100,9 +101,9 @@ struct option_db_t : public std::vector<option_tuple_t>
   std::unordered_map<std::string, std::string> var_map;
 
   option_db_t();
-  void add( const std::string& scope, const std::string& name, const std::string& value )
+  void add( util::string_view scope, util::string_view name, util::string_view value )
   {
-    push_back( option_tuple_t( scope, name, value ) );
+    emplace_back( scope, name, value );
   }
   bool parse_file( std::istream& file );
   void parse_token( const std::string& token );

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -3111,9 +3111,9 @@ bool sim_t::execute()
 }
 
 /// find player in sim by name
-player_t* sim_t::find_player( const std::string& name ) const
+player_t* sim_t::find_player( util::string_view name ) const
 {
-  auto it = range::find_if( actor_list, [name](const player_t* p) { return name == p -> name(); });
+  auto it = range::find( actor_list, name, &player_t::name );
   if ( it != actor_list.end())
     return *it;
   return nullptr;
@@ -3122,7 +3122,7 @@ player_t* sim_t::find_player( const std::string& name ) const
 /// find player in sim by actor index
 player_t* sim_t::find_player( int index ) const
 {
-  auto it = range::find_if( actor_list, [index](const player_t* p) { return index == p -> index; });
+  auto it = range::find( actor_list, index, &player_t::index );
   if ( it != actor_list.end())
     return *it;
   return nullptr;
@@ -3130,18 +3130,13 @@ player_t* sim_t::find_player( int index ) const
 
 // sim_t::get_cooldown ======================================================
 
-cooldown_t* sim_t::get_cooldown( const std::string& name )
+cooldown_t* sim_t::get_cooldown( util::string_view name )
 {
-  cooldown_t* c;
+  auto it = range::find( cooldown_list, name, &cooldown_t::name_str );
+  if ( it != cooldown_list.end() )
+    return *it;
 
-  for ( size_t i = 0; i < cooldown_list.size(); ++i )
-  {
-    c = cooldown_list[ i ];
-    if ( c -> name_str == name )
-      return c;
-  }
-
-  c = new cooldown_t( name, *this );
+  cooldown_t* c = new cooldown_t( name, *this );
 
   cooldown_list.push_back( c );
 

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -3306,7 +3306,7 @@ std::unique_ptr<expr_t> sim_t::create_expression( const std::string& name_str )
       std::string type;
       std::string filter;
 
-      raid_event_expr_t( sim_t* s, std::string& type, std::string& filter ) :
+      raid_event_expr_t( sim_t* s, util::string_view type, util::string_view filter ) :
         expr_t( "raid_event" ), s( s ), type( type ), filter( filter )
       {}
 

--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -601,9 +601,9 @@ struct sim_t : private sc_thread_t
   bool      parse_option( const std::string& name, const std::string& value );
   void      setup( sim_control_t* );
   bool      time_to_think( timespan_t proc_time );
-  player_t* find_player( const std::string& name ) const;
+  player_t* find_player( util::string_view name ) const;
   player_t* find_player( int index ) const;
-  cooldown_t* get_cooldown( const std::string& name );
+  cooldown_t* get_cooldown( util::string_view name );
   void      use_optimal_buffs_and_debuffs( int value );
   std::unique_ptr<expr_t>   create_expression( const std::string& name );
   /**

--- a/engine/sim/shuffled_rng.hpp
+++ b/engine/sim/shuffled_rng.hpp
@@ -6,6 +6,8 @@
 #pragma once
 
 #include "config.hpp"
+#include "util/string_view.hpp"
+
 #include <string>
 
 namespace rng {
@@ -26,8 +28,8 @@ private:
   int          total_entries_remaining;
   
 public:
-  
-  shuffled_rng_t(const std::string& name, rng::rng_t& rng, int success_entries = 0, int total_entries = 0) :
+
+  shuffled_rng_t(util::string_view name, rng::rng_t& rng, int success_entries = 0, int total_entries = 0) :
     rng(rng),
     name_str(name),
     success_entries(success_entries),

--- a/engine/sim/uptime.hpp
+++ b/engine/sim/uptime.hpp
@@ -72,7 +72,7 @@ public:
   extended_sample_data_t uptime_sum;
   extended_sample_data_t uptime_instance;
 
-  uptime_t(sim_t& s, const std::string& n) : uptime_common_t(),
+  uptime_t(sim_t& s, util::string_view n) : uptime_common_t(),
     name_str(n),
     sim(s),
     uptime_sum("Uptime", true),

--- a/engine/util/sample_data.hpp
+++ b/engine/util/sample_data.hpp
@@ -10,7 +10,9 @@
 #include <numeric>
 #include <sstream>
 #include <vector>
+
 #include "util/generic.hpp"
+#include "util/string_view.hpp"
 
 /* Collection of statistical formulas for sequences
  * Note: Returns 0 for empty sequences
@@ -339,7 +341,7 @@ private:
   bool is_sorted;
 
 public:
-  explicit extended_sample_data_t( const std::string& n, bool s = true )
+  explicit extended_sample_data_t( util::string_view n, bool s = true )
     : base_t(),
       name_str( n ),
       _mean(),


### PR DESCRIPTION
Main goal was to reduce the amount of unneeded `std::string` temporaries we create all over the place. Mainly in the different `player_t` "finders" and "getters". Got a bit carried away by converting action constructors too.

One explicit goal was to not touch anything that would require changes to the class modules. The only change is the removal of a no-op override of `player_t::create_proc_action()` from the priest module that was required for `unique_gear::create_proc_action` helper conversion.

The main effect is reduced binary size:
```
nuohep@r2d2:~/dev/simc> bloaty -d segments,sections build-optimized/simc.sv -- build-optimized/simc.shl
    FILE SIZE        VM SIZE
 --------------  --------------
  [ = ]       0  -0.6%     -16    LOAD #4 [RW]
  -1.8% -44.2Ki  [ = ]       0    [Unmapped]
    -0.9%     -14  [ = ]       0    [Unmapped]
    -2.2% -15.0Ki  [ = ]       0    .symtab
    -1.6% -29.2Ki  [ = ]       0    .strtab
  -0.3%  -119Ki  -0.3%  -119Ki    LOAD #2 [R]
    +2.0%     +15  +2.0%     +15    [LOAD #2 [R]]
    -3.0%    -506  -3.0%    -506    .gnu.version
    -0.2% -1.22Ki  -0.2% -1.22Ki    .eh_frame
    -2.2% -1.23Ki  -2.2% -1.23Ki    .gnu.hash
    -3.0% -1.98Ki  -3.0% -1.98Ki    .hash
    -2.4% -2.74Ki  -2.4% -2.74Ki    .eh_frame_hdr
    -3.0% -5.93Ki  -3.0% -5.93Ki    .dynsym
    -0.0% -10.5Ki  -0.0% -10.5Ki    .rodata
    -3.9% -24.6Ki  -3.9% -24.6Ki    .dynstr
   -24.7% -71.3Ki -24.7% -71.3Ki    .gcc_except_table
 -12.7%  -910Ki -12.7%  -910Ki    LOAD #3 [RX]
   -12.7%  -910Ki -12.7%  -910Ki    .text
  -1.9% -1.05Mi  -1.9% -1.01Mi    TOTAL
```
[ both binaries compiled in the same cmake-configured build dir with `clang++-10 -O3 -ffast-math -flto=thin -DNDEBUG` and linked with lld-10 ]

Perf wise it should be either a complete no-op, or even a slight speed-up for init.