### PR TITLE
Drop the action name tokenization. It is unlikely that we get any unt…

### DIFF
--- a/engine/report/sc_report_html_player.cpp
+++ b/engine/report/sc_report_html_player.cpp
@@ -2366,7 +2366,7 @@ void print_html_player_action_priority_list( report::sc_html_stream& os, const p
       continue;
 
     os << "<tr>\n";
-    std::string as = util::encode_html( a->signature->action_.c_str() );
+    std::string as = util::encode_html( a->signature_str );
     if ( !a->signature->comment_.empty() )
       as += "<br/><small><em>" +
             util::encode_html( a->signature->comment_.c_str() ) +


### PR DESCRIPTION
Drop the action name tokenization. It is unlikely that we get any untokenized action names in the APL since it does not support whitespace anyway without escaping. (eg. writing action+=/"Shadow Bolt" )
At least for CI.simc, there is no problem with any action name.

Also change html action priority list to use the actions signature_str, which includes the final input used to create the action, including any modifications by modify_action. Again, not sure if anyone is using modify_action= at all, but if they do you can now see the effective action string in the html report.