### PR TITLE
Spell Query: plug a memory leak for 'binary' expressions

### DIFF
--- a/engine/dbc/spell_query/spell_data_expr.hpp
+++ b/engine/dbc/spell_query/spell_data_expr.hpp
@@ -8,6 +8,8 @@
 #include "config.hpp"
 #include "sim/sc_expressions.hpp"
 
+#include <memory>
+
 class dbc_t;
 
 // Spell query expression types
@@ -84,9 +86,8 @@ struct spell_data_expr_t
       result_str( "" )
   {
   }
-  virtual ~spell_data_expr_t()
-  {
-  }
+  virtual ~spell_data_expr_t() = default;
+
   virtual int evaluate()
   {
     return result_tok;
@@ -110,6 +111,6 @@ struct spell_data_expr_t
   virtual std::vector<uint32_t> in( const spell_data_expr_t& /* other */ ) { return std::vector<uint32_t>(); }
   virtual std::vector<uint32_t> not_in( const spell_data_expr_t& /* other */ ) { return std::vector<uint32_t>(); }
 
-  static spell_data_expr_t* parse( sim_t* sim, const std::string& expr_str );
-  static spell_data_expr_t* create_spell_expression( dbc_t& dbc, util::string_view name_str );
+  static std::unique_ptr<spell_data_expr_t> parse( sim_t* sim, const std::string& expr_str );
+  static std::unique_ptr<spell_data_expr_t> create_spell_expression( dbc_t& dbc, util::string_view name_str );
 };

--- a/engine/report/report_helper.hpp
+++ b/engine/report/report_helper.hpp
@@ -30,7 +30,6 @@ struct spell_data_t;
 class extended_sample_data_t;
 struct player_processed_report_information_t;
 struct sim_report_information_t;
-struct spell_data_expr_t;
 
 /**
  * Automatic Timer reporting the time between construction and desctruction of

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -822,7 +822,7 @@ bool parse_spell_query( sim_t*             sim,
     sq_str = sq_str.substr( 0, lvl_offset );
   }
 
-  sim -> spell_query = std::unique_ptr<spell_data_expr_t>( spell_data_expr_t::parse( sim, sq_str ) );
+  sim -> spell_query = spell_data_expr_t::parse( sim, sq_str );
 
   if (sim -> spell_query == nullptr)
   {

--- a/engine/simulationcraft.hpp
+++ b/engine/simulationcraft.hpp
@@ -39,7 +39,6 @@
 
 #include "dbc/dbc.hpp"
 #include "dbc/item_database.hpp"
-#include "dbc/spell_query/spell_data_expr.hpp"
 #include "dbc/data_enums.hh"
 #include "dbc/data_definitions.hh"
 


### PR DESCRIPTION
Plugs 2 memory leaks in `sd_expr_binary_t` as it never deletes the 2 passed in
expressions. While at it converts it all to unique_ptrs to be safe.