### PR TITLE
[DBC] export max spell targets

### DIFF
--- a/SpellDataDump/deathknight.txt
+++ b/SpellDataDump/deathknight.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Dual Wield (desc=Passive) (id=674) [Passive] 
 Class            : Frost Warrior, Hunter, Rogue, Death Knight, Monk, Demon Hunter
@@ -7343,6 +7343,7 @@ Class            : Death Knight
 School           : Shadow
 Spell Type       : None
 Resource         : 30 Runic Power (6) (id=11019)
+Max Targets      : 20
 GCD              : 1.5 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Sudden Doom (81340 effect#1)
@@ -7691,6 +7692,7 @@ Class            : Death Knight
 School           : Shadow
 Spell Type       : Magic
 Range            : 100 yards
+Max Targets      : 7
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Mastery: Dreadblade (77515 effect#1), Sudden Doom (81340 effect#1), Frost Death Knight (137006 effect#1), Unholy Death Knight (137007 effect#1), Blood Death Knight (137008 effect#1), Master of Ghouls (246995 effect#1), 
 Family Flags     : 43, 78, 121
@@ -12737,6 +12739,7 @@ Class            : Death Knight
 School           : Shadow
 Spell Type       : Magic
 Range            : 20 yards
+Max Targets      : 1
 Labels           : 16: Agonizing Backlash (320035 effect#3)
                  : 1062: Brutal Grasp (338651 effect#1)
 Mechanic         : Grip

--- a/SpellDataDump/demonhunter.txt
+++ b/SpellDataDump/demonhunter.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Dual Wield (desc=Passive) (id=674) [Passive] 
 Class            : Frost Warrior, Hunter, Rogue, Death Knight, Monk, Demon Hunter
@@ -3512,6 +3512,7 @@ School           : Shadow
 Spell Type       : Magic
 Spell Level      : 34
 Range            : 20 yards
+Max Targets      : 1
 GCD              : 1.5 seconds
 Duration         : 60 seconds
 Cooldown         : 45 seconds

--- a/SpellDataDump/druid.txt
+++ b/SpellDataDump/druid.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Incapacitating Roar (id=99) [Spell Family (7)] 
 Class            : Guardian Druid
@@ -1383,6 +1383,7 @@ Spell Type       : Magic
 Resource         : 8% Base Mana (0) (id=1447)
 Spell Level      : 20
 Range            : 40 yards
+Max Targets      : 1
 GCD              : 1.5 seconds
 Duration         : 15 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -3694,6 +3695,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 40 yards
+Max Targets      : 1
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ........ ........ ........ ........   ........ ..x..... ........ ........ 
                  : ........ ........ ........ .....x..   ........ ........ ........ ......x. 
@@ -3733,6 +3735,7 @@ School           : Physical
 Spell Type       : None
 Spell Level      : 19
 Range            : 40 yards
+Max Targets      : 1
 Velocity         : 20 yards/sec
 Duration         : 3600 seconds
 Cooldown         : 30 seconds
@@ -4601,6 +4604,7 @@ Class            : Druid
 School           : Nature
 Spell Type       : Magic
 Range            : 40 yards
+Max Targets      : 60
 Duration         : 8 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Stacks           : 5 maximum
@@ -11536,6 +11540,7 @@ School           : Arcane
 Spell Type       : None
 Resource         : 2% Base Mana (0) (id=192730)
 Range            : 40 yards
+Max Targets      : 1
 Cast Time        : 2.5 seconds
 GCD              : 1.5 seconds
 Duration         : 3600 seconds

--- a/SpellDataDump/hunter.txt
+++ b/SpellDataDump/hunter.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Auto Shot (id=75) [Spell Family (9)] 
 Class            : Hunter
@@ -314,6 +314,7 @@ Spell Type       : Ranged
 Resource         : 40 Focus (2) (id=11195)
 Spell Level      : 29
 Range            : 40 yards
+Max Targets      : 5
 GCD              : 1.5 seconds
 Velocity         : 50 yards/sec
 Requires weapon  : Bow, Gun, Crossbow
@@ -2379,6 +2380,7 @@ Class            : Hunter
 School           : Physical
 Spell Type       : Melee
 Range            : 5 yards
+Max Targets      : 5
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Family Flags     : 111
 Attributes       : ....x... ........ ..x..... ........   ........ ........ ........ ........ 
@@ -2449,6 +2451,7 @@ School           : Physical
 Spell Type       : Ranged
 Spell Level      : 1
 Range            : 50 yards
+Max Targets      : 8
 Requires weapon  : Bow, Gun, Crossbow
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Freezing Trap (3355 effect#2), Bestial Wrath (19574 effect#1), Mortal Shots (36413 effect#1), Beast Mastery Hunter (137015 effect#1), Marksmanship Hunter (137016 effect#1), Survival Hunter (137017 effect#1), Lone Wolf (155228 effect#1), Mastery: Sniper Training (193468 effect#1), Aspect of the Wild (193530 effect#1), Unseen Predator's Cloak (248212 effect#1), Thrill of the Hunt (257946 effect#1), Coordinated Assault (266779 effect#1), 
@@ -4028,6 +4031,7 @@ Spell Type       : Melee
 Resource         : 35 Focus (2) (id=10219)
 Spell Level      : 29
 Range            : 8 yards
+Max Targets      : 5
 GCD              : 1.5 seconds
 Requires weapon  : Two-handed Axe, Two-handed Mace, Polearm, Two-handed Sword, Staff
 Cooldown         : 6 seconds
@@ -4987,6 +4991,7 @@ Spell Type       : Melee
 Resource         : 30 Focus (2) (id=191496)
 Spell Level      : 1
 Range            : 8 yards
+Max Targets      : 5
 GCD              : 1.5 seconds
 Requires weapon  : Two-handed Axe, Two-handed Mace, Polearm, Two-handed Sword, Staff
 Charges          : 3 (9 seconds cooldown)
@@ -5019,6 +5024,7 @@ School           : Fire
 Spell Type       : Ranged
 Spell Level      : 1
 Range            : 100 yards
+Max Targets      : 6
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Freezing Trap (3355 effect#2), Bestial Wrath (19574 effect#1), Mortal Shots (36413 effect#1), Beast Mastery Hunter (137015 effect#1), Marksmanship Hunter (137016 effect#1), Survival Hunter (137017 effect#1), Lone Wolf (155228 effect#1), Mastery: Sniper Training (193468 effect#2), Aspect of the Wild (193530 effect#1), Unseen Predator's Cloak (248212 effect#1), Thrill of the Hunt (257946 effect#1), Coordinated Assault (266779 effect#1), 
 Family Flags     : 73, 106
@@ -5537,6 +5543,7 @@ Spell Type       : Ranged
 Resource         : 15 Focus (2) (id=12491)
 Spell Level      : 29
 Range            : 40 yards
+Max Targets      : 5
 GCD              : 1.5 seconds
 Velocity         : 50 yards/sec
 Requires weapon  : Bow, Gun, Crossbow

--- a/SpellDataDump/mage.txt
+++ b/SpellDataDump/mage.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Invisibility (id=66) [Spell Family (3)] 
 Class            : Paladin, Mage
@@ -1864,6 +1864,7 @@ School           : Frost
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 100 yards
+Max Targets      : 10
 Duration         : 10 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Proc Chance      : 101%
@@ -2426,6 +2427,7 @@ Spell Type       : Magic
 Resource         : 1.5% Base Mana (0) (id=5675)
 Spell Level      : 1
 Range            : 40 yards
+Max Targets      : 1
 GCD              : 1.5 seconds
 Duration         : 12 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -9248,6 +9250,7 @@ School           : Arcane
 Spell Type       : None
 Resource         : 2% Base Mana (0) (id=192604)
 Range            : 40 yards
+Max Targets      : 1
 Duration         : 1800 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Stacks           : 1 maximum
@@ -9272,6 +9275,7 @@ Class            : Mage
 School           : Arcane
 Spell Type       : None
 Range            : 40 yards
+Max Targets      : 1
 Duration         : 10 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Stacks           : 1 maximum
@@ -9376,6 +9380,7 @@ Spell Type       : None
 Resource         : 5% Base Mana (0) (id=192607)
 Spell Level      : 37
 Range            : 40 yards
+Max Targets      : 1
 Cast Time        : 1.5 seconds
 GCD              : 1.5 seconds
 Cooldown         : 45 seconds
@@ -9824,6 +9829,7 @@ Class            : Mage
 School           : Arcane
 Spell Type       : None
 Range            : 40 yards
+Max Targets      : 1
 Duration         : 10 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Stacks           : 8 maximum

--- a/SpellDataDump/monk.txt
+++ b/SpellDataDump/monk.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Dual Wield (desc=Passive) (id=674) [Passive] 
 Class            : Frost Warrior, Hunter, Rogue, Death Knight, Monk, Demon Hunter
@@ -849,6 +849,7 @@ Resource         : 20 Energy (3) (id=6420) w/ Stagger (id=115069)
 Resource         : 20 Energy (3) (id=6421) w/ Windwalker Monk (id=137025)
 Spell Level      : 22
 Range            : 20 yards
+Max Targets      : 1
 GCD              : 1.5 seconds
 Duration         : 60 seconds
 Cooldown         : 45 seconds
@@ -908,6 +909,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 7
 Range            : 10 yards
+Max Targets      : 1
 Velocity         : 20 yards/sec
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Family Flags     : 74
@@ -2594,6 +2596,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 50000 yards
+Max Targets      : 3
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Xuen's Bond (336616 effect#1)
 Triggered by     : Crackling Tiger Lightning Driver (123999)
@@ -2763,6 +2766,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 50000 yards
+Max Targets      : 1
 Velocity         : 20 yards/sec
 Duration         : 6 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -2938,6 +2942,7 @@ School           : Physical
 Spell Type       : None
 Spell Level      : 1
 Range            : 50000 yards
+Max Targets      : 1
 Duration         : 10 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ........ x....... ........ ........   ........ ........ ........ ........ 
@@ -4344,6 +4349,7 @@ Class            : Monk
 School           : Nature
 Spell Type       : Melee
 Range            : 100 yards
+Max Targets      : 2
 Duration         : 8 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Brewmaster Monk (137023 effect#1), Windwalker Monk (137025 effect#1), Serenity (152173 effect#2), Extend Life (185158 effect#2), Hit Combo (196741 effect#1), The Wind Blows (281452 effect#1), Extend Life (337993 effect#2)
@@ -5296,6 +5302,7 @@ Class            : Monk
 School           : Physical
 Spell Type       : None
 Spell Level      : 1
+Max Targets      : 5
 Duration         : 15 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Stacks           : 5 maximum
@@ -5394,6 +5401,7 @@ School           : Physical
 Spell Type       : None
 Spell Level      : 1
 Range            : 100 yards
+Max Targets      : 5
 Duration         : 15 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -8761,6 +8769,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 100 yards
+Max Targets      : 1
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ .x...... .....x..   ........ ........ ........ ........ 

--- a/SpellDataDump/paladin.txt
+++ b/SpellDataDump/paladin.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Haste (id=65) [Scaling Spell (-1)] 
 Class            : Paladin
@@ -398,6 +398,7 @@ Spell Type       : Magic
 Resource         : 6% Base Mana (0) (id=816)
 Spell Level      : 1
 Range            : 30 yards
+Max Targets      : 1
 Cast Time        : 1.7 seconds
 GCD              : 1.5 seconds
 Duration         : 60 seconds
@@ -1677,6 +1678,7 @@ Spell Type       : Melee
 Resource         : 3 Holy Power (9) (id=3982)
 Spell Level      : 10
 Range            : 5 yards
+Max Targets      : Unlimited(-1)
 GCD              : 1.5 seconds
 Requires weapon  : Two-handed Axe, Two-handed Mace, Polearm, Two-handed Sword, Staff
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -4397,6 +4399,7 @@ School           : Holy
 Spell Type       : Melee
 Resource         : 5 Holy Power (9) (id=11251)
 Range            : 5 yards
+Max Targets      : Unlimited(-1)
 GCD              : 1.5 seconds
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -4655,6 +4658,7 @@ Class            : Paladin
 School           : Holy
 Spell Type       : Melee
 Range            : 100 yards
+Max Targets      : Unlimited(-1)
 Requires weapon  : Two-handed Axe, Two-handed Mace, Polearm, Two-handed Sword, Staff
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Avenging Wrath (31884 effect#1), Inquisition (84963 effect#1), Retribution Paladin (137027 effect#1), Protection Paladin (137028 effect#1), Judgment (197277 effect#1), Whisper of the Nathrezim (207635 effect#1), Item - Paladin T19 Retribution 2P Bonus (211444 effect#1), Divine Purpose (223819 effect#2), Crusade (231895 effect#1), Wake of Ashes (255937 effect#4), Mastery: Hand of Light (267316 effect#1), Righteous Verdict (267611 effect#1), Execution Sentence (267799 effect#1), Avenging Wrath (294027 effect#1), Blessing of Dawn (337747 effect#1), 

--- a/SpellDataDump/priest.txt
+++ b/SpellDataDump/priest.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Power Word: Shield (id=17) [Spell Family (6)] 
 Class            : Priest
@@ -486,6 +486,7 @@ School           : Shadow
 Spell Type       : Magic
 Resource         : 1.2% Base Mana (0) (id=328)
 Spell Level      : 7
+Max Targets      : 5
 GCD              : 1.5 seconds
 Duration         : 8 seconds
 Cooldown         : 60 seconds
@@ -1817,6 +1818,7 @@ School           : Holy
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 40 yards
+Max Targets      : 60
 Duration         : 8 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Spirit of Redemption (27827 effect#2), Twist of Fate (123254 effect#1), Holy Priest (137031 effect#1), Discipline Priest (137032 effect#1), Surrender to Madness (193223 effect#2), Light of T'uure (208065 effect#1), Twist of Fate (265258 effect#1), Dejahna's Inspiration (281456 effect#1), Kam Xi'raff (281457 effect#1), Surrender to Madness (319952 effect#7)
@@ -1955,6 +1957,7 @@ Class            : Priest
 School           : Holy
 Spell Type       : None
 Spell Level      : 27
+Max Targets      : 10
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Triggered by     : Mass Dispel (32375)
 Attributes       : .......x x....... x....... ........   ........ ........ ........ ........ 
@@ -2183,6 +2186,7 @@ Name             : Sin and Punishment (id=87204) [Spell Family (5)]
 Class            : Priest
 School           : Shadow
 Spell Type       : Magic
+Max Targets      : 5
 Duration         : 3 seconds
 Proc Chance      : 100%
 Mechanic         : Horrify

--- a/SpellDataDump/rogue.txt
+++ b/SpellDataDump/rogue.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Backstab (id=53) [Spell Family (8)] 
 Replaces         : Sinister Strike (id=1752)
@@ -529,6 +529,7 @@ School           : Physical
 Spell Type       : Ranged
 Spell Level      : 41
 Range            : 15 yards
+Max Targets      : 1
 GCD              : 1 seconds
 Duration         : 60 seconds
 Cooldown         : 120 seconds
@@ -1905,6 +1906,7 @@ School           : Physical
 Spell Type       : Melee
 Spell Level      : 1
 Range            : 5 yards
+Max Targets      : 1
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Master of Subtlety (31665 effect#1), Vendetta (79140 effect#1), Subtlety Rogue (137035 effect#1), Outlaw Rogue (137036 effect#1), Assassination Rogue (137037 effect#1), Shadow Dance (185313 effect#4), Ruthless Precision (193357 effect#1), Elaborate Planning (193641 effect#1), Symbols of Death (212283 effect#1), Headshot (242277 effect#1), Master Assassin (256735 effect#1)
@@ -2174,6 +2176,7 @@ Class            : Subtlety Rogue
 School           : Physical
 Spell Type       : None
 Spell Level      : 10
+Max Targets      : Unknown(-6)
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ......x. x....... ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -4443,6 +4446,7 @@ School           : Physical
 Spell Type       : Melee
 Resource         : 35 Energy (3) (id=10714)
 Spell Level      : 33
+Max Targets      : 8
 GCD              : 1 seconds
 Velocity         : 35 yards/sec
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -7926,6 +7930,7 @@ Class            : Rogue
 School           : Physical
 Spell Type       : Melee
 Range            : 50000 yards
+Max Targets      : 6
 Requires weapon  : Dagger
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Master of Subtlety (31665 effect#1), Mastery: Executioner (76808 effect#1), Vendetta (79140 effect#1), Subtlety Rogue (137035 effect#1), Outlaw Rogue (137036 effect#1), Assassination Rogue (137037 effect#1), Shadow Dance (185313 effect#4), Ruthless Precision (193357 effect#1), Deeper Stratagem (193531 effect#1), Elaborate Planning (193641 effect#1), Symbols of Death (212283 effect#1), Headshot (242277 effect#1), Master Assassin (256735 effect#1)
@@ -8720,6 +8725,7 @@ Spell Type       : Melee
 Resource         : 35 Energy (3) (id=192568)
 Resource         : 1 - 5 Combo Points (4) (id=192569)
 Spell Level      : 52
+Max Targets      : 8
 GCD              : 1 seconds
 Velocity         : 35 yards/sec
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
@@ -9288,6 +9294,7 @@ Class            : Rogue
 School           : Physical
 Spell Type       : Melee
 Range            : 20 yards
+Max Targets      : 5
 Requires weapon  : One-handed Axe, One-handed Mace, One-handed Sword, Fist Weapon
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Master of Subtlety (31665 effect#1), Vendetta (79140 effect#1), Subtlety Rogue (137035 effect#1), Outlaw Rogue (137036 effect#1), Assassination Rogue (137037 effect#1), Shadow Dance (185313 effect#4), Ruthless Precision (193357 effect#1), Elaborate Planning (193641 effect#1), Acrobatic Strikes (196924 effect#4), Symbols of Death (212283 effect#1), Headshot (242277 effect#1), Master Assassin (256735 effect#1)

--- a/SpellDataDump/shaman.txt
+++ b/SpellDataDump/shaman.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Block (desc=Passive) (id=107) [Passive] 
 Class            : Warrior, Paladin, Shaman
@@ -2802,6 +2802,7 @@ Class            : Shaman
 School           : Fire
 Spell Type       : Magic
 Range            : 40 yards
+Max Targets      : 8
 Velocity         : 1 yards/sec
 Cooldown         : 60 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -4365,6 +4366,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 10 yards
+Max Targets      : 1
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Energized Shield (24499 effect#1), Elemental Fury (60188 effect#1), Mastery: Enhanced Elements (77223 effect#1), Spiritwalker's Grace (79206 effect#1), Restoration Shaman (137039 effect#3), Elemental Shaman (137040 effect#1), Enhancement Shaman (137041 effect#1), Lightning Crash (242284 effect#1)
 Triggered by     : Lightning Shield (192106)
@@ -5681,6 +5683,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 13
 Range            : 100 yards
+Max Targets      : 3
 GCD              : 1.5 seconds
 Duration         : 12 seconds
 Charges          : 3 (12 seconds cooldown)
@@ -7518,6 +7521,7 @@ School           : Nature
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 40 yards
+Max Targets      : 6
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Triggered by     : Eye of the Storm (157375)
 Attributes       : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -10346,6 +10350,7 @@ School           : Arcane
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 40 yards
+Max Targets      : 6
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ........ ........ x.x..... ........   ........ ........ ........ ........ 
                  : ..x..... ........ ........ ........   ........ ........ ........ ........ 
@@ -10547,6 +10552,7 @@ Class            : Shaman
 School           : Nature
 Spell Type       : Magic
 Range            : 100 yards
+Max Targets      : 4
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Mastery: Enhanced Elements (77223 effect#1), Spiritwalker's Grace (79206 effect#1), Restoration Shaman (137039 effect#3), Elemental Shaman (137040 effect#1), Enhancement Shaman (137041 effect#1), Lightning Crash (242284 effect#1), Essential Extraction (339183 effect#1), 
 Family Flags     : 39, 56, 125
@@ -10568,6 +10574,7 @@ Class            : Shaman
 School           : Nature
 Spell Type       : Magic
 Range            : 100 yards
+Max Targets      : 8
 GCD              : 1.5 seconds
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Earth Shield (974 effect#1), Mastery: Deep Healing (77226 effect#1), Spiritwalker's Grace (79206 effect#1), Restoration Shaman (137039 effect#1), 
@@ -10731,6 +10738,7 @@ Class            : Shaman
 School           : Fire
 Spell Type       : Magic
 Range            : 100 yards
+Max Targets      : 6
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Mastery: Enhanced Elements (77223 effect#1), Spiritwalker's Grace (79206 effect#1), Shaman (137038 effect#2), Restoration Shaman (137039 effect#3), Elemental Shaman (137040 effect#1), Enhancement Shaman (137041 effect#1), Lightning Crash (242284 effect#1)
 Family Flags     : 27, 39, 56

--- a/SpellDataDump/warlock.txt
+++ b/SpellDataDump/warlock.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Eye of Kilrogg (id=126) [Spell Family (5)] 
 Class            : Warlock
@@ -578,6 +578,7 @@ Class            : Warlock
 School           : Shadow
 Spell Type       : Magic
 Spell Level      : 1
+Max Targets      : 5
 Cast Time        : 1.5 seconds
 Duration         : 20 seconds
 Cooldown         : 40 seconds
@@ -3226,6 +3227,7 @@ School           : Shadow
 Spell Type       : Magic
 Spell Level      : 12
 Range            : 30 yards
+Max Targets      : 1
 Duration         : 20 seconds
 Category         : 1266
 Labels           : 16: Agonizing Backlash (320035 effect#3)
@@ -4322,6 +4324,7 @@ Class            : Warlock
 School           : Fire
 Spell Type       : Magic
 Range            : 40 yards
+Max Targets      : 1
 Velocity         : 16 yards/sec
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : .......x x....... ........ ........   ........ ..x..... ........ ........ 
@@ -4622,6 +4625,7 @@ School           : Shadow
 Spell Type       : Magic
 Spell Level      : 1
 Range            : 40 yards
+Max Targets      : 1
 Cast Time        : 1.5 seconds
 GCD              : 1.5 seconds
 Duration         : 600 seconds
@@ -4730,6 +4734,7 @@ Class            : Warlock
 School           : Shadow
 Spell Type       : Melee
 Range            : 50000 yards
+Max Targets      : 1
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Attributes       : ........ ........ ........ ........   ........ ........ ........ ........ 
                  : ........ ........ ........ ........   ........ ........ ........ ........ 
@@ -9421,6 +9426,7 @@ Spell Type       : Magic
 Resource         : 1% Base Mana (0) (id=192752)
 Spell Level      : 13
 Range            : 40 yards
+Max Targets      : 1
 Cast Time        : 1.5 seconds
 GCD              : 1.5 seconds
 Duration         : 16 seconds

--- a/SpellDataDump/warrior.txt
+++ b/SpellDataDump/warrior.txt
@@ -1,4 +1,4 @@
-SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc df97e687b9)
+SimulationCraft 901-01 for World of Warcraft 9.0.1.35282 shadowlands-BETA (git build dbc 87d1e7cf32)
 
 Name             : Vanguard (id=71) [Spell Family (4), Passive] 
 Class            : Protection Warrior
@@ -1364,6 +1364,7 @@ Class            : Warrior
 School           : Physical
 Spell Type       : Melee
 Spell Level      : 1
+Max Targets      : Unlimited(-1)
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Demoralizing Shout (1160 effect#3), Recklessness (1719 effect#1), Mastery: Unshackled Fury (76856 effect#1), Single-Minded Fury (81099 effect#1), Avatar (107574 effect#1), Protection Warrior (137048 effect#1), Arms Warrior (137049 effect#2), Fury Warrior (137050 effect#1), Colossus Smash (208086 effect#1), Deep Wounds (262115 effect#2), Siegebreaker (280773 effect#1), Unnerving Focus (337155 effect#5)
 Triggered by     : Bladestorm (46924), Bladestorm (227847)
@@ -2003,6 +2004,7 @@ Class            : Warrior
 School           : Physical
 Spell Type       : Melee
 Spell Level      : 1
+Max Targets      : Unlimited(-1)
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
 Labels           : 16: Agonizing Backlash (320035 effect#3)
 Affecting spells : Demoralizing Shout (1160 effect#3), Recklessness (1719 effect#1), Mastery: Unshackled Fury (76856 effect#1), Single-Minded Fury (81099 effect#1), Avatar (107574 effect#1), Protection Warrior (137048 effect#1), Arms Warrior (137049 effect#2), Fury Warrior (137050 effect#1), Colossus Smash (208086 effect#1), Deep Wounds (262115 effect#2), Siegebreaker (280773 effect#1), Unnerving Focus (337155 effect#5)
@@ -4369,6 +4371,7 @@ Name             : Odyn's Fury (desc=Artifact) (id=205545) [Spell Family (4)]
 Class            : Warrior
 School           : Physical
 Spell Type       : Melee
+Max Targets      : Unlimited(-1)
 GCD              : 1.5 seconds
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
 Cooldown         : 45 seconds
@@ -4392,6 +4395,7 @@ Name             : Odyn's Fury (id=205546) [Spell Family (4)]
 Class            : Warrior
 School           : Fire
 Spell Type       : Melee
+Max Targets      : Unlimited(-1)
 Duration         : 4 seconds
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
 Triggered by     : Odyn's Fury (205545)
@@ -4417,6 +4421,7 @@ Name             : Odyn's Fury (id=205547) [Spell Family (4)]
 Class            : Warrior
 School           : Fire
 Spell Type       : Melee
+Max Targets      : Unlimited(-1)
 Requires weapon  : One-handed Axe, Two-handed Axe, One-handed Mace, Two-handed Mace, Polearm, One-handed Sword, Two-handed Sword, Staff, Fist Weapon, Dagger, Spear
 Triggered by     : Odyn's Fury (205545)
 Attributes       : ....x... ........ x.x..... ........   ....x... .x...... ........ ........ 

--- a/dbc_extract3/dbc/data.py
+++ b/dbc_extract3/dbc/data.py
@@ -1,4 +1,4 @@
-import struct, sys, math, types
+import struct, sys, math, types, logging
 
 import dbc.fmt
 import dbc.db
@@ -85,6 +85,17 @@ class RawDBCRecord:
 
         db = dbc.db.datastore().get(child_db)
         return db.records_for_parent(self._id)
+
+    def child(self, child_db):
+        if not dbc.db.datastore():
+            raise ValueError
+
+        db = dbc.db.datastore().get(child_db)
+        records = db.records_for_parent(self._id)
+        if len(records) > 1:
+            logging.warning('Record "%s"(%d) associated with more than one child in "%s"',
+                            self.dbc_name(), self._id, child_db)
+        return len(records) and records[0] or db.default()
 
     def child_refs(self, child_db):
         if not dbc.db.datastore():

--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -2780,19 +2780,19 @@ class SpellDataGenerator(DataGenerator):
             fields = sname.field('name', 'id')
             hotfix.add(sname, ('name', 0))
 
-            fields += misc.field('proj_speed', 'school')
+            fields += misc.field('school', 'proj_speed')
             hotfix.add(misc, ('proj_speed', 3), ('school', 4))
 
             # Hack in the combined class from the id_tuples dict
-            fields += [ u'%#.8x' % ids.get(id, { 'mask_class' : 0, 'mask_race': 0 })['mask_class'] ]
             fields += [ u'%#.16x' % ids.get(id, { 'mask_class' : 0, 'mask_race': 0 })['mask_race'] ]
+            fields += [ u'%#.8x' % ids.get(id, { 'mask_class' : 0, 'mask_race': 0 })['mask_class'] ]
 
             # Set the scaling index for the spell
             fields += spell.get_link('scaling').field('id_class', 'max_scaling_level')
             hotfix.add(spell.get_link('scaling'), ('id_class', 7), ('max_scaling_level', 8))
 
-            fields += spell.get_link('level').field('base_level', 'max_level')
-            hotfix.add(spell.get_link('level'), ('base_level', 9), ('max_level', 10))
+            fields += spell.get_link('level').field('base_level', 'max_level', 'req_max_level')
+            hotfix.add(spell.get_link('level'), ('base_level', 9), ('max_level', 10), ('req_max_level', 46))
 
             range_entry = self._spellrange_db[misc.id_range]
             fields += range_entry.field('min_range_1', 'max_range_1')
@@ -2812,6 +2812,8 @@ class SpellDataGenerator(DataGenerator):
             else:
                 fields += category.field('cooldown_category')
                 hotfix.add(category, ('cooldown_category', 18))
+            fields += category.field('dmg_class')
+            hotfix.add(category, ('dmg_class', 47))
 
             duration_entry = self._spellduration_db[misc.id_duration]
             fields += duration_entry.field('duration_1')
@@ -2871,12 +2873,6 @@ class SpellDataGenerator(DataGenerator):
                     fields.append(essences[0])
             else:
                 fields.append('0')
-
-            fields += spell.get_link('level').field('req_max_level')
-            # hotfix.add(spell.get_link('level'), ('req_max_level', 46))
-
-            fields += category.field('dmg_class')
-            # hotfix.add(category, ('dmg_class', 47))
 
             # Pad struct with empty pointers for direct access to spell effect data
             fields += [ u'0', u'0', u'0', u'0' ]

--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -2815,6 +2815,9 @@ class SpellDataGenerator(DataGenerator):
             fields += category.field('dmg_class')
             hotfix.add(category, ('dmg_class', 47))
 
+            fields += spell.child('SpellTargetRestrictions').field('max_affected_targets')
+            hotfix.add(spell.child('SpellTargetRestrictions'), ('max_affected_targets', 48))
+
             duration_entry = self._spellduration_db[misc.id_duration]
             fields += duration_entry.field('duration_1')
             hotfix.add(duration_entry, ('duration_1', 19))

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -90,7 +90,8 @@ static constexpr auto spell_data_fields = std::make_tuple(
   data_field( "proc_flags",        &spell_data_t::_proc_flags ),
   data_field( "cast_time",         &spell_data_t::_cast_time ),
   data_field( "rppm",              &spell_data_t::_rppm ),
-  data_field( "dmg_class",         &spell_data_t::_dmg_class )
+  data_field( "dmg_class",         &spell_data_t::_dmg_class ),
+  data_field( "max_targets",       &spell_data_t::_max_targets )
 );
 
 bool spell_data_t::override_field( util::string_view field, double value )

--- a/engine/dbc/sc_spell_data.cpp
+++ b/engine/dbc/sc_spell_data.cpp
@@ -175,7 +175,7 @@ struct spell_desc_vars_t : func_field_t<spell_desc_vars_t, spell_data_t> {
   }
 };
 
-static constexpr std::array<sdata_field_t, 37> _spell_data_fields { {
+static constexpr std::array<sdata_field_t, 38> _spell_data_fields { {
   { "name",              FIELD( &spell_data_t::_name ) },
   { "id",                FIELD( &spell_data_t::_id ) },
   { "speed",             FIELD( &spell_data_t::_prj_speed ) },
@@ -213,6 +213,7 @@ static constexpr std::array<sdata_field_t, 37> _spell_data_fields { {
   { "desc_vars",         spell_desc_vars_t{} },
   { "req_max_level",     FIELD( &spell_data_t::_req_max_level ) },
   { "dmg_class",         FIELD( &spell_data_t::_dmg_class ) },
+  { "max_targets",       FIELD( &spell_data_t::_max_targets ) },
 } };
 
 #undef FIELD

--- a/engine/dbc/sc_spell_info.cpp
+++ b/engine/dbc/sc_spell_info.cpp
@@ -97,6 +97,7 @@ static constexpr auto _hotfix_spell_map = util::make_static_map<unsigned, util::
   { 41, "Azerite Essence Id" },
   { 46, "Required Max Level" },
   { 47, "Spell Type" },
+  { 48, "Max Targets" },
 } );
 
 static constexpr auto _hotfix_spelltext_map = util::make_static_map<unsigned, util::string_view>( {
@@ -1362,6 +1363,15 @@ std::string spell_info::to_str( const dbc_t& dbc, const spell_data_t* spell, int
       s << ( int ) spell -> min_range() << " - ";
 
     s << ( int ) spell -> max_range() << " yards" << std::endl;
+  }
+
+  if ( spell -> max_targets() != 0 )
+  {
+    fmt::print( s, "Max Targets      : {}{}{}\n",
+      spell -> max_targets() == -1 ? "Unlimited(" :
+        spell -> max_targets() < 0 ? "Unknown(" : "",
+      spell -> max_targets(),
+      spell -> max_targets() < 0 ? ")" : "" );
   }
 
   if ( spell -> cast_time() > 0_ms )

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -365,15 +365,16 @@ struct spell_data_t
 {
   const char* _name;               // Spell name from Spell.dbc stringblock (enGB)
   unsigned    _id;                 // Spell ID in dbc
-  double      _prj_speed;          // Projectile Speed
   unsigned    _school;             // Spell school mask
-  unsigned    _class_mask;         // Class mask for spell
+  double      _prj_speed;          // Projectile Speed
   uint64_t    _race_mask;          // Racial mask for the spell
+  unsigned    _class_mask;         // Class mask for spell
   int         _scaling_type;       // Array index for gtSpellScaling.dbc. -1 means the first non-class-specific sub array, and so on, 0 disabled
   int         _max_scaling_level;  // Max scaling level(?), 0 == no restrictions, otherwise min( player_level, max_scaling_level )
   // SpellLevels.dbc
   unsigned    _spell_level;        // Spell learned on level. NOTE: Only accurate for "class abilities"
   unsigned    _max_level;          // Maximum level for scaling
+  unsigned    _req_max_level;
   // SpellRange.dbc
   double      _min_range;          // Minimum range in yards
   double      _max_range;          // Maximum range in yards
@@ -386,6 +387,7 @@ struct spell_data_t
   unsigned    _charge_cooldown;    // Cooldown duration of charges
   // SpellCategories.dbc
   unsigned    _category;           // Spell category (for shared cooldowns, effects?)
+  unsigned    _dmg_class;          // Classification for the spell
   // SpellDuration.dbc
   double      _duration;           // Spell duration in milliseconds
   // SpellAuraOptions.dbc
@@ -412,9 +414,6 @@ struct spell_data_t
   // Azerite stuff
   unsigned    _power_id;           // Azerite power id
   unsigned    _essence_id;         // Azerite essence id
-
-  unsigned    _req_max_level;
-  unsigned    _dmg_class;          // SpellCategories.db2 classification for the spell
 
   // Pointers for runtime linking
   const spelleffect_data_t* _effects;

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -388,6 +388,7 @@ struct spell_data_t
   // SpellCategories.dbc
   unsigned    _category;           // Spell category (for shared cooldowns, effects?)
   unsigned    _dmg_class;          // Classification for the spell
+  int         _max_targets;        // Max number of targets
   // SpellDuration.dbc
   double      _duration;           // Spell duration in milliseconds
   // SpellAuraOptions.dbc
@@ -519,6 +520,9 @@ struct spell_data_t
 
   unsigned mechanic() const
   { return _mechanic; }
+
+  int max_targets() const
+  { return _max_targets; }
 
   unsigned power_id() const
   { return _power_id; }


### PR DESCRIPTION
Basically a rebase of https://github.com/simulationcraft/simc/pull/5143 with all review comments addressed.

The fields in `spell_data_t` are shuffled a bit to simplify the generator and not grow structure size unnecessarily.