### PR TITLE
Wrathful faerie

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1654,6 +1654,8 @@ void priest_t::init_background_actions()
 {
   action.ascended_eruption = new actions::spells::ascended_eruption_t( *this );
 
+  active_spells.wrathful_faerie = new actions::spells::wrathful_faerie_t( *this );
+
   init_background_actions_shadow();
 }
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -364,6 +364,17 @@ struct wrathful_faerie_t final : public priest_spell_t
     energize_type     = action_energize::ON_HIT;
     energize_resource = RESOURCE_INSANITY;
     energize_amount   = insanity_gain;
+
+    cooldown->duration = data().internal_cooldown();
+  }
+
+  void trigger()
+  {
+    if ( priest().cooldowns.wrathful_faerie->is_ready() )
+    {
+      execute();
+      priest().cooldowns.wrathful_faerie->start();
+    }
   }
 };
 
@@ -1113,6 +1124,7 @@ priest_t::priest_t( sim_t* sim, util::string_view name, race_e r )
 /** Construct priest cooldowns */
 void priest_t::create_cooldowns()
 {
+  cooldowns.wrathful_faerie    = get_cooldown( "wrathful_faerie" );
   cooldowns.holy_fire          = get_cooldown( "holy_fire" );
   cooldowns.holy_word_serenity = get_cooldown( "holy_word_serenity" );
   cooldowns.void_bolt          = get_cooldown( "void_bolt" );
@@ -1509,7 +1521,7 @@ void priest_t::trigger_lucid_dreams( double cost )
 
 void priest_t::trigger_wrathful_faerie()
 {
-  active_spells.wrathful_faerie->execute();
+  active_spells.wrathful_faerie->trigger();
 }
 
 void priest_t::init_base_stats()

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1507,6 +1507,11 @@ void priest_t::trigger_lucid_dreams( double cost )
   }
 }
 
+void priest_t::trigger_wrathful_faerie()
+{
+  active_spells.wrathful_faerie->execute();
+}
+
 void priest_t::init_base_stats()
 {
   base_t::init_base_stats();
@@ -1648,7 +1653,6 @@ void priest_t::init_rng()
 void priest_t::init_background_actions()
 {
   action.ascended_eruption = new actions::spells::ascended_eruption_t( *this );
-  action.wrathful_faerie   = new actions::spells::wrathful_faerie_t( *this );
 
   init_background_actions_shadow();
 }

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -353,6 +353,20 @@ struct fae_guardians_t final : public priest_spell_t
   }
 };
 
+struct wrathful_faerie_t final : public priest_spell_t
+{
+  double insanity_gain;
+
+  wrathful_faerie_t( priest_t& p )
+    : priest_spell_t( "wrathful_faerie", p, p.find_spell( 342132 ) ),
+      insanity_gain( p.find_spell( 327703 )->effectN( 2 ).resource( RESOURCE_INSANITY ) )
+  {
+    energize_type     = action_energize::ON_HIT;
+    energize_resource = RESOURCE_INSANITY;
+    energize_amount   = insanity_gain;
+  }
+};
+
 // ==========================================================================
 // Unholy Nova - Necrolord Covenant
 // ==========================================================================
@@ -1124,7 +1138,6 @@ void priest_t::create_gains()
   gains.insanity_mindgames                = get_gain( "Insanity Gained from Mindgames" );
   gains.insanity_eternal_call_to_the_void = get_gain( "Insanity Gained from Eternal Call to the Void Mind Flays" );
   gains.insanity_mind_sear                = get_gain( "Insanity Gained from Mind Sear" );
-  gains.wrathful_faerie                   = get_gain( "Insanity Gained from Fae Guardians Wrathful Faerie" );
 }
 
 /** Construct priest procs */
@@ -1635,6 +1648,7 @@ void priest_t::init_rng()
 void priest_t::init_background_actions()
 {
   action.ascended_eruption = new actions::spells::ascended_eruption_t( *this );
+  action.wrathful_faerie   = new actions::spells::wrathful_faerie_t( *this );
 
   init_background_actions_shadow();
 }

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -772,6 +772,13 @@ struct fae_guardians_t final : public priest_buff_t<buff_t>
       }
     } );
   }
+
+  void expire_override( int expiration_stacks, timespan_t remaining_duration ) override
+  {
+    buff_t::expire_override( expiration_stacks, remaining_duration );
+
+    priest().remove_wrathful_faerie();
+  }
 };
 
 // ==========================================================================
@@ -1032,6 +1039,7 @@ priest_td_t::priest_td_t( player_t* target, priest_t& p ) : actor_target_data_t(
   buffs.death_and_madness_debuff    = make_buff<buffs::death_and_madness_debuff_t>( *this );
   buffs.surrender_to_madness_debuff = make_buff<buffs::surrender_to_madness_debuff_t>( *this );
   buffs.shadow_crash_debuff         = make_buff( *this, "shadow_crash_debuff", p.talents.shadow_crash->effectN( 1 ).trigger() );
+  buffs.wrathful_faerie             = make_buff( *this, "wrathful_faerie", p.find_spell( 327703 ) );
 
   target->callbacks_on_demise.emplace_back( [ this ]( player_t* ) { target_demise(); } );
 }
@@ -1116,6 +1124,7 @@ void priest_t::create_gains()
   gains.insanity_mindgames                = get_gain( "Insanity Gained from Mindgames" );
   gains.insanity_eternal_call_to_the_void = get_gain( "Insanity Gained from Eternal Call to the Void Mind Flays" );
   gains.insanity_mind_sear                = get_gain( "Insanity Gained from Mind Sear" );
+  gains.wrathful_faerie                   = get_gain( "Insanity Gained from Fae Guardians Wrathful Faerie" );
 }
 
 /** Construct priest procs */
@@ -1941,6 +1950,18 @@ void priest_t::trigger_eternal_call_to_the_void( const dot_t* )
   {
     procs.void_tendril->occur();
     auto spawned_pets = pets.void_tendril.spawn();
+  }
+}
+
+// Fae Guardian Wrathful Faerie helper
+void priest_t::remove_wrathful_faerie()
+{
+  for ( priest_td_t* priest_td : _target_data.get_entries() )
+  {
+    if ( priest_td && priest_td->buffs.wrathful_faerie->check() )
+    {
+      priest_td->buffs.wrathful_faerie->expire();
+    }
   }
 }
 

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -362,6 +362,7 @@ public:
     propagate_const<actions::spells::mind_sear_tick_t*> mind_sear_tick;
     propagate_const<actions::spells::shadowy_apparition_spell_t*> shadowy_apparitions;
     propagate_const<actions::spells::psychic_link_t*> psychic_link;
+    propagate_const<actions::spells::wrathful_faerie_t*> wrathful_faerie;
   } active_spells;
 
   // Items
@@ -410,7 +411,6 @@ public:
   struct actions_t
   {
     actions::spells::ascended_eruption_t* ascended_eruption;
-    actions::spells::wrathful_faerie_t* wrathful_faerie;
   } action;
 
   // Azerite
@@ -573,6 +573,7 @@ public:
   void trigger_eternal_call_to_the_void( const dot_t* d );
   void trigger_shadowy_apparitions( action_state_t* );
   void trigger_psychic_link( action_state_t* );
+  void trigger_wrathful_faerie();
   void remove_wrathful_faerie();
   const priest_td_t* find_target_data( player_t* target ) const
   {
@@ -1332,7 +1333,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
         const priest_td_t* td = find_td( s->target );
         if ( td && td->buffs.wrathful_faerie->check() )
         {
-          priest().action.wrathful_faerie->execute();
+          priest().trigger_wrathful_faerie();
         }
       }
     }

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -290,6 +290,9 @@ public:
   // Cooldowns
   struct
   {
+    // Shared
+    propagate_const<cooldown_t*> wrathful_faerie;
+
     // Shadow
     propagate_const<cooldown_t*> void_bolt;
     propagate_const<cooldown_t*> mind_blast;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -36,6 +36,7 @@ struct summon_pet_t;
 struct summon_shadowfiend_t;
 struct summon_mindbender_t;
 struct ascended_eruption_t;
+struct wrathful_faerie_t;
 struct psychic_link_t;
 }  // namespace spells
 namespace heals
@@ -326,7 +327,6 @@ public:
     propagate_const<gain_t*> insanity_mindgames;
     propagate_const<gain_t*> insanity_eternal_call_to_the_void;
     propagate_const<gain_t*> insanity_mind_sear;
-    propagate_const<gain_t*> wrathful_faerie;
   } gains;
 
   // Benefits
@@ -410,6 +410,7 @@ public:
   struct actions_t
   {
     actions::spells::ascended_eruption_t* ascended_eruption;
+    actions::spells::wrathful_faerie_t* wrathful_faerie;
   } action;
 
   // Azerite
@@ -1268,11 +1269,8 @@ struct priest_heal_t : public priest_action_t<heal_t>
 
 struct priest_spell_t : public priest_action_t<spell_t>
 {
-  double wrathful_faerie_insanity;
-
   priest_spell_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
-    : base_t( name, player, s ),
-      wrathful_faerie_insanity( player.find_spell( 327703 )->effectN( 2 ).resource( RESOURCE_INSANITY ) )
+    : base_t( name, player, s )
   {
     weapon_multiplier = 0.0;
   }
@@ -1334,7 +1332,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
         const priest_td_t* td = find_td( s->target );
         if ( td && td->buffs.wrathful_faerie->check() )
         {
-          priest().generate_insanity( wrathful_faerie_insanity, priest().gains.wrathful_faerie, s->action );
+          priest().action.wrathful_faerie->execute();
         }
       }
     }

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -736,6 +736,26 @@ struct shadow_word_pain_t final : public priest_spell_t
     parse_options( options_str );
   }
 
+  void impact( action_state_t* s ) override
+  {
+    priest_spell_t::impact( s );
+
+    if ( result_is_hit( s->result ) )
+    {
+      if ( priest().buffs.fae_guardians->check() )
+      {
+        priest_td_t& td = get_td( s->target );
+
+        if ( !td.buffs.wrathful_faerie->up() )
+        {
+          // There can only be one of these out at once so clear it first
+          priest().remove_wrathful_faerie();
+          td.buffs.wrathful_faerie->trigger();
+        }
+      }
+    }
+  }
+
   void tick( dot_t* d ) override
   {
     priest_spell_t::tick( d );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -2506,7 +2506,6 @@ void priest_t::trigger_shadowy_apparitions( action_state_t* s )
   }
 }
 
-// Trigger psychic link on any targets that weren't the original target and have Vampiric Touch ticking on them
 // ==========================================================================
 // Trigger Psychic Link on any targets that weren't the original target and have Vampiric Touch ticking on them
 // ==========================================================================


### PR DESCRIPTION
Implements the Wrathful Faerie part of the Night Fae Priest Covenant ability: [Fae Guardians](https://shadowlands.wowhead.com/spell=327661/fae-guardians).

```
Wrathful Faerie: Direct attacks against the target restore 0.5% Mana or 3 Insanity. Follows your Shadow Word: Pain.
```

So what I do here is the following:
1. If Fae Guardians is active when casting SW:P we apply `wrathful_faerie` to our target. Before this we make sure to call `remove_wrathful_faerie()` to clear out any existing debuffs. We do this because this can only be active on a single target
2. By overriding the default `impact()` in `priest_spell_t` we can check for if the actor is Shadow spec, if the impact action is a `DMG_DIRECT`, and that it hit for more than 0. We do this to avoid hard-coding which spells can proc this and which ones can't, since DoT damage/Mind Flay doesn't proc it since it doesn't have direct damage. If all of these conditions are true we `trigger_wrathful_faerie` to call our `wrathful_faerie_t` spell
3. The `wrathful_faerie_t` spell is just here to give the actor insanity, and make sure the ICD of 1.5s is respected
4. Once Fae Guardians expires we call `remove_wrathful_faerie()` again to eliminate the debuff

Unfortunately all of these spell IDs need to be hard coded since they are only in the tooltip string for Fae Guardians.