### PR TITLE
[DBC] pseudo-runtime spell data linking

### DIFF
--- a/SpellDataDump/deathknight.txt
+++ b/SpellDataDump/deathknight.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Dual Wield (rank=Passive) (id=674) [Passive] 
 Class            : Frost Warrior, Hunter, Rogue, Death Knight, Monk, Demon Hunter
@@ -8512,7 +8512,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -8616,7 +8616,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -9006,7 +9006,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/demonhunter.txt
+++ b/SpellDataDump/demonhunter.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Dual Wield (rank=Passive) (id=674) [Passive] 
 Class            : Frost Warrior, Hunter, Rogue, Death Knight, Monk, Demon Hunter
@@ -3619,7 +3619,7 @@ School           : Physical
 Spell Type       : None
 Duration         : 15 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
-Triggered by     : Soul Fragment (204255), Soul Fragment (203795)
+Triggered by     : Soul Fragment (203795), Soul Fragment (204255)
 Attributes       : .......x ........ ........ x..x....   .....x.. ........ ........ ........ 
                  : ........ ......x. ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ...x.... ........ .xx..... ........ 
@@ -4630,7 +4630,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -4754,7 +4754,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -5186,7 +5186,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/druid.txt
+++ b/SpellDataDump/druid.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Incapacitating Roar (id=99) [Spell Family (7)] 
 Class            : Guardian Druid
@@ -964,7 +964,7 @@ Labels           : 16: Agonizing Backlash (320035 effect#3)
 Stacks           : 3 maximum
 Proc Chance      : 101%
 Stance Mask      : 0x00000001
-Triggered by     : Primal Fury (159286), The Wildshaper's Clutch (208319), Heart of the Wild (108292)
+Triggered by     : Heart of the Wild (108292), Primal Fury (159286), The Wildshaper's Clutch (208319)
 Attributes       : ....x... ........ ........ x.......   ........ ........ ........ ........ 
                  : ..x..... ........ ........ ........   ........ ........ xx...... ........ 
                  : x......x ........ ...x.... ........   ...x.... ........ ........ ........ 
@@ -7493,7 +7493,7 @@ Name             : Essence of G'Hanir (id=218889) [Spell Family (7), Hidden]
 Class            : Druid
 School           : Nature
 Spell Type       : Magic
-Triggered by     : Essence of G'Hanir (208253), Flourish (197721)
+Triggered by     : Flourish (197721), Essence of G'Hanir (208253)
 Attributes       : .......x ........ ..x..... ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -8244,7 +8244,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -8348,7 +8348,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -8787,7 +8787,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/hunter.txt
+++ b/SpellDataDump/hunter.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Auto Shot (id=75) [Spell Family (9)] 
 Class            : Hunter
@@ -7086,7 +7086,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -7644,7 +7644,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -8694,7 +8694,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/mage.txt
+++ b/SpellDataDump/mage.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Invisibility (id=66) [Spell Family (3)] 
 Class            : Paladin, Mage
@@ -6388,7 +6388,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6601,7 +6601,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -7125,7 +7125,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/monk.txt
+++ b/SpellDataDump/monk.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Dual Wield (rank=Passive) (id=674) [Passive] 
 Class            : Frost Warrior, Hunter, Rogue, Death Knight, Monk, Demon Hunter
@@ -6225,7 +6225,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6353,7 +6353,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6787,7 +6787,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/paladin.txt
+++ b/SpellDataDump/paladin.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Haste (id=65) [Scaling Spell (-1)] 
 Class            : Paladin
@@ -5346,7 +5346,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -5450,7 +5450,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6056,7 +6056,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6467,7 +6467,7 @@ Class            : Paladin
 School           : Holy
 Spell Type       : None
 Azerite Power Id : 233
-Triggered by     : Divine Revelations (275469), Divine Revelations (275468)
+Triggered by     : Divine Revelations (275468), Divine Revelations (275469)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/priest.txt
+++ b/SpellDataDump/priest.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Power Word: Shield (id=17) [Spell Family (6)] 
 Class            : Priest
@@ -5893,7 +5893,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6103,7 +6103,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6587,7 +6587,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/rogue.txt
+++ b/SpellDataDump/rogue.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Backstab (id=53) [Spell Family (8)] 
 Replaces         : Sinister Strike (id=1752)
@@ -5809,7 +5809,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -5913,7 +5913,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6364,7 +6364,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/shaman.txt
+++ b/SpellDataDump/shaman.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Block (rank=Passive) (id=107) [Passive] 
 Class            : Warrior, Paladin, Shaman
@@ -6934,7 +6934,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -7111,7 +7111,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -7521,7 +7521,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/warlock.txt
+++ b/SpellDataDump/warlock.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Eye of Kilrogg (id=126) [Spell Family (5)] 
 Class            : Warlock
@@ -5794,7 +5794,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6354,7 +6354,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -7381,7 +7381,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/SpellDataDump/warrior.txt
+++ b/SpellDataDump/warrior.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build shadowlands 2fa6bde648)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.34972 shadowlands-BETA (git build dbc_spells 1877d36fa6)
 
 Name             : Vanguard (id=71) [Spell Family (4), Passive] 
 Class            : Protection Warrior
@@ -5872,7 +5872,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 21
-Triggered by     : Elemental Whirl (268953), Elemental Whirl (268956), Elemental Whirl (268955), Elemental Whirl (268954)
+Triggered by     : Elemental Whirl (268953), Elemental Whirl (268954), Elemental Whirl (268955), Elemental Whirl (268956)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -5976,7 +5976,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 31
-Triggered by     : Gutripper (270668), Gutripper (269031)
+Triggered by     : Gutripper (269031), Gutripper (270668)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -6366,7 +6366,7 @@ Class            : Warrior, Paladin, Hunter, Rogue, Priest, Death Knight, Shaman
 School           : Physical
 Spell Type       : None
 Azerite Power Id : 98
-Triggered by     : Crystalline Carapace (271539), Crystalline Carapace (271538)
+Triggered by     : Crystalline Carapace (271538), Crystalline Carapace (271539)
 Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -9362,7 +9362,7 @@ Proc Chance      : 100%
 Proc Flags       : ....x... ........ ........ ........ 
                  : Yellow Melee
 Affecting spells : Warrior (137047 effect#2)
-Triggered by     : Glory (325787), Conqueror's Banner (325784)
+Triggered by     : Conqueror's Banner (325784), Glory (325787)
 Family Flags     : 8
 Attributes       : ....x... ........ x....... ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 

--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -2983,12 +2983,10 @@ class SpellDataGenerator(DataGenerator):
             self.format_str('spelleffect'), len(effects) ))
 
         for index, effect_id in enumerate(effects):
-            if effect_id == 0:
-                self._out.write('  spelleffect_data_nil_v,\n')
-                continue
-
             effect = self.db('SpellEffect')[effect_id]
-            spelleffect_id_index.append((effect.id, index))
+
+            if effect_id != 0:
+                spelleffect_id_index.append((effect.id, index))
 
             #if index % 20 == 0:
             #    self._out.write('//{     Id,Flags,   SpId,Idx, EffectType                  , EffectSubType                              ,       Coefficient,         Delta,       Unknown,   Coefficient, APCoefficient,  Ampl,  Radius,  RadMax,   BaseV,   MiscV,  MiscV2, {     Flags1,     Flags2,     Flags3,     Flags4 }, Trigg,   DmgMul,  CboP, RealP,Die,Mech,ChTrg,0, 0 },\n')

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -565,9 +565,9 @@ void action_t::parse_spell_data( const spell_data_t& spell_data )
       base_costs_per_tick[ pd.resource() ] = floor( pd.cost_per_tick() * player->resources.base[ pd.resource() ] );
   }
 
-  for ( const spelleffect_data_t* ed : spell_data.effects() )
+  for ( const spelleffect_data_t& ed : spell_data.effects() )
   {
-    parse_effect_data( *ed );
+    parse_effect_data( ed );
   }
 }
 

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -234,14 +234,6 @@ struct action_execute_event_t : public player_event_t
   }
 };
 
-struct power_entry_without_aura
-{
-  bool operator()( const spellpower_data_t* p )
-  {
-    return p->aura_id() == 0;
-  }
-};
-
 }  // unnamed namespace
 
 action_t::options_t::options_t()
@@ -544,33 +536,33 @@ void action_t::parse_spell_data( const spell_data_t& spell_data )
   }
 
   const auto spell_powers = spell_data.powers();
-  if ( spell_powers.size() == 1 && spell_powers.front()->aura_id() == 0 )
+  if ( spell_powers.size() == 1 && spell_powers.front().aura_id() == 0 )
   {
-    resource_current = spell_powers.front()->resource();
+    resource_current = spell_powers.front().resource();
   }
   else
   {
     // Find the first power entry without a aura id
-    auto it = range::find_if( spell_powers, power_entry_without_aura() );
+    auto it = range::find( spell_powers, 0u, &spellpower_data_t::aura_id );
     if ( it != spell_powers.end() )
     {
-      resource_current = ( *it )->resource();
+      resource_current = it->resource();
     }
   }
 
-  for ( const spellpower_data_t* pd : spell_powers )
+  for ( const spellpower_data_t& pd : spell_powers )
   {
-    if ( pd->_cost != 0 )
-      base_costs[ pd->resource() ] = pd->cost();
+    if ( pd._cost != 0 )
+      base_costs[ pd.resource() ] = pd.cost();
     else
-      base_costs[ pd->resource() ] = floor( pd->cost() * player->resources.base[ pd->resource() ] );
+      base_costs[ pd.resource() ] = floor( pd.cost() * player->resources.base[ pd.resource() ] );
 
-    secondary_costs[ pd->resource() ] = pd->max_cost();
+    secondary_costs[ pd.resource() ] = pd.max_cost();
 
-    if ( pd->_cost_per_tick != 0 )
-      base_costs_per_tick[ pd->resource() ] = pd->cost_per_tick();
+    if ( pd._cost_per_tick != 0 )
+      base_costs_per_tick[ pd.resource() ] = pd.cost_per_tick();
     else
-      base_costs_per_tick[ pd->resource() ] = floor( pd->cost_per_tick() * player->resources.base[ pd->resource() ] );
+      base_costs_per_tick[ pd.resource() ] = floor( pd.cost_per_tick() * player->resources.base[ pd.resource() ] );
   }
 
   for ( const spelleffect_data_t* ed : spell_data.effects() )

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -35,14 +35,14 @@ struct spell_data_ptr_t
 
 void parse_affecting_aura( action_t *const action, const spell_data_t *const spell )
 {
-  for ( const spelleffect_data_t* effect : spell -> effects() )
+  for ( const spelleffect_data_t& effect : spell -> effects() )
   {
-    if ( ! effect -> ok() || effect -> type() != E_APPLY_AURA )
+    if ( ! effect.ok() || effect.type() != E_APPLY_AURA )
       continue;
 
     if ( action -> data().affected_by( effect ) )
     {
-      switch ( effect -> subtype() )
+      switch ( effect.subtype() )
       {
       case A_HASTED_GCD:
         action -> gcd_type = gcd_haste_type::ATTACK_HASTE;
@@ -53,10 +53,10 @@ void parse_affecting_aura( action_t *const action, const spell_data_t *const spe
         break;
 
       case A_ADD_FLAT_MODIFIER:
-        switch( effect -> misc_value1() )
+        switch( effect.misc_value1() )
         {
         case P_RESOURCE_COST:
-          action -> base_costs[ RESOURCE_FOCUS ] += effect -> base_value();
+          action -> base_costs[ RESOURCE_FOCUS ] += effect.base_value();
           break;
 
         default: break;
@@ -64,14 +64,14 @@ void parse_affecting_aura( action_t *const action, const spell_data_t *const spe
         break;
 
       case A_ADD_PCT_MODIFIER:
-        switch ( effect -> misc_value1() )
+        switch ( effect.misc_value1() )
         {
         case P_GENERIC:
-          action -> base_dd_multiplier *= 1 + effect -> percent();
+          action -> base_dd_multiplier *= 1 + effect.percent();
           break;
 
         case P_TICK_DAMAGE:
-          action -> base_td_multiplier *= 1 + effect -> percent();
+          action -> base_td_multiplier *= 1 + effect.percent();
           break;
 
         default: break;
@@ -81,9 +81,9 @@ void parse_affecting_aura( action_t *const action, const spell_data_t *const spe
       default: break;
       }
     }
-    else if ( action -> data().category() == as<unsigned>( effect -> misc_value1() ) )
+    else if ( action -> data().category() == as<unsigned>( effect.misc_value1() ) )
     {
-      switch ( effect -> subtype() )
+      switch ( effect.subtype() )
       {
       case A_HASTED_CATEGORY:
         action -> cooldown -> hasted = true;
@@ -4914,10 +4914,10 @@ void hunter_t::init_base_stats()
   resources.base_regen_per_second[ RESOURCE_FOCUS ] = 10;
   for ( auto spell : { specs.marksmanship_hunter, specs.survival_hunter } )
   {
-    for ( const spelleffect_data_t* effect : spell -> effects() )
+    for ( const spelleffect_data_t& effect : spell -> effects() )
     {
-      if ( effect -> ok() && effect -> type() == E_APPLY_AURA && effect -> subtype() == A_MOD_POWER_REGEN_PERCENT )
-        resources.base_regen_per_second[ RESOURCE_FOCUS ] *= 1 + effect -> percent();
+      if ( effect.ok() && effect.type() == E_APPLY_AURA && effect.subtype() == A_MOD_POWER_REGEN_PERCENT )
+        resources.base_regen_per_second[ RESOURCE_FOCUS ] *= 1 + effect.percent();
     }
   }
 

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -2374,24 +2374,24 @@ public:
 
     /* Iterate through power entries, and find if there are resources linked to one of our stances
      */
-    for ( const spellpower_data_t* pd : ab::data().powers() )
+    for ( const spellpower_data_t& pd : ab::data().powers() )
     {
-      switch ( pd->aura_id() )
+      switch ( pd.aura_id() )
       {
         case 137023:
           assert( _resource_by_stance[ specdata::spec_idx( MONK_BREWMASTER ) ] == RESOURCE_MAX &&
                   "Two power entries per aura id." );
-          _resource_by_stance[ specdata::spec_idx( MONK_BREWMASTER ) ] = pd->resource();
+          _resource_by_stance[ specdata::spec_idx( MONK_BREWMASTER ) ] = pd.resource();
           break;
         case 137024:
           assert( _resource_by_stance[ specdata::spec_idx( MONK_MISTWEAVER ) ] == RESOURCE_MAX &&
                   "Two power entries per aura id." );
-          _resource_by_stance[ specdata::spec_idx( MONK_MISTWEAVER ) ] = pd->resource();
+          _resource_by_stance[ specdata::spec_idx( MONK_MISTWEAVER ) ] = pd.resource();
           break;
         case 137025:
           assert( _resource_by_stance[ specdata::spec_idx( MONK_WINDWALKER ) ] == RESOURCE_MAX &&
                   "Two power entries per aura id." );
-          _resource_by_stance[ specdata::spec_idx( MONK_WINDWALKER ) ] = pd->resource();
+          _resource_by_stance[ specdata::spec_idx( MONK_WINDWALKER ) ] = pd.resource();
           break;
         default:
           break;

--- a/engine/dbc/client_data.hpp
+++ b/engine/dbc/client_data.hpp
@@ -49,6 +49,17 @@ util::span<const T> find_many( unsigned key, bool ptr, Compare comp = Compare{},
   return util::span<const T>( r.first, r.second );
 }
 
+template <typename T, size_t N, typename U, size_t M, typename Proj>
+const T& find_indexed( unsigned key, util::span<const T, N> data, util::span<const U, M> index, Proj proj )
+{
+  auto it = range::lower_bound( index, key, {}, [ data, &proj ]( auto index ) {
+      return range::invoke( proj, data[ index ] );
+    } );
+  if ( it != index.end() && range::invoke( proj, data[ *it ] ) == key )
+    return data[ *it ];
+  return T::nil();
+}
+
 // "Index" to provide access to a filtered list of dbc data.
 template <typename T, typename Filter>
 class filtered_dbc_index_t

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -131,7 +131,7 @@ namespace hotfix
   struct custom_dbc_data_t
   {
     auto_dispose< std::vector<spell_data_t*> > spells_[ 2 ];
-    auto_dispose< std::vector<spelleffect_data_t*> > effects_[ 2 ];
+    std::vector<spelleffect_data_t*> effects_[ 2 ];
     std::vector<spellpower_data_t*> powers_[ 2 ];
 
     util::bump_ptr_allocator_t<> allocator_;

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -18,6 +18,7 @@
 #include "specialization.hpp"
 #include "sc_enums.hpp"
 #include "util/util.hpp"
+#include "util/allocator.hpp"
 
 #include "dbc/azerite.hpp"
 #include "dbc/rand_prop_points.hpp"
@@ -133,6 +134,8 @@ namespace hotfix
     auto_dispose< std::vector<spell_data_t*> > spells_[ 2 ];
     auto_dispose< std::vector<spelleffect_data_t*> > effects_[ 2 ];
     auto_dispose< std::vector<spellpower_data_t*> > powers_[ 2 ];
+
+    util::bump_ptr_allocator_t<> allocator_;
 
     ~custom_dbc_data_t();
 

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -75,7 +75,6 @@ enum : uint64_t
 // Initialization
 void init();
 void init_item_data();
-void de_init();
 
 // Utility functions
 uint32_t get_school_mask( school_e s );
@@ -137,8 +136,6 @@ namespace hotfix
 
     util::bump_ptr_allocator_t<> allocator_;
     std::unordered_map<unsigned, util::span<const spell_data_t*>> spell_driver_map_[ 2 ];
-
-    ~custom_dbc_data_t();
 
     bool add_spell( spell_data_t* spell, bool ptr = false );
     spell_data_t* get_mutable_spell( unsigned spell_id, bool ptr = false );

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -132,7 +132,7 @@ namespace hotfix
   {
     auto_dispose< std::vector<spell_data_t*> > spells_[ 2 ];
     auto_dispose< std::vector<spelleffect_data_t*> > effects_[ 2 ];
-    auto_dispose< std::vector<spellpower_data_t*> > powers_[ 2 ];
+    std::vector<spellpower_data_t*> powers_[ 2 ];
 
     util::bump_ptr_allocator_t<> allocator_;
     std::unordered_map<unsigned, util::span<const spell_data_t*>> spell_driver_map_[ 2 ];

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -136,6 +136,7 @@ namespace hotfix
     auto_dispose< std::vector<spellpower_data_t*> > powers_[ 2 ];
 
     util::bump_ptr_allocator_t<> allocator_;
+    std::unordered_map<unsigned, util::span<const spell_data_t*>> spell_driver_map_[ 2 ];
 
     ~custom_dbc_data_t();
 

--- a/engine/dbc/generated/item_effect.inc
+++ b/engine/dbc/generated/item_effect.inc
@@ -6615,7 +6615,7 @@ static const std::array<item_effect_t, 6613> __item_effect_data { {
   { 126155, 336586, 181459,   0,   1,    0,      -1,      -1 }, // Drust Trinket
 } };
 
-static constexpr std::array<uint16_t, 6613> __item_effect_id_index { {
+static const std::array<uint16_t, 6613> __item_effect_id_index { {
     169,   170,   171,   172,   173,   174,   177,   178,
     179,   180,   181,   182,   183,   184,   187,   188,
     189,   190,   191,   192,   193,   194,   195,   196,
@@ -7444,3 +7444,4 @@ static constexpr std::array<uint16_t, 6613> __item_effect_id_index { {
      89,    90,    91,    92,    93,    94,    95,    96,
      97,    98,    99,   100,   101,
 } };
+

--- a/engine/dbc/item_effect.cpp
+++ b/engine/dbc/item_effect.cpp
@@ -17,11 +17,6 @@ util::span<const item_effect_t> item_effect_t::data( bool ptr )
 
 /* static */ const item_effect_t& item_effect_t::find( unsigned id, bool ptr )
 {
-  const auto data = item_effect_t::data( ptr );
-  const auto id_index = SC_DBC_GET_DATA( __item_effect_id_index, __ptr_item_effect_id_index, ptr );
-
-  auto it = range::lower_bound( id_index, id, {}, [ data ]( auto index ) { return data[ index ].id; } );
-  if ( it != id_index.end() && data[ *it ].id == id )
-    return data[ *it ];
-  return nil();
+  const auto index = SC_DBC_GET_DATA( __item_effect_id_index, __ptr_item_effect_id_index, ptr );
+  return dbc::find_indexed( id, data( ptr ), index, &item_effect_t::id );
 }

--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -171,20 +171,20 @@ static void generate_indices( bool ptr )
       spell_label_index.add_spell( label.label(), &spell, ptr );
     }
 
-    for ( const spelleffect_data_t* effect : spell.effects() )
+    for ( const spelleffect_data_t& effect : spell.effects() )
     {
-      if ( effect -> subtype() == A_HASTED_CATEGORY )
+      if ( effect.subtype() == A_HASTED_CATEGORY )
       {
-        const unsigned value = as<unsigned>( effect -> misc_value1() );
+        const unsigned value = as<unsigned>( effect.misc_value1() );
         if ( value != 0 )
-          spell_categories_index.add_effect( value, effect, ptr );
+          spell_categories_index.add_effect( value, &effect, ptr );
       }
 
-      if ( effect -> subtype() == A_ADD_PCT_LABEL_MODIFIER )
+      if ( effect.subtype() == A_ADD_PCT_LABEL_MODIFIER )
       {
-        const short value = as<short>( effect -> misc_value2() );
+        const short value = as<short>( effect.misc_value2() );
         if ( value != 0 )
-          spell_label_index.add_effect( value, effect, ptr );
+          spell_label_index.add_effect( value, &effect, ptr );
       }
     }
   }

--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -217,18 +217,6 @@ void dbc::init()
   }
 }
 
-/* De-Initialize database
- */
-void dbc::de_init()
-{
-  spell_data_t::de_link( false );
-
-  if ( SC_USE_PTR )
-  {
-    spell_data_t::de_link( true );
-  }
-}
-
 /* Validate gem color */
 bool dbc::valid_gem_color( unsigned color )
 {

--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -200,14 +200,12 @@ void dbc::init()
   // runtime linking, eg. from spell_data to all its effects
   spell_data_t::link( false );
   spelleffect_data_t::link( false );
-  spellpower_data_t::link( false );
   talent_data_t::link( false );
 
   if ( SC_USE_PTR )
   {
     spell_data_t::link( true );
     spelleffect_data_t::link( true );
-    spellpower_data_t::link( true );
     talent_data_t::link( true );
   }
 

--- a/engine/dbc/sc_const_data.cpp
+++ b/engine/dbc/sc_const_data.cpp
@@ -166,9 +166,9 @@ static void generate_indices( bool ptr )
       spell_categories_index.add_spell( spell.category(), &spell, ptr );
     }
 
-    for ( const spelllabel_data_t* label : spell.labels() )
+    for ( const spelllabel_data_t& label : spell.labels() )
     {
-      spell_label_index.add_spell( label -> label(), &spell, ptr );
+      spell_label_index.add_spell( label.label(), &spell, ptr );
     }
 
     for ( const spelleffect_data_t* effect : spell.effects() )
@@ -301,8 +301,8 @@ std::vector<const spelleffect_data_t*> dbc_t::effect_labels_affecting_spell( con
 {
   std::vector<const spelleffect_data_t*> effects;
 
-  range::for_each( spell -> labels(), [ &effects, this ]( const spelllabel_data_t* label ) {
-    auto label_effects = spell_label_index.affected_by( label -> label(), ptr );
+  range::for_each( spell -> labels(), [ &effects, this ]( const spelllabel_data_t& label ) {
+    auto label_effects = spell_label_index.affected_by( label.label(), ptr );
 
     // Add all effects affecting a specific label to the vector containing all the effects, if the
     // effect is not yet in the vector.

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -660,10 +660,10 @@ spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool 
     clone -> _effects = clone_effects;
   }
 
-  const spellpower_data_t** clone_power = nullptr;
+  spellpower_data_t* clone_power = nullptr;
   if ( source -> power_count() > 0 )
   {
-    clone_power = allocator_.create_n<const spellpower_data_t*>( source -> power_count(), &spellpower_data_t::nil() );
+    clone_power = allocator_.create_n<spellpower_data_t>( source -> power_count(), spellpower_data_t::nil() );
     clone -> _power = clone_power;
   }
 
@@ -726,20 +726,14 @@ spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool 
   const auto source_powers = source -> powers();
   for ( size_t i = 0; i < source_powers.size(); ++i )
   {
-    auto p_source = source_powers[ i ];
-    if ( p_source -> id() == 0 )
+    const auto& p_source = source_powers[ i ];
+    if ( p_source.id() == 0 )
     {
       continue;
     }
 
-    auto p_clone = get_mutable_power( p_source -> id(), ptr );
-    if ( p_clone == nullptr )
-    {
-      p_clone = new spellpower_data_t( spellpower_data_t::find( p_source -> id(), ptr ) );
-      add_power( p_clone, ptr );
-    }
-
-    clone_power[ i ] = p_clone;
+    clone_power[ i ] = spellpower_data_t::find( p_source.id(), ptr );
+    add_power( &clone_power[ i ], ptr );
   }
 
   return clone;

--- a/engine/dbc/sc_item_data.cpp
+++ b/engine/dbc/sc_item_data.cpp
@@ -783,14 +783,14 @@ bool item_database::parse_item_spell_enchant( item_t& item,
       // Handle All stats enchants
       if ( es )
       {
-        for ( const spelleffect_data_t* ed : es -> effects() )
+        for ( const spelleffect_data_t& ed : es -> effects() )
         {
           // All stats is indicated by a misc value of -1
-          if ( ed -> type() == E_APPLY_AURA &&
-               ed -> subtype() == A_MOD_STAT &&
-               ed -> misc_value1() == -1 )
+          if ( ed.type() == E_APPLY_AURA &&
+               ed.subtype() == A_MOD_STAT &&
+               ed.misc_value1() == -1 )
           {
-            stats.emplace_back( STAT_ALL, static_cast<int>( ed -> average( item.player ) ) );
+            stats.emplace_back( STAT_ALL, static_cast<int>( ed.average( item.player ) ) );
             break;
           }
         }

--- a/engine/dbc/sc_spell_info.cpp
+++ b/engine/dbc/sc_spell_info.cpp
@@ -1308,49 +1308,49 @@ std::string spell_info::to_str( const dbc_t& dbc, const spell_data_t* spell, int
   }
   s << "Spell Type       : " << spell_type_str << std::endl;
 
-  for ( const spellpower_data_t* pd : spell -> powers() )
+  for ( const spellpower_data_t& pd : spell -> powers() )
   {
     s << "Resource         : ";
 
-    if ( pd -> type() == POWER_MANA )
-      s << pd -> cost() * 100.0 << "%";
+    if ( pd.type() == POWER_MANA )
+      s << pd.cost() * 100.0 << "%";
     else
-      s << pd -> cost();
+      s << pd.cost();
 
     s << " ";
 
-    if ( pd -> max_cost() != 0 )
+    if ( pd.max_cost() != 0 )
     {
       s << "- ";
-      if ( pd -> type() == POWER_MANA )
-        s << ( pd -> cost() + pd -> max_cost() ) * 100.0 << "%";
+      if ( pd.type() == POWER_MANA )
+        s << ( pd.cost() + pd.max_cost() ) * 100.0 << "%";
       else
-        s << ( pd -> cost() + pd -> max_cost() );
+        s << ( pd.cost() + pd.max_cost() );
       s << " ";
     }
 
-    s << map_string( _resource_strings, pd -> raw_type() );
+    s << map_string( _resource_strings, pd.raw_type() );
 
-    if ( pd -> cost_per_tick() != 0 )
+    if ( pd.cost_per_tick() != 0 )
     {
       s << " and ";
 
-      if ( pd -> type() == POWER_MANA )
-        s << pd -> cost_per_tick() * 100.0 << "%";
+      if ( pd.type() == POWER_MANA )
+        s << pd.cost_per_tick() * 100.0 << "%";
       else
-        s << pd -> cost_per_tick();
+        s << pd.cost_per_tick();
 
-      s << " " << map_string( _resource_strings, pd -> raw_type() ) << " per tick";
+      s << " " << map_string( _resource_strings, pd.raw_type() ) << " per tick";
     }
 
-    s << " (id=" << pd -> id() << ")";
+    s << " (id=" << pd.id() << ")";
 
-    if ( pd -> aura_id() > 0 && dbc.spell( pd -> aura_id() ) -> id() == pd -> aura_id() )
-      s << " w/ " << dbc.spell( pd -> aura_id() ) -> name_cstr() << " (id=" << pd -> aura_id() << ")";
+    if ( pd.aura_id() > 0 && dbc.spell( pd.aura_id() ) -> id() == pd.aura_id() )
+      s << " w/ " << dbc.spell( pd.aura_id() ) -> name_cstr() << " (id=" << pd.aura_id() << ")";
 
-    if ( pd -> _hotfix != 0 )
+    if ( pd._hotfix != 0 )
     {
-      auto hotfix_str = power_hotfix_map_str( dbc, pd );
+      auto hotfix_str = power_hotfix_map_str( dbc, &pd );
       if ( ! hotfix_str.empty() )
       {
         s << " [Hotfixed: " << hotfix_str << "]";
@@ -2071,34 +2071,34 @@ void spell_info::to_xml( const dbc_t& dbc, const spell_data_t* spell, xml_node_t
     }
   }
 
-  for ( const spellpower_data_t* pd : spell -> powers() )
+  for ( const spellpower_data_t& pd : spell -> powers() )
   {
-    if ( pd -> cost() == 0 )
+    if ( pd.cost() == 0 )
       continue;
 
     xml_node_t* resource_node = node -> add_child( "resource" );
-    resource_node -> add_parm( "type", ( signed ) pd -> type() );
+    resource_node -> add_parm( "type", ( signed ) pd.type() );
 
-    if ( pd -> type() == POWER_MANA )
-      resource_node -> add_parm( "cost", spell -> cost( pd -> type() ) * 100.0 );
+    if ( pd.type() == POWER_MANA )
+      resource_node -> add_parm( "cost", spell -> cost( pd.type() ) * 100.0 );
     else
-      resource_node -> add_parm( "cost", spell -> cost( pd -> type() ) );
+      resource_node -> add_parm( "cost", spell -> cost( pd.type() ) );
 
-    if ( _resource_strings.contains( pd -> raw_type() ) )
+    if ( _resource_strings.contains( pd.raw_type() ) )
     {
-      resource_node -> add_parm( "type_name", map_string( _resource_strings, pd -> raw_type() ) );
+      resource_node -> add_parm( "type_name", map_string( _resource_strings, pd.raw_type() ) );
     }
 
-    if ( pd -> type() == POWER_MANA )
+    if ( pd.type() == POWER_MANA )
     {
-      resource_node -> add_parm( "cost_mana_flat", floor( dbc.resource_base( pt, level ) * pd -> cost() ) );
+      resource_node -> add_parm( "cost_mana_flat", floor( dbc.resource_base( pt, level ) * pd.cost() ) );
       resource_node -> add_parm( "cost_mana_flat_level", level );
     }
 
-    if ( pd -> aura_id() > 0 && dbc.spell( pd -> aura_id() ) -> id() == pd -> aura_id() )
+    if ( pd.aura_id() > 0 && dbc.spell( pd.aura_id() ) -> id() == pd.aura_id() )
     {
-      resource_node -> add_parm( "cost_aura_id", pd -> aura_id() );
-      resource_node -> add_parm( "cost_aura_name", dbc.spell( pd -> aura_id() ) -> name_cstr() );
+      resource_node -> add_parm( "cost_aura_id", pd.aura_id() );
+      resource_node -> add_parm( "cost_aura_name", dbc.spell( pd.aura_id() ) -> name_cstr() );
     }
   }
 

--- a/engine/dbc/sc_spell_info.cpp
+++ b/engine/dbc/sc_spell_info.cpp
@@ -1751,16 +1751,12 @@ std::string spell_info::to_str( const dbc_t& dbc, const spell_data_t* spell, int
 
   s << "Effects          :" << std::endl;
 
-  for ( size_t i = 0; i < spell -> effect_count(); i++ )
+  for ( const spelleffect_data_t& e : spell -> effects() )
   {
-    const spelleffect_data_t* e;
-    uint32_t effect_id;
-    if ( ! ( effect_id = spell -> effectN( i + 1 ).id() ) )
+    if ( e.id() == 0 )
       continue;
-    else
-      e = &( spell -> effectN( i + 1 ) );
 
-    spell_info::effect_to_str( dbc, spell, e, s, level );
+    spell_info::effect_to_str( dbc, spell, &e, s, level );
   }
 
   if ( spell -> desc() )
@@ -2181,14 +2177,12 @@ void spell_info::to_xml( const dbc_t& dbc, const spell_data_t* spell, xml_node_t
   xml_node_t* effect_node = node -> add_child( "effects" );
   effect_node -> add_parm( "count", spell -> effect_count() );
 
-  for ( const spelleffect_data_t* e : spell -> effects() )
+  for ( const spelleffect_data_t& e : spell -> effects() )
   {
-    if ( e -> id() == 0 )
+    if ( e.id() == 0 )
       continue;
 
-    e = dbc.effect( e -> id() ); // XXX: Why?
-
-    spell_info::effect_to_xml( dbc, spell, e, effect_node, level );
+    spell_info::effect_to_xml( dbc, spell, &e, effect_node, level );
   }
 
   if ( spell -> desc() )

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -257,8 +257,15 @@ void spelleffect_data_t::link( bool ptr )
 {
   for ( spelleffect_data_t& ed : _data( ptr ) )
   {
-    ed._spell         = spell_data_t::find( ed.spell_id(), ptr );
-    ed._trigger_spell = spell_data_t::find( ed.trigger_spell_id(), ptr );
+    if ( ed.id() == 0 )
+    {
+      ed._spell = ed._trigger_spell = spell_data_t::not_found();
+    }
+    else
+    {
+      ed._spell         = spell_data_t::find( ed.spell_id(), ptr );
+      ed._trigger_spell = spell_data_t::find( ed.trigger_spell_id(), ptr );
+    }
   }
 }
 

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -434,23 +434,14 @@ static auto spell_data_linker(util::span<T, N> data) {
 void spell_data_t::link( bool ptr )
 {
   auto link_power = spell_data_linker( SC_DBC_GET_DATA( __spellpower_index_data, __ptr_spellpower_index_data, ptr ) );
+  auto link_labels = spell_data_linker( SC_DBC_GET_DATA( __spelllabel_index_data, __ptr_spelllabel_index_data, ptr ) );
 
   for ( spell_data_t& sd : data( ptr ) )
   {
     sd._effects = new std::vector<const spelleffect_data_t*>;
 
     link_power( sd._power, sd._power_count );
-  }
-
-  for ( const spelllabel_data_t& label : spelllabel_data_t::data( ptr ) )
-  {
-    auto spell = spell_data_t::find( label.id_spell(), ptr );
-    if ( spell -> _labels == nullptr )
-    {
-      spell -> _labels = new std::vector<const spelllabel_data_t*>();
-    }
-
-    spell -> _labels -> push_back( &label );
+    link_labels( sd._labels, sd._labels_count );
   }
 }
 
@@ -460,7 +451,6 @@ void spell_data_t::de_link( bool ptr )
   {
     delete sd._effects;
     delete sd._driver;
-    delete sd._labels;
   }
 }
 

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -256,17 +256,6 @@ void spelleffect_data_t::link( bool ptr )
   {
     ed._spell         = spell_data_t::find( ed.spell_id(), ptr );
     ed._trigger_spell = spell_data_t::find( ed.trigger_spell_id(), ptr );
-    if ( ed._trigger_spell -> id() > 0 )
-    {
-      if ( ! ed._trigger_spell -> _driver )
-      {
-        ed._trigger_spell -> _driver = new std::vector<spell_data_t*>;
-      }
-      if ( range::find( *ed._trigger_spell -> _driver, ed._spell ) == ed._trigger_spell -> _driver -> end() )
-      {
-        ed._trigger_spell -> _driver -> push_back( ed._spell );
-      }
-    }
 
     if ( ed._spell -> _effects -> size() < ( ed.index() + 1 ) )
       ed._spell -> _effects -> resize( ed.index() + 1, &spelleffect_data_t::nil() );
@@ -434,6 +423,7 @@ static auto spell_data_linker(util::span<T, N> data) {
 void spell_data_t::link( bool ptr )
 {
   auto link_power = spell_data_linker( SC_DBC_GET_DATA( __spellpower_index_data, __ptr_spellpower_index_data, ptr ) );
+  auto link_driver = spell_data_linker( SC_DBC_GET_DATA( __spelldriver_index_data, __ptr_spelldriver_index_data, ptr ) );
   auto link_labels = spell_data_linker( SC_DBC_GET_DATA( __spelllabel_index_data, __ptr_spelllabel_index_data, ptr ) );
 
   for ( spell_data_t& sd : data( ptr ) )
@@ -441,6 +431,7 @@ void spell_data_t::link( bool ptr )
     sd._effects = new std::vector<const spelleffect_data_t*>;
 
     link_power( sd._power, sd._power_count );
+    link_driver( sd._driver, sd._driver_count );
     link_labels( sd._labels, sd._labels_count );
   }
 }
@@ -450,7 +441,6 @@ void spell_data_t::de_link( bool ptr )
   for ( spell_data_t& sd : data( ptr ) )
   {
     delete sd._effects;
-    delete sd._driver;
   }
 }
 

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -244,11 +244,8 @@ double spelleffect_data_t::scaled_max( double avg, double delta ) const
 
 const spelleffect_data_t* spelleffect_data_t::find( unsigned id, bool ptr )
 {
-  const auto __data = data( ptr );
-  auto it = range::lower_bound( __data, id, {}, &spelleffect_data_t::id );
-  if ( it != __data.end() && it->id() == id )
-    return &*it;
-  return &spelleffect_data_t::nil();
+  const auto index = SC_DBC_GET_DATA( __spelleffect_id_index, __ptr_spelleffect_id_index, ptr );
+  return &dbc::find_indexed( id, data( ptr ), index, &spelleffect_data_t::id );
 }
 
 util::span<const spelleffect_data_t> spelleffect_data_t::data( bool ptr )
@@ -420,7 +417,7 @@ static auto spell_data_linker(util::span<T, N> data) {
 
 void spell_data_t::link( bool ptr )
 {
-  auto link_effects = spell_data_linker( SC_DBC_GET_DATA( __spelleffect_index_data, __ptr_spelleffect_index_data, ptr ) );
+  auto link_effects = spell_data_linker( spelleffect_data_t::data( ptr ) );
   auto link_power = spell_data_linker( spellpower_data_t::data() );
   auto link_driver = spell_data_linker( SC_DBC_GET_DATA( __spelldriver_index_data, __ptr_spelldriver_index_data, ptr ) );
   auto link_labels = spell_data_linker( spelllabel_data_t::data( ptr ) );

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -37,6 +37,12 @@ resource_e spellpower_data_t::resource() const
   return util::translate_power_type( type() );
 }
 
+const spellpower_data_t& spellpower_data_t::find( unsigned id, bool ptr )
+{
+  const auto index = SC_DBC_GET_DATA( __spellpower_id_index, __ptr_spellpower_id_index, ptr );
+  return dbc::find_indexed( id, data( ptr ), index, &spellpower_data_t::_id );
+}
+
 util::span<const spellpower_data_t> spellpower_data_t::data( bool ptr )
 {
   return SC_DBC_GET_DATA( __spellpower_data, __ptr_spellpower_data, ptr );
@@ -415,7 +421,7 @@ static auto spell_data_linker(util::span<T, N> data) {
 void spell_data_t::link( bool ptr )
 {
   auto link_effects = spell_data_linker( SC_DBC_GET_DATA( __spelleffect_index_data, __ptr_spelleffect_index_data, ptr ) );
-  auto link_power = spell_data_linker( SC_DBC_GET_DATA( __spellpower_index_data, __ptr_spellpower_index_data, ptr ) );
+  auto link_power = spell_data_linker( spellpower_data_t::data() );
   auto link_driver = spell_data_linker( SC_DBC_GET_DATA( __spelldriver_index_data, __ptr_spelldriver_index_data, ptr ) );
   auto link_labels = spell_data_linker( spelllabel_data_t::data( ptr ) );
 

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -320,8 +320,7 @@ bool spell_data_t::affected_by_label( const spelleffect_data_t& effect ) const
 
 bool spell_data_t::affected_by_label( int label ) const
 {
-  const auto labels = this -> labels();
-  return range::find(labels, label, &spelllabel_data_t::label) != labels.end();
+  return range::contains(labels(), label, &spelllabel_data_t::label);
 }
 
 bool spell_data_t::affected_by( const spell_data_t* spell ) const
@@ -418,7 +417,7 @@ void spell_data_t::link( bool ptr )
   auto link_effects = spell_data_linker( SC_DBC_GET_DATA( __spelleffect_index_data, __ptr_spelleffect_index_data, ptr ) );
   auto link_power = spell_data_linker( SC_DBC_GET_DATA( __spellpower_index_data, __ptr_spellpower_index_data, ptr ) );
   auto link_driver = spell_data_linker( SC_DBC_GET_DATA( __spelldriver_index_data, __ptr_spelldriver_index_data, ptr ) );
-  auto link_labels = spell_data_linker( SC_DBC_GET_DATA( __spelllabel_index_data, __ptr_spelllabel_index_data, ptr ) );
+  auto link_labels = spell_data_linker( spelllabel_data_t::data( ptr ) );
 
   for ( spell_data_t& sd : _data( ptr ) )
   {

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -443,7 +443,7 @@ struct spell_data_t
   const spelleffect_data_t* const* _effects;
   const spellpower_data_t* const* _power;
   const spell_data_t* const* _driver; // The triggered spell's driver(s)
-  const spelllabel_data_t* const* _labels; // Applied (known) labels to the spell
+  const spelllabel_data_t* _labels; // Applied (known) labels to the spell
 
   uint8_t _effects_count;
   uint8_t _power_count;
@@ -630,7 +630,7 @@ struct spell_data_t
   {
     const auto labels = this -> labels();
     if ( idx > 0 && idx <= labels.size() )
-      return labels[ idx - 1 ] -> label();
+      return labels[ idx - 1 ].label();
     return 0;
   }
 
@@ -658,7 +658,7 @@ struct spell_data_t
     return { _power, _power_count };
   }
 
-  util::span<const spelllabel_data_t* const> labels() const
+  util::span<const spelllabel_data_t> labels() const
   {
     assert( _labels != nullptr || _labels_count == 0 );
     return { _labels, _labels_count };

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -443,9 +443,10 @@ struct spell_data_t
   std::vector<const spelleffect_data_t*>* _effects;
   const spellpower_data_t* const* _power;
   std::vector<spell_data_t*>* _driver; // The triggered spell's driver(s)
-  std::vector<const spelllabel_data_t*>* _labels; // Applied (known) labels to the spell
+  const spelllabel_data_t* const* _labels; // Applied (known) labels to the spell
 
   uint8_t _power_count;
+  uint8_t _labels_count;
 
   unsigned equipped_class() const
   { return _equipped_class; }
@@ -579,7 +580,7 @@ struct spell_data_t
   { return _driver ? _driver -> size() : 0; }
 
   size_t label_count() const
-  { return _labels ? _labels -> size() : 0; }
+  { return _labels_count; }
 
   bool found() const
   { return ( this != not_found() ); }
@@ -657,9 +658,8 @@ struct spell_data_t
 
   util::span<const spelllabel_data_t* const> labels() const
   {
-    if ( _labels )
-      return *_labels;
-    return {};
+    assert( _labels != nullptr || _labels_count == 0 );
+    return { _labels, _labels_count };
   }
 
   util::span<const spell_data_t* const> drivers() const

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -439,7 +439,7 @@ struct spell_data_t
   unsigned    _dmg_class;          // 47 SpellCategories.db2 classification for the spell
 
   // Pointers for runtime linking
-  const spelleffect_data_t* const* _effects;
+  const spelleffect_data_t* _effects;
   const spellpower_data_t* _power;
   const spell_data_t* const* _driver; // The triggered spell's driver(s)
   const spelllabel_data_t* _labels; // Applied (known) labels to the spell
@@ -609,7 +609,7 @@ struct spell_data_t
 
     assert( idx <= effect_count() && "effect index out of bound!" );
 
-    return *( effects()[ idx - 1 ] );
+    return effects()[ idx - 1 ];
   }
 
   const spellpower_data_t& powerN( size_t idx ) const
@@ -645,7 +645,7 @@ struct spell_data_t
     return spellpower_data_t::nil();
   }
 
-  util::span<const spelleffect_data_t* const> effects() const
+  util::span<const spelleffect_data_t> effects() const
   {
     assert( _effects != nullptr || _effects_count == 0 );
     return { _effects, _effects_count };
@@ -729,7 +729,7 @@ struct spell_data_t
   uint32_t effect_id( uint32_t effect_num ) const
   {
     assert( effect_num >= 1 && effect_num <= effect_count() );
-    return effects()[ effect_num - 1 ] -> id();
+    return effects()[ effect_num - 1 ].id();
   }
 
   bool flags( spell_attribute attr ) const

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -129,8 +129,7 @@ struct spellpower_data_t
   static const spellpower_data_t& nil()
   { return dbc::nil<spellpower_data_t>; }
 
-  static const spellpower_data_t& find( unsigned id, bool ptr = false )
-  { return dbc::find<spellpower_data_t>( id, ptr, &spellpower_data_t::_id ); }
+  static const spellpower_data_t& find( unsigned id, bool ptr = false );
 
   static util::span<const spellpower_data_t> data( bool ptr = false );
 
@@ -441,7 +440,7 @@ struct spell_data_t
 
   // Pointers for runtime linking
   const spelleffect_data_t* const* _effects;
-  const spellpower_data_t* const* _power;
+  const spellpower_data_t* _power;
   const spell_data_t* const* _driver; // The triggered spell's driver(s)
   const spelllabel_data_t* _labels; // Applied (known) labels to the spell
 
@@ -620,7 +619,7 @@ struct spell_data_t
     {
       assert( idx > 0 && idx <= powers.size() );
 
-      return *( powers[ idx - 1 ] );
+      return powers[ idx - 1 ];
     }
 
     return spellpower_data_t::nil();
@@ -637,10 +636,10 @@ struct spell_data_t
   const spellpower_data_t& powerN( power_e pt ) const
   {
     assert( pt >= POWER_HEALTH && pt < POWER_MAX );
-    for ( const spellpower_data_t* pd : powers() )
+    for ( const spellpower_data_t& pd : powers() )
     {
-      if ( pd -> _power_type == pt )
-        return *pd;
+      if ( pd._power_type == pt )
+        return pd;
     }
 
     return spellpower_data_t::nil();
@@ -652,7 +651,7 @@ struct spell_data_t
     return { _effects, _effects_count };
   }
 
-  util::span<const spellpower_data_t* const> powers() const
+  util::span<const spellpower_data_t> powers() const
   {
     assert( _power != nullptr || _power_count == 0 );
     return { _power, _power_count };
@@ -718,10 +717,10 @@ struct spell_data_t
 
   double cost( power_e pt ) const
   {
-    for ( const spellpower_data_t* pd : powers() )
+    for ( const spellpower_data_t& pd : powers() )
     {
-      if ( pd -> _power_type == pt )
-        return pd -> cost();
+      if ( pd._power_type == pt )
+        return pd.cost();
     }
 
     return 0.0;

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -442,10 +442,11 @@ struct spell_data_t
   // Pointers for runtime linking
   std::vector<const spelleffect_data_t*>* _effects;
   const spellpower_data_t* const* _power;
-  std::vector<spell_data_t*>* _driver; // The triggered spell's driver(s)
+  const spell_data_t* const* _driver; // The triggered spell's driver(s)
   const spelllabel_data_t* const* _labels; // Applied (known) labels to the spell
 
   uint8_t _power_count;
+  uint8_t _driver_count;
   uint8_t _labels_count;
 
   unsigned equipped_class() const
@@ -577,7 +578,7 @@ struct spell_data_t
   { return _power_count; }
 
   size_t driver_count() const
-  { return _driver ? _driver -> size() : 0; }
+  { return _driver_count; }
 
   size_t label_count() const
   { return _labels_count; }
@@ -664,9 +665,8 @@ struct spell_data_t
 
   util::span<const spell_data_t* const> drivers() const
   {
-    if ( _driver ) // explicit for gcc & msvc because of extra cv
-      return { _driver -> data(), _driver -> size() };
-    return {};
+    assert( _driver != nullptr || _driver_count == 0 );
+    return { _driver, _driver_count };
   }
 
   bool is_class( player_e c ) const;

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -133,7 +133,6 @@ struct spellpower_data_t
   { return dbc::find<spellpower_data_t>( id, ptr, &spellpower_data_t::_id ); }
 
   static util::span<const spellpower_data_t> data( bool ptr = false );
-  static void link( bool ptr = false );
 
   bool override_field( util::string_view field, double value );
   double get_field( util::string_view field ) const;
@@ -442,9 +441,11 @@ struct spell_data_t
 
   // Pointers for runtime linking
   std::vector<const spelleffect_data_t*>* _effects;
-  std::vector<const spellpower_data_t*>*  _power;
+  const spellpower_data_t* const* _power;
   std::vector<spell_data_t*>* _driver; // The triggered spell's driver(s)
   std::vector<const spelllabel_data_t*>* _labels; // Applied (known) labels to the spell
+
+  uint8_t _power_count;
 
   unsigned equipped_class() const
   { return _equipped_class; }
@@ -572,7 +573,7 @@ struct spell_data_t
   { assert( _effects ); return _effects -> size(); }
 
   size_t power_count() const
-  { return _power ? _power -> size() : 0; }
+  { return _power_count; }
 
   size_t driver_count() const
   { return _driver ? _driver -> size() : 0; }
@@ -650,9 +651,8 @@ struct spell_data_t
 
   util::span<const spellpower_data_t* const> powers() const
   {
-    if ( _power )
-      return *_power;
-    return {};
+    assert( _power != nullptr || _power_count == 0 );
+    return { _power, _power_count };
   }
 
   util::span<const spelllabel_data_t* const> labels() const

--- a/engine/player/sc_consumable.cpp
+++ b/engine/player/sc_consumable.cpp
@@ -858,14 +858,14 @@ struct food_t : public dbc_consumable_base_t
     }
 
     // Find the "Well Fed" buff from the base food
-    for ( const spelleffect_data_t* effect : driver -> effects() )
+    for ( const spelleffect_data_t& effect : driver -> effects() )
     {
       // Return the "Well Fed" effect of the food (might not always be named well fed)
-      if ( effect -> type() == E_APPLY_AURA &&
-           effect -> subtype() == A_PERIODIC_TRIGGER_SPELL &&
-           effect -> period() == timespan_t::from_millis( 10000 ) )
+      if ( effect.type() == E_APPLY_AURA &&
+           effect.subtype() == A_PERIODIC_TRIGGER_SPELL &&
+           effect.period() == timespan_t::from_millis( 10000 ) )
       {
-        return effect -> trigger();
+        return effect.trigger();
       }
     }
 

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -1521,15 +1521,15 @@ void player_t::init_base_stats()
     // Automatically parse mana regen and max mana modifiers from class passives.
     for ( auto spell : dbc::class_passives( this ) )
     {
-      for ( auto effect : spell->effects() )
+      for ( const spelleffect_data_t& effect : spell->effects() )
       {
-        if ( effect->subtype() == A_MOD_MANA_REGEN_PCT )
+        if ( effect.subtype() == A_MOD_MANA_REGEN_PCT )
         {
-          resources.base_regen_per_second[ RESOURCE_MANA ] *= 1.0 + effect->percent();
+          resources.base_regen_per_second[ RESOURCE_MANA ] *= 1.0 + effect.percent();
         }
-        if ( effect->subtype() == A_MOD_MAX_MANA_PCT || effect->subtype() == A_MOD_MANA_POOL_PCT )
+        if ( effect.subtype() == A_MOD_MAX_MANA_PCT || effect.subtype() == A_MOD_MANA_POOL_PCT )
         {
-          resources.base[ RESOURCE_MANA ] *= 1.0 + effect->percent();
+          resources.base[ RESOURCE_MANA ] *= 1.0 + effect.percent();
         }
       }
     }

--- a/engine/sc_main.cpp
+++ b/engine/sc_main.cpp
@@ -202,14 +202,6 @@ std::string get_cache_directory()
   return s;
 }
 
-// RAII-wrapper for dbc init / de-init
-struct dbc_initializer_t {
-  dbc_initializer_t()
-  { dbc::init(); }
-  ~dbc_initializer_t()
-  { dbc::de_init(); }
-};
-
 // RAII-wrapper for http cache load / save
 struct cache_initializer_t {
   cache_initializer_t( const std::string& fn ) :
@@ -262,7 +254,7 @@ int sim_t::main( const std::vector<std::string>& args )
 #if !defined( SC_NO_NETWORKING )
     apitoken_initializer_t apitoken_init;
 #endif
-    dbc_initializer_t dbc_init;
+    dbc::init();
     module_t::init();
     unique_gear::register_hotfixes();
 

--- a/engine/util/allocator.hpp
+++ b/engine/util/allocator.hpp
@@ -1,0 +1,112 @@
+// ==========================================================================
+// Dedmonwakeen's Raid DPS/TPS Simulator.
+// Send questions to natehieter@gmail.com
+// ==========================================================================
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <vector>
+
+namespace util {
+
+// Allocates memory in an ever-growing pool
+//
+// Not strictly a true bump-pointer allocator as it uses backing pages instead
+// of a boundless contigous heap. However, it is semantically pretty much equivalent
+// as it uses a monotonically growing pool of memory.
+//
+// PageSize is the size of a single page.
+//
+// Allocating objects that do not fit a single page is a hard error, there is no
+// separate allocation path for such cases. It is caught at compile time for the
+// single object allocation case but only at runtime for the multi-object case.
+template <size_t PageSize = 4096>
+class bump_ptr_allocator_t
+{
+  static constexpr size_t PageAlignment = alignof(std::max_align_t);
+public:
+  bump_ptr_allocator_t() noexcept = default;
+
+  bump_ptr_allocator_t(const bump_ptr_allocator_t&) = delete;
+  bump_ptr_allocator_t& operator=(const bump_ptr_allocator_t&) = delete;
+
+  // XXX: we could easily make it at least move-contructible /shrug
+  bump_ptr_allocator_t(bump_ptr_allocator_t&&) = delete;
+  bump_ptr_allocator_t& operator=(bump_ptr_allocator_t&&) = delete;
+
+  template <typename T>
+  void* allocate() {
+    static_assert(fits_in_page(sizeof(T), alignof(T)), "The object does not fit in a single page.");
+
+    return allocate(sizeof(T), alignof(T));
+  }
+
+  template <typename T>
+  void* allocate(size_t n) {
+    static_assert(fits_in_page(sizeof(T), alignof(T)), "Even a single object does not fit in a single page.");
+
+    if (fits_in_page(sizeof(T) * n, alignof(T)))
+      return allocate(sizeof(T) * n, alignof(T));
+
+    throw std::bad_alloc();
+  }
+
+  // helpers for "fused" allocation + construction
+  template <typename T, typename... Args>
+  T* create(Args&&... args) {
+    return ::new(allocate<T>()) T(std::forward<Args>(args)...);
+  }
+
+  template <typename T>
+  T* create_n(size_t n, const T& value = {}) {
+    T* p = reinterpret_cast<T*>(allocate<T>(n));
+    std::uninitialized_fill_n(p, n, value);
+    return p;
+  }
+
+private:
+  struct page_t {
+    alignas(PageAlignment) char data[PageSize];
+    page_t() noexcept {}
+  };
+
+  void* allocate(size_t size, size_t alignment) {
+    assert(fits_in_page(size, alignment) && "The allocation does not fit in a single page");
+
+    if (std::align(alignment, size, current_, size_))
+        return finalize_allocation(size);
+
+    allocate_page();
+    std::align(alignment, size, current_, size_);
+    return finalize_allocation(size);
+  }
+
+  void* finalize_allocation(size_t size) {
+    void* result = current_;
+    current_ = static_cast<char*>(current_) + size;
+    size_ -= size;
+    return result;
+  }
+
+  void allocate_page() {
+    pages_.push_back(std::make_unique<page_t>());
+    current_ = pages_.back()->data;
+    size_ = PageSize;
+  }
+
+  static constexpr bool fits_in_page(size_t size, size_t alignment) {
+    if (alignment <= PageAlignment)
+      return size <= PageSize;
+    return size <= PageSize - alignment + PageAlignment;
+  }
+
+  void* current_ = nullptr; // current pointer inside the page
+  size_t size_ = 0; // number of bytes left in the page
+  std::vector<std::unique_ptr<page_t>> pages_;
+};
+
+} // namespace util

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -134,8 +134,6 @@ int main( int argc, char *argv[] )
 
   auto ret = a.exec();
 
-  dbc::de_init();
-
   #ifndef SC_NO_NETWORKING
   bcp_api::token_save();
   #endif

--- a/source_files/QT_engine.pri
+++ b/source_files/QT_engine.pri
@@ -141,6 +141,7 @@ HEADERS += engine/sim/sim_control.hpp
 HEADERS += engine/sim/sim_ostream.hpp
 HEADERS += engine/sim/uptime.hpp
 HEADERS += engine/simulationcraft.hpp
+HEADERS += engine/util/allocator.hpp
 HEADERS += engine/util/cache.hpp
 HEADERS += engine/util/chrono.hpp
 HEADERS += engine/util/concurrency.hpp

--- a/source_files/VS_engine.props
+++ b/source_files/VS_engine.props
@@ -145,6 +145,7 @@ To change the list of source files run synchronize.py
 		<ClInclude Include="..\engine\sim\sim_ostream.hpp" />
 		<ClInclude Include="..\engine\sim\uptime.hpp" />
 		<ClInclude Include="..\engine\simulationcraft.hpp" />
+		<ClInclude Include="..\engine\util\allocator.hpp" />
 		<ClInclude Include="..\engine\util\cache.hpp" />
 		<ClInclude Include="..\engine\util\chrono.hpp" />
 		<ClInclude Include="..\engine\util\concurrency.hpp" />

--- a/source_files/cmake_engine.txt
+++ b/source_files/cmake_engine.txt
@@ -139,6 +139,7 @@ sim/sim_control.hpp
 sim/sim_ostream.hpp
 sim/uptime.hpp
 simulationcraft.hpp
+util/allocator.hpp
 util/cache.hpp
 util/chrono.hpp
 util/concurrency.hpp


### PR DESCRIPTION
Generate per-spell spell power/label/effect/driver "arrays" during spell data export generation.

Specifically we generate array of pointers to relevant struct sorted by (parent_spell_id, index/id) tuple and store the record counts in each exported spell. Linking then is a simple matter of "slicing" the pointer arrays using the counts and a running index.

While it somewhat complicates SpellDataGenerator we get several benefits on the c++ side:
  * one less indirection on access to the records through a spell
  * no dynamic memory allocations in init
  * in the end we get to slap const on a bunch of pointers
  * no need to "deinit" spell data

While this increases binary size a bit we should have less memory consumption overall (not like this is a major source of memory allocations in the sim, so meh).
```
nuohep@r2d2:~/dev/simc> bloaty -d symbols -n 5 build-optimized/simc.HEAD -- build-optimized/simc.b4326944e6
    FILE SIZE        VM SIZE
 --------------  --------------
  [NEW]  +179Ki  [NEW]  +179Ki    __spelleffect_index_data
  +2.3%  +123Ki  +2.3%  +123Ki    __spell_data
  [NEW] +31.7Ki  [NEW] +31.6Ki    __spelllabel_index_data
  [NEW] +31.6Ki  [NEW] +31.5Ki    __spelldriver_index_data
  [NEW] +4.75Ki  [NEW] +4.67Ki    __spellpower_index_data
  -0.2% -16.3Ki  -0.2% -15.5Ki    [3307 Others]
  +0.9%  +354Ki  +1.0%  +354Ki    TOTAL
```

Runtime-wise this is a *very* slight speedup (at least for my setup here with all the usual caveats). `profiles/CI.simc deterministic=1 iterations=2000` compiled by clang-10 `-O3 -flto-thin -ffast-math` comparing `WallSeconds`.
```
nuohep@r2d2:~/dev/simc> ministat -q wall-b4326944e6.csv wall-HEAD.csv
x wall-b4326944e6.csv
+ wall-HEAD.csv
    N           Min           Max        Median           Avg        Stddev
x 500     11.412602     14.173276     11.574831     11.590959    0.14507114
+ 500     11.355447     13.196773     11.478599     11.493844     0.1127418
Difference at 95.0% confidence
        -0.0971155 +/- 0.0161046
        -0.837855% +/- 0.138941%
        (Student's t, pooled s = 0.129916)
```