### PR TITLE
Random micro-optimizations

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1277,13 +1277,16 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
     amount = 0;
   }
 
-  sim->print_debug(
-      "{} direct amount for {}: amount={} initial_amount={} weapon={} base={} s_mod={} s_power={} "
-      "a_mod={} a_power={} mult={} w_mult={} w_slot_mod={} bonus_da={}",
-      player->name(), name(), amount, state->result_raw, weapon_amount, base_direct_amount,
-      spell_direct_power_coefficient( state ), state->composite_spell_power(),
-      attack_direct_power_coefficient( state ), state->composite_attack_power(), state->composite_da_multiplier(),
-      weapon_multiplier, weapon_slot_modifier, bonus_da( state ) );
+  if ( sim->debug )
+  {
+    sim->print_debug(
+        "{} direct amount for {}: amount={} initial_amount={} weapon={} base={} s_mod={} s_power={} "
+        "a_mod={} a_power={} mult={} w_mult={} w_slot_mod={} bonus_da={}",
+        player->name(), name(), amount, state->result_raw, weapon_amount, base_direct_amount,
+        spell_direct_power_coefficient( state ), state->composite_spell_power(),
+        attack_direct_power_coefficient( state ), state->composite_attack_power(), state->composite_da_multiplier(),
+        weapon_multiplier, weapon_slot_modifier, bonus_da( state ) );
+  }
 
   // Record total amount to state
   if ( result_is_miss( state->result ) )

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1566,7 +1566,7 @@ void action_t::execute()
     {
       action_state_t* s = get_state( pre_execute_state );
       s->target         = tl[ t ];
-      s->n_targets      = as<size_t>( num_targets );
+      s->n_targets      = as<unsigned>( num_targets );
       s->chain_target   = t;
       if ( !pre_execute_state )
       {

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1519,7 +1519,8 @@ void action_t::execute()
     sim->cancel();
   }
 
-  if ( n_targets() == 0 && target->is_sleeping() )
+  int num_targets = n_targets();
+  if ( num_targets == 0 && target->is_sleeping() )
     return;
 
   if ( !execute_targeting( this ) )
@@ -1555,18 +1556,18 @@ void action_t::execute()
     tick_action->snapshot_state( tick_action->execute_state, amount_type( tick_action->execute_state, tick_action->direct_tick ) );
   }
 
-  size_t num_targets;
-  if ( is_aoe() )  // aoe
+  if ( num_targets == -1 || num_targets > 0 )  // aoe
   {
     std::vector<player_t*>& tl = target_list();
-    num_targets                = ( n_targets() < 0 ) ? tl.size() : std::min( tl.size(), as<size_t>( n_targets() ) );
+    const int max_targets = as<int>( tl.size() );
+    num_targets           = ( num_targets < 0 ) ? max_targets : std::min( max_targets, num_targets );
 
-    for ( size_t t = 0, max_targets = tl.size(); t < num_targets && t < max_targets; t++ )
+    for ( int t = 0; t < num_targets; t++ )
     {
       action_state_t* s = get_state( pre_execute_state );
       s->target         = tl[ t ];
-      s->n_targets      = std::min( num_targets, tl.size() );
-      s->chain_target   = as<int>( t );
+      s->n_targets      = as<size_t>( num_targets );
+      s->chain_target   = t;
       if ( !pre_execute_state )
       {
         snapshot_state( s, amount_type( s ) );

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -768,7 +768,7 @@ void action_t::parse_effect_data( const spelleffect_data_t& spelleffect_data )
         energize_amount   = spelleffect_data.resource( energize_resource );
       }
       break;
-      
+
     default:
       break;
   }
@@ -1672,7 +1672,8 @@ void action_t::execute()
     target = default_target;
   }
 
-  if ( energize_type_() == action_energize::ON_CAST || ( energize_type_() == action_energize::ON_HIT && hit_any_target ) )
+  const action_energize energize_type = energize_type_();
+  if ( energize_type == action_energize::ON_CAST || ( energize_type == action_energize::ON_HIT && hit_any_target ) )
   {
     auto amount = composite_energize_amount( execute_state );
     if ( amount != 0 )
@@ -1680,7 +1681,7 @@ void action_t::execute()
       gain_energize_resource( energize_resource_(), amount, energize_gain( execute_state ) );
     }
   }
-  else if ( energize_type_() == action_energize::PER_HIT )
+  else if ( energize_type == action_energize::PER_HIT )
   {
     auto amount = composite_energize_amount( execute_state ) * num_targets_hit;
     if ( amount != 0 )
@@ -1747,7 +1748,7 @@ void action_t::tick( dot_t* d )
   }
 
   if ( energize_type_() == action_energize::PER_TICK && d->get_last_tick_factor() >= 1.0)
-  {    
+  {
     // Partial tick is not counted for resource gain
     gain_energize_resource( energize_resource_(), composite_energize_amount( d->state ), gain );
   }
@@ -3486,7 +3487,7 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
       {
         if ( proxy_expr.size() <= action.target->actor_index )
         {
-          
+
           std::generate_n(std::back_inserter(proxy_expr), action.target->actor_index + 1 - proxy_expr.size(), []{ return std::unique_ptr<expr_t>(); });
         }
 
@@ -4414,7 +4415,7 @@ bool action_t::execute_targeting(action_t* action) const
   return true;
 }
 
-// This returns a list of all targets currently in range. 
+// This returns a list of all targets currently in range.
 std::vector<player_t*> action_t::targets_in_range_list(
   std::vector<player_t*>& tl) const
 {

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1433,7 +1433,8 @@ std::vector<player_t*>& action_t::target_list() const
   {
     available_targets( target_cache.list );  // This grabs the full list of targets, which will also pickup various
                                              // awfulness that some classes have.. such as prismatic crystal.
-    check_distance_targeting( target_cache.list );
+    if ( sim->distance_targeting_enabled )
+      check_distance_targeting( target_cache.list );
     target_cache.is_valid = true;
   }
 
@@ -1523,7 +1524,7 @@ void action_t::execute()
   if ( num_targets == 0 && target->is_sleeping() )
     return;
 
-  if ( !execute_targeting( this ) )
+  if ( sim->distance_targeting_enabled && !execute_targeting( this ) )
   {
     cancel();  // This cancels the cast if the target moves out of range while the spell is casting.
     return;

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -587,6 +587,14 @@ public:
   void apply_affecting_aura(const spell_data_t*);
   void apply_affecting_effect( const spelleffect_data_t& effect );
 
+  action_state_t* get_state( const action_state_t* = nullptr );
+
+private:
+  friend struct action_state_t;
+  void release_state( action_state_t* );
+
+public:
+
   // =======================
   // Const virtual functions
   // =======================
@@ -908,11 +916,6 @@ public:
 
   virtual action_state_t* new_state();
 
-  virtual action_state_t* get_state(const action_state_t* = nullptr);
-private:
-  friend struct action_state_t;
-  virtual void release_state( action_state_t* );
-public:
   virtual void do_schedule_travel( action_state_t*, timespan_t );
 
   virtual void schedule_travel( action_state_t* );

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -544,7 +544,10 @@ public:
   dot_t* find_dot( player_t* target ) const;
 
   bool is_aoe() const
-  { return n_targets() == -1 || n_targets() > 0; }
+  {
+    const int num_targets = n_targets();
+    return num_targets == -1 || num_targets > 0;
+  }
 
   const char* name() const
   { return name_str.c_str(); }

--- a/engine/action/sc_action_state.hpp
+++ b/engine/action/sc_action_state.hpp
@@ -24,7 +24,7 @@ struct action_state_t : private noncopyable
   action_t*       action;
   player_t*       target;
   // Execution attributes
-  size_t          n_targets;            // Total number of targets the execution hits.
+  unsigned        n_targets;            // Total number of targets the execution hits.
   int             chain_target;         // The chain target number, 0 == no chain, 1 == first target, etc.
   double original_x;
   double original_y;

--- a/engine/action/sc_dot.cpp
+++ b/engine/action/sc_dot.cpp
@@ -907,7 +907,8 @@ void dot_t::tick()
       // This should capture most dot driver spells that require a target in
       // range, such as mind sear, while avoiding abilities like bladestorm that
       // do not.
-      if ( !current_action->execute_targeting( current_action ) )
+      if ( current_action->sim->distance_targeting_enabled &&
+           !current_action->execute_targeting( current_action ) )
       {
         current_action->reset();
         return;

--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -61,6 +61,11 @@ school_e spelleffect_data_t::school_type() const
   return dbc::get_school_type( as<uint32_t>( misc_value1() ) );
 }
 
+bool spelleffect_data_t::has_common_school( school_e school ) const
+{
+  return ( as<uint32_t>( misc_value1() ) & dbc::get_school_mask( school ) ) != 0;
+}
+
 double spelleffect_data_t::delta( const player_t* p, unsigned level ) const
 {
   assert( level <= MAX_SCALING_LEVEL );

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -238,6 +238,8 @@ struct spelleffect_data_t
 
   school_e school_type() const;
 
+  bool has_common_school( school_e ) const;
+
   double mastery_value() const
   { return _sp_coeff * ( 1 / 100.0 ); }
 

--- a/engine/player/player_collected_data.hpp
+++ b/engine/player/player_collected_data.hpp
@@ -101,13 +101,13 @@ struct player_collected_data_t
 
     double get_bin_size() const
     {
-      if ( timeline.get_bin_size() != timeline_normalized.get_bin_size() || timeline.get_bin_size() != merged_timeline.get_bin_size() )
+      if ( timeline.bin_size() != timeline_normalized.bin_size() || timeline.bin_size() != merged_timeline.bin_size() )
       {
         assert( false );
         return 0.0;
       }
       else
-        return timeline.get_bin_size();
+        return timeline.bin_size();
     }
   };
 

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -4375,10 +4375,10 @@ double player_t::composite_player_vulnerability( school_e school ) const
     m *= 1.0 + debuffs.damage_taken->current_stack * 0.01;
 
   if ( debuffs.mystic_touch &&
-       dbc::has_common_school( debuffs.mystic_touch->data().effectN( 1 ).school_type(), school ) )
+       debuffs.mystic_touch->data().effectN( 1 ).has_common_school( school ) )
     m *= 1.0 + debuffs.mystic_touch->value();
 
-  if ( debuffs.chaos_brand && dbc::has_common_school( debuffs.chaos_brand->data().effectN( 1 ).school_type(), school ) )
+  if ( debuffs.chaos_brand && debuffs.chaos_brand->data().effectN( 1 ).has_common_school( school ) )
     m *= 1.0 + debuffs.chaos_brand->value();
 
   return m;

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -4187,21 +4187,21 @@ std::vector<double> sc_timeline_t::build_divisor_timeline( const extended_sample
 void sc_timeline_t::adjust( sim_t& sim )
 {
   // Check if we have divisor timeline cached
-  auto it = sim.divisor_timeline_cache.find( bin_size );
+  auto it = sim.divisor_timeline_cache.find( bin_size_ );
   if ( it == sim.divisor_timeline_cache.end() )
   {
     // If we don't have a cached divisor timeline, build one
-    sim.divisor_timeline_cache[ bin_size ] = build_divisor_timeline( sim.simulation_length, bin_size );
+    sim.divisor_timeline_cache[ bin_size_ ] = build_divisor_timeline( sim.simulation_length, bin_size_ );
   }
 
   // Do the timeline adjustement
-  base_t::adjust( sim.divisor_timeline_cache[ bin_size ] );
+  timeline_t::adjust( sim.divisor_timeline_cache[ bin_size_ ] );
 }
 
 void sc_timeline_t::adjust( const extended_sample_data_t& adjustor )
 {
   // Do the timeline adjustement
-  base_t::adjust( build_divisor_timeline( adjustor, bin_size ) );
+  timeline_t::adjust( build_divisor_timeline( adjustor, bin_size_ ) );
 }
 
 // FIXME!  Move this to util at some point.

--- a/engine/util/sample_data.hpp
+++ b/engine/util/sample_data.hpp
@@ -258,18 +258,16 @@ private:
   using base_t = simple_sample_data_t;
 
 protected:
-  bool _found  = false;
   value_t _min = std::numeric_limits<value_t>::max();
   value_t _max = std::numeric_limits<value_t>::lowest();
+
   void set_min( double x )
   {
-    _min   = x;
-    _found = true;
+    _min = x < _min ? x : _min;
   }
   void set_max( double x )
   {
-    _max   = x;
-    _found = true;
+    _max = x > _max ? x : _max;
   }
 
 public:
@@ -277,44 +275,32 @@ public:
   {
     base_t::add( x );
 
-    if ( x < _min )
-    {
-      set_min( x );
-    }
-    if ( x > _max )
-    {
-      set_max( x );
-    }
+    set_min( x );
+    set_max( x );
   }
 
-  bool found_min_max() const
-  {
-    return _found;
-  }
   value_t min() const
   {
-    return _found ? _min : base_t::nan();
+    return _min <= _max ? _min : base_t::nan();
   }
   value_t max() const
   {
-    return _found ? _max : base_t::nan();
+    return _min <= _max ? _max : base_t::nan();
   }
 
   void merge( const simple_sample_data_with_min_max_t& other )
   {
     base_t::merge( other );
 
-    if ( other.found_min_max() )
-    {
-      if ( other._min < _min )
-      {
-        set_min( other._min );
-      }
-      if ( other._max > _max )
-      {
-        set_max( other._max );
-      }
-    }
+    set_min( other._min );
+    set_max( other._max );
+  }
+
+  void reset()
+  {
+    base_t::reset();
+    _min = std::numeric_limits<value_t>::max();
+    _max = std::numeric_limits<value_t>::lowest();
   }
 };
 
@@ -508,8 +494,7 @@ public:
 
   void clear()
   {
-    base_t::_count = 0;
-    base_t::_sum   = 0.0;
+    base_t::reset();
     _sorted_data.clear();
     _data.clear();
     distribution.clear();


### PR DESCRIPTION
A bunch of assorted "low hanging fruit" micro-optimizations.

500 runs each of `./simc profiles/CI.simc deterministic=1 iterations=2000`, comparing reported `WallSeconds`, run on i5-4670:
```
nuohep@r2d2:~/dev/simc> ministat -q time-sl.csv time-opt.csv
x time-sl.csv
+ time-opt.csv
    N           Min           Max        Median           Avg        Stddev
x 500     14.424525     16.535181     14.647144     14.661221    0.28289978
+ 500      14.04275     15.538632     14.302173     14.308267    0.13311956
Difference at 95.0% confidence
        -0.352955 +/- 0.0274054
        -2.4074% +/- 0.186924%
        (Student's t, pooled s = 0.22108)
```
So an almost 2.5% speed-up.

Also contains a bug-fix in adf6a3c.