### PR TITLE
Switch more stuff to fmt formatting (take 2)

### DIFF
--- a/engine/action/dbc_proc_callback.cpp
+++ b/engine/action/dbc_proc_callback.cpp
@@ -84,8 +84,8 @@ void dbc_proc_callback_t::trigger( action_t* a, void* call_data )
 
   bool triggered = roll( a );
   if ( listener->sim->debug )
-    listener->sim->out_debug.printf( "%s attempts to proc %s on %s: %d", listener->name(), effect.to_string().c_str(),
-                                     a->name(), triggered );
+    listener->sim->print_debug( "{} attempts to proc {} on {}: {:d}", listener->name(), effect, a->name(), triggered );
+
   if ( triggered )
   {
     // Detach proc execution from proc triggering

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -4721,7 +4721,7 @@ void action_t::apply_affecting_effect( const spelleffect_data_t& effect )
           case P_RESOURCE_COST:
             base_costs[ resource_current ] += effect.base_value();
             sim->print_debug( "{} base resource cost for resource {} modified by {}", *this,
-                              util::resource_type_string( resource_current ), effect.base_value() );
+                              resource_current, effect.base_value() );
             break;
 
           case P_TARGET:
@@ -4755,7 +4755,7 @@ void action_t::apply_affecting_effect( const spelleffect_data_t& effect )
           case P_RESOURCE_COST:
             base_costs[ resource_current ] *= 1 + effect.percent();
             sim->print_debug( "{} base resource cost for resource {} modified by {}", *this,
-                              util::resource_type_string( resource_current ), effect.base_value() );
+                              resource_current, effect.base_value() );
             break;
 
           case P_TICK_DAMAGE:

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -5588,7 +5588,7 @@ void hunter_t::init_action_list()
   if ( specialization() == HUNTER_SURVIVAL && main_hand_weapon.group() != WEAPON_2H )
   {
     sim -> error( "Player {} does not have a proper weapon at the Main Hand slot: {}.",
-                  name(), util::weapon_type_string( main_hand_weapon.type ) );
+                  name(), main_hand_weapon.type );
   }
 
   if ( action_list_str.empty() )

--- a/engine/item/item.cpp
+++ b/engine/item/item.cpp
@@ -356,150 +356,98 @@ std::string item_t::socket_bonus_stats_str() const
   return str;
 }
 
-std::ostream& operator<<(std::ostream& s, const item_t& item )
+void format_to( const item_t& item, fmt::format_context::iterator out )
 {
-
-  s << "name=" << item.name_str;
-  s << " id=" << item.parsed.data.id;
+  fmt::format_to( out, "name={} id={}", item.name_str, item.parsed.data.id );
   if ( item.slot != SLOT_INVALID )
-  {
-    s << " slot=" << item.slot_name();
-  }
-  s << " quality=" << util::item_quality_string( item.parsed.data.quality );
-  s << " ilevel=" << item.item_level();
+    fmt::format_to( out, " slot={}", item.slot_name() );
+  fmt::format_to( out, " quality={}", util::item_quality_string( item.parsed.data.quality ) );
+  fmt::format_to( out, " ilevel={}", item.item_level() );
   if ( item.parent_slot == SLOT_INVALID )
   {
     if ( item.parsed.drop_level > 0 )
-      s << " drop_level=" << item.parsed.drop_level;
+      fmt::format_to( out, " drop_level={}", item.parsed.drop_level );
   }
   else
   {
-    s << " (" << item.player -> items[ item.parent_slot ].slot_name() << ")";
+    fmt::format_to( out, " ({})", item.player -> items[ item.parent_slot ].slot_name() );
   }
 
   if ( item.parsed.azerite_level > 0 )
-  {
-    s << " azerite_level=" << item.parsed.azerite_level;
-  }
+    fmt::format_to( out, " azerite_level={}", item.parsed.azerite_level );
 
   if ( item.parsed.data.lfr() )
-    s << " LFR";
+    fmt::format_to( out, " LFR" );
   if ( item.parsed.data.heroic() )
-    s << " Heroic";
+    fmt::format_to( out, " Heroic" );
   if ( item.parsed.data.mythic() )
-    s << " Mythic";
+    fmt::format_to( out, " Mythic" );
   if ( item.parsed.data.warforged() )
-    s << " Warforged";
+    fmt::format_to( out, " Warforged" );
   if ( util::is_match_slot( item.slot ) )
-    s << " match=" << item.is_matching_type();
+    fmt::format_to( out, " match={:d}", item.is_matching_type() );
 
   bool is_weapon = false;
   if ( item.parsed.data.item_class == ITEM_CLASS_ARMOR )
-    s << " type=armor/" << util::armor_type_string( item.parsed.data.item_subclass );
+  {
+    fmt::format_to( out, " type=armor/{}", util::armor_type_string( item.parsed.data.item_subclass ) );
+  }
   else if ( item.parsed.data.item_class == ITEM_CLASS_WEAPON )
   {
-    std::string class_str;
-    if ( util::weapon_class_string( item.parsed.data.inventory_type ) )
-      class_str = util::weapon_class_string( item.parsed.data.inventory_type );
-    else
-      class_str = "Unknown";
-    std::string str = util::weapon_subclass_string( item.parsed.data.item_subclass );
-    util::tokenize( str );
-    util::tokenize( class_str );
-    s << " type=" << class_str << "/" << str;
+    const char* class_cstr = util::weapon_class_string( item.parsed.data.inventory_type );
+    std::string class_str = class_cstr ? util::tokenize_fn( class_cstr ) : "unknown";
+    std::string subclass_str = util::tokenize_fn( util::weapon_subclass_string( item.parsed.data.item_subclass ) );
+    fmt::format_to( out, " type={}/{}", class_str, subclass_str );
     is_weapon = true;
   }
 
   if ( item.has_stats() )
-  {
-    s << " stats={ ";
-    s << item.item_stats_str();
-    s << " }";
-  }
+    fmt::format_to( out, " stats={{ {} }}", item.item_stats_str() );
 
   if ( item.parsed.gem_stats.size() > 0 )
-  {
-    s << " gems={ ";
-    s << item.gem_stats_str();
-    s << " }";
-  }
+    fmt::format_to( out, " gems={{ {} }}", item.gem_stats_str() );
 
   if ( item.socket_color_match() && item.parsed.socket_bonus_stats.size() > 0 )
-  {
-    s << " socket_bonus={ ";
-    s << item.socket_bonus_stats_str();
-    s << " }";
-  }
+    fmt::format_to( out, " socket_bonus={{ {} }}", item.socket_bonus_stats_str() );
 
   if ( is_weapon )
   {
-    s << " damage={ ";
     weapon_t* w = item.weapon();
-    s << w -> min_dmg;
-    s << " - ";
-    s << w -> max_dmg;
-    s << " }";
-
-    s << " speed=";
-    s << w -> swing_time.total_seconds();
+    fmt::format_to( out, " damage={{ {} - {} }} speed={}",
+      w -> min_dmg, w -> max_dmg, w -> swing_time );
   }
 
   if ( item.parsed.enchant_stats.size() > 0 && item.parsed.encoded_enchant.empty() )
-  {
-    s << " enchant={ ";
-    s << item.enchant_stats_str();
-    s << " }";
-  }
+    fmt::format_to( out, " enchant={{ {} }}", item.enchant_stats_str() );
   else if ( ! item.parsed.encoded_enchant.empty() )
-    s << " enchant={ " << item.parsed.encoded_enchant << " }";
+    fmt::format_to( out, " enchant={{ {} }}", item.parsed.encoded_enchant );
 
-  for ( size_t i = 0; i < item.parsed.special_effects.size(); i++ )
-  {
-    s << " effect={ ";
-    s << item.parsed.special_effects[ i ] -> to_string();
-    s << " }";
-  }
+  for ( const special_effect_t* effect : item.parsed.special_effects )
+    fmt::format_to( out, " effect={{ {} }}", *effect );
 
   if ( ! item.source_str.empty() )
-    s << " source=" << item.source_str;
+    fmt::format_to( out, " source={}", item.source_str );
 
   if ( range::any_of( item.parsed.data.effects, []( const auto& e ) { return e.spell_id != 0; } ) )
   {
-    s << " proc_spells={ ";
+    fmt::format_to( out, " proc_spells={{ " );
+    unsigned count = 0;
     for ( const item_effect_t& effect : item.parsed.data.effects )
     {
       if ( effect.spell_id == 0 )
         continue;
 
-      s << "proc=";
-      switch ( effect.type )
-      {
-        case ITEM_SPELLTRIGGER_ON_USE:
-          s << "OnUse";
-          break;
-        case ITEM_SPELLTRIGGER_ON_EQUIP:
-          s << "OnEquip";
-          break;
-        default:
-          s << "Unknown";
-          break;
-      }
-      s << "/" << effect.spell_id << ", ";
+      auto proc_type_str = []( int8_t type ) -> util::string_view {
+        if ( type == ITEM_SPELLTRIGGER_ON_USE )
+          return "OnUse";
+        if ( type == ITEM_SPELLTRIGGER_ON_EQUIP )
+          return "OnEquip";
+        return "Unknown";
+      };
+      fmt::format_to( out, "{}proc={}/{}", count++ ? ", " : "", proc_type_str( effect.type ), effect.spell_id );
     }
-
-    std::streampos x = s.tellp(); s.seekp( x - std::streamoff( 2 ) );
-    s << " }";
+    fmt::format_to( out, " }}" );
   }
-
-  return s;
-}
-
-std::string item_t::to_string() const
-{
-
-  std::ostringstream s;
-  s << *this;
-  return s.str();
 }
 
 // item_t::has_item_stat ====================================================
@@ -1025,7 +973,7 @@ std::string item_t::encoded_item() const
 
   if ( ! option_enchant_str.empty() )
     s << ",enchant=" << encoded_enchant();
-  else if ( option_enchant_id_str.empty() && 
+  else if ( option_enchant_id_str.empty() &&
             ( parsed.enchant_stats.size() > 0 || ! parsed.encoded_enchant.empty() ) )
     s << ",enchant=" << encoded_enchant();
 
@@ -1211,14 +1159,7 @@ std::string item_t::encoded_stats() const
     if ( ! stat_str.empty() ) stats.push_back( stat_str );
   }
 
-  std::string str;
-  for ( size_t i = 0; i < stats.size(); i++ )
-  {
-    if ( i ) str += '_';
-    str += stats[ i ];
-  }
-
-  return str;
+  return util::string_join( stats, "_" );
 }
 
 // item_t::encoded_weapon ===================================================

--- a/engine/item/item.hpp
+++ b/engine/item/item.hpp
@@ -12,6 +12,7 @@
 #include "sc_enums.hpp"
 #include "sc_timespan.hpp"
 #include "util/generic.hpp"
+#include "util/format.hpp"
 #include "util/string_view.hpp"
 
 #include <array>
@@ -198,7 +199,6 @@ struct item_t
   static std::vector<stat_pair_t> str_to_stat_pair( const std::string& stat_str );
   static std::string stat_pairs_to_str( const std::vector<stat_pair_t>& stat_pairs );
 
-  std::string to_string() const;
   std::string item_stats_str() const;
   std::string weapon_stats_str() const;
   std::string gem_stats_str() const;
@@ -212,5 +212,6 @@ struct item_t
 
   const special_effect_t* special_effect( special_effect_source_e source = SPECIAL_EFFECT_SOURCE_NONE, special_effect_e type = SPECIAL_EFFECT_NONE ) const;
   const special_effect_t* special_effect_with_name( util::string_view name, special_effect_source_e source = SPECIAL_EFFECT_SOURCE_NONE, special_effect_e type = SPECIAL_EFFECT_NONE ) const;
+
+  friend void format_to( const item_t&, fmt::format_context::iterator );
 };
-std::ostream& operator<<(std::ostream&, const item_t&);

--- a/engine/item/special_effect.hpp
+++ b/engine/item/special_effect.hpp
@@ -8,6 +8,8 @@
 #include "config.hpp"
 #include "sc_enums.hpp"
 #include "sc_timespan.hpp"
+#include "util/format.hpp"
+
 #include <string>
 #include <vector>
 #include <functional>
@@ -99,7 +101,7 @@ struct special_effect_t
   { buff_disabled = true; }
 
   void reset();
-  std::string to_string() const;
+
   bool active() { return stat != STAT_NONE || school != SCHOOL_NONE || execute_action; }
 
   const spell_data_t* driver() const;
@@ -149,6 +151,6 @@ struct special_effect_t
   /* Accessors for buff specific features of the proc. */
   timespan_t duration() const;
   timespan_t tick_time() const;
-};
 
-std::ostream& operator<<(std::ostream &os, const special_effect_t& x);
+  friend void format_to( const special_effect_t&, fmt::format_context::iterator );
+};

--- a/engine/player/gear_stats.hpp
+++ b/engine/player/gear_stats.hpp
@@ -7,10 +7,11 @@
 
 #include "config.hpp"
 #include "util/generic.hpp"
+#include "util/format.hpp"
 #include "sc_enums.hpp"
+
 #include <array>
 #include <functional>
-#include <string>
 
 
 struct gear_stats_t
@@ -134,6 +135,7 @@ struct gear_stats_t
   void   add_stat( stat_e stat, double value );
   void   set_stat( stat_e stat, double value );
   double get_stat( stat_e stat ) const;
-  std::string to_string();
   static double stat_mod( stat_e stat );
+
+  friend void format_to( const gear_stats_t&, fmt::format_context::iterator );
 };

--- a/engine/player/rating.cpp
+++ b/engine/player/rating.cpp
@@ -97,13 +97,8 @@ void rating_t::init(dbc_t& dbc, int level)
   }
 }
 
-std::string rating_t::to_string()
+void format_to( const rating_t& r, fmt::format_context::iterator out )
 {
-  fmt::memory_buffer buf;
   for (rating_e i = static_cast<rating_e>(0); i < RATING_MAX; ++i)
-  {
-    fmt::format_to( buf, "{}{}={}",
-      i > 0 ? " " : "", util::cache_type_string(cache_from_rating(i)), get(i) ); // hacky
-  }
-  return fmt::to_string( buf );
+    fmt::format_to( out, "{}{}={}", i ? " " : "", cache_from_rating(i), r.get(i) ); // hacky
 }

--- a/engine/player/rating.hpp
+++ b/engine/player/rating.hpp
@@ -7,8 +7,9 @@
 
 #include "config.hpp"
 #include "sc_enums.hpp"
+#include "util/format.hpp"
+
 #include <cassert>
-#include <string>
 
 class dbc_t;
 
@@ -34,5 +35,5 @@ struct rating_t
 
   void init(dbc_t& dbc, int level);
 
-  std::string to_string();
+  friend void format_to( const rating_t&, fmt::format_context::iterator );
 };

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -1359,40 +1359,37 @@ player_t::base_initial_current_t::base_initial_current_t() :
   range::fill( attribute_multiplier, 1.0 );
 }
 
-std::string player_t::base_initial_current_t::to_string()
+void format_to( const player_t::base_initial_current_t& s, fmt::format_context::iterator out )
 {
-  std::ostringstream s;
-
-  fmt::print( s, "{}", stats );
-  s << " spell_power_per_intellect=" << spell_power_per_intellect;
-  s << " spell_power_per_attack_power=" << spell_power_per_attack_power;
-  s << " spell_crit_per_intellect=" << spell_crit_per_intellect;
-  s << " attack_power_per_strength=" << attack_power_per_strength;
-  s << " attack_power_per_agility=" << attack_power_per_agility;
-  s << " attack_crit_per_agility=" << attack_crit_per_agility;
-  s << " dodge_per_agility=" << dodge_per_agility;
-  s << " parry_per_strength=" << parry_per_strength;
-  s << " health_per_stamina=" << health_per_stamina;
+  fmt::format_to( out, "{}", s.stats );
+  fmt::format_to( out, " spell_power_per_intellect={}", s.spell_power_per_intellect );
+  fmt::format_to( out, " spell_power_per_attack_power={}", s.spell_power_per_attack_power );
+  fmt::format_to( out, " spell_crit_per_intellect={}", s.spell_crit_per_intellect );
+  fmt::format_to( out, " attack_power_per_strength={}", s.attack_power_per_strength );
+  fmt::format_to( out, " attack_power_per_agility={}", s.attack_power_per_agility );
+  fmt::format_to( out, " attack_crit_per_agility={}", s.attack_crit_per_agility );
+  fmt::format_to( out, " dodge_per_agility={}", s.dodge_per_agility );
+  fmt::format_to( out, " parry_per_strength={}", s.parry_per_strength );
+  fmt::format_to( out, " health_per_stamina={}", s.health_per_stamina );
   // resource_reduction
-  s << " miss=" << miss;
-  s << " dodge=" << dodge;
-  s << " parry=" << parry;
-  s << " block=" << block;
-  s << " spell_crit_chance=" << spell_crit_chance;
-  s << " attack_crit_chance=" << attack_crit_chance;
-  s << " block_reduction=" << block_reduction;
-  s << " mastery=" << mastery;
-  s << " skill=" << skill;
-  s << " distance=" << distance;
-  s << " armor_coeff=" << armor_coeff;
-  s << " sleeping=" << sleeping;
+  fmt::format_to( out, " miss={}", s.miss );
+  fmt::format_to( out, " dodge={}", s.dodge );
+  fmt::format_to( out, " parry={}", s.parry );
+  fmt::format_to( out, " block={}", s.block );
+  fmt::format_to( out, " spell_crit_chance={}", s.spell_crit_chance );
+  fmt::format_to( out, " attack_crit_chance={}", s.attack_crit_chance );
+  fmt::format_to( out, " block_reduction={}", s.block_reduction );
+  fmt::format_to( out, " mastery={}", s.mastery );
+  fmt::format_to( out, " skill={}", s.skill );
+  fmt::format_to( out, " distance={}", s.distance );
+  fmt::format_to( out, " armor_coeff={}", s.armor_coeff );
+  fmt::format_to( out, " sleeping={}", s.sleeping );
   // attribute_multiplier
-  s << " spell_power_multiplier=" << spell_power_multiplier;
-  s << " attack_power_multiplier=" << attack_power_multiplier;
-  s << " base_armor_multiplier=" << base_armor_multiplier;
-  s << " armor_multiplier=" << armor_multiplier;
-  s << " position=" << util::position_type_string( position );
-  return s.str();
+  fmt::format_to( out, " spell_power_multiplier={}", s.spell_power_multiplier );
+  fmt::format_to( out, " attack_power_multiplier={}", s.attack_power_multiplier );
+  fmt::format_to( out, " base_armor_multiplier={}", s.base_armor_multiplier );
+  fmt::format_to( out, " armor_multiplier={}", s.armor_multiplier );
+  fmt::format_to( out, " position={}", s.position );
 }
 
 void player_t::init()
@@ -1635,7 +1632,7 @@ void player_t::init_base_stats()
       collected_data.dtps.change_mode( false );
   }
 
-  sim->print_debug( "{} generic base stats: {}", *this, base.to_string() );
+  sim->print_debug( "{} generic base stats: {}", *this, base );
 }
 
 /**
@@ -1686,7 +1683,7 @@ void player_t::init_initial_stats()
 
   initial.stats += total_gear;
 
-  sim->print_debug( "{} generic initial stats: %s", *this, initial.to_string() );
+  sim->print_debug( "{} generic initial stats: {}", *this, initial );
 }
 
 void player_t::init_items()
@@ -5065,7 +5062,7 @@ void player_t::reset()
   // Restore default target
   target = default_target;
 
-  sim->print_debug( "{} resets current stats ( reset to initial ): {}", *this, current.to_string() );
+  sim->print_debug( "{} resets current stats ( reset to initial ): {}", *this, current );
 
   for ( auto& buff : buff_list )
     buff->reset();

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -3070,7 +3070,7 @@ void player_t::init_finished()
     range::for_each( items, [this]( const item_t& item ) {
       if ( item.active() )
       {
-        sim->out_debug << item.to_string();
+        sim->print_debug( "{}", item );
       }
     } );
   }

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -1363,7 +1363,7 @@ std::string player_t::base_initial_current_t::to_string()
 {
   std::ostringstream s;
 
-  s << stats.to_string();
+  fmt::print( s, "{}", stats );
   s << " spell_power_per_intellect=" << spell_power_per_intellect;
   s << " spell_power_per_attack_power=" << spell_power_per_attack_power;
   s << " spell_crit_per_intellect=" << spell_crit_per_intellect;
@@ -1678,7 +1678,7 @@ void player_t::init_initial_stats()
         total_gear.add_stat( stat, gear.get_stat( stat ) );
     }
 
-    sim->print_debug( "{} total gear stats: {}", *this, total_gear.to_string() );
+    sim->print_debug( "{} total gear stats: {}", *this, total_gear );
 
     initial.stats += enchant;
     initial.stats += sim->enchant;
@@ -6166,7 +6166,7 @@ void player_t::stat_gain( stat_e stat, double amount, gain_t* gain, action_t* ac
 
   if ( sim->debug )
   {
-    sim->out_debug.print( "{} stats: {}", name(), current.stats.to_string() );
+    sim->out_debug.print( "{} stats: {}", name(), current.stats );
   }
 }
 
@@ -6306,7 +6306,7 @@ void player_t::stat_loss( stat_e stat, double amount, gain_t* gain, action_t* ac
 
   if ( sim->debug )
   {
-    sim->out_debug.print( "{} stats: {}", name(), current.stats.to_string() );
+    sim->out_debug.print( "{} stats: {}", name(), current.stats );
   }
 }
 

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -1921,8 +1921,7 @@ void player_t::init_defense()
 
 void player_t::init_weapon( weapon_t& w )
 {
-  sim->print_debug( "Initializing weapon ( type {} ) for {}.", util::weapon_type_string( w.type ),
-                           *this );
+  sim->print_debug( "Initializing weapon ( type {} ) for {}.", w.type, *this );
 
   if ( w.type == WEAPON_NONE )
     return;

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -1483,7 +1483,7 @@ void player_t::init_base_stats()
   if ( !is_enemy() )
     base.rating.init( *dbc, level() );
 
-  sim->print_debug( "{} base ratings initialized: {}", *this, base.rating.to_string() );
+  sim->print_debug( "{} base ratings initialized: {}", *this, base.rating );
 
   if ( !is_enemy() )
   {

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -189,7 +189,7 @@ struct player_t : public actor_t
   struct base_initial_current_t
   {
     base_initial_current_t();
-    std::string to_string();
+
     gear_stats_t stats;
 
     double spell_power_per_intellect, spell_power_per_attack_power, spell_crit_per_intellect;
@@ -211,6 +211,8 @@ struct player_t : public actor_t
     std::array<double, ATTRIBUTE_MAX> attribute_multiplier;
     double spell_power_multiplier, attack_power_multiplier, base_armor_multiplier, armor_multiplier;
     position_e position;
+
+    friend void format_to( const base_initial_current_t&, fmt::format_context::iterator );
   }
   base, // Base values, from some database or overridden by user
   initial, // Base + Passive + Gear (overridden or items) + Player Enchants + Global Enchants

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -4125,8 +4125,8 @@ void unique_gear::init( player_t* p )
     for ( size_t j = 0; j < item.parsed.special_effects.size(); j++ )
     {
       special_effect_t* effect = item.parsed.special_effects[ j ];
-      if ( p -> sim -> debug )
-        p -> sim -> out_debug.printf( "Initializing item-based special effect %s", effect -> to_string().c_str() );
+
+      p -> sim -> print_debug( "Initializing item-based special effect {}", *effect );
 
       initialize_special_effect_2( effect );
     }
@@ -4136,8 +4136,8 @@ void unique_gear::init( player_t* p )
   for ( size_t i = 0; i < p -> special_effects.size(); i++ )
   {
     special_effect_t* effect = p -> special_effects[ i ];
-    if ( p -> sim -> debug )
-      p -> sim -> out_debug.printf( "Initializing generic special effect %s", effect -> to_string().c_str() );
+
+    p -> sim -> print_debug( "Initializing generic special effect {}", *effect );
 
     initialize_special_effect_2( effect );
   }

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -4802,11 +4802,7 @@ item_t init_punchcard( const special_effect_t& effect )
   // Punchcards use the item level of he trinket itself, apparently.
   punchcard.parsed.data.level = effect.item->item_level();
 
-  if ( effect.player->sim->debug )
-  {
-    effect.player->sim->out_debug.print( "{} initializing punchcard: {}", effect.player->name(),
-                                         punchcard.to_string() );
-  }
+  effect.player->sim->print_debug( "{} initializing punchcard: {}", effect.player->name(), punchcard );
 
   return punchcard;
 }

--- a/engine/sim/sc_gear_stats.cpp
+++ b/engine/sim/sc_gear_stats.cpp
@@ -239,18 +239,6 @@ double gear_stats_t::get_stat( stat_e stat ) const
   return default_value;
 }
 
-std::string gear_stats_t::to_string()
-{
-  std::ostringstream s;
-  for ( stat_e i = STAT_STRENGTH; i < STAT_MAX; i++ )
-  {
-    if ( i > 0 )
-      s << " ";
-    s << util::stat_type_abbrev( i ) << "=" << get_stat( i );
-  }
-  return s.str();
-}
-
 // gear_stats_t::stat_mod ===================================================
 
 double gear_stats_t::stat_mod( stat_e stat )
@@ -260,5 +248,15 @@ double gear_stats_t::stat_mod( stat_e stat )
     case STAT_ATTACK_POWER:      return 1.0;
     case STAT_SPELL_POWER:       return 1.0;
     default:                     return 1.0;
+  }
+}
+
+void format_to( const gear_stats_t& s, fmt::format_context::iterator out )
+{
+  for ( stat_e i = STAT_STRENGTH; i < STAT_MAX; i++ )
+  {
+    if ( i > 0 )
+      fmt::format_to( out, " " );
+    fmt::format_to( out, "{}={}", util::stat_type_abbrev( i ), s.get_stat( i ) );
   }
 }

--- a/engine/util/format.hpp
+++ b/engine/util/format.hpp
@@ -1,0 +1,40 @@
+// ==========================================================================
+// Dedmonwakeen's Raid DPS/TPS Simulator.
+// Send questions to natehieter@gmail.com
+// ==========================================================================
+#ifndef SC_UTIL_FORMAT_HPP_INCLUDED
+#define SC_UTIL_FORMAT_HPP_INCLUDED
+
+#include <type_traits>
+
+#include "fmt/core.h"
+
+namespace util { namespace fmt_detail {
+template <typename...> using void_t = void;
+template <typename T, typename = void> struct has_format_to : std::false_type {};
+template <typename T>
+struct has_format_to<T,
+  void_t<decltype( format_to( std::declval<const T&>(),
+                              std::declval<::fmt::format_context::iterator>() ) ) > > : std::true_type {};
+} } // namespace util::fmt_detail
+
+namespace fmt {
+
+/**
+ * Generic fmt::formatter that supports any type T that has adl-discoverable
+ *  format_to( const T&, fmt::format_context::iterator )
+ * overload.
+ */
+template <typename T>
+struct formatter<T, char, std::enable_if_t<::util::fmt_detail::has_format_to<T>::value>> {
+  constexpr auto parse( format_parse_context& ctx ) { return ctx.begin(); }
+  format_context::iterator format( const T& v, format_context& ctx ) {
+    auto out = ctx.out();
+    format_to( v, out );
+    return out;
+  }
+};
+
+} // namespace fmt
+
+#endif // SC_UTIL_FORMAT_HPP_INCLUDED

--- a/source_files/QT_engine.pri
+++ b/source_files/QT_engine.pri
@@ -151,6 +151,7 @@ HEADERS += engine/util/allocator.hpp
 HEADERS += engine/util/cache.hpp
 HEADERS += engine/util/chrono.hpp
 HEADERS += engine/util/concurrency.hpp
+HEADERS += engine/util/format.hpp
 HEADERS += engine/util/generic.hpp
 HEADERS += engine/util/git_info.hpp
 HEADERS += engine/util/io.hpp

--- a/source_files/VS_engine.props
+++ b/source_files/VS_engine.props
@@ -155,6 +155,7 @@ To change the list of source files run synchronize.py
 		<ClInclude Include="..\engine\util\cache.hpp" />
 		<ClInclude Include="..\engine\util\chrono.hpp" />
 		<ClInclude Include="..\engine\util\concurrency.hpp" />
+		<ClInclude Include="..\engine\util\format.hpp" />
 		<ClInclude Include="..\engine\util\generic.hpp" />
 		<ClInclude Include="..\engine\util\git_info.hpp" />
 		<ClInclude Include="..\engine\util\io.hpp" />

--- a/source_files/cmake_engine.txt
+++ b/source_files/cmake_engine.txt
@@ -149,6 +149,7 @@ util/allocator.hpp
 util/cache.hpp
 util/chrono.hpp
 util/concurrency.hpp
+util/format.hpp
 util/generic.hpp
 util/git_info.hpp
 util/io.hpp


### PR DESCRIPTION
This is basically a resubmit of #5183 now that we seem to properly set `/permissive-` for msvc everywhere.

Minus the enum formatters that already went in.

---

* Add `util/format.hpp` - small helper to reduce boilerplate necessary to add fmtlib formatting support to a type. With this one can add a `void format_to( T, fmt::format_context::iterator )` overload to make the type formattable.
* Switch a bunch of types that had only `.to_string()` member functions to be formattable (through the `format_to()` helper)
* Switch `special_effect_t` & `item_t` to `format_to()` from `operator<<(ostream)`
* Some misc conversions to python-style formatting and formatting enums directly.