### PR TITLE
Switch all item related dbc exported data to floats

### DIFF
--- a/engine/dbc/item_armor.hpp
+++ b/engine/dbc/item_armor.hpp
@@ -13,7 +13,7 @@
 struct item_armor_quality_data_t
 {
   unsigned ilevel;
-  double   multiplier[7];
+  float    multiplier[7];
 
   static const item_armor_quality_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_armor_quality_data_t>( ilevel, ptr, &item_armor_quality_data_t::ilevel ); }
@@ -23,18 +23,18 @@ struct item_armor_quality_data_t
 
   static util::span<const item_armor_quality_data_t> data( bool ptr );
 
-  double value( int quality ) const
+  float value( int quality ) const
   {
     return as<unsigned>( quality ) < range::size( multiplier )
       ? multiplier[ as<unsigned>( quality ) ]
-      : 0.0;
+      : 0;
   }
 };
 
 struct item_armor_shield_data_t
 {
   unsigned ilevel;
-  double   values[7];
+  float    values[7];
 
   static const item_armor_shield_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_armor_shield_data_t>( ilevel, ptr, &item_armor_shield_data_t::ilevel ); }
@@ -44,18 +44,18 @@ struct item_armor_shield_data_t
 
   static util::span<const item_armor_shield_data_t> data( bool ptr );
 
-  double value( int quality ) const
+  float value( int quality ) const
   {
     return as<unsigned>( quality ) < range::size( values )
       ? values[ as<unsigned>( quality ) ]
-      : 0.0;
+      : 0;
   }
 };
 
 struct item_armor_total_data_t
 {
   unsigned ilevel;
-  double   values[7];
+  float    values[7];
 
   static const item_armor_total_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_armor_total_data_t>( ilevel, ptr, &item_armor_total_data_t::ilevel ); }
@@ -65,18 +65,18 @@ struct item_armor_total_data_t
 
   static util::span<const item_armor_total_data_t> data( bool ptr );
 
-  double value( int subclass ) const
+  float value( int subclass ) const
   {
     return as<unsigned>( subclass ) < range::size( values )
       ? values[ as<unsigned>( subclass ) ]
-      : 0.0;
+      : 0;
   }
 };
 
 struct item_armor_location_data_t
 {
   unsigned inv_type;
-  double   multiplier[4];
+  float    multiplier[4];
 
   static const item_armor_location_data_t& find( unsigned inv_type, bool ptr )
   { return dbc::find<item_armor_location_data_t>( inv_type, ptr, &item_armor_location_data_t::inv_type ); }
@@ -86,11 +86,11 @@ struct item_armor_location_data_t
 
   static util::span<const item_armor_location_data_t> data( bool ptr );
 
-  double value( int subclass ) const
+  float value( int subclass ) const
   {
     return as<unsigned>( subclass ) < range::size( multiplier )
       ? multiplier[ as<unsigned>( subclass ) ]
-      : 0.0;
+      : 0;
   }
 };
 

--- a/engine/dbc/item_data.hpp
+++ b/engine/dbc/item_data.hpp
@@ -29,14 +29,14 @@ struct item_data_t {
   int      item_class;
   int      item_subclass;
   int      bind_type;
-  double   delay;
-  double   dmg_range;
-  double   item_modifier;
+  float    delay;
+  float    dmg_range;
+  float    item_modifier;
   uint64_t race_mask;
   unsigned class_mask;
   int      stat_type_e[MAX_ITEM_STAT];       // item_mod_type
   int      stat_alloc[MAX_ITEM_STAT];
-  double   stat_socket_mul[MAX_ITEM_STAT];
+  float    stat_socket_mul[MAX_ITEM_STAT];
   int      trigger_spell[MAX_ITEM_EFFECT];      // item_spell_trigger_type
   int      id_spell[MAX_ITEM_EFFECT];
   int      cooldown_duration[MAX_ITEM_EFFECT];

--- a/engine/dbc/item_scaling.hpp
+++ b/engine/dbc/item_scaling.hpp
@@ -13,10 +13,10 @@ struct curve_point_t
 {
   unsigned curve_id;
   unsigned index;
-  double   primary1;
-  double   primary2;
-  double   secondary1;
-  double   secondary2;
+  float    primary1;
+  float    primary2;
+  float    secondary1;
+  float    secondary2;
 
   static util::span<const curve_point_t> find( unsigned id, bool ptr );
 

--- a/engine/dbc/item_weapon.hpp
+++ b/engine/dbc/item_weapon.hpp
@@ -13,7 +13,7 @@
 struct item_damage_one_hand_data_t
 {
   unsigned ilevel;
-  double   dps[7];
+  float    dps[7];
 
   static const item_damage_one_hand_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_damage_one_hand_data_t>( ilevel, ptr, &item_damage_one_hand_data_t::ilevel ); }
@@ -23,18 +23,18 @@ struct item_damage_one_hand_data_t
 
   static util::span<const item_damage_one_hand_data_t> data( bool ptr );
 
-  double value( int quality ) const
+  float value( int quality ) const
   {
     return as<unsigned>( quality ) < range::size( dps )
       ? dps[ as<unsigned>( quality ) ]
-      : 0.0;
+      : 0;
   }
 };
 
 struct item_damage_one_hand_caster_data_t
 {
   unsigned ilevel;
-  double   dps[7];
+  float    dps[7];
 
   static const item_damage_one_hand_caster_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_damage_one_hand_caster_data_t>( ilevel, ptr, &item_damage_one_hand_caster_data_t::ilevel ); }
@@ -44,18 +44,18 @@ struct item_damage_one_hand_caster_data_t
 
   static util::span<const item_damage_one_hand_caster_data_t> data( bool ptr );
 
-  double value( int quality ) const
+  float value( int quality ) const
   {
     return as<unsigned>( quality ) < range::size( dps )
       ? dps[ as<unsigned>( quality ) ]
-      : 0.0;
+      : 0;
   }
 };
 
 struct item_damage_two_hand_data_t
 {
   unsigned ilevel;
-  double   dps[7];
+  float    dps[7];
 
   static const item_damage_two_hand_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_damage_two_hand_data_t>( ilevel, ptr, &item_damage_two_hand_data_t::ilevel ); }
@@ -65,18 +65,18 @@ struct item_damage_two_hand_data_t
 
   static util::span<const item_damage_two_hand_data_t> data( bool ptr );
 
-  double value( int quality ) const
+  float value( int quality ) const
   {
     return as<unsigned>( quality ) < range::size( dps )
       ? dps[ as<unsigned>( quality ) ]
-      : 0.0;
+      : 0;
   }
 };
 
 struct item_damage_two_hand_caster_data_t
 {
   unsigned ilevel;
-  double   dps[7];
+  float    dps[7];
 
   static const item_damage_two_hand_caster_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<item_damage_two_hand_caster_data_t>( ilevel, ptr, &item_damage_two_hand_caster_data_t::ilevel ); }
@@ -86,11 +86,11 @@ struct item_damage_two_hand_caster_data_t
 
   static util::span<const item_damage_two_hand_caster_data_t> data( bool ptr );
 
-  double value( int quality ) const
+  float value( int quality ) const
   {
     return as<unsigned>( quality ) < range::size( dps )
       ? dps[ as<unsigned>( quality ) ]
-      : 0.0;
+      : 0;
   }
 };
 

--- a/engine/dbc/rand_prop_points.hpp
+++ b/engine/dbc/rand_prop_points.hpp
@@ -14,9 +14,9 @@ struct random_prop_data_t
   unsigned ilevel;
   unsigned damage_replace_stat;
   unsigned damage_secondary;
-  double   p_epic[5];
-  double   p_rare[5];
-  double   p_uncommon[5];
+  float    p_epic[5];
+  float    p_rare[5];
+  float    p_uncommon[5];
 
   static const random_prop_data_t& find( unsigned ilevel, bool ptr )
   { return dbc::find<random_prop_data_t>( ilevel, ptr, &random_prop_data_t::ilevel ); }


### PR DESCRIPTION
Client source data is in floats, so we don't really need the extended
precision of storing this data in doubles. As item data is accessed only during
init the perf impact of extra `cvtss2sd`s should be minimal, while we can save
rather substantial amount of memory.

"Theoretically" it should be a no-op, results numbers wise. Conceptually we
simply move where the float -> double conversion takes place. But because of
the way floating point numbers work the results do change numerically.

This is basically the "canonical" problem of representing the value `0.1` in
ieee 754 fp. As a 32b float it's `0.10000000149...`, as a 64b double it's
`0.10000000000000000555`. Previosly we were getting the latter, but now we are
getting the former (as all floats are exactly representable by doubles).

Maybe we could "lessen" the effect of this by dropping rounding of fp numbers
in dbc export. But I'm not really sure if it's a big problem in the first place
tbh. Nor if we should (can) do anything about it. Unless we switch the whole
sim to floats we will always be getting slightly "off" numbers.

Below stats are compiled with `clang-10 -O3 -flto-thin -ffast-math`:
```
nuohep@r2d2:~/dev/simc> for i in `seq 1 500`; do \
>for exec in 'fp32' 'shl'; do \
>  ./build-optimized/simc.$exec profiles/CI.simc iterations=2500 deterministic=1 2>&1 \
>     | rg -o -r '$1' -e 'WallSeconds\s*=\s*([0-9.]+)' >> $exec-time.csv ;\
>done; done
nuohep@r2d2:~/dev/simc> ministat -q shl-time.csv fp32-time.csv
x shl-time.csv
+ fp32-time.csv
    N           Min           Max        Median           Avg        Stddev
x 500     14.637505     16.250196     14.745589     14.769417    0.14067457
+ 500     14.668977      16.61916     14.795802     14.819548    0.13413553
Difference at 95.0% confidence
        0.0501312 +/- 0.0170377
        0.339426% +/- 0.115358%
        (Student's t, pooled s = 0.137444)
nuohep@r2d2:~/dev/simc> bloaty -d symbols -n 10 build-optimized/simc.fp32 -- build-optimized/simc.shl
    FILE SIZE        VM SIZE
 --------------  --------------
  -0.0%    -741  -0.0% -1.14Ki    [764 Others]
 -50.0% -40.6Ki -50.0% -40.6Ki    __item_armor_quality_data
 -50.0% -40.6Ki -50.0% -40.6Ki    __item_armor_shield_data
 -50.0% -40.6Ki -50.0% -40.6Ki    __item_armor_total_data
 -49.9% -40.6Ki -50.0% -40.6Ki    __item_damage_one_hand_caster_data
 -50.0% -40.6Ki -50.0% -40.6Ki    __item_damage_one_hand_data
 -49.9% -40.6Ki -50.0% -40.6Ki    __item_damage_two_hand_caster_data
 -50.0% -40.6Ki -50.0% -40.6Ki    __item_damage_two_hand_data
 -47.0% -81.2Ki -47.1% -81.2Ki    __rand_prop_points_data
 -40.0%  -664Ki -40.0%  -664Ki    __curve_point_data
 -14.0% -3.60Mi -14.0% -3.60Mi    __item_data
  -8.4% -4.61Mi  -8.8% -4.61Mi    TOTAL
```