### PR TITLE
[Priest] add SW:D baseline

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -577,6 +577,7 @@ priest_td_t::priest_td_t( player_t* target, priest_t& p ) : actor_target_data_t(
 {
   dots.shadow_word_pain = target->get_dot( "shadow_word_pain", &p );
   dots.vampiric_touch   = target->get_dot( "vampiric_touch", &p );
+  dots.vampiric_touch   = target->get_dot( "devouring_plague", &p );
 
   buffs.schism = make_buff( *this, "schism", p.talents.schism );
 
@@ -689,6 +690,7 @@ void priest_t::create_gains()
   gains.insanity_dark_void                     = get_gain( "Insanity Gained from Dark Void" );
   gains.insanity_lucid_dreams                  = get_gain( "Insanity Gained from Lucid Dreams" );
   gains.insanity_memory_of_lucid_dreams        = get_gain( "Insanity Gained from Memory of Lucid Dreams" );
+  gains.insanity_death_and_madness             = get_gain( "Insanity Gained from Death and Madness" );
   gains.shadow_word_death_self_damage          = get_gain( "Shadow Word: Death self inflicted damage" );
 }
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -652,6 +652,7 @@ void priest_t::create_cooldowns()
   cooldowns.psychic_horror     = get_cooldown( "psychic_horror" );
   cooldowns.dark_ascension     = get_cooldown( "dark_ascension" );
   cooldowns.power_infusion     = get_cooldown( "power_infusion" );
+  cooldowns.shadow_word_death  = get_cooldown( "shadow_word_death" );
 
   if ( specialization() == PRIEST_DISCIPLINE )
   {

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1099,6 +1099,9 @@ void priest_t::init_spells()
   // runeforge legendary
   legendary.kiss_of_death    = find_runeforge_legendary( "Kiss of Death" );
   legendary.the_penitent_one = find_runeforge_legendary( "The Penitent One" );
+
+  // Shadow Legendaries
+  legendary.painbreaker_psalm = find_runeforge_legendary( "Painbreaker Psalm" );
 }
 
 void priest_t::create_buffs()

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -411,6 +411,7 @@ public:
   {
     const spell_data_t* kiss_of_death;
     const spell_data_t* the_penitent_one;  // Effect implemented, but not hooked up the PW:Radiance
+    const spell_data_t* painbreaker_psalm;
   } legendary;
 
   struct insanity_end_event_t;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -115,7 +115,7 @@ public:
     propagate_const<buff_t*> vampiric_embrace;
     propagate_const<buff_t*> void_torrent;
     propagate_const<buff_t*> voidform;
-    propagate_const<buff_t*> death_and_madness;
+    propagate_const<buff_t*> death_and_madness_debuff;
     propagate_const<buff_t*> death_and_madness_buff;
 
     // Azerite Powers

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -55,6 +55,7 @@ public:
   {
     propagate_const<dot_t*> shadow_word_pain;
     propagate_const<dot_t*> vampiric_touch;
+    propagate_const<dot_t*> devouring_plague;
   } dots;
 
   struct buffs_t
@@ -114,6 +115,8 @@ public:
     propagate_const<buff_t*> vampiric_embrace;
     propagate_const<buff_t*> void_torrent;
     propagate_const<buff_t*> voidform;
+    propagate_const<buff_t*> death_and_madness;
+    propagate_const<buff_t*> death_and_madness_buff;
 
     // Azerite Powers
     // Shadow
@@ -206,7 +209,7 @@ public:
     const spell_data_t* psychic_horror;  // NYI
     // T75
     const spell_data_t* auspicious_spirits;
-    const spell_data_t* death_and_madness;  // NYI
+    const spell_data_t* death_and_madness;
     const spell_data_t* shadow_crash;
     // T90
     const spell_data_t* lingering_insanity;
@@ -279,6 +282,8 @@ public:
     propagate_const<cooldown_t*> mind_bomb;
     propagate_const<cooldown_t*> psychic_horror;
     propagate_const<cooldown_t*> dark_ascension;
+    propagate_const<cooldown_t*> shadow_word_death;
+    propagate_const<cooldown_t*> devouring_plague;
 
     // Holy
     propagate_const<cooldown_t*> holy_word_chastise;
@@ -320,6 +325,7 @@ public:
     propagate_const<gain_t*> insanity_lucid_dreams;
     propagate_const<gain_t*> insanity_memory_of_lucid_dreams;
     propagate_const<gain_t*> shadow_word_death_self_damage;
+    propagate_const<gain_t*> insanity_death_and_madness;
   } gains;
 
   // Benefits
@@ -1309,34 +1315,7 @@ struct priest_module_t final : public module_t
   }
   void register_hotfixes() const override
   {
-    /** December 5th 2017 hotfixes
-
-    hotfix::register_effect("Priest", "2017-12-05", "Shadow Priest damage increased by 3%", 191068)
-    .field("base_value")
-    .operation(hotfix::HOTFIX_SET)
-    .modifier(23.0)
-    .verification_value(20.0);
-
-    hotfix::register_effect("Priest", "2017-12-05", "Shadow Priest damage increased by 3%", 179717)
-    .field("base_value")
-    .operation(hotfix::HOTFIX_SET)
-    .modifier(23.0)
-    .verification_value(20.0);
-
-    hotfix::register_effect("Priest", "2017-12-05", "Vampiric Touch damage reduced by 15%.", 25010)
-    .field("sp_coefficient")
-    .operation(hotfix::HOTFIX_SET)
-    .modifier(0.579)
-    .verification_value(0.6816);
-
-    hotfix::register_effect("Priest", "2017-12-05", "Shadow Word: Pain damage reduced by 15%.", 254257)
-    .field("sp_coefficient")
-    .operation(hotfix::HOTFIX_SET)
-    .modifier(0.31)
-    .verification_value(0.365);
-    **/
   }
-
   void combat_begin( sim_t* ) const override
   {
   }

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -370,8 +370,7 @@ struct shadow_word_death_t final : public priest_spell_t
 
       if ( priest().talents.death_and_madness->ok() )
       {
-        residual_action::trigger( p()->death_and_madness, s->target );
-        // priest().buffs.death_and_madness->trigger( p()->ignite, s->target );
+		  // trigger death_and_madness_debuff on current target
       }
 
       priest().generate_insanity( total_insanity_gain, priest().gains.insanity_shadow_word_death, s->action );
@@ -1472,7 +1471,8 @@ struct death_and_madness_buff_t final : public priest_buff_t<buff_t>
   {
     set_tick_callback( [ this ] ( buff_t*, int, timespan_t )
     {
-      priest().generate_insanity( insanity_gain, priest().gains.insanity_mind_blast, this );
+		// generate insanity per tick
+		// priest().generate_insanity( insanity_gain, priest().gains.insanity_mind_blast, this );
     } );
   }
 };

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -370,7 +370,8 @@ struct shadow_word_death_t final : public priest_spell_t
 
       if ( priest().talents.death_and_madness->ok() )
       {
-		  // trigger death_and_madness_debuff on current target
+  		  // NYI
+  		  // trigger death_and_madness_debuff on current target
       }
 
       priest().generate_insanity( total_insanity_gain, priest().gains.insanity_shadow_word_death, s->action );
@@ -1471,8 +1472,7 @@ struct death_and_madness_buff_t final : public priest_buff_t<buff_t>
   {
     set_tick_callback( [ this ] ( buff_t*, int, timespan_t )
     {
-		// generate insanity per tick
-		// priest().generate_insanity( insanity_gain, priest().gains.insanity_mind_blast, this );
+      priest().generate_insanity( insanity_gain, priest().gains.insanity_death_and_madness, nullptr );
     } );
   }
 };

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -322,28 +322,10 @@ struct mind_flay_t final : public priest_spell_t
   }
 };
 
-struct death_and_madness_t final : public priest_spell_t
-{
-  death_and_madness_t( priest_t& p )
-    : priest_spell_t( "death_and_madness", p, p.talents.death_and_madness )
-  {
-    may_miss = may_crit = harmful = callbacks = false;
-  }
-
-  void impact( action_state_t* s ) override
-  {
-    priest_spell_t::impact( s );
-    priest().buffs.death_and_madness->trigger();
-  }
-};
-
 struct shadow_word_death_t final : public priest_spell_t
 {
-  propagate_const<death_and_madness_t*> child_death_and_madness;
-
   shadow_word_death_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "shadow_word_death", p, p.find_class_spell( "Shadow Word: Death" ) ),
-      child_death_and_madness( new death_and_madness_t( priest() ) )
+  : priest_spell_t( "shadow_word_death", p, p.find_class_spell( "Shadow Word: Death" ) )
   {
     parse_options( options_str );
     cooldown           = priest().cooldowns.shadow_word_death;
@@ -367,8 +349,7 @@ struct shadow_word_death_t final : public priest_spell_t
     {
       total_insanity_gain = data().effectN( 3 ).base_value();
 
-      // TODO: Check for Painbreaker Psalm Legendary
-      if ( false )
+      if ( priest().legendary.painbreaker_psalm->ok() )
       {
         // TODO: Check if this ever gets un-hardcoded for (336165)
         total_insanity_gain += 10;
@@ -384,8 +365,7 @@ struct shadow_word_death_t final : public priest_spell_t
 
       if ( priest().talents.death_and_madness->ok() )
       {
-        child_death_and_madness->target = s->target;
-        child_death_and_madness->execute();
+        priest().buffs.death_and_madness->trigger();
       }
 
       priest().generate_insanity( total_insanity_gain, priest().gains.insanity_shadow_word_death, s->action );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -322,12 +322,32 @@ struct mind_flay_t final : public priest_spell_t
   }
 };
 
+struct death_and_madness_t final : public priest_spell_t
+{
+  death_and_madness_t( priest_t& p )
+    : priest_spell_t( "death_and_madness", p, p.talents.death_and_madness )
+  {
+    may_miss = may_crit = harmful = callbacks = false;
+  }
+
+  void impact( action_state_t* s ) override
+  {
+    priest_spell_t::impact( s );
+    priest().buffs.death_and_madness->trigger();
+  }
+};
+
 struct shadow_word_death_t final : public priest_spell_t
 {
+  propagate_const<death_and_madness_t*> child_death_and_madness;
+
   shadow_word_death_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "shadow_word_death", p, p.find_class_spell( "Shadow Word: Death" ) )
+    : priest_spell_t( "shadow_word_death", p, p.find_class_spell( "Shadow Word: Death" ) ),
+      child_death_and_madness( new death_and_madness_t( priest() ) )
   {
     parse_options( options_str );
+    cooldown           = priest().cooldowns.shadow_word_death;
+    cooldown->duration = data().cooldown();
 
     auto rank2 = p.find_rank_spell( "Shadow Word: Death", "Rank 2" );
     if ( rank2->ok() )
@@ -347,12 +367,25 @@ struct shadow_word_death_t final : public priest_spell_t
     {
       total_insanity_gain = data().effectN( 3 ).base_value();
 
+      // TODO: Check for Painbreaker Psalm Legendary
+      if ( false )
+      {
+        // TODO: Check if this ever gets un-hardcoded for (336165)
+        total_insanity_gain += 10;
+      }
+
       // TODO: Add in a custom buff that checks after 1 second to see if the target SWD was cast on is now dead.
 
       if ( !( ( save_health_percentage > 0.0 ) && ( s->target->health_percentage() <= 0.0 ) ) )
       {
         // target is not killed
         inflict_self_damage( s->result_amount );
+      }
+
+      if ( priest().talents.death_and_madness->ok() )
+      {
+        child_death_and_madness->target = s->target;
+        child_death_and_madness->execute();
       }
 
       priest().generate_insanity( total_insanity_gain, priest().gains.insanity_shadow_word_death, s->action );
@@ -1191,6 +1224,25 @@ struct void_torrent_t final : public priest_spell_t
     return priest_spell_t::ready();
   }
 };
+
+struct death_and_madness_insanity_t final : public priest_spell_t
+{
+  double insanity_gain;
+
+  death_and_madness_insanity_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "death_and_madness", p, p.find_spell( 321973 ) ),
+      insanity_gain( p.find_spell( 321973 )->effectN( 1 ).base_value() / 55 )
+  {
+    parse_options( options_str );
+    may_crit      = false;
+  }
+
+  void tick( dot_t* d ) override
+  {
+    priest_spell_t::tick( d );
+    priest().generate_insanity( insanity_gain, priest().gains.insanity_death_and_madness, d->state->action );
+  }
+};
 }  // namespace spells
 
 namespace heals
@@ -1418,6 +1470,38 @@ struct lingering_insanity_t final : public priest_buff_t<buff_t>
       expire();
     }
   }
+};
+
+struct death_and_madness_debuff_t final : public priest_buff_t<buff_t>
+{
+  death_and_madness_debuff_t( priest_t& p ) : base_t( p, "death_and_madness", p.talents.death_and_madness )
+  {
+  }
+
+  void expire_override( int expiration_stacks, timespan_t remaining_duration ) override
+  {
+    if ( remaining_duration > timespan_t::zero() )
+    {
+      if ( sim -> debug )
+      {
+        sim -> out_debug.printf("%s death_and_madness insanity triggered", player -> name() );
+      }
+
+      priest().buffs.death_and_madness_buff->trigger();
+      priest().cooldowns.shadow_word_death->reset( true );
+    }
+
+    buff_t::expire_override( expiration_stacks, remaining_duration );
+  }
+};
+
+struct death_and_madness_buff_t final : public priest_buff_t<buff_t>
+{
+  death_and_madness_buff_t( priest_t& p ) : base_t( p, "death_and_madness", p.talents.death_and_madness )
+  {
+    set_trigger_spell( p.find_spell( 321973 )->effectN( 1 ).trigger() );
+  }
+
 };
 
 struct chorus_of_insanity_t final : public priest_buff_t<stat_buff_t>
@@ -1804,7 +1888,6 @@ void priest_t::insanity_state_t::adjust_end_event()
 void priest_t::create_buffs_shadow()
 {
   // Baseline
-
   buffs.shadowform            = make_buff<buffs::shadowform_t>( *this );
   buffs.shadowform_state      = make_buff<buffs::shadowform_state_t>( *this );
   buffs.shadowy_insight       = make_buff<buffs::shadowy_insight_t>( *this );
@@ -1817,10 +1900,11 @@ void priest_t::create_buffs_shadow()
   buffs.surrender_to_madness   = make_buff<buffs::surrender_to_madness_t>( *this );
   buffs.surrendered_to_madness = make_buff<buffs::surrendered_to_madness_t>( *this );
   buffs.lingering_insanity     = make_buff<buffs::lingering_insanity_t>( *this );
+  buffs.death_and_madness      = make_buff<buffs::death_and_madness_debuff_t>( *this );
+  buffs.death_and_madness_buff = make_buff<buffs::death_and_madness_buff_t>( *this );
 
   // Azerite Powers
   buffs.chorus_of_insanity = make_buff<buffs::chorus_of_insanity_t>( *this );
-
   buffs.harvested_thoughts     = make_buff<buffs::harvested_thoughts_t>( *this );
   buffs.whispers_of_the_damned = make_buff<buffs::whispers_of_the_damned_t>( *this );
 }
@@ -2091,20 +2175,14 @@ void priest_t::generate_apl_shadow()
       "azerite.searing_dialogue.rank>=1",
       "Use Mind Sear on ST only if you get a Thought Harvester Proc with at least 1 Searing Dialogue Trait." );
   single->add_action( this, "Shadow Word: Death",
-                      "if=target.time_to_die<3|"
-                      "cooldown.shadow_word_death.charges=2|"
-                      "(cooldown.shadow_word_death.charges=1&"
-                      "cooldown.shadow_word_death.remains<gcd.max)",
-                      "Use SWD before capping charges, or the target is about to die." );
+                      "if=target.time_to_die<3",
+                      "Use SWD if the target is about to die." );
   single->add_talent( this, "Surrender to Madness", "if=buff.voidform.stack>10+(10*buff.bloodlust.up)" );
   single->add_talent( this, "Dark Void", "if=raid_event.adds.in>10",
                       "Use Dark Void on CD unless adds are incoming in 10s or less." );
   single->add_talent( this, "Mindbender", "if=talent.mindbender.enabled|(buff.voidform.stack>18|target.time_to_die<15)",
                       "Use Mindbender at 19 or more stacks, or if the target will die in less than 15s." );
-  single->add_action( this, "Shadow Word: Death",
-                      "if=!buff.voidform.up|"
-                      "(cooldown.shadow_word_death.charges=2&"
-                      "buff.voidform.stack<15)" );
+  single->add_action( this, "Shadow Word: Death" );
   single->add_talent( this, "Shadow Crash", "if=raid_event.adds.in>5&raid_event.adds.duration<20",
                       "Use Shadow Crash on CD unless there are adds incoming." );
   single->add_action( this, "Mind Blast",


### PR DESCRIPTION
- adds support for SW:D back in
- hasted CD on SW:D
- start work on Painbreaker Psalm legendary
- start work on Death and Madness talent
  - debuff on target created matching Marked for Death
  - buff for player created matching spell data
  - TODO/NYI: trigger the "debuff" on the target in simc