### PR TITLE
Decoare pets with npc id

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -855,6 +855,7 @@ struct shadowfiend_pet_t final : public base_fiend_pet_t
       power_leech_insanity( o().find_spell( 262485 )->effectN( 1 ).resource( RESOURCE_INSANITY ) )
   {
     direct_power_mod = 0.408;  // New modifier after Spec Spell has been 0'd -- Anshlun 2020-10-06
+    npc_id = 19668;
 
     main_hand_weapon.min_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;
     main_hand_weapon.max_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;
@@ -883,6 +884,7 @@ struct mindbender_pet_t final : public base_fiend_pet_t
       power_leech_insanity( o().find_spell( 200010 )->effectN( 1 ).resource( RESOURCE_INSANITY ) )
   {
     direct_power_mod = 0.442;  // New modifier after Spec Spell has been 0'd -- Anshlun 2020-10-06
+    npc_id = 62982;
 
     main_hand_weapon.min_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;
     main_hand_weapon.max_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;

--- a/engine/player/pet.hpp
+++ b/engine/player/pet.hpp
@@ -21,10 +21,11 @@ struct pet_t : public player_t
   double intellect_per_owner;
   bool summoned;
   bool dynamic;
+  bool affects_wod_legendary_ring;
   pet_e pet_type;
   event_t* expiration;
   timespan_t duration;
-  bool affects_wod_legendary_ring;
+  int npc_id; // WoW NPC id, can be used to display icons/links for the pet
 
   struct owner_coefficients_t
   {

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -59,10 +59,11 @@ pet_t::pet_t( sim_t*             sim,
   intellect_per_owner( 0.30 ),
   summoned( false ),
   dynamic( dynamic ),
+  affects_wod_legendary_ring( true ),
   pet_type( type ),
   expiration( nullptr ),
   duration( timespan_t::zero() ),
-  affects_wod_legendary_ring( true ),
+  npc_id(),
   owner_coeff()
 {
   target = owner -> target;

--- a/engine/report/decorators.cpp
+++ b/engine/report/decorators.cpp
@@ -59,6 +59,12 @@ namespace {
       return {};
     }
 
+    // shown when data can not be decorated
+    virtual std::string undecorated_fallback() const
+    {
+      return fmt::format( "<a href=\"#\">{}</a>", token() );
+    }
+
     std::vector<std::string> params;
   };
 
@@ -70,7 +76,7 @@ namespace {
 
     if (!data.can_decorate())
     {
-      return "<a href=\"#\">" + data.token() + "</a>";
+      return data.undecorated_fallback();
     }
 
     const std::string url_name = data.url_name();
@@ -325,6 +331,11 @@ namespace {
     {
       fmt::format_to(buf, "<a href=\"https://{}.wowhead.com/npc={}",
                      report_decorators::decoration_domain(*m_sim), m_npc_id);
+    }
+
+    std::string undecorated_fallback() const override
+    {
+      return token();
     }
 
     bool can_decorate() const override

--- a/engine/report/decorators.cpp
+++ b/engine/report/decorators.cpp
@@ -10,6 +10,7 @@
 #include "dbc/dbc.hpp"
 #include "item/item.hpp"
 #include "player/sc_player.hpp"
+#include "player/pet.hpp"
 #include "report/color.hpp"
 #include "util/util.hpp"
 
@@ -302,6 +303,46 @@ namespace {
   };
 
 
+  // Generic spell data decorator, supports player and item driven spell data
+  class npc_decorator_t : public decorator_data_t
+  {
+    const sim_t* m_sim;
+    const std::string m_name;
+    const int m_npc_id;
+
+  public:
+    npc_decorator_t(const sim_t* obj, util::string_view name, int npc_id) :
+      m_sim(obj), m_name(name), m_npc_id(npc_id)
+    { }
+
+    npc_decorator_t(const pet_t& pet) :
+      npc_decorator_t(pet.sim, pet.name_str, pet.npc_id)
+    {
+      
+    }
+
+    void base_url(fmt::memory_buffer& buf) const override
+    {
+      fmt::format_to(buf, "<a href=\"https://{}.wowhead.com/npc={}",
+                     report_decorators::decoration_domain(*m_sim), m_npc_id);
+    }
+
+    bool can_decorate() const override
+    {
+      return m_sim->decorated_tooltips && m_npc_id > 0;
+    }
+
+    std::string url_name() const override
+    {
+      return util::encode_html(m_name);
+    }
+    
+    std::string token() const override
+    {
+      return util::encode_html( util::tokenize_fn( m_name ) );
+    }
+  };
+
 } // unnamed namespace
 
 namespace report_decorators {
@@ -405,4 +446,10 @@ namespace report_decorators {
   {
     return decorate(item_decorator_t(&item));
   }
+  
+  std::string decorated_npc(const pet_t& pet)
+  {
+    return decorate(npc_decorator_t(pet));
+  }
+
 } // report_decorators

--- a/engine/report/decorators.hpp
+++ b/engine/report/decorators.hpp
@@ -15,6 +15,7 @@ struct buff_t;
 struct item_t;
 struct sim_t;
 struct spell_data_t;
+struct pet_t;
 namespace color {
   struct rgb;
 }
@@ -29,4 +30,5 @@ namespace report_decorators {
   std::string decorated_spell_data(const sim_t& sim, const spell_data_t* spell);
   std::string decorated_spell_data_item(const sim_t& sim, const spell_data_t* spell, const item_t& item);
   std::string decorated_item(const item_t& item);
+  std::string decorated_npc(const pet_t& pet);
 }  // report_decorators

--- a/engine/report/sc_report_html_player.cpp
+++ b/engine/report/sc_report_html_player.cpp
@@ -2660,7 +2660,7 @@ void print_html_resource_gains_table( report::sc_html_stream& os, const player_t
         {
           first = false;
           os << "<tr class=\"petrow\">\n"
-              << "<th colspan=\"8\" class=\"left small\">pet - " << util::encode_html( pet->name_str ) << "</th>\n"
+              << "<th colspan=\"8\" class=\"left small\">pet - " << report_decorators::decorated_npc( *pet ) << "</th>\n"
               << "</tr>\n";
         }
       }
@@ -2711,9 +2711,10 @@ void print_html_resource_usage_table( report::sc_html_stream& os, const player_t
         if ( first )
         {
           first = false;
-          os << "<tr class=\"petrow\">\n"
-             << "<th <th colspan=\"8\" class=\"left small\">pet - " << util::encode_html( pet->name_str ) << "</th>\n"
-             << "</tr>\n";
+          fmt::print(os, "<tr class=\"petrow\">\n");
+          fmt::print(os, "<th <th colspan=\"8\" class=\"left small\">pet - {}</th>\n", report_decorators::decorated_npc( *pet ));
+          fmt::print(os, "</tr>\n");
+
         }
         print_html_action_resource( os, *stat );
       }
@@ -4081,7 +4082,7 @@ void output_player_damage_summary( report::sc_html_stream& os, const player_t& a
             "<th class=\"right small\">%.0f / %.0f</th>\n"
             "<td colspan=\"%d\" class=\"filler\"></td>\n"
             "</tr>\n",
-            util::encode_html( pet->name_str ).c_str(), pet->collected_data.dps.mean(),
+            report_decorators::decorated_npc( *pet ), pet->collected_data.dps.mean(),
             pet->collected_data.dpse.mean(),
             static_columns + n_optional_columns );
         os << "</tbody>\n";
@@ -4183,7 +4184,7 @@ void output_player_heal_summary( report::sc_html_stream& os, const player_t& act
             "<th class=\"right small\">%.0f / %.0f</th>\n"
             "<td colspan=\"%d\" class=\"filler\"></td>\n"
             "</tr>\n",
-            util::encode_html( pet->name_str ).c_str(), pet->collected_data.dps.mean(),
+            report_decorators::decorated_npc( *pet ), pet->collected_data.dps.mean(),
             pet->collected_data.dpse.mean(),
             static_columns + n_optional_columns );
         os << "</tbody>\n";
@@ -4256,7 +4257,7 @@ void output_player_simple_ability_summary( report::sc_html_stream& os, const pla
         else
           os << "<tr>\n";
 
-        os << "<th <th colspan=\"3\" class=\"left small\">pet - " << util::encode_html( pet->name_str ) << "</th>\n"
+        os << "<th <th colspan=\"3\" class=\"left small\">pet - " << report_decorators::decorated_npc( *pet ) << "</th>\n"
            << "</tr>\n"
            << "</tbody>\n";
       }


### PR DESCRIPTION
Add option to add npc_id to pet_t.

Use that to decorate the pet name in the html report if npc_id > 0.