### PR TITLE
[DBC] switch to span spell_data_t accessors

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -543,28 +543,23 @@ void action_t::parse_spell_data( const spell_data_t& spell_data )
     cooldown->duration = spell_data.cooldown();
   }
 
-  if ( spell_data._power )
+  const auto spell_powers = spell_data.powers();
+  if ( spell_powers.size() == 1 && spell_powers.front()->aura_id() == 0 )
   {
-    if ( spell_data._power->size() == 1 && spell_data._power->at( 0 )->aura_id() == 0 )
+    resource_current = spell_powers.front()->resource();
+  }
+  else
+  {
+    // Find the first power entry without a aura id
+    auto it = range::find_if( spell_powers, power_entry_without_aura() );
+    if ( it != spell_powers.end() )
     {
-      resource_current = spell_data._power->at( 0 )->resource();
-    }
-    else
-    {
-      // Find the first power entry without a aura id
-      std::vector<const spellpower_data_t*>::iterator it =
-          std::find_if( spell_data._power->begin(), spell_data._power->end(), power_entry_without_aura() );
-      if ( it != spell_data._power->end() )
-      {
-        resource_current = ( *it )->resource();
-      }
+      resource_current = ( *it )->resource();
     }
   }
 
-  for ( size_t i = 0; spell_data._power && i < spell_data._power->size(); i++ )
+  for ( const spellpower_data_t* pd : spell_powers )
   {
-    const spellpower_data_t* pd = ( *spell_data._power )[ i ];
-
     if ( pd->_cost != 0 )
       base_costs[ pd->resource() ] = pd->cost();
     else
@@ -578,9 +573,9 @@ void action_t::parse_spell_data( const spell_data_t& spell_data )
       base_costs_per_tick[ pd->resource() ] = floor( pd->cost_per_tick() * player->resources.base[ pd->resource() ] );
   }
 
-  for ( size_t i = 1; i <= spell_data.effect_count(); i++ )
+  for ( const spelleffect_data_t* ed : spell_data.effects() )
   {
-    parse_effect_data( spell_data.effectN( i ) );
+    parse_effect_data( *ed );
   }
 }
 

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -2374,9 +2374,8 @@ public:
 
     /* Iterate through power entries, and find if there are resources linked to one of our stances
      */
-    for ( size_t i = 0; ab::data()._power && i < ab::data()._power->size(); i++ )
+    for ( const spellpower_data_t* pd : ab::data().powers() )
     {
-      const spellpower_data_t* pd = ( *ab::data()._power )[ i ];
       switch ( pd->aura_id() )
       {
         case 137023:

--- a/engine/dbc/sc_spell_info.cpp
+++ b/engine/dbc/sc_spell_info.cpp
@@ -1309,10 +1309,8 @@ std::string spell_info::to_str( const dbc_t& dbc, const spell_data_t* spell, int
   }
   s << "Spell Type       : " << spell_type_str << std::endl;
 
-  for ( size_t i = 0; spell -> _power && i < spell -> _power -> size(); i++ )
+  for ( const spellpower_data_t* pd : spell -> powers() )
   {
-    const spellpower_data_t* pd = spell -> _power -> at( i );
-
     s << "Resource         : ";
 
     if ( pd -> type() == POWER_MANA )
@@ -1679,18 +1677,13 @@ std::string spell_info::to_str( const dbc_t& dbc, const spell_data_t* spell, int
     }
   }
 
-  if ( spell -> _driver )
+  if ( spell -> driver_count() > 0 )
   {
     s << "Triggered by     : ";
-    for ( size_t driver_idx = 0; driver_idx < spell -> _driver -> size(); ++driver_idx )
-    {
-      const spell_data_t* driver = spell -> _driver -> at( driver_idx );
-      s << driver -> name_cstr() << " (" << driver -> id() << ")";
-      if ( driver_idx < spell -> _driver -> size() - 1 )
-      {
-        s << ", ";
-      }
-    }
+    s << concatenate( spell -> drivers(),
+        []( std::stringstream& s, const spell_data_t* spell ) {
+          s << spell -> name_cstr() << " (" << spell -> id() << ")";
+        } );
     s << std::endl;
   }
 
@@ -2079,10 +2072,8 @@ void spell_info::to_xml( const dbc_t& dbc, const spell_data_t* spell, xml_node_t
     }
   }
 
-  for ( size_t i = 0; spell -> _power && i < spell -> _power -> size(); i++ )
+  for ( const spellpower_data_t* pd : spell -> powers() )
   {
-    const spellpower_data_t* pd = spell -> _power -> at( i );
-
     if ( pd -> cost() == 0 )
       continue;
 

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -346,13 +346,8 @@ bool spell_data_t::affected_by_label( const spelleffect_data_t& effect ) const
 
 bool spell_data_t::affected_by_label( int label ) const
 {
-  if (_labels == nullptr || _labels->size() == 0)
-  {
-    return false;
-  }
-
-  auto it = range::find(*_labels, label, &spelllabel_data_t::label);
-  return it != _labels->end();
+  const auto labels = this -> labels();
+  return range::find(labels, label, &spelllabel_data_t::label) != labels.end();
 }
 
 bool spell_data_t::affected_by( const spell_data_t* spell ) const


### PR DESCRIPTION
For effects/labels/powers/drivers. Instead of going directly through the
pointer to the underlying vector in the places where we don't need it.

When/if we change the way linking is done we will most definitely not have
vectors here anymore. Nor something that will behave as a vector. Change it now
as a preparation to a possible future rework.

It's also a much nicer api to work with (like when you simply need to iterate
over the whole list).