### PR TITLE
Drastically (5-10%) improve performance by eliding to_string call when debug logging is disabled.

### DIFF
--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -5069,7 +5069,10 @@ void player_t::reset()
   // Restore default target
   target = default_target;
 
-  sim->print_debug( "{} resets current stats ( reset to initial ): {}", *this, current.to_string() );
+  if ( sim->debug )
+  {
+    sim->print_debug( "{} resets current stats ( reset to initial ): {}", *this, current.to_string() );
+  }
 
   for ( auto& buff : buff_list )
     buff->reset();


### PR DESCRIPTION
I had started doing some performance analysis on simc last year, but got sidetracked and left it on the ground (besides one small PR). Now that I have some more time and interest, the number one low hanging fruit on my list is debug logging.

The common pattern for debug logging in simc is:

```c++
sim->print_debug( "my object {} with field {} and field {} and field {}", name(), other_function, other_field, ... );
```

And in various places the pattern of first checking if `sim->debug()` is true has been adopted (as in this CL)
```c++
  if ( sim->debug )
  {
    sim->print_debug( "my object {} with field {} and field {} and field {}", name(), other_function, other_field, ... );
  }
```

The issue with the former pattern is that all the functions that feed into the log message are evaluated regardless of whether we're actually going to log or not. This might not seem like a big deal, but some of these functions are called thousands or millions of times per run and there are numerous functions that call `print_debug`.

It's unfortunately a bit hard to quantify the total CPU that would be saved by moving all calls to the latter pattern because the wasted calls are not trivially associated with the print_debug statement in most perf tools (I'm working on this).  That being said, the following change addresses the most egregious of these calls to print_debug where in some of my sample sims it was consuming >10% of the total CPU.

I have plans to propose larger scale changes to how logging is done to improve on this point, but the savings in this instance is so large I just wanted to get it in. 

FWIW the problematic print_debug was the second one, but I figured I'd change both while I'm changing this function.

Note: CPU includes the function and all child functions.
(Resolution is a bit funky, just click and enlarge the images)
Windows (NDEBUG Release) - VS Profiler Warlock (11.18% total CPU)
![to_string_cpu_usage_warlock](https://user-images.githubusercontent.com/1725187/88268231-1e18d900-cca0-11ea-867a-9acf432c1cfa.png)
Windows (NDEBUG Release) DH - VS Profiler (4.28% total CPU)
![to_string_cpu_usage](https://user-images.githubusercontent.com/1725187/88268201-122d1700-cca0-11ea-9faa-9aa32d0c03e0.png)
Linux (gcc, optimized LTO) warlock patchwerk sim - Valgrind (callgrind) (9.33% total CPU)
![to_string](https://user-images.githubusercontent.com/1725187/88268121-f0cc2b00-cc9f-11ea-88f0-47d24fba7f2c.png)

Fixed Windows (NDEBUG Release) Warlock - VS Profiler (0.00% total CPU)
![fixed_to_string](https://user-images.githubusercontent.com/1725187/88269361-e317a500-cca1-11ea-922d-0d971b298c6e.png)
Fixed Linux (gcc, optimized LTO) warlock patchwerk - Valgrind (callgrind) (0.21% total CPU)
![fixed_player_t_to_string_cpu](https://user-images.githubusercontent.com/1725187/88271112-b4e79480-cca4-11ea-9395-1d689921ed7f.png)

