### PR TITLE
Per-sim spell overrides

### DIFF
--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -115,6 +115,10 @@ struct custom_dbc_data_t
   spellpower_data_t* get_mutable_power( unsigned power_id );
   const spellpower_data_t* find_power( unsigned power_id ) const;
 
+  // Copies spells from another custom data
+  // Effectively a copy-assignement operator
+  void copy_from( const custom_dbc_data_t& other );
+
 private:
   spell_data_t* create_clone( const spell_data_t* s );
 
@@ -533,10 +537,17 @@ public:
   };
 
   dbc_override_t() = default;
+  explicit dbc_override_t( const dbc_override_t& parent ) : parent_( &parent ) {}
 
   void register_effect( const dbc_t&, unsigned, util::string_view, double );
   void register_spell( const dbc_t&, unsigned, util::string_view, double );
   void register_power( const dbc_t&, unsigned, util::string_view, double );
+
+  void parse( const dbc_t&, util::string_view );
+
+  // Copies spells from another dbc override storage
+  // Effectively a copy-assignement operator
+  void copy_from( const dbc_override_t& other );
 
   const spell_data_t* find_spell( unsigned, bool ptr = false ) const;
   const spelleffect_data_t* find_effect( unsigned, bool ptr = false ) const;
@@ -545,6 +556,7 @@ public:
   const std::vector<override_entry_t>& override_entries( bool ptr = false ) const;
 
 private:
+  const dbc_override_t* parent_ = nullptr;
   std::array<custom_dbc_data_t, 2> override_db_;
   std::array<std::vector<override_entry_t>, 2> override_entries_;
 };

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -537,6 +537,7 @@ public:
 
 namespace dbc
 {
+
 // Wrapper for fetching spell data through various spell data variants
 template <typename T>
 const spell_data_t* find_spell( const T* obj, const spell_data_t* spell )
@@ -570,37 +571,6 @@ const spell_data_t* find_spell( const T* obj, unsigned spell_id )
   return obj -> dbc->spell( spell_id );
 }
 
-template <typename T>
-const spelleffect_data_t* find_effect( const T* obj, const spelleffect_data_t* effect )
-{
-  if ( const spelleffect_data_t* override_effect = dbc_override::find_effect( effect -> id(), obj -> dbc->ptr ) )
-  {
-    return override_effect;
-  }
-
-  if ( ! obj -> disable_hotfixes )
-  {
-    return hotfix::find_effect( effect, obj -> dbc->ptr );
-  }
-
-  return effect;
-}
-
-template <typename T>
-const spelleffect_data_t* find_effect( const T* obj, unsigned effect_id )
-{
-  if ( const spelleffect_data_t* override_effect = dbc_override::find_effect( effect_id, obj -> dbc->ptr ) )
-  {
-    return override_effect;
-  }
-
-  if ( ! obj -> disable_hotfixes )
-  {
-    return hotfix::find_effect( obj -> dbc.effect( effect_id ), obj -> dbc->ptr );
-  }
-
-  return obj -> dbc->effect( effect_id );
-}
 } // dbc namespace ends
 
 #endif // SC_DBC_HPP

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -698,14 +698,8 @@ spell_data_t* custom_dbc_data_t::clone_spell( const spell_data_t* spell )
   return get_mutable_spell( spell->id() );
 }
 
-namespace dbc_override
-{
-  custom_dbc_data_t override_db_[ 2 ];
-  std::vector<dbc_override_entry_t> override_entries_;
-}
-
 // Applies overrides immediately, and records an entry
-void dbc_override::register_spell( dbc_t& dbc, unsigned spell_id, util::string_view field, double v )
+void dbc_override_t::register_spell( const dbc_t& dbc, unsigned spell_id, util::string_view field, double v )
 {
   spell_data_t* spell = override_db_[ dbc.ptr ].clone_spell( dbc.spell( spell_id ) );
   if (!spell)
@@ -717,10 +711,10 @@ void dbc_override::register_spell( dbc_t& dbc, unsigned spell_id, util::string_v
     throw std::invalid_argument(fmt::format("Invalid field '{}'.", field));
   }
 
-  override_entries_.emplace_back( DBC_OVERRIDE_SPELL, field, spell_id, v );
+  override_entries_[ dbc.ptr ].emplace_back( OVERRIDE_SPELL, field, spell_id, v );
 }
 
-void dbc_override::register_effect( dbc_t& dbc, unsigned effect_id, util::string_view field, double v )
+void dbc_override_t::register_effect( const dbc_t& dbc, unsigned effect_id, util::string_view field, double v )
 {
   spelleffect_data_t* effect = override_db_[ dbc.ptr ].get_mutable_effect( effect_id );
   if ( ! effect )
@@ -739,10 +733,10 @@ void dbc_override::register_effect( dbc_t& dbc, unsigned effect_id, util::string
     throw std::invalid_argument(fmt::format("Invalid field '{}'.", field));
   }
 
-  override_entries_.emplace_back( DBC_OVERRIDE_EFFECT, field, effect_id, v );
+  override_entries_[ dbc.ptr ].emplace_back( OVERRIDE_EFFECT, field, effect_id, v );
 }
 
-void dbc_override::register_power( dbc_t& dbc, unsigned power_id, util::string_view field, double v )
+void dbc_override_t::register_power( const dbc_t& dbc, unsigned power_id, util::string_view field, double v )
 {
   auto power = override_db_[ dbc.ptr ].get_mutable_power( power_id );
   if ( power == nullptr )
@@ -761,19 +755,24 @@ void dbc_override::register_power( dbc_t& dbc, unsigned power_id, util::string_v
     throw std::invalid_argument(fmt::format("Invalid field '{}'.", field));
   }
 
-  override_entries_.emplace_back( DBC_OVERRIDE_POWER, field, power_id, v );
+  override_entries_[ dbc.ptr ].emplace_back( OVERRIDE_POWER, field, power_id, v );
 }
 
-const spell_data_t* dbc_override::find_spell( unsigned spell_id, bool ptr )
+const spell_data_t* dbc_override_t::find_spell( unsigned spell_id, bool ptr ) const
 {
   return override_db_[ ptr ].find_spell( spell_id );
 }
 
-const spelleffect_data_t* dbc_override::find_effect( unsigned effect_id, bool ptr )
+const spelleffect_data_t* dbc_override_t::find_effect( unsigned effect_id, bool ptr ) const
 {
   return override_db_[ ptr ].find_effect( effect_id );
 }
 
-const std::vector<dbc_override::dbc_override_entry_t>& dbc_override::override_entries()
-{ return override_entries_; }
+const spellpower_data_t* dbc_override_t::find_power( unsigned power_id, bool ptr ) const
+{
+  return override_db_[ ptr ].find_power( power_id );
+}
+
+const std::vector<dbc_override_t::override_entry_t>& dbc_override_t::override_entries( bool ptr ) const
+{ return override_entries_[ ptr ]; }
 

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -164,7 +164,7 @@ double spellpower_data_t::get_field( util::string_view field ) const
 namespace hotfix
 {
 static auto_dispose< std::vector< hotfix_entry_t* > > hotfixes_;
-static custom_dbc_data_t hotfix_db_;
+static custom_dbc_data_t hotfix_db_[ 2 ];
 }
 
 // Very simple comparator, just checks for some equality in the data. There's no need for fanciful
@@ -204,7 +204,7 @@ void hotfix::apply()
 // Return a hotfixed spell if available, otherwise return the original dbc-based spell
 const spell_data_t* hotfix::find_spell( const spell_data_t* dbc_spell, bool ptr )
 {
-  if ( const spell_data_t* hotfixed_spell = hotfix_db_.find_spell( dbc_spell -> id(), ptr ) )
+  if ( const spell_data_t* hotfixed_spell = hotfix_db_[ ptr ].find_spell( dbc_spell -> id() ) )
   {
     return hotfixed_spell;
   }
@@ -213,7 +213,7 @@ const spell_data_t* hotfix::find_spell( const spell_data_t* dbc_spell, bool ptr 
 
 const spelleffect_data_t* hotfix::find_effect( const spelleffect_data_t* dbc_effect, bool ptr )
 {
-  if ( const spelleffect_data_t* hotfixed_effect = hotfix_db_.find_effect( dbc_effect -> id(), ptr ) )
+  if ( const spelleffect_data_t* hotfixed_effect = hotfix_db_[ ptr ].find_effect( dbc_effect -> id() ) )
   {
     return hotfixed_effect;
   }
@@ -376,7 +376,7 @@ std::string spell_hotfix_entry_t::to_str() const
   s << hotfix_entry_t::to_str();
   s << std::endl;
 
-  const spell_data_t* spell = hotfix_db_.find_spell( id_, false );
+  const spell_data_t* spell = hotfix_db_[ false ].find_spell( id_ );
   s << "             ";
   s << "Spell: " << spell -> name_cstr();
   s << " | Field: " << field_name_;
@@ -397,7 +397,7 @@ std::string effect_hotfix_entry_t::to_str() const
   s << hotfix_entry_t::to_str();
   s << std::endl;
 
-  const spelleffect_data_t* e = hotfix_db_.find_effect( id_, false );
+  const spelleffect_data_t* e = hotfix_db_[ false ].find_effect( id_ );
   s << "             ";
   s << "Spell: " << e -> spell() -> name_cstr();
   s << " effect#" << ( e -> index() + 1 );
@@ -419,7 +419,7 @@ std::string power_hotfix_entry_t::to_str() const
   s << hotfix_entry_t::to_str();
   s << std::endl;
 
-  const spellpower_data_t* p = hotfix_db_.find_power( id_, false );
+  const spellpower_data_t* p = hotfix_db_[ false ].find_power( id_ );
   s << "             ";
   s << "Power: " << p -> id();
   s << " | Field: " << field_name_;
@@ -436,7 +436,9 @@ std::string power_hotfix_entry_t::to_str() const
 
 void spell_hotfix_entry_t::apply_hotfix( bool ptr )
 {
-  spell_data_t* s = hotfix_db_.clone_spell( id_, ptr );
+  const spell_data_t* source_spell = spell_data_t::find( id_, ptr );
+
+  spell_data_t* s = hotfix_db_[ ptr ].clone_spell( source_spell );
 
   assert( s && "Could not clone spell to apply hotfix" );
 
@@ -462,10 +464,10 @@ void effect_hotfix_entry_t::apply_hotfix( bool ptr )
   const spelleffect_data_t* source_effect = spelleffect_data_t::find( id_, ptr );
 
   // Cloning the spell chain will guarantee that the effect is also always cloned
-  const spell_data_t* s = hotfix_db_.clone_spell( source_effect -> spell() -> id(), ptr );
+  const spell_data_t* s = hotfix_db_[ ptr ].clone_spell( source_effect -> spell() );
   assert( s && "Could not clone spell to apply hotfix" );
 
-  spelleffect_data_t* e = hotfix_db_.get_mutable_effect( id_, ptr );
+  spelleffect_data_t* e = hotfix_db_[ ptr ].get_mutable_effect( id_ );
   if ( !e ) { return; }
 
   dbc_value_ = e -> get_field( field_name_ );
@@ -486,12 +488,13 @@ void effect_hotfix_entry_t::apply_hotfix( bool ptr )
 void power_hotfix_entry_t::apply_hotfix( bool ptr )
 {
   const spellpower_data_t& source_power = spellpower_data_t::find( id_, ptr );
+  const spell_data_t* source_spell = spell_data_t::find( source_power.spell_id(), ptr );
 
-  // Cloning the spell chain will guarantee that the effect is also always cloned
-  const spell_data_t* s = hotfix_db_.clone_spell( source_power.spell_id(), ptr );
+  // Cloning the spell chain will guarantee that the power is also always cloned
+  const spell_data_t* s = hotfix_db_[ ptr ].clone_spell( source_spell );
   assert( s && "Could not clone spell to apply hotfix" );
 
-  spellpower_data_t* p = hotfix_db_.get_mutable_power( id_, ptr );
+  spellpower_data_t* p = hotfix_db_[ ptr ].get_mutable_power( id_ );
   if ( !p ) { return; }
 
   dbc_value_ = p -> get_field( field_name_ );
@@ -509,119 +512,61 @@ void power_hotfix_entry_t::apply_hotfix( bool ptr )
   do_hotfix( this, p );
 }
 
-spell_data_t* custom_dbc_data_t::get_mutable_spell( unsigned spell_id, bool ptr )
+spell_data_t* custom_dbc_data_t::get_mutable_spell( unsigned spell_id )
 {
-  for ( size_t i = 0, end = spells_[ ptr ].size(); i < end; ++i )
-  {
-    if ( spells_[ ptr ][ i ] -> id() == spell_id )
-    {
-      return spells_[ ptr ][ i ];
-    }
-  }
+  return const_cast<spell_data_t*>( find_spell( spell_id ) );
+}
 
+const spell_data_t* custom_dbc_data_t::find_spell( unsigned spell_id ) const
+{
+  auto spell = range::find( spells_, spell_id, &spell_data_t::id );
+  if ( spell != spells_.end() )
+    return *spell;
   return nullptr;
 }
 
-const spell_data_t* custom_dbc_data_t::find_spell( unsigned spell_id, bool ptr ) const
+void custom_dbc_data_t::add_spell( spell_data_t* spell )
 {
-  for ( size_t i = 0, end = spells_[ ptr ].size(); i < end; ++i )
-  {
-    if ( spells_[ ptr ][ i ] -> id() == spell_id )
-    {
-      return spells_[ ptr ][ i ];
-    }
-  }
+  assert( find_spell( spell->id() ) == nullptr );
+  spells_.push_back( spell );
+}
 
+spelleffect_data_t* custom_dbc_data_t::get_mutable_effect( unsigned effect_id )
+{
+  return const_cast<spelleffect_data_t*>( find_effect( effect_id ) );
+}
+
+const spelleffect_data_t* custom_dbc_data_t::find_effect( unsigned effect_id ) const
+{
+  auto effect = range::find( effects_, effect_id, &spelleffect_data_t::id );
+  if ( effect != effects_.end() )
+    return *effect;
   return nullptr;
 }
 
-bool custom_dbc_data_t::add_spell( spell_data_t* spell, bool ptr )
+void custom_dbc_data_t::add_effect( spelleffect_data_t* effect )
 {
-  if ( find_spell( spell -> id(), ptr ) )
-  {
-    return false;
-  }
-
-  spells_[ ptr ].push_back( spell );
-
-  return true;
+  assert( find_effect( effect->id() ) == nullptr );
+  effects_.push_back( effect );
 }
 
-spelleffect_data_t* custom_dbc_data_t::get_mutable_effect( unsigned effect_id, bool ptr )
+spellpower_data_t* custom_dbc_data_t::get_mutable_power( unsigned power_id )
 {
-  for ( size_t i = 0, end = effects_[ ptr ].size(); i < end; ++i )
-  {
-    if ( effects_[ ptr ][ i ] -> id() == effect_id )
-    {
-      return effects_[ ptr ][ i ];
-    }
-  }
+  return const_cast<spellpower_data_t*>( find_power( power_id ) );
+}
 
+const spellpower_data_t* custom_dbc_data_t::find_power( unsigned power_id ) const
+{
+  auto power = range::find( powers_, power_id, &spellpower_data_t::id );
+  if ( power != powers_.end() )
+    return *power;
   return nullptr;
 }
 
-const spelleffect_data_t* custom_dbc_data_t::find_effect( unsigned effect_id, bool ptr ) const
+void custom_dbc_data_t::add_power( spellpower_data_t* power )
 {
-  for ( size_t i = 0, end = effects_[ ptr ].size(); i < end; ++i )
-  {
-    if ( effects_[ ptr ][ i ] -> id() == effect_id )
-    {
-      return effects_[ ptr ][ i ];
-    }
-  }
-
-  return nullptr;
-}
-
-bool custom_dbc_data_t::add_effect( spelleffect_data_t* effect, bool ptr )
-{
-  if ( find_effect( effect -> id(), ptr ) )
-  {
-    return false;
-  }
-
-  effects_[ ptr ].push_back( effect );
-
-  return true;
-}
-
-spellpower_data_t* custom_dbc_data_t::get_mutable_power( unsigned power_id, bool ptr )
-{
-  for ( size_t i = 0, end = powers_[ ptr ].size(); i < end; ++i )
-  {
-    if ( powers_[ ptr ][ i ] -> id() == power_id )
-    {
-      return powers_[ ptr ][ i ];
-    }
-  }
-
-  return nullptr;
-}
-
-const spellpower_data_t* custom_dbc_data_t::find_power( unsigned power_id, bool ptr ) const
-{
-  auto it = range::find_if( powers_[ ptr ], [ power_id ]( spellpower_data_t* power ) {
-      return power -> id() == power_id;
-  } );
-
-  if ( it != powers_[ ptr ].end() )
-  {
-    return *it;
-  }
-
-  return nullptr;
-}
-
-bool custom_dbc_data_t::add_power( spellpower_data_t* power, bool ptr )
-{
-  if ( find_power( power -> id(), ptr ) )
-  {
-    return false;
-  }
-
-  powers_[ ptr ].push_back( power );
-
-  return true;
+  assert( find_power( power -> id() ) == nullptr );
+  powers_.push_back( power );
 }
 
 static void collect_base_spells( const spell_data_t* spell, std::vector<const spell_data_t*>& roots )
@@ -643,15 +588,15 @@ static void collect_base_spells( const spell_data_t* spell, std::vector<const sp
   }
 }
 
-spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool ptr )
+spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source )
 {
-  spell_data_t* clone = get_mutable_spell( source -> id(), ptr );
+  spell_data_t* clone = get_mutable_spell( source -> id() );
   if ( clone )
   {
     return clone;
   }
 
-  clone = new spell_data_t( *source );
+  clone = allocator_.create<spell_data_t>( *source );
 
   spelleffect_data_t* clone_effects = nullptr;
   if ( source -> effect_count() > 0 )
@@ -670,7 +615,7 @@ spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool 
   // Drivers are set up in the parent's cloning of the trigger spell
   clone -> _driver = nullptr;
   clone -> _driver_count = 0;
-  add_spell( clone, ptr );
+  add_spell( clone );
 
   // Clone effects
   const auto source_effects = source -> effects();
@@ -684,8 +629,8 @@ spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool 
 
     spelleffect_data_t& e_clone = clone_effects[ i ];
 
-    e_clone = *spelleffect_data_t::find( e_source.id(), ptr );
-    add_effect( &e_clone, ptr );
+    e_clone = e_source;
+    add_effect( &e_clone );
 
     // Link cloned spell to cloned effect
     e_clone._spell = clone;
@@ -698,12 +643,12 @@ spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool 
 
     // Clone the trigger, and re-link drivers in the trigger spell so they also point to cloned
     // data. This is necessary because Blizzard re-uses trigger spells in multiple drivers.
-    auto e_clone_trigger = create_clone( e_source.trigger(), ptr );
+    auto e_clone_trigger = create_clone( e_source.trigger() );
     e_clone._trigger_spell = e_clone_trigger;
     assert( e_source.trigger() -> _driver );
 
     const auto e_source_trigger_drivers = e_source.trigger() -> drivers();
-    auto& e_clone_trigger_drivers = spell_driver_map_[ ptr ][ e_source.trigger() -> id() ];
+    auto& e_clone_trigger_drivers = spell_driver_map_[ e_source.trigger() -> id() ];
     if ( e_clone_trigger_drivers.empty() )
     {
       auto driver_data = allocator_.create_n<const spell_data_t*>( e_source_trigger_drivers.size(), spell_data_t::nil() );
@@ -727,42 +672,42 @@ spell_data_t* custom_dbc_data_t::create_clone( const spell_data_t* source, bool 
       continue;
     }
 
-    clone_power[ i ] = spellpower_data_t::find( p_source.id(), ptr );
-    add_power( &clone_power[ i ], ptr );
+    clone_power[ i ] = p_source;
+    add_power( &clone_power[ i ] );
   }
 
   return clone;
 }
 
-spell_data_t* custom_dbc_data_t::clone_spell( unsigned clone_spell_id, bool ptr )
+spell_data_t* custom_dbc_data_t::clone_spell( const spell_data_t* spell )
 {
   // If a spell is found, we can be sure that the whole spell chain has already been cloned, so just
   // return the base spell
-  if ( spell_data_t* c = get_mutable_spell( clone_spell_id, ptr ) )
+  if ( spell_data_t* c = get_mutable_spell( spell->id() ) )
     return c;
 
   // Get to the root of the potential chain
   std::vector<const spell_data_t*> base_spells;
-  collect_base_spells( spell_data_t::find( clone_spell_id, ptr ), base_spells );
+  collect_base_spells( spell, base_spells );
   for ( auto base_spell : base_spells )
   {
     // Create clones of the base spell chains, we don't really care about individual spells for now
-    create_clone( base_spell, ptr );
+    create_clone( base_spell );
   }
 
-  return get_mutable_spell( clone_spell_id, ptr );
+  return get_mutable_spell( spell->id() );
 }
 
 namespace dbc_override
 {
-  custom_dbc_data_t override_db_;
+  custom_dbc_data_t override_db_[ 2 ];
   std::vector<dbc_override_entry_t> override_entries_;
 }
 
 // Applies overrides immediately, and records an entry
 void dbc_override::register_spell( dbc_t& dbc, unsigned spell_id, util::string_view field, double v )
 {
-  spell_data_t* spell = override_db_.clone_spell( spell_id, dbc.ptr );
+  spell_data_t* spell = override_db_[ dbc.ptr ].clone_spell( dbc.spell( spell_id ) );
   if (!spell)
   {
     throw std::invalid_argument("Could not find spell");
@@ -777,12 +722,12 @@ void dbc_override::register_spell( dbc_t& dbc, unsigned spell_id, util::string_v
 
 void dbc_override::register_effect( dbc_t& dbc, unsigned effect_id, util::string_view field, double v )
 {
-  spelleffect_data_t* effect = override_db_.get_mutable_effect( effect_id, dbc.ptr );
+  spelleffect_data_t* effect = override_db_[ dbc.ptr ].get_mutable_effect( effect_id );
   if ( ! effect )
   {
     const spelleffect_data_t* dbc_effect = dbc.effect( effect_id );
-    override_db_.clone_spell( dbc_effect -> spell() -> id(), dbc.ptr );
-    effect = override_db_.get_mutable_effect( effect_id, dbc.ptr );
+    override_db_[ dbc.ptr ].clone_spell( dbc_effect -> spell() );
+    effect = override_db_[ dbc.ptr ].get_mutable_effect( effect_id );
   }
   if (!effect)
   {
@@ -799,12 +744,12 @@ void dbc_override::register_effect( dbc_t& dbc, unsigned effect_id, util::string
 
 void dbc_override::register_power( dbc_t& dbc, unsigned power_id, util::string_view field, double v )
 {
-  auto power = override_db_.get_mutable_power( power_id, dbc.ptr );
+  auto power = override_db_[ dbc.ptr ].get_mutable_power( power_id );
   if ( power == nullptr )
   {
     const auto& dbc_power = dbc.power( power_id );
-    override_db_.clone_spell( dbc_power.spell_id(), dbc.ptr );
-    power = override_db_.get_mutable_power( power_id, dbc.ptr );
+    override_db_[ dbc.ptr ].clone_spell( dbc.spell( dbc_power.spell_id() ) );
+    power = override_db_[ dbc.ptr ].get_mutable_power( power_id );
   }
   if (!power)
   {
@@ -821,12 +766,12 @@ void dbc_override::register_power( dbc_t& dbc, unsigned power_id, util::string_v
 
 const spell_data_t* dbc_override::find_spell( unsigned spell_id, bool ptr )
 {
-  return override_db_.find_spell( spell_id, ptr );
+  return override_db_[ ptr ].find_spell( spell_id );
 }
 
 const spelleffect_data_t* dbc_override::find_effect( unsigned effect_id, bool ptr )
 {
-  return override_db_.find_effect( effect_id, ptr );
+  return override_db_[ ptr ].find_effect( effect_id );
 }
 
 const std::vector<dbc_override::dbc_override_entry_t>& dbc_override::override_entries()

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -75,6 +75,7 @@ pet_t::pet_t( sim_t*             sim,
 
   // Inherit owner's dbc state
   dbc->ptr = owner -> dbc->ptr;
+  dbc_override = owner -> dbc_override;
 
   // Set pet dps data collection to level 2 or higher, so our 32bit GUI users can at least
   // do scale factor simulations with default settings.

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -1119,6 +1119,7 @@ player_t::player_t( sim_t* s, player_e t, util::string_view n, race_e r )
     world_lag_stddev_override( false ),
     cooldown_tolerance_( timespan_t::min() ),
     dbc( new dbc_t(*(s->dbc)) ),
+    dbc_override( sim->dbc_override.get() ),
     talent_points(),
     profession(),
     azerite( nullptr ),

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -10869,6 +10869,13 @@ void player_t::copy_from( player_t* source )
     covenant->copy_state( source->covenant );
   }
 
+  if ( source->dbc_override_ )
+  {
+    dbc_override_ = std::make_unique<dbc_override_t>( *dbc_override );
+    dbc_override_->copy_from( *source->dbc_override_ );
+    dbc_override = dbc_override_.get();
+  }
+
   talent_overrides_str = source->talent_overrides_str;
   action_list_str      = source->action_list_str;
   alist_map            = source->alist_map;
@@ -11084,6 +11091,17 @@ void player_t::create_options()
     {
       covenant->register_options( this );
     }
+
+    add_option( opt_func( "override.player.spell_data",
+        [ this ]( sim_t*, util::string_view, util::string_view value ) {
+          if ( dbc_override_ == nullptr )
+          {
+            dbc_override_ = std::make_unique<dbc_override_t>( *dbc_override );
+            dbc_override = dbc_override_.get();
+          }
+          dbc_override_->parse( *dbc, value );
+          return true;
+        } ) );
   }
 
   // Obsolete options

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -630,6 +630,9 @@ private:
   };
   std::vector<resource_callback_entry_t> resource_callbacks;
 
+  /// Per-player custom dbc data
+  std::unique_ptr<dbc_override_t> dbc_override_;
+
 public:
 
 

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -169,6 +169,7 @@ struct player_t : public actor_t
 
   // Data access
   std::unique_ptr<dbc_t> dbc;
+  const dbc_override_t*  dbc_override;
 
   // Option Parsing
   std::vector<std::unique_ptr<option_t>> options;

--- a/engine/report/reports.cpp
+++ b/engine/report/reports.cpp
@@ -174,10 +174,15 @@ void print_spell_query(std::ostream& out, const sim_t& sim, const spell_data_exp
     {
       std::ostringstream sqs;
       const spelleffect_data_t* base_effect = sim.dbc->effect(*i);
-      if (const spell_data_t* spell = dbc::find_spell(&(sim), base_effect->spell()))
+      if ( const spell_data_t* spell = dbc::find_spell( &(sim), base_effect->spell() ) )
       {
-        spell_info::effect_to_str(*sim.dbc, spell, dbc::find_effect(&(sim), base_effect), sqs, level);
-        out << sqs.str();
+        const auto spell_effects = spell->effects();
+        auto effect = range::find( spell_effects, base_effect->id(), &spelleffect_data_t::id );
+        if ( effect != spell_effects.end() )
+        {
+          spell_info::effect_to_str( *sim.dbc, spell, &( *effect ), sqs, level );
+          out << sqs.str();
+        }
       }
     }
     break;
@@ -205,9 +210,12 @@ void print_spell_query(xml_node_t* root, FILE* file, const sim_t& sim, const spe
     {
       std::ostringstream sqs;
       const spelleffect_data_t* dbc_effect = sim.dbc->effect(*i);
-      if (const spell_data_t* spell = dbc::find_spell(&(sim), dbc_effect->spell()))
+      if ( const spell_data_t* spell = dbc::find_spell( &(sim), dbc_effect->spell() ) )
       {
-        spell_info::effect_to_xml(*sim.dbc, spell, dbc::find_effect(&(sim), dbc_effect), root, level);
+        const auto spell_effects = spell->effects();
+        auto effect = range::find( spell_effects, dbc_effect->id(), &spelleffect_data_t::id );
+        if ( effect != spell_effects.end() )
+          spell_info::effect_to_xml(*sim.dbc, spell, &( *effect ), root, level);
       }
     }
     break;

--- a/engine/report/sc_report_html_sim.cpp
+++ b/engine/report/sc_report_html_sim.cpp
@@ -1177,7 +1177,7 @@ void print_html_hotfixes( report::sc_html_stream& os, const sim_t& sim )
 
 void print_html_overrides( report::sc_html_stream& os, const sim_t& sim )
 {
-  const auto& entries = dbc_override::override_entries();
+  const auto& entries = sim.dbc_override->override_entries();
   if ( entries.empty() )
   {
     return;
@@ -1198,7 +1198,7 @@ void print_html_overrides( report::sc_html_stream& os, const sim_t& sim )
   for ( const auto& entry : entries )
   {
     os << "<tr>\n";
-    if ( entry.type_ == dbc_override::DBC_OVERRIDE_SPELL )
+    if ( entry.type_ == dbc_override_t::OVERRIDE_SPELL )
     {
       const spell_data_t* spell = hotfix::find_spell( sim.dbc->spell( entry.id_ ), sim.dbc->ptr );
       std::string name = report_decorators::decorated_spell_name( sim, *spell );
@@ -1208,7 +1208,7 @@ void print_html_overrides( report::sc_html_stream& os, const sim_t& sim )
       os << "<td class=\"left\">" << spell->get_field( entry.field_ )
          << "</td>\n";
     }
-    else if ( entry.type_ == dbc_override::DBC_OVERRIDE_EFFECT )
+    else if ( entry.type_ == dbc_override_t::OVERRIDE_EFFECT )
     {
       const spelleffect_data_t* effect = hotfix::find_effect( sim.dbc->effect( entry.id_ ), sim.dbc->ptr );
       const spell_data_t* spell        = effect->spell();

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -720,15 +720,9 @@ bool parse_fight_style( sim_t*             sim,
 // parse_override_spell_data ================================================
 
 bool parse_override_spell_data( sim_t*             sim,
-                                       util::string_view /* name */,
-                                       util::string_view value )
+                                util::string_view /* name */,
+                                util::string_view value )
 {
-  // Register overrides only once, for the main thread
-  if ( sim -> parent )
-  {
-    return true;
-  }
-
   auto v_pos = value.find( '=' );
 
   if ( v_pos == util::string_view::npos )
@@ -754,15 +748,15 @@ bool parse_override_spell_data( sim_t*             sim,
 
   if ( util::str_compare_ci( splits[ 0 ], "spell" ) )
   {
-    dbc_override::register_spell( *(sim -> dbc), id, splits[ 2 ], v );
+    sim->dbc_override->register_spell( *(sim->dbc), id, splits[ 2 ], v );
   }
   else if ( util::str_compare_ci( splits[ 0 ], "effect" ) )
   {
-    dbc_override::register_effect(*(sim->dbc), id, splits[ 2 ], v );
+    sim->dbc_override->register_effect( *(sim->dbc), id, splits[ 2 ], v );
   }
   else if ( util::str_compare_ci( splits[ 0 ], "power" ) )
   {
-    dbc_override::register_power(*(sim->dbc), id, splits[ 2 ], v );
+    sim->dbc_override->register_power( *(sim->dbc), id, splits[ 2 ], v );
   }
   else
   {
@@ -1526,6 +1520,7 @@ sim_t::sim_t() :
   target_adds( 0 ), desired_targets( 1 ), enable_taunts( false ),
   use_item_verification( true ),
   dbc(new dbc_t()),
+  dbc_override( std::make_unique<dbc_override_t>() ),
   challenge_mode( false ), timewalk( -1 ), scale_to_itemlevel( -1 ), scale_itemlevel_down_only( false ),
   disable_set_bonuses( false ), disable_2_set( 1 ), disable_4_set( 1 ), enable_2_set( 1 ), enable_4_set( 1 ),
   pvp_crit( false ),

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -723,46 +723,7 @@ bool parse_override_spell_data( sim_t*             sim,
                                 util::string_view /* name */,
                                 util::string_view value )
 {
-  auto v_pos = value.find( '=' );
-
-  if ( v_pos == util::string_view::npos )
-  {
-    throw std::invalid_argument("Invalid form. Spell data override takes the form <spell|effect|power>.<id>.<field>=value");
-  }
-
-  auto splits = util::string_split<util::string_view>( value.substr( 0, v_pos ), "." );
-
-  if ( splits.size() != 3 )
-  {
-    throw std::invalid_argument("Invalid form. Spell data override takes the form <spell|effect|power>.<id>.<field>=value");
-  }
-
-  int parsed_id = util::to_int( splits[ 1 ] );
-  if ( parsed_id <= 0 )
-  {
-    throw std::invalid_argument("Invalid spell id (negative or zero).");
-  }
-  unsigned id = as<unsigned>(parsed_id);
-
-  double v = util::to_double( value.substr( v_pos + 1 ) );
-
-  if ( util::str_compare_ci( splits[ 0 ], "spell" ) )
-  {
-    sim->dbc_override->register_spell( *(sim->dbc), id, splits[ 2 ], v );
-  }
-  else if ( util::str_compare_ci( splits[ 0 ], "effect" ) )
-  {
-    sim->dbc_override->register_effect( *(sim->dbc), id, splits[ 2 ], v );
-  }
-  else if ( util::str_compare_ci( splits[ 0 ], "power" ) )
-  {
-    sim->dbc_override->register_power( *(sim->dbc), id, splits[ 2 ], v );
-  }
-  else
-  {
-    throw std::invalid_argument("Invalid form. Spell data override takes the form <spell|effect|power>.<id>.<field>=value");
-  }
-
+  sim->dbc_override->parse( *(sim->dbc), value );
   return true;
 }
 

--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -27,6 +27,7 @@ struct actor_target_data_t;
 struct buff_t;
 struct cooldown_t;
 class dbc_t;
+class dbc_override_t;
 struct expr_t;
 namespace highchart {
     struct chart_t;
@@ -151,7 +152,8 @@ struct sim_t : private sc_thread_t
   bool        use_item_verification;
 
   // Data access
-  std::unique_ptr<dbc_t>       dbc;
+  std::unique_ptr<dbc_t> dbc;
+  std::unique_ptr<dbc_override_t> dbc_override;
 
   // Default stat enchants
   gear_stats_t enchant;


### PR DESCRIPTION
Make the existing `override.spell_data=` option to be per-sim instead of simulator global.
Should make it possible to use overrides with profilesets without any gotchas as nothing should "leak out of profilesets".

As a bonus also add an `override.player.spell_data=` option which overrides spell data for the currently active player.