### PR TITLE
Move static data to constexpr

### DIFF
--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -225,14 +225,14 @@ spell_mapping_reference_t<spell_data_t, unsigned> spell_categories_index(
     return 0U;
   }
 );
+
 struct class_passives_entry_t
   {
     player_e         type;
     specialization_e spec;
     unsigned         spell_id;
   };
-
-const std::vector<class_passives_entry_t> _class_passives {
+static constexpr std::array<class_passives_entry_t, 48> _class_passives { {
   { DEATH_KNIGHT, SPEC_NONE,              137005 },
   { DEATH_KNIGHT, DEATH_KNIGHT_BLOOD,     137008 },
   { DEATH_KNIGHT, DEATH_KNIGHT_UNHOLY,    137007 },
@@ -281,7 +281,7 @@ const std::vector<class_passives_entry_t> _class_passives {
   { WARRIOR,      WARRIOR_ARMS,           137049 },
   { WARRIOR,      WARRIOR_FURY,           137050 },
   { WARRIOR,      WARRIOR_PROTECTION,     137048 },
-};
+} };
 
 } // ANONYMOUS namespace ====================================================
 

--- a/engine/dbc/spell_query/spell_data_expr.hpp
+++ b/engine/dbc/spell_query/spell_data_expr.hpp
@@ -36,7 +36,7 @@ struct spell_data_expr_t
   std::vector<uint32_t> result_spell_list;
   std::string result_str;
 
-  spell_data_expr_t( dbc_t& dbc, const std::string& n,
+  spell_data_expr_t( dbc_t& dbc, util::string_view n,
                      expr_data_e dt = DATA_SPELL, bool eq = false,
                      expression::token_e t = expression::TOK_UNKNOWN )
     : name_str( n ),
@@ -49,7 +49,7 @@ struct spell_data_expr_t
       result_str( "" )
   {
   }
-  spell_data_expr_t(dbc_t& dbc, const std::string& n, double constant_value )
+  spell_data_expr_t(dbc_t& dbc, util::string_view n, double constant_value )
     : name_str( n ),
       dbc(dbc),
       data_type( DATA_SPELL ),
@@ -60,8 +60,8 @@ struct spell_data_expr_t
       result_str( "" )
   {
   }
-  spell_data_expr_t(dbc_t& dbc, const std::string& n,
-                     const std::string& constant_value )
+  spell_data_expr_t(dbc_t& dbc, util::string_view n,
+                     util::string_view constant_value )
     : name_str( n ),
       dbc(dbc),
       data_type( DATA_SPELL ),
@@ -72,7 +72,7 @@ struct spell_data_expr_t
       result_str( constant_value )
   {
   }
-  spell_data_expr_t(dbc_t& dbc, const std::string& n,
+  spell_data_expr_t(dbc_t& dbc, util::string_view n,
                      const std::vector<uint32_t>& constant_value )
     : name_str( n ),
       dbc(dbc),
@@ -111,5 +111,5 @@ struct spell_data_expr_t
   virtual std::vector<uint32_t> not_in( const spell_data_expr_t& /* other */ ) { return std::vector<uint32_t>(); }
 
   static spell_data_expr_t* parse( sim_t* sim, const std::string& expr_str );
-  static spell_data_expr_t* create_spell_expression( dbc_t& dbc, const std::string& name_str );
+  static spell_data_expr_t* create_spell_expression( dbc_t& dbc, util::string_view name_str );
 };

--- a/engine/item/special_effect.cpp
+++ b/engine/item/special_effect.cpp
@@ -20,11 +20,11 @@ namespace {
 
 struct proc_parse_opt_t
 {
-  const char* opt;
-  unsigned    flags;
+  util::string_view opt;
+  unsigned flags;
 };
 
-const proc_parse_opt_t __proc_opts[] =
+constexpr proc_parse_opt_t __proc_opts[] =
 {
   { "genericspell", PF_NONE_SPELL                                               },
   { "spell",        PF_MAGIC_SPELL | PF_PERIODIC                                },
@@ -43,7 +43,7 @@ const proc_parse_opt_t __proc_opts[] =
   { "sranged",      PF_RANGED_ABILITY                                           },
 };
 
-const proc_parse_opt_t __proc2_opts[] =
+constexpr proc_parse_opt_t __proc2_opts[] =
 {
   { "hit",         PF2_ALL_HIT          },
   { "crit",        PF2_CRIT             },
@@ -57,7 +57,7 @@ const proc_parse_opt_t __proc2_opts[] =
   { "tickdamage",  PF2_PERIODIC_DAMAGE  },
 };
 
-bool has_proc( const std::vector<std::string>& opts, const std::string& proc )
+bool has_proc( util::span<const std::string> opts, util::string_view proc )
 {
   for ( auto & opt : opts )
   {
@@ -67,9 +67,8 @@ bool has_proc( const std::vector<std::string>& opts, const std::string& proc )
   return false;
 }
 
-template<size_t N>
-void parse_proc_flags( const std::string&      flags,
-                       const proc_parse_opt_t ( &opts)[ N ],
+void parse_proc_flags( util::string_view flags,
+                       util::span<const proc_parse_opt_t> opts,
                        unsigned& proc_flags )
 {
   std::vector<std::string> splits = util::string_split( flags, "/" );

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -1,5 +1,7 @@
 #include "azerite_data.hpp"
+
 #include "simulationcraft.hpp"
+#include "util/static_map.hpp"
 
 namespace
 {
@@ -2934,10 +2936,10 @@ void meticulous_scheming( special_effect_t& effect )
 {
   // Apparently meticulous scheming bugs and does not proc from some foreground abilities. Blacklist
   // specific abilities here
-  static std::unordered_map<unsigned, bool> __spell_blacklist {{
-    { 201427, true }, // Demon Hunter: Annihilation
-    { 210152, true }, // Demon Hunter: Death Sweep
-  } };
+  static constexpr auto __spell_blacklist = util::make_static_set<unsigned>( {
+    201427, // Demon Hunter: Annihilation
+    210152, // Demon Hunter: Death Sweep
+  } );
 
   struct seize_driver_t : public dbc_proc_callback_t
   {

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -15,14 +15,6 @@ using namespace unique_gear;
 
 namespace { // UNNAMED NAMESPACE
 
-// Prefix/Suffix map to allow shorthand consumable names, when searching for the item (for potion
-// action).
-std::map<item_subclass_consumable, std::pair<std::vector<std::string>, std::vector<std::string>>> __consumable_substrings = {
-  { ITEM_SUBCLASS_POTION, { { "potion_of_the_", "potion_of_", "potion_" }, { "_potion" } } },
-  { ITEM_SUBCLASS_FLASK,  { { "flask_of_the_", "flask_of_", "flask_" }, { "_flask" } } }
-};
-
-
 /**
  * Forward declarations so we can reorganize the file a bit more sanely.
  */

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -5,6 +5,7 @@
 
 #include "simulationcraft.hpp"
 #include "darkmoon_deck.hpp"
+#include "util/static_map.hpp"
 
 using namespace unique_gear;
 
@@ -5235,7 +5236,7 @@ struct convergence_of_fates_callback_t : public dbc_proc_callback_t
   }
 };
 
-bool player_talent( player_t* player_, const std::string talent )
+bool player_talent( player_t* player_, ::util::string_view talent )
 {
   return player_ -> find_talent_spell( talent ) -> ok();
 }
@@ -5487,12 +5488,12 @@ struct cinidaria_the_symbiote_t : public class_scoped_callback_t
   void initialize( special_effect_t& effect ) override
   {
     // Vector of blacklisted spell ids that cannot proc Cinidaria.
-    const std::unordered_map<unsigned, bool> spell_blacklist = {
-      { 207694, true }, // Symbiote Strike (Cinidaria itself)
-      { 191259, true }, // Mark of the Hidden Satyr
-      { 191380, true }, // Mark of the Distant Army
-      { 220893, true }, // Soul Rip (Subtlety Rogue Akaari pet)
-    };
+    static constexpr auto spell_blacklist = ::util::make_static_set<unsigned>( {
+      207694, // Symbiote Strike (Cinidaria itself)
+      191259, // Mark of the Hidden Satyr
+      191380, // Mark of the Distant Army
+      220893, // Soul Rip (Subtlety Rogue Akaari pet)
+    } );
 
     // Health percentage threshold and damage multiplier
     const double threshold = effect.driver() -> effectN( 2 ).base_value();
@@ -5506,7 +5507,7 @@ struct cinidaria_the_symbiote_t : public class_scoped_callback_t
     // also resolved, and that state -> result_amount will hold the "final actual damage" of the
     // ability.
     effect.player -> assessor_out_damage.add( assessor::TARGET_DAMAGE + 1,
-      [ spell_blacklist, threshold, multiplier, spell ](result_amount_type, action_state_t* state )
+      [ threshold, multiplier, spell ](result_amount_type, action_state_t* state )
       {
         const auto source_action = state -> action;
         const auto target = state -> target;
@@ -5558,7 +5559,7 @@ struct cinidaria_the_symbiote_t : public class_scoped_callback_t
 template <typename T>
 struct legion_potion_damage_t : public T
 {
-  legion_potion_damage_t( const special_effect_t& effect, const std::string& name_str, const spell_data_t* spell ) :
+  legion_potion_damage_t( const special_effect_t& effect, ::util::string_view name_str, const spell_data_t* spell ) :
     T( name_str, effect.player, spell )
   {
     this -> background = this -> may_crit = this -> special = true;

--- a/engine/sim/sc_profileset.cpp
+++ b/engine/sim/sc_profileset.cpp
@@ -13,6 +13,7 @@
 #include "report/sc_highchart.hpp"
 #include "player/sc_player.hpp"
 #include "item/item.hpp"
+#include "util/string_view.hpp"
 
 #ifndef SC_NO_THREADING
 
@@ -258,13 +259,13 @@ void populate_chart_data( highchart::bar_chart_t& profileset,
 // Figure out if the option is the beginning of a player-scope option
 bool in_player_scope( const option_tuple_t& opt )
 {
-  static const std::vector<std::string> player_scope_opts {
+  static constexpr std::array<util::string_view, 14> player_scope_opts { {
     "demonhunter", "deathknight", "druid", "hunter", "mage", "monk",
     "paladin", "priest", "rogue", "shaman", "warrior", "warlock",
     "armory", "local_json"
-  };
+  } };
 
-  return range::find_if( player_scope_opts, [ &opt ]( const std::string& name ) {
+  return range::find_if( player_scope_opts, [ &opt ]( util::string_view name ) {
     return util::str_compare_ci( opt.name, name );
   } ) != player_scope_opts.end();
 }

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -30,6 +30,7 @@
 #include "sim/sc_cooldown.hpp"
 #include "dbc/spell_query/spell_data_expr.hpp"
 #include "util/xml.hpp"
+#include "util/string_view.hpp"
 #include <random>
 #ifdef SC_WINDOWS
 #include <direct.h>
@@ -479,7 +480,7 @@ class names_and_options_t
 private:
   static bool is_valid_region( const std::string& s )
   {
-    static const std::vector<std::string> REGIONS { "us", "eu", "kr", "tw", "cn" };
+    static constexpr std::array<util::string_view, 5> REGIONS { { "us", "eu", "kr", "tw", "cn" } };
     return s.size() == 2 && range::find( REGIONS, s ) != REGIONS.end();
   }
 
@@ -696,12 +697,12 @@ bool parse_fight_style( sim_t*             sim,
                         const std::string& /*name*/,
                         const std::string& value )
 {
-  static std::vector<std::string> FIGHT_STYLES {
+  static constexpr std::array<util::string_view, 10> FIGHT_STYLES { {
     "Patchwerk", "Ultraxion", "CleaveAdd", "HelterSkelter", "LightMovement", "HeavyMovement",
     "HecticAddCleave", "Beastlord", "CastingPatchwerk", "DungeonSlice"
-  };
+  } };
 
-  auto it = range::find_if( FIGHT_STYLES, [ &value ]( const std::string& n ) {
+  auto it = range::find_if( FIGHT_STYLES, [ &value ]( util::string_view n ) {
     return util::str_compare_ci( value, n );
   } );
 
@@ -711,7 +712,7 @@ bool parse_fight_style( sim_t*             sim,
       value, fmt::join( FIGHT_STYLES, ", " ) ) );
   }
 
-  sim->fight_style = *it;
+  sim->fight_style = to_string( *it );
 
   return true;
 }

--- a/engine/util/static_map.hpp
+++ b/engine/util/static_map.hpp
@@ -1,0 +1,232 @@
+// ==========================================================================
+// Dedmonwakeen's Raid DPS/TPS Simulator.
+// Send questions to natehieter@gmail.com
+// ==========================================================================
+#ifndef SC_UTIL_STATIC_MAP_HPP_INCLUDED
+#define SC_UTIL_STATIC_MAP_HPP_INCLUDED
+
+#include <cassert>
+#include <cstddef>
+#include <utility>
+
+namespace util {
+namespace detail {
+
+// minimal std::array clone, std::array non-const operator[] is constexpr only in c++17
+template <typename T, size_t N>
+struct array {
+  T data_[N] {};
+
+  constexpr T& operator[](size_t n) { return data_[n]; }
+  constexpr const T& operator[](size_t n) const { return data_[n]; }
+
+  constexpr const T* begin() const { return data_; }
+  constexpr const T* end() const { return data_ + N; }
+};
+
+template <typename T, typename U, size_t N, size_t... I>
+constexpr array<T, N> to_array_impl(const U (&init)[N], std::index_sequence<I...>) {
+  return {{ static_cast<T>(init[I])... }};
+}
+
+template <typename T, typename U, size_t N>
+constexpr array<T, N> to_array(const U (&init)[N]) {
+  return to_array_impl<T>(init, std::make_index_sequence<N>{});
+}
+
+// *very* minimal std::pair clone, std::pair operator= is constexpr only in c++20
+template <typename T, typename U>
+struct pair {
+  T first;
+  U second;
+};
+
+struct less {
+  template <typename T, typename U>
+  constexpr bool operator()(const T& lhs, const U& rhs) const {
+    return lhs < rhs;
+  }
+  template <typename T, typename U>
+  constexpr bool operator()(const pair<T, U>& lhs, const pair<T, U>& rhs) const {
+    return lhs.first < rhs.first;
+  }
+  template <typename T, typename T2, typename U2>
+  constexpr bool operator()(const T& lhs, const pair<T2, U2>& rhs) const {
+    return lhs < rhs.first;
+  }
+};
+
+template <typename T, size_t N, typename Compare = less>
+constexpr array<T, N> sorted(const array<T, N>& items, Compare cmp = {}) {
+  // simple insertion sort
+  array<T, N> res = items;
+  for (size_t i = 1; i < N; i++) {
+    T temp = res[i];
+    ptrdiff_t j = i - 1;
+    for (; j >= 0 && cmp(temp, res[j]); j--)
+      res[j + 1] = res[j];
+    res[j + 1] = temp;
+  }
+  return res;
+}
+
+template <typename T, size_t N, typename U, typename Compare = less>
+constexpr const T* lower_bound(const array<T, N>& items, const U& value, Compare cmp = {}) {
+  size_t l = 0;
+  size_t r = N - 1;
+  while (l != r) {
+    const size_t mid = (l + r + 1) / 2;
+    if (cmp(value, items[mid]))
+      r = mid - 1;
+    else
+      l = mid;
+  }
+  return &items[l];
+}
+
+template <typename T, size_t N, typename Compare = less>
+constexpr bool is_unique(const array<T, N>& items, Compare cmp = {}) {
+  if (N <= 1)
+    return true;
+  for (size_t i = 1; i < N; i++) {
+    if (!cmp(items[i-1], items[i]))
+      return false;
+  }
+  return true;
+}
+
+struct dummy {};
+
+template <typename T, size_t N>
+class static_set_base {
+  static_assert(N > 0, "Empty maps/sets are not supported.");
+public:
+  using value_type      = T;
+  using size_type       = size_t;
+  using difference_type = ptrdiff_t;
+  using reference       = const value_type&;
+  using const_reference = reference;
+  using pointer         = const value_type*;
+  using const_pointer   = pointer;
+  using iterator        = pointer;
+  using const_iterator  = pointer;
+
+  constexpr static_set_base(const array<value_type, N>& items)
+    : data_(sorted(items))
+  {
+    assert(is_unique(data_));
+  }
+
+  constexpr iterator begin() const { return cbegin(); }
+  constexpr iterator cbegin() const { return data_.begin(); }
+
+  constexpr iterator end() const { return cend(); }
+  constexpr iterator cend() const { return data_.end(); }
+
+  constexpr size_t size() const { return N; }
+  constexpr bool empty() const { return false; }
+
+protected:
+  array<value_type, N> data_;
+};
+
+template <typename T>
+class static_set_base<T, 0> {
+public:
+  using value_type      = T;
+  using size_type       = size_t;
+  using difference_type = ptrdiff_t;
+  using reference       = const value_type&;
+  using const_reference = reference;
+  using pointer         = const value_type*;
+  using const_pointer   = pointer;
+  using iterator        = pointer;
+  using const_iterator  = pointer;
+
+  constexpr static_set_base() = default;
+
+  constexpr iterator begin() const { return nullptr; }
+  constexpr iterator cbegin() const { return nullptr; }
+
+  constexpr iterator end() const { return nullptr; }
+  constexpr iterator cend() const { return nullptr; }
+
+  constexpr size_t size() const { return 0; }
+  constexpr bool empty() const { return true; }
+
+  template <typename U>
+  constexpr iterator find(const U&) const { return end(); }
+  template <typename U>
+  constexpr bool contains(const U&) const { return false; }
+};
+
+} // namespace detail
+
+template <typename Key, typename T, size_t N>
+class static_map : public detail::static_set_base<detail::pair<Key, T>, N> {
+  using base = detail::static_set_base<detail::pair<Key, T>, N>;
+public:
+  using key_type    = Key;
+  using mapped_type = T;
+
+  using base::base;
+
+  constexpr typename base::iterator find(const Key& key) const {
+    auto it = detail::lower_bound(this->data_, key);
+    return it->first == key ? it : this->end();
+  }
+
+  constexpr bool contains(const Key& key) const {
+    return find(key) != this->end();
+  }
+};
+
+template <typename Key, typename T>
+class static_map<Key, T, 0> : public detail::static_set_base<detail::pair<Key, T>, 0> {
+public:
+  using key_type    = Key;
+  using mapped_type = T;
+};
+
+template <typename T, typename U>
+constexpr auto make_static_map(detail::dummy = {}) -> static_map<T, U, 0> {
+  return {};
+}
+
+template <typename T, typename U, size_t N>
+constexpr auto make_static_map(const detail::pair<T, U> (&items)[N]) -> static_map<T, U, N> {
+  return { detail::to_array<detail::pair<T, U>>(items) };
+}
+
+template <typename T, size_t N>
+class static_set : public detail::static_set_base<T, N> {
+  using base = detail::static_set_base<T, N>;
+public:
+  using base::base;
+
+  constexpr typename base::iterator find(const T& value) const {
+    auto it = detail::lower_bound(this->data_, value);
+    return *it == value ? it : this->end();
+  }
+
+  constexpr bool contains(const T& value) const {
+    return find(value) != this->end();
+  }
+};
+
+template <typename T>
+class static_set<T, 0> : public detail::static_set_base<T, 0> {};
+
+template <typename T>
+constexpr auto make_static_set(detail::dummy = {}) -> static_set<T, 0> {
+  return {};
+}
+
+template <typename T, typename U, size_t N>
+constexpr auto make_static_set(const U (&items)[N]) -> static_set<T, N> {
+  return { detail::to_array<T>(items) };
+}
+
+} // namespace util
+
+#endif // SC_UTIL_STATIC_MAP_HPP_INCLUDED

--- a/source_files/QT_engine.pri
+++ b/source_files/QT_engine.pri
@@ -149,6 +149,7 @@ HEADERS += engine/util/sample_data.hpp
 HEADERS += engine/util/sc_resourcepaths.hpp
 HEADERS += engine/util/scoped_callback.hpp
 HEADERS += engine/util/span.hpp
+HEADERS += engine/util/static_map.hpp
 HEADERS += engine/util/stopwatch.hpp
 HEADERS += engine/util/string_view.hpp
 HEADERS += engine/util/timeline.hpp

--- a/source_files/VS_engine.props
+++ b/source_files/VS_engine.props
@@ -153,6 +153,7 @@ To change the list of source files run synchronize.py
 		<ClInclude Include="..\engine\util\sc_resourcepaths.hpp" />
 		<ClInclude Include="..\engine\util\scoped_callback.hpp" />
 		<ClInclude Include="..\engine\util\span.hpp" />
+		<ClInclude Include="..\engine\util\static_map.hpp" />
 		<ClInclude Include="..\engine\util\stopwatch.hpp" />
 		<ClInclude Include="..\engine\util\string_view.hpp" />
 		<ClInclude Include="..\engine\util\timeline.hpp" />

--- a/source_files/cmake_engine.txt
+++ b/source_files/cmake_engine.txt
@@ -147,6 +147,7 @@ util/sample_data.hpp
 util/sc_resourcepaths.hpp
 util/scoped_callback.hpp
 util/span.hpp
+util/static_map.hpp
 util/stopwatch.hpp
 util/string_view.hpp
 util/timeline.hpp


### PR DESCRIPTION
A bunch of things here:

* now that we have `string_view` - move static strings that were previously in `std::string`s to constexpr string views

* use constexpr `std::array`s instead of `std::vector`s for "static" arrays

* add and use `static_map`/`static_set` for static data stored in associative containers

Some info on the `static_` containers:
Fully constexpr (depending on the stored types obviously), internally the data is stored in a sorted array, so a search is a simple binary search. Performance wise for searches:
* for cheap to compare keys - always faster than corresponding `std` containers
* for strings - always faster than an `std::map`/`std::set`; compared to `unordered` containers - it depends - faster for small data sets and "short" strings, as data sets and/or string lengths grow in size become slower

The branch reduces binary size by ~145kB. It also reduces dynamic memory consumption by some amount as all of this data is now baked into the executable instead of being allocated at runtime (during binary load, which should also make it a bit faster).