### PR TITLE
Util: string_view - rewrite detail::strcmp()

### DIFF
--- a/engine/util/static_map.hpp
+++ b/engine/util/static_map.hpp
@@ -93,10 +93,10 @@ constexpr const T* lower_bound(util::span<const T, N> items, const U& value, Com
 }
 
 template <typename T, size_t N, typename Compare = less>
-constexpr bool is_unique(const array<T, N>& items, Compare cmp = {}) {
-  if (N <= 1)
+constexpr bool is_unique(util::span<const T, N> items, Compare cmp = {}) {
+  if (items.size() <= 1)
     return true;
-  for (size_t i = 1; i < N; i++) {
+  for (size_t i = 1; i < items.size(); i++) {
     if (!cmp(items[i-1], items[i]))
       return false;
   }
@@ -122,7 +122,8 @@ public:
   constexpr static_set_base(const array<value_type, N>& items)
     : data_(sorted(items))
   {
-    assert(is_unique(data_));
+    util::span<const T, N> data(data_.begin(), N);
+    assert( is_unique(data) );
   }
 
   constexpr iterator begin() const { return cbegin(); }

--- a/engine/util/string_view.hpp
+++ b/engine/util/string_view.hpp
@@ -59,9 +59,9 @@ constexpr int strcmp(const char* s1, const char* s2, size_t n) {
 #elif defined(SC_GCC) || (defined(SC_CLANG) && SC_CLANG >= 40000)
   return __builtin_memcmp(s1, s2, n);
 #else
-  for (; n; --n, ++s1, ++s2) {
-    const auto c1 = static_cast<unsigned char>(*s1);
-    const auto c2 = static_cast<unsigned char>(*s2);
+  for (size_t i = 0; i < n; i++) {
+    const auto c1 = static_cast<unsigned>(s1[i]);
+    const auto c2 = static_cast<unsigned>(s2[i]);
     if (c1 < c2) return -1;
     if (c2 < c1) return 1;
   }


### PR DESCRIPTION
GCC versions less than 8.1 can miscompile the current loop at certain optimization levels.