### PR TITLE
[DBC] separate out item effects from item data

### DIFF
--- a/engine/dbc/item_data.cpp
+++ b/engine/dbc/item_data.cpp
@@ -13,4 +13,3 @@ util::span<const dbc_item_data_t> dbc_item_data_t::data( bool ptr )
 {
   return SC_DBC_GET_DATA( dbc::items(), dbc::items_ptr(), ptr );
 }
-

--- a/engine/dbc/item_data.hpp
+++ b/engine/dbc/item_data.hpp
@@ -21,6 +21,14 @@ struct dbc_item_data_t {
     float   socket_mul;
   };
 
+  struct effect_t {
+    unsigned spell_id;
+    int16_t  type; // item_spell_trigger_type
+    int16_t  cooldown_group;
+    int      cooldown_duration;
+    int      cooldown_group_duration;
+  };
+
   const char* name;
   unsigned id;
   unsigned flags_1;
@@ -39,14 +47,11 @@ struct dbc_item_data_t {
   float    dmg_range;
   float    item_modifier;
   const stats_t* _dbc_stats;
+  const effect_t* _effects;
   uint8_t  _dbc_stats_count;
+  uint8_t  _effects_count;
   unsigned class_mask;
   uint64_t race_mask;
-  int      trigger_spell[MAX_ITEM_EFFECT];      // item_spell_trigger_type
-  int      id_spell[MAX_ITEM_EFFECT];
-  int      cooldown_duration[MAX_ITEM_EFFECT];
-  int      cooldown_group[MAX_ITEM_EFFECT];
-  int      cooldown_group_duration[MAX_ITEM_EFFECT];
   int      socket_color[MAX_ITEM_SOCKET_SLOT];       // item_socket_color
   int      gem_properties;
   int      id_socket_bonus;
@@ -67,6 +72,12 @@ struct dbc_item_data_t {
   bool mythic() const
   { return ( type_flags & RAID_TYPE_MYTHIC ) == RAID_TYPE_MYTHIC; }
 
+  util::span<const effect_t> effects() const
+  {
+    assert( _effects || _effects_count == 0 );
+    return { _effects, _effects_count };
+  }
+
   static const dbc_item_data_t& find( unsigned id, bool ptr )
   { return dbc::find<dbc_item_data_t>( id, ptr, &dbc_item_data_t::id ); }
 
@@ -74,6 +85,13 @@ struct dbc_item_data_t {
   { return dbc::nil<dbc_item_data_t>; }
 
   static util::span<const dbc_item_data_t> data( bool ptr );
+
+protected:
+  dbc_item_data_t( const dbc_item_data_t& ) = default;
+  dbc_item_data_t& operator=( const dbc_item_data_t& ) = default;
+
+  void copy_from( const dbc_item_data_t& other )
+  { *this = other; }
 };
 
 #endif /* ITEM_HPP */

--- a/engine/dbc/sc_item_data.cpp
+++ b/engine/dbc/sc_item_data.cpp
@@ -317,21 +317,7 @@ bool item_database::apply_item_bonus( item_t& item, const item_bonus_entry_t& en
         return true;
       }
 
-      size_t index = 0;
-      for ( index = 0; index < range::size( item.parsed.data.trigger_spell ); ++index )
-      {
-        if ( item.parsed.data.id_spell[ index ] <= 0 )
-        {
-          break;
-        }
-      }
-
-      item.parsed.data.trigger_spell[ index ] = effect.type;
-      item.parsed.data.id_spell[ index ] = effect.spell_id;
-      item.parsed.data.cooldown_duration[ index ] = effect.cooldown_duration;
-      item.parsed.data.cooldown_group[ index ] = effect.cooldown_group;
-      item.parsed.data.cooldown_group_duration[ index ] = effect.cooldown_group_duration;
-
+      const size_t index = item.parsed.data.add_effect( effect );
       item.player->sim->print_debug( "Player {} item '{}' adding effect {} (type={}, index={})",
           item.player->name(), item.name(), effect.spell_id,
           util::item_spell_trigger_string( static_cast<item_spell_trigger_type>( effect.type ) ),

--- a/engine/interfaces/bcp_api.cpp
+++ b/engine/interfaces/bcp_api.cpp
@@ -954,14 +954,13 @@ void download_item_data( item_t& item, cache::behavior_e caching )
     if ( js.HasMember( "itemSpells" ) )
     {
       const rapidjson::Value& spells = js[ "itemSpells" ];
-      size_t spell_idx = 0;
-      for ( rapidjson::SizeType i = 0, n = spells.Size(); i < n && spell_idx < range::size( item.parsed.data.id_spell ); ++i )
+      for ( rapidjson::SizeType i = 0, n = spells.Size(); i < n; ++i )
       {
         const rapidjson::Value& spell = spells[ i ];
         if ( ! spell.HasMember( "spellId" ) || ! spell.HasMember( "trigger" ) )
           continue;
 
-        int spell_id = spell[ "spellId" ].GetInt();
+        unsigned spell_id = spell[ "spellId" ].GetUint();
         int trigger_type = -1;
 
         if ( util::str_compare_ci( spell[ "trigger" ].GetString(), "ON_EQUIP" ) )
@@ -973,9 +972,7 @@ void download_item_data( item_t& item, cache::behavior_e caching )
 
         if ( trigger_type != -1 && spell_id > 0 )
         {
-          item.parsed.data.id_spell[ spell_idx ] = spell_id;
-          item.parsed.data.trigger_spell[ spell_idx ] = trigger_type;
-          spell_idx++;
+          item.parsed.data.add_effect( spell_id, trigger_type );
         }
       }
     }

--- a/engine/interfaces/wowhead.cpp
+++ b/engine/interfaces/wowhead.cpp
@@ -258,8 +258,6 @@ bool wowhead::download_item_data( item_t&            item,
       xml->get_value(htmltooltip, "htmlTooltip/cdata");
 
       // Parse out Equip: and On use: strings
-      int spell_idx = 0;
-
       std::shared_ptr<xml_node_t> htmltooltip_xml = xml_node_t::create(htmltooltip);
       //htmltooltip_xml -> print( item.sim -> output_file, 2 );
       std::vector<xml_node_t*> spell_links = htmltooltip_xml->get_nodes("span");
@@ -293,9 +291,7 @@ bool wowhead::download_item_data( item_t&            item,
         }
         if (parsed_spell_id > 0 && trigger_type != -1)
         {
-          item.parsed.data.id_spell[spell_idx] = parsed_spell_id;
-          item.parsed.data.trigger_spell[spell_idx] = trigger_type;
-          spell_idx++;
+          item.parsed.data.add_effect( as<unsigned>( parsed_spell_id ), trigger_type );
         }
       }
     }

--- a/engine/item/item.hpp
+++ b/engine/item/item.hpp
@@ -22,6 +22,7 @@ struct sim_t;
 struct special_effect_t;
 struct weapon_t;
 struct xml_node_t;
+struct item_effect_t;
 
 struct stat_pair_t
 {
@@ -38,23 +39,39 @@ struct stat_pair_t
 struct parsed_item_data_t : dbc_item_data_t {
   std::array<int, MAX_ITEM_STAT> stat_type_e;
   std::array<int, MAX_ITEM_STAT> stat_alloc;
+  std::array<dbc_item_data_t::effect_t, MAX_ITEM_EFFECT> _effects_data;
 
   parsed_item_data_t()
-    : dbc_item_data_t{}
+    : dbc_item_data_t{}, stat_alloc{}, _effects_data{}
   {
     range::fill( stat_type_e, -1 );
-    range::fill( stat_alloc, 0 );
+    _effects = _effects_data.data();
   }
 
-  void init( const dbc_item_data_t& raw )
+  parsed_item_data_t( const parsed_item_data_t& other )
+    : dbc_item_data_t( other )
+    , stat_type_e( other.stat_type_e ), stat_alloc( other.stat_alloc )
+    , _effects_data( other._effects_data )
   {
-    *static_cast<dbc_item_data_t*>( this ) = raw;
-    for ( size_t i = 0; i < stat_type_e.size(); i++ )
-    {
-      stat_type_e[ i ] = i < _dbc_stats_count ? _dbc_stats[ i ].type_e : -1;
-      stat_alloc[ i ] = i < _dbc_stats_count ? _dbc_stats[ i ].alloc : 0;
-    }
+    _effects = _effects_data.data();
   }
+
+  parsed_item_data_t& operator=( const parsed_item_data_t& other )
+  {
+    this -> copy_from( other );
+    stat_type_e = other.stat_type_e;
+    stat_alloc = other.stat_alloc;
+    _effects_data = other._effects_data;
+    _effects = _effects_data.data();
+    return *this;
+  }
+
+  void init( const dbc_item_data_t& raw );
+
+  size_t add_effect( unsigned spell_id, int type );
+  size_t add_effect( const item_effect_t& effect );
+private:
+  size_t find_free_effect_slot() const;
 };
 
 struct item_t

--- a/engine/item/special_effect.cpp
+++ b/engine/item/special_effect.cpp
@@ -738,10 +738,10 @@ timespan_t special_effect_t::cooldown() const
   // spell cooldown may be
   if ( source == SPECIAL_EFFECT_SOURCE_ITEM && item )
   {
-    for ( size_t i = 0; i < MAX_ITEM_EFFECT; i++ )
+    for ( const auto& effect : item -> parsed.data.effects() )
     {
-      if ( item -> parsed.data.id_spell[ i ] == as<int>(spell_id) && item -> parsed.data.cooldown_duration[ i ] > 0 )
-        return timespan_t::from_millis( item -> parsed.data.cooldown_duration[ i ] );
+      if ( effect.spell_id == spell_id && effect.cooldown_duration > 0 )
+        return timespan_t::from_millis( effect.cooldown_duration );
     }
   }
 
@@ -1235,11 +1235,11 @@ int special_effect_t::cooldown_group() const
   }
 
   // For everything else, look at the item effects for a cooldown group
-  for (size_t i = 0; i < MAX_ITEM_EFFECT; ++i)
+  for ( const auto& effect : item -> parsed.data.effects() )
   {
-    if (item->parsed.data.cooldown_group[i] > 0)
+    if ( effect.cooldown_group > 0 )
     {
-      return item->parsed.data.cooldown_group[i];
+      return effect.cooldown_group;
     }
   }
 
@@ -1261,11 +1261,11 @@ timespan_t special_effect_t::cooldown_group_duration() const
   }
 
   // For everything else, look at the item effects with a cooldown group
-  for (size_t i = 0; i < MAX_ITEM_EFFECT; ++i)
+  for ( const auto& effect : item -> parsed.data.effects() )
   {
-    if (item->parsed.data.cooldown_group[i] > 0)
+    if ( effect.cooldown_group > 0 )
     {
-      return timespan_t::from_millis(item->parsed.data.cooldown_group_duration[i]);
+      return timespan_t::from_millis( effect.cooldown_group_duration );
     }
   }
 

--- a/engine/player/sc_consumable.cpp
+++ b/engine/player/sc_consumable.cpp
@@ -394,12 +394,12 @@ struct dbc_consumable_base_t : public action_t
       return spell_data_t::not_found();
     }
 
-    for ( const auto& spell_id : item_data -> id_spell )
+    for ( const auto& effect : item_data -> effects() )
     {
       // Note, bypasses level check from the spell itself, since it seems some consumable spells are
       // flagged higher level than the actual food they are in.
-      auto ptr = dbc::find_spell( player, spell_id );
-      if ( ptr && ptr -> id() == as<unsigned>( spell_id ) )
+      auto ptr = dbc::find_spell( player, effect.spell_id );
+      if ( ptr && ptr -> id() == effect.spell_id )
       {
         return ptr;
       }
@@ -617,11 +617,11 @@ struct potion_t : public dbc_consumable_base_t
     dbc_consumable_base_t::initialize_consumable();
 
     // Setup a cooldown duration for the potion
-    for ( size_t i = 0; i < range::size( item_data -> cooldown_group ); i++ )
+    for ( const auto& effect : item_data -> effects() )
     {
-      if ( item_data -> cooldown_group[ i ] > 0 && item_data -> cooldown_group_duration[ i ] > 0 )
+      if ( effect.cooldown_group > 0 && effect.cooldown_group_duration > 0 )
       {
-        cooldown -> duration = timespan_t::from_millis( item_data -> cooldown_group_duration[ i ] );
+        cooldown -> duration = timespan_t::from_millis( effect.cooldown_group_duration );
         break;
       }
     }

--- a/engine/report/sc_report_html_player.cpp
+++ b/engine/report/sc_report_html_player.cpp
@@ -1295,18 +1295,17 @@ void print_html_gear( report::sc_html_stream& os, const player_t& p )
 
     {
       std::stringstream s;
-      for ( int i = 0; i < MAX_ITEM_EFFECT; i++ )
+      for ( const auto& effect : item.parsed.data.effects() )
       {
-        int id = item.parsed.data.id_spell[ i ];
-        if ( id )
-        {
-          if ( !s.str().empty() )
-            s << ", ";
+        if ( effect.spell_id == 0 )
+          continue;
 
-          s << util::item_spell_trigger_string( static_cast<item_spell_trigger_type>( item.parsed.data.trigger_spell[ i ] ) ) << ": ";
-          auto spell = item.player->find_spell( id );
-          s << report_decorators::decorated_spell_data_item(*item.sim, spell, item);
-        }
+        if ( !s.str().empty() )
+          s << ", ";
+
+        s << util::item_spell_trigger_string( static_cast<item_spell_trigger_type>( effect.type ) ) << ": ";
+        auto spell = item.player->find_spell( effect.spell_id );
+        s << report_decorators::decorated_spell_data_item(*item.sim, spell, item);
       }
 
       if ( !s.str().empty() )


### PR DESCRIPTION
This is a bit more complicated than stats as the effects are accessed both
through the `dbc_item_data_t` (which is immutable) and through
`parsed_item_data_t` (where effects can come from wowhead/bcp_api/item
bonuses).

To minimize potential problems with effects getting out of sync (in case a
`parsed_item_data_t` is accessed through a `dbc_item_data_t` pointer) we use an
inner pointer for effects and forbid copying of `dbc_item_data_t`. Pretty sure
the problem is a bit theoretical and maybe there is a more elegant solution,
comments welcome.

We also can't deduplicate as much - the effects have indexes (so we can't sort
them) and are not always "contiguous" (there are "holes"). We *seem* to care
about that. But we still reduce `6439` total effects to 4171 unique "effect
records". The comparison is a bit off as the latter also includes 470 'nil'
effects where client data has "holes".

Reasons for not using `item_effect_t`:
 * exporting the effects as part of ItemEffectGenerator is much more
   complicated - we would have to store per item effect id arrays and then do
   some kind of runtime linking in init (which would require memory
   allocations and making item data non-const); this seems pretty suboptimal
   to me

 * exporting `item_effect_t`s as part of ItemDataGenerator simply wastes more
   space as we can't deduplicate the effects - `item_effect_t` contains an
   (id, index) tuple which is pretty much unique (for comparison, 6439
   `item_effect_t`s is ~176KiB + we would need either 470 "nils" (~12.8KiB) or
   6909 pointers (~54KiB))

In the end it's both more simple and takes less space to use a "custom" struct
that has only what we need (and uses smaller types for some fields) storing it
in a flat array that is easier to deduplicate.

```
nuohep@r2d2:~/dev/simc> bloaty -d symbols -n 5 build-optimized/simc -- build-optimized/simc.shl
    FILE SIZE        VM SIZE
 --------------  --------------
  [NEW] +65.2Ki  [NEW] +65.2Ki    __item_effects_data
  +0.0% +1.39Ki  +0.0% +1.12Ki    [753 Others]
  [NEW]    +613  [NEW]    +472    parsed_item_data_t::add_effect()
 -19.1%    -626 -19.6%    -626    enchant::initialize_relic()
 -40.0%    -633 -42.2%    -633    (anonymous namespace)::bfa::init_punchcard()
 -41.4% -6.22Mi -41.4% -6.22Mi    __item_data
 -14.3% -6.16Mi -15.1% -6.16Mi    TOTAL```