### PR TITLE
Adjust action logging calls

### DIFF
--- a/engine/action/absorb.cpp
+++ b/engine/action/absorb.cpp
@@ -76,8 +76,8 @@ void absorb_t::assess_damage(result_amount_type  /*heal_type*/, action_state_t* 
     target_specific[s->target]->trigger(1, s->result_amount);
 
     sim->print_log("{} {} applies absorb on {} for {} ({}) ({})",
-      player->name(), name(), s->target->name(), s->result_amount, s->result_total,
-      util::result_type_string(s->result));
+      *player, *this, *s->target, s->result_amount, s->result_total,
+      s->result);
   }
 
   stats->add_result(0.0, s->result_total, result_amount_type::ABSORB, s->result, s->block_result, s->target);

--- a/engine/action/dot.hpp
+++ b/engine/action/dot.hpp
@@ -10,6 +10,7 @@
 #include "sc_enums.hpp"
 #include "util/generic.hpp"
 #include "util/string_view.hpp"
+#include "util/format.hpp"
 
 #include <string>
 #include <memory>
@@ -114,6 +115,7 @@ public:
   void last_tick();
   bool channel_interrupt();
 
+  friend void format_to( const dot_t&, fmt::format_context::iterator );
 private:
   void tick_zero();
   void schedule_tick();

--- a/engine/action/heal.cpp
+++ b/engine/action/heal.cpp
@@ -179,13 +179,15 @@ double heal_t::calculate_tick_amount(action_state_t* state, double dmg_multiplie
     // Record total amount to state
     state->result_total = amount;
 
-    sim->print_debug(
-      "{} amount for {} on {}: "
-      "ta={} pct={} b_ta={} bonus_ta={} s_mod={} s_power={} a_mod={} a_power={} mult={}",
-      player->name(), name(), target->name(),
-      amount, tick_pct_heal, base_ta(state), bonus_ta(state), spell_tick_power_coefficient(state),
-      state->composite_spell_power(), attack_tick_power_coefficient(state), state->composite_attack_power(),
-      state->composite_ta_multiplier());
+    if ( sim->debug )
+    {
+      sim->print_debug(
+          "{} amount for {} on {}: "
+          "ta={} pct={} b_ta={} bonus_ta={} s_mod={} s_power={} a_mod={} a_power={} mult={}",
+          *player, *this, *target, amount, tick_pct_heal, base_ta( state ), bonus_ta( state ),
+          spell_tick_power_coefficient( state ), state->composite_spell_power(), attack_tick_power_coefficient( state ),
+          state->composite_attack_power(), state->composite_ta_multiplier() );
+    }
 
     return amount;
   }
@@ -200,8 +202,8 @@ void heal_t::assess_damage(result_amount_type heal_type, action_state_t* s)
   if (heal_type == result_amount_type::HEAL_DIRECT)
   {
     sim->print_log("{} {} heals {} for {} ({}) ({})",
-      player->name(), name(), s->target->name(), s->result_total, s->result_amount,
-      util::result_type_string(s->result));
+      *player, *this, *s->target, s->result_total, s->result_amount,
+      s->result);
   }
   else // result_amount_type::HEAL_OVER_TIME
   {
@@ -210,8 +212,8 @@ void heal_t::assess_damage(result_amount_type heal_type, action_state_t* s)
       dot_t* dot = find_dot(s->target);
       assert(dot);
       sim->print_log("{} {} ticks ({} of {}) {} for {} ({}) heal ({})",
-        player->name(), name(), dot->current_tick, dot->num_ticks, s->target->name(), s->result_total,
-        s->result_amount, util::result_type_string(s->result));
+        *player, *this, dot->current_tick, dot->num_ticks, *s->target, s->result_total,
+        s->result_amount, s->result);
     }
   }
 

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -3718,7 +3718,7 @@ void action_t::do_schedule_travel( action_state_t* state, timespan_t time_ )
   }
   else
   {
-    sim->print_log( "{} schedules travel ({}) for {}", player->name(), time_, name() );
+    sim->print_log( "{} schedules travel ({}) for {}", *player, time_, *this );
 
     travel_events.push_back( make_event<travel_event_t>( *sim, this, state, time_ ) );
   }
@@ -3765,8 +3765,7 @@ void action_t::impact( action_state_t* s )
   }
   else
   {
-    if ( sim->log )
-      sim->print_log( "Target {} avoids {} {} ({})", s->target->name(), player->name(), name(), s->result );
+    sim->print_log( "Target {} avoids {} {} ({})", *s->target, *player, *this, s->result );
   }
 }
 

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -147,9 +147,12 @@ struct action_execute_event_t : public player_event_t
     : player_event_t( *a->player, time_to_execute ), action( a ), execute_state( state ),
     has_cast_time( time_to_execute > timespan_t::zero() )
   {
-    sim().print_debug( "New Action Execute Event: player='{}' action='{}' time_to_execute={} (target={}, marker={})",
-        p()->name(), a->name(), time_to_execute, ( state ) ? state->target->name() : a->target->name(),
-            ( a->marker ) ? a->marker : '0' );
+    if ( sim().debug )
+    {
+      sim().print_debug( "New Action Execute Event: {} {} time_to_execute={} (target={}, marker={})", *p(), *a,
+                         time_to_execute, ( state ) ? state->target->name() : a->target->name(),
+                         ( a->marker ) ? a->marker : '0' );
+    }
   }
 
   const char* name() const override
@@ -214,8 +217,8 @@ struct action_execute_event_t : public player_event_t
     {
       if ( p()->readying )
       {
-        throw std::runtime_error( fmt::format( "Non-channeling action '{}' for actor {} is trying to overwrite "
-          "player-ready-event upon execute.", action->name(), p()->name() ) );
+        throw std::runtime_error( fmt::format( "Non-channeling action {} for {} is trying to overwrite "
+          "player-ready-event upon execute.", action->name(), *p() ) );
       }
 
       p()->schedule_ready( timespan_t::zero() );
@@ -417,7 +420,7 @@ action_t::action_t( action_e ty, util::string_view token, player_t* p, const spe
   }
 
   if ( sim->debug )
-    sim->out_debug.printf( "Player %s creates action %s (%d)", player->name(), name(),
+    sim->out_debug.print( "{} creates {} ({})", *player, *this,
                            ( data().ok() ? data().id() : -1 ) );
 
   if ( !player->initialized )
@@ -968,8 +971,8 @@ double action_t::cost() const
     c = 0;
 
   if ( sim->debug )
-    sim->out_debug.printf( "action_t::cost: %s base_cost=%.2f secondary_cost=%.2f cost=%.2f resource=%s", name(),
-                           base_costs[ cr ], secondary_costs[ cr ], c, util::resource_type_string( cr ) );
+    sim->out_debug.print( "{} action_t::cost: base_cost={} secondary_cost={} cost={} resource={}", *this,
+                           base_costs[ cr ], secondary_costs[ cr ], c, cr );
 
   return floor( c );
 }
@@ -1099,8 +1102,11 @@ double action_t::total_crit_bonus( action_state_t* state ) const
   double bonus =
       ( ( 1.0 + base_crit_bonus ) * crit_multiplier_buffed - 1.0 ) * composite_crit_damage_bonus_multiplier();
 
-  sim->print_debug("{} crit_bonus for {}: total={} base={} mult_buffed={} damage_bonus_mult={}",
-      player->name(), name(), bonus, crit_bonus, crit_multiplier_buffed, composite_crit_damage_bonus_multiplier() );
+  if ( sim->debug )
+  {
+    sim->print_debug( "{} crit_bonus for {}: total={} base={} mult_buffed={} damage_bonus_mult={}", *player, *this,
+                      bonus, crit_bonus, crit_multiplier_buffed, composite_crit_damage_bonus_multiplier() );
+  }
 
   return bonus;
 }
@@ -1117,7 +1123,7 @@ double action_t::calculate_weapon_damage( double attack_power ) const
 
   sim->print_debug("{} weapon damage for {}: base=({} to {}) total={} weapon_damage={} bonus_damage={} "
       "speed={} power_damage={} ap={}",
-      player->name(), name(), weapon->min_dmg, weapon->max_dmg, total_dmg, dmg, weapon->bonus_dmg,
+      *player, *this, weapon->min_dmg, weapon->max_dmg, total_dmg, dmg, weapon->bonus_dmg,
       weapon_speed, power_damage, attack_power );
 
   return total_dmg;
@@ -1154,12 +1160,15 @@ double action_t::calculate_tick_amount( action_state_t* state, double dot_multip
   // subsequent impact).
   amount = calculate_crit_damage_bonus( state );
 
-  sim->print_debug("{} tick amount for {} on {}: amount={} initial_amount={} base={} bonus={} s_mod={} s_power={} a_mod={} "
+  if ( sim->debug )
+  {
+    sim->print_debug(
+        "{} tick amount for {} on {}: amount={} initial_amount={} base={} bonus={} s_mod={} s_power={} a_mod={} "
         "a_power={} mult={}, tick_mult={}",
-        player->name(), name(), state->target->name(),
-        amount, init_tick_amount, base_ta( state ), bonus_ta( state ),
+        *player, *this, *state->target, amount, init_tick_amount, base_ta( state ), bonus_ta( state ),
         spell_tick_power_coefficient( state ), state->composite_spell_power(), attack_tick_power_coefficient( state ),
         state->composite_attack_power(), state->composite_ta_multiplier(), dot_multiplier );
+  }
 
   return amount;
 }
@@ -1282,7 +1291,7 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
     sim->print_debug(
         "{} direct amount for {}: amount={} initial_amount={} weapon={} base={} s_mod={} s_power={} "
         "a_mod={} a_power={} mult={} w_mult={} w_slot_mod={} bonus_da={}",
-        player->name(), name(), amount, state->result_raw, weapon_amount, base_direct_amount,
+        *player, *this, amount, state->result_raw, weapon_amount, base_direct_amount,
         spell_direct_power_coefficient( state ), state->composite_spell_power(),
         attack_direct_power_coefficient( state ), state->composite_attack_power(), state->composite_da_multiplier(),
         weapon_multiplier, weapon_slot_modifier, bonus_da( state ) );
@@ -1360,7 +1369,7 @@ void action_t::consume_resource()
   player->resource_loss( cr, last_resource_cost, nullptr, this );
 
   sim->print_log("{} consumes {} {} for {} ({})",
-      player->name(), last_resource_cost, cr, name(), player->resources.current[ cr ] );
+      *player, last_resource_cost, cr, *this, player->resources.current[ cr ] );
 
   stats->consume_resource( cr, last_resource_cost );
 }
@@ -1400,10 +1409,10 @@ size_t action_t::available_targets( std::vector<player_t*>& tl ) const
 
   if ( sim->debug && !sim->distance_targeting_enabled )
   {
-    sim->print_debug("{} regenerated target cache for {} ({})", player->name(), signature_str, name() );
+    sim->print_debug("{} regenerated target cache for {} ({})", *player, signature_str, *this );
     for ( size_t i = 0; i < tl.size(); i++ )
     {
-      sim->print_debug( "[{}, {} (id={})]", i, tl[ i ]->name(), tl[ i ]->actor_index );
+      sim->print_debug( "[{}, {} (id={})]", i, *tl[ i ], tl[ i ]->actor_index );
     }
   }
 
@@ -1481,7 +1490,7 @@ block_result_e action_t::calculate_block_result( action_state_t* s ) const
     }
   }
 
-  sim->print_debug("{} result for {} is {}", player->name(), name(), block_result );
+  sim->print_debug("{} result for {} is {}", *player, *this, block_result );
 
   return block_result;
 }
@@ -1494,7 +1503,7 @@ void action_t::execute()
   if ( !initialized )
   {
     throw std::runtime_error(
-        fmt::format( "action_t::execute: action {} from player {} is not initialized.\n", name(), player->name() ) );
+        fmt::format( "{} {} action_t::execute: is not initialized.\n", *player, *this ) );
   }
 #endif
 
@@ -1517,7 +1526,7 @@ void action_t::execute()
   if ( sim->log && !dual )
   {
     sim->print_log("{} performs {} ({})",
-        player->name(), name(), player->resources.current[ player->primary_resource() ] );
+        *player, *this, player->resources.current[ player->primary_resource() ] );
   }
 
   hit_any_target               = false;
@@ -1527,7 +1536,7 @@ void action_t::execute()
   if ( harmful )
   {
     if ( player->in_combat == false && sim->debug )
-      sim->out_debug.printf( "%s enters combat.", player->name() );
+      sim->print_debug( "{} enters combat.", *player );
 
     player->in_combat = true;
   }
@@ -1716,7 +1725,7 @@ void action_t::tick( dot_t* d )
     tick_action->schedule_execute( tick_state );
 
     sim->print_log("{} {} ticks ({} of {}) {}",
-        player->name(), name(), d->current_tick, d->num_ticks, d->target->name() );
+        *player, *this, d->current_tick, d->num_ticks, *d->target );
   }
   else
   {
@@ -1767,11 +1776,8 @@ void action_t::last_tick( dot_t* d )
     // current baseline target all actions share (with some exceptions, such as fixed targeting).
     if ( option.target_number == 0 && target != player->target )
     {
-      if ( sim->debug )
-      {
-        sim->out_debug.print( "{} adjust channel target on last tick, current={}, new={}",
-          player->name(), target->name(), player->target->name() );
-      }
+      sim->print_debug( "{} adjust channel target on last tick, current={}, new={}", *player, *target,
+                        *player->target );
       target = player->target;
     }
   }
@@ -1879,7 +1885,7 @@ void action_t::schedule_execute( action_state_t* execute_state )
   if ( target->is_sleeping() )
   {
     sim->print_debug( "{} action={} attempted to schedule on a dead target {}",
-      player->name(), name(), target->name() );
+      *player, *this, *target );
 
     if ( execute_state )
     {
@@ -1888,10 +1894,7 @@ void action_t::schedule_execute( action_state_t* execute_state )
     return;
   }
 
-  if ( sim->log )
-  {
-    sim->out_log.printf( "%s schedules execute for %s", player->name(), name() );
-  }
+  sim->print_log( "{} schedules execute for {}", *player, *this );
 
   time_to_execute = execute_time();
 
@@ -1947,10 +1950,7 @@ void action_t::schedule_execute( action_state_t* execute_state )
 
 void action_t::reschedule_execute( timespan_t time )
 {
-  if ( sim->log )
-  {
-    sim->out_log.printf( "%s reschedules execute for %s", player->name(), name() );
-  }
+  sim->print_log( "{} reschedules execute for {}", *player, *this );
 
   timespan_t delta_time = sim->current_time() + time - execute_event->occurs();
 
@@ -1990,9 +1990,7 @@ void action_t::update_ready( timespan_t cd_duration /* = timespan_t::min() */ )
       if ( delay > timespan_t::from_millis( 400 ) )
       {
         delay -= timespan_t::from_millis( 400 );  // Even high latency players get some benefit from CLT.
-        if ( sim->debug )
-          sim->out_debug.printf( "%s delaying the cooldown finish of %s by %f", player->name(), name(),
-                                 delay.total_seconds() );
+        sim->print_debug( "{} delaying the cooldown finish of {} by {}", *player, *this, delay );
       }
       else
         delay = timespan_t::zero();
@@ -2003,7 +2001,7 @@ void action_t::update_ready( timespan_t cd_duration /* = timespan_t::min() */ )
     sim->print_debug(
           "{} starts cooldown for {} ({}, {}/{}). Duration={} Delay={}. Will "
           "be ready at {}",
-          player->name(), name(), cooldown->name(), cooldown->current_charge, cooldown->charges,
+          *player, *this, *cooldown, cooldown->current_charge, cooldown->charges,
           cd_duration, delay, cooldown->ready );
 
     if ( internal_cooldown->duration > timespan_t::zero() )
@@ -2011,7 +2009,7 @@ void action_t::update_ready( timespan_t cd_duration /* = timespan_t::min() */ )
       internal_cooldown->start( this );
 
       sim->print_debug("{} starts internal_cooldown for {} ({}). Will be ready at {}",
-          player->name(), name(), internal_cooldown->name(), internal_cooldown->ready );
+          *player, *this, *internal_cooldown, internal_cooldown->ready );
 
     }
   }
@@ -2422,8 +2420,8 @@ void action_t::init()
   initialized = true;
 
 #ifndef NDEBUG
-  if ( sim->debug && sim->distance_targeting_enabled )
-    sim->out_debug.printf( "%s - radius %.1f - range - %.1f", name(), radius, range );
+  if ( sim->distance_targeting_enabled )
+    sim->print_debug( "{} - radius={} range={}", *this, radius, range );
 #endif
 
   consume_per_tick_ =
@@ -2608,8 +2606,7 @@ void action_t::reset()
 
 void action_t::cancel()
 {
-  if ( sim->debug )
-    sim->out_debug.printf( "action %s of %s is canceled", name(), player->name() );
+  sim->print_debug( "{} {} is canceled", *player, *this );
 
   if ( channeled )
   {
@@ -2646,8 +2643,7 @@ void action_t::cancel()
 
 void action_t::interrupt_action()
 {
-  if ( sim->debug )
-    sim->out_debug.printf( "action %s of %s is interrupted", name(), player->name() );
+  sim->print_debug( "{} {} is interrupted", *player, *this );
 
   if ( player->executing == this )
     player->executing = nullptr;
@@ -2914,11 +2910,11 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
       {
         if ( action.sim->debug )
         {
-          action.sim->out_debug.printf(
-              "%s %s cast_delay(): can_react_at=%f cur_time=%f", action.player->name_str.c_str(),
-              action.name_str.c_str(),
-              ( action.player->cast_delay_occurred + action.player->cast_delay_reaction ).total_seconds(),
-              action.sim->current_time().total_seconds() );
+          action.sim->print_debug(
+              "{} {} cast_delay(): can_react_at={} cur_time={}", *action.player,
+              action,
+              ( action.player->cast_delay_occurred + action.player->cast_delay_reaction ),
+              action.sim->current_time() );
         }
 
         if ( action.player->cast_delay_occurred == timespan_t::zero() ||
@@ -3958,8 +3954,7 @@ swap_action_list_t::swap_action_list_t( player_t* player, util::string_view opti
 
 void swap_action_list_t::execute()
 {
-  if ( sim->log )
-    sim->out_log.printf( "%s swaps to action list %s", player->name(), alist->name_str.c_str() );
+  sim->print_log( "{} swaps to action list {}", player->name(), alist->name_str );
   player->activate_action_list( alist, player->current_execute_type );
 }
 
@@ -3982,8 +3977,8 @@ void run_action_list_t::execute()
 {
   if ( sim->log )
     sim->out_log.print( "{} runs action list {}{}",
-        player->name(),
-        alist->name_str.c_str(),
+        *player,
+        alist->name_str,
         player->readying ? " (off-gcd)" : "");
 
   if ( player->restore_action_list == nullptr )
@@ -4004,8 +3999,7 @@ bool action_t::consume_cost_per_tick( const dot_t& /* dot */ )
 
   if ( player->get_active_dots( internal_id ) == 0 )
   {
-    if ( sim->debug )
-      sim->out_debug.printf( "%s: %s ticking cost ends because dot is no longer ticking.", player->name(), name() );
+    sim->print_debug( "{} {} ticking cost ends because dot is no longer ticking.", *player, *this );
     return false;
   }
 
@@ -4025,19 +4019,15 @@ bool action_t::consume_cost_per_tick( const dot_t& /* dot */ )
     bool enough_resource_available = player->resource_available( r, cost );
     if ( !enough_resource_available )
     {
-      if ( sim->log )
-        sim->out_log.printf(
-            "%s: %s not enough resource for ticking cost %.1f %s for %s (%.0f). Going to cancel the action.",
-            player->name(), name(), cost, util::resource_type_string( r ), name(), player->resources.current[ r ] );
+      sim->print_log( "{} {} not enough resource for ticking cost {} {} (current={}). Going to cancel the action.",
+                      *player, *this, cost, r, player->resources.current[ r ] );
     }
 
     last_resource_cost = player->resource_loss( r, cost, nullptr, this );
     stats->consume_resource( r, last_resource_cost );
 
-    if ( sim->log )
-      sim->out_log.printf( "%s: %s consumes ticking cost %.1f (%.1f) %s for %s (%.0f).", player->name(), name(), cost,
-                           last_resource_cost, util::resource_type_string( r ), name(),
-                           player->resources.current[ r ] );
+    sim->print_log( "{} {} consumes ticking cost {} ({}) {} (current={}).", *player, *this, cost, last_resource_cost, r,
+                    player->resources.current[ r ] );
 
     if ( !enough_resource_available )
     {
@@ -4248,7 +4238,7 @@ void action_t::reschedule_queue_event()
   }
 
   sim->print_debug( "{} {} adjusting queue-delayed execution, old={} new={}",
-      player->name(), name(), remaining.total_seconds(), new_queue_delay.total_seconds() );
+      *player, *this, remaining, new_queue_delay );
 
   if ( new_queue_delay > remaining )
   {
@@ -4302,7 +4292,7 @@ void action_t::acquire_target( retarget_source /* event */, player_t* /* context
   {
     if ( sim->debug )
     {
-      sim->out_debug.printf( "%s %s target change, current=%s candidate=%s", player->name(), name(),
+      sim->out_debug.print( "{} {} target change, current={} candidate={}", *player, *this,
                              target ? target->name() : "(none)", candidate_target->name() );
     }
     target                = candidate_target;
@@ -4381,7 +4371,7 @@ bool action_t::execute_targeting(action_t* action) const
 {
   if (action->sim->distance_targeting_enabled)
   {
-    if (action->sim->log)
+    if (action->sim->debug)
     {
       action->sim->out_debug.printf(
         "%s action %s - Range %.3f, Radius %.3f, player location "
@@ -4442,7 +4432,7 @@ std::vector<player_t*>& action_t::check_distance_targeting(
       player_t* t = tl[i];
       if (t != target)
       {
-        if (sim->log)
+        if (sim->debug)
         {
           sim->out_debug.printf(
             "%s action %s - Range %.3f, Radius %.3f, player location "
@@ -4460,7 +4450,7 @@ std::vector<player_t*>& action_t::check_distance_targeting(
         {  // Abilities with range/radius radiate from the target.
           if (ground_aoe && parent_dot && parent_dot->is_ticking())
           {  // We need to check the parents dot for location.
-            if (sim->log)
+            if (sim->debug)
               sim->out_debug.printf("parent_dot location: x=%.3f,y%.3f",
                 parent_dot->state->original_x,
                 parent_dot->state->original_y);
@@ -4498,7 +4488,7 @@ std::vector<player_t*>& action_t::check_distance_targeting(
         }
       }
     }
-    if (sim->log)
+    if (sim->debug)
     {
       sim->out_debug.printf("%s regenerated target cache for %s (%s)",
         player->name(), signature_str.c_str(), name());
@@ -4546,10 +4536,9 @@ player_t* action_t::select_target_if_target()
     {
       master_list = target_cache.list;
     }
-    if (sim->log)
-      sim->out_debug.printf("%s Number of targets found in range - %.3f",
-        player->name(),
-        static_cast<double>(master_list.size()));
+
+    sim->print_debug( "{} Number of targets found in range: {}", *player, master_list.size() );
+
     if (master_list.size() <= 1)
       return target;
   }
@@ -4610,22 +4599,13 @@ player_t* action_t::select_target_if_target()
   // action
   if (target_if_mode == TARGET_IF_FIRST && current_target_v == 0)
   {
-    if (sim->debug)
-    {
-      sim->out_debug.printf("%s target_if no target found for %s", player->name(),
-        signature_str.c_str());
-    }
+    sim->print_debug( "{} target_if no target found for {}", *player, signature_str );
+
     return nullptr;
   }
 
-  if (sim->debug)
-  {
-    sim->out_debug.printf(
-      "%s target_if best target: %s - original target - %s - current target "
-      "-%s",
-      player->name(), proposed_target->name(), original_target->name(),
-      target->name());
-  }
+  sim->print_debug( "{} target_if best: {} - original: {} - current target: {}", *player,
+                    *proposed_target, *original_target, *target );
 
   return proposed_target;
 }
@@ -4668,8 +4648,11 @@ void action_t::apply_affecting_effect( const spelleffect_data_t& effect )
     const auto& spell_text = player->dbc->spell_text( spell.id() );
     if ( spell_text.rank() )
       desc_str = fmt::format( " (desc={})", spell_text.rank() );
-    sim->print_debug( "{} {} is affected by effect {} ({}{} (id={}) - effect #{})", *player, *this, effect.id(),
-                      spell.name_cstr(), desc_str, spell.id(), effect.spell_effect_num() + 1 );
+    if ( sim->debug )
+    {
+      sim->print_debug( "{} {} is affected by effect {} ({}{} (id={}) - effect #{})", *player, *this, effect.id(),
+                        spell.name_cstr(), desc_str, spell.id(), effect.spell_effect_num() + 1 );
+    }
   }
 
   auto apply_effect_n_multiplier = [ this ]( const spelleffect_data_t& effect, unsigned n ) {

--- a/engine/action/sc_action_state.cpp
+++ b/engine/action/sc_action_state.cpp
@@ -229,17 +229,14 @@ std::ostringstream& action_state_t::debug_str( std::ostringstream& s )
 void action_state_t::debug()
 {
   std::ostringstream s;
-  action->sim->out_debug.printf( "%s", debug_str( s ).str().c_str() );
+  action->sim->out_debug.print( "{}", debug_str( s ).str() );
 }
 
 travel_event_t::travel_event_t( action_t* a, action_state_t* state,
                                 timespan_t time_to_travel )
   : event_t( *a->player, time_to_travel ), action( a ), state( state )
 {
-  if ( sim().debug )
-    sim().out_debug.printf( "New Stateless Action Travel Event: %s %s %.2f",
-                            a->player->name(), a->name(),
-                            time_to_travel.total_seconds() );
+  sim().print_debug( "New Stateless Action Travel Event: {} {} {}", *a->player, *a, time_to_travel );
 }
 
 travel_event_t::~travel_event_t()

--- a/engine/action/sc_attack.cpp
+++ b/engine/action/sc_attack.cpp
@@ -382,9 +382,12 @@ void attack_t::reschedule_auto_attack( double old_swing_haste )
       return;
     }
 
-    sim->print_debug("Haste change, reschedule {} attack from {} to {} (speed {} -> {}, remains {})",
-        name(), execute_event->remains(), new_time_to_hit, old_swing_haste, player->cache.attack_speed(),
-        time_to_hit);
+    if ( sim->debug )
+    {
+      sim->print_debug( "Haste change, reschedule {} from {} to {} (speed {} -> {}, remains {})", *this,
+                        execute_event->remains(), new_time_to_hit, old_swing_haste, player->cache.attack_speed(),
+                        time_to_hit );
+    }
 
     if ( new_time_to_hit > time_to_hit )
       execute_event->reschedule( new_time_to_hit );
@@ -515,8 +518,11 @@ double ranged_attack_t::composite_target_multiplier( player_t* target ) const
 
 void ranged_attack_t::schedule_execute( action_state_t* execute_state )
 {
-  sim->print_log( "{} schedules execute for {} ({})",
-      player->name(), name(), player->resources.current[ player->primary_resource() ] );
+  if ( sim->debug )
+  {
+    sim->print_log( "{} schedules execute for {} ({})", *player, *this,
+                    player->resources.current[ player->primary_resource() ] );
+  }
 
   time_to_execute = execute_time();
 

--- a/engine/action/sc_dot.cpp
+++ b/engine/action/sc_dot.cpp
@@ -137,8 +137,7 @@ void dot_t::reduce_duration( timespan_t remove_seconds, uint32_t state_flags, bo
   if ( !ticking )
     return;
 
-  sim.print_debug("{} attempts to reduce duration of {} by {}.", source->name(),
-      name(), remove_seconds);
+  sim.print_debug( "{} attempts to reduce duration of {} by {}.", *source, name(), remove_seconds );
 
   assert(remove_seconds > timespan_t::zero() && "Cannot reduce dot duration by a negative amount of time.");
 
@@ -152,6 +151,7 @@ void dot_t::reduce_duration( timespan_t remove_seconds, uint32_t state_flags, bo
       state, state_flags,
       current_action->type == ACTION_HEAL ? result_amount_type::HEAL_OVER_TIME : result_amount_type::DMG_OVER_TIME );
 
+  
   if ( remove_seconds >= remains() )
   {
     cancel();
@@ -175,8 +175,10 @@ void dot_t::reduce_duration( timespan_t remove_seconds, uint32_t state_flags, bo
                         remove_seconds.total_seconds() );
   }
 
-  sim.print_debug("{} dot {} new remains {}.", source->name(),
-      name(), remains());
+  if ( sim.debug )
+  {
+    sim.print_debug( "{} dot {} new remains {}.", *source, name(), remains() );
+  }
 
   assert( end_event && "Dot is ticking but has no end event." );
   timespan_t remains = end_event->remains();

--- a/engine/action/sc_dot.cpp
+++ b/engine/action/sc_dot.cpp
@@ -1340,3 +1340,8 @@ void dot_t::dot_end_event_t::execute()
   assert(dot->current_tick == dot->num_ticks);
   dot->last_tick();
 }
+
+void format_to( const dot_t& dot, fmt::format_context::iterator out )
+{
+  fmt::format_to( out, "Dot {}", dot.name_str );
+}

--- a/engine/action/sc_dot.cpp
+++ b/engine/action/sc_dot.cpp
@@ -113,12 +113,9 @@ void dot_t::extend_duration( timespan_t extra_seconds, timespan_t max_total_time
   current_duration += extra_seconds;
   extended_time += extra_seconds;
 
-  if ( sim.log )
-  {
-    sim.out_log.printf( "%s extends duration of %s on %s by %.1f second(s).",
-                        source->name(), name(), target->name(),
-                        extra_seconds.total_seconds() );
-  }
+  sim.print_log( "{} extends duration of {} on {} by {} second(s).",
+                        *source, *this, *target,
+                        extra_seconds );
 
   assert( end_event && "Dot is ticking but has no end event." );
   timespan_t remains = end_event->remains();
@@ -137,7 +134,7 @@ void dot_t::reduce_duration( timespan_t remove_seconds, uint32_t state_flags, bo
   if ( !ticking )
     return;
 
-  sim.print_debug( "{} attempts to reduce duration of {} by {}.", *source, name(), remove_seconds );
+  sim.print_debug( "{} attempts to reduce duration of {} by {}.", *source, *this, remove_seconds );
 
   assert(remove_seconds > timespan_t::zero() && "Cannot reduce dot duration by a negative amount of time.");
 
@@ -156,28 +153,19 @@ void dot_t::reduce_duration( timespan_t remove_seconds, uint32_t state_flags, bo
   {
     cancel();
 
-    if ( sim.log )
-    {
-      sim.out_log.printf(
-          "%s reduces duration of %s on %s by %.1f second(s), removing it.",
-          source->name(), name(), target->name(),
-          remove_seconds.total_seconds() );
-    }
+    sim.print_log( "{} reduces duration of {} on {} by {} second(s), removing it.", *source, *this, *target,
+                   remove_seconds );
+
     return;
   }
   current_duration -= remove_seconds;
   reduced_time -= remove_seconds;
 
-  if ( sim.log )
-  {
-    sim.out_log.printf( "%s reduces duration of %s on %s by %.1f second(s).",
-                        source->name(), name(), target->name(),
-                        remove_seconds.total_seconds() );
-  }
+  sim.print_log( "{} reduces duration of {} on {} by {} second(s).", *source, *this, *target, remove_seconds );
 
   if ( sim.debug )
   {
-    sim.print_debug( "{} dot {} new remains {}.", *source, name(), remains() );
+    sim.print_debug( "{} {} new remains {}.", *source, *this, remains() );
   }
 
   assert( end_event && "Dot is ticking but has no end event." );
@@ -476,12 +464,11 @@ void dot_t::copy( dot_t* other_dot ) const
   }
 
   if ( sim.debug )
-    sim.out_debug.printf(
-        "%s cloning %s on %s to %s: source_remains=%.3f target_remains=%.3f "
-        "target_duration=%.3f",
-        current_action->player->name(), current_action->name(), target->name(),
-        other_dot->name(), remains().total_seconds(),
-        other_dot->remains().total_seconds(), new_duration.total_seconds() );
+  {
+    sim.print_debug( "{} cloning {} on {} to {}: source_remains={} target_remains={} target_duration={}",
+                     *current_action->player, *current_action, *target, *other_dot, remains(), other_dot->remains(),
+                     new_duration );
+  }
 
   // To compute new number of ticks, we use the new duration, plus the
   // source's ongoing remaining tick time, since we are copying the ongoing
@@ -837,8 +824,7 @@ int dot_t::ticks_left() const
  */
 void dot_t::tick_zero()
 {
-  if ( sim.debug )
-    sim.out_debug.printf( "%s zero-tick.", name() );
+  sim.print_debug( "{} {} zero-tick.", *source, *this );
 
   tick();
 }
@@ -919,11 +905,9 @@ void dot_t::tick()
       }
     }
   }
-  if ( sim.debug )
-    sim.out_debug.printf(
-        "%s ticks (%d of %d). last_start=%.4f, dur=%.4f tt=%.4f", name(),
-        current_tick, num_ticks, last_start.total_seconds(),
-        current_duration.total_seconds(), time_to_tick.total_seconds() );
+
+  sim.print_debug( "{} ticks ({} of {}). last_start={}, duration={} time_to_tick={}", *this, current_tick, num_ticks,
+                   last_start, current_duration, time_to_tick );
 
   current_action->tick( this );
   prev_tick_time = sim.current_time();
@@ -933,8 +917,7 @@ void dot_t::tick()
  */
 void dot_t::last_tick()
 {
-  if ( sim.debug )
-    sim.out_debug.printf( "%s fades from %s", name(), state->target->name() );
+  sim.print_debug( "{} fades from {}", *this, *state->target );
 
   // call action_t::last_tick
   current_action->last_tick( this );
@@ -960,9 +943,7 @@ void dot_t::schedule_tick()
     return;
   }
 
-  if ( sim.debug )
-    sim.out_debug.printf( "%s schedules tick for %s on %s", source->name(),
-                          name(), target->name() );
+  sim.print_debug( "{} schedules tick for {} on {}", *source, *this, *target );
 
   timespan_t base_tick_time = current_action->tick_time( state );
   time_to_tick              = std::min( base_tick_time, remains() );
@@ -1034,10 +1015,7 @@ void dot_t::start( timespan_t duration )
 
   end_event = make_event<dot_end_event_t>( sim, this, current_duration );
 
-  if ( sim.debug )
-    sim.out_debug.printf( "%s starts dot for %s on %s. duration=%.3f",
-                          source->name(), name(), target->name(),
-                          duration.total_seconds() );
+  sim.print_debug( "{} starts {} on {} with duration={}", *source, *this, *target, duration );
 
   state->original_x = target->x_position;
   state->original_y = target->y_position;
@@ -1082,14 +1060,9 @@ void dot_t::refresh( timespan_t duration )
   recalculate_num_ticks();
 
   if ( sim.debug )
-    sim.out_debug.printf(
-        "%s refreshes dot %s (%d) on %s%s. old_remains=%.3f "
-        "refresh_duration=%.3f duration=%.3f",
-        source->name(), name(), stack, target->name(),
-        current_action->dot_refreshable( this, duration ) ? " (no penalty)"
-                                                          : "",
-        remaining_duration.total_seconds(), duration.total_seconds(),
-        current_duration.total_seconds() );
+    sim.print_debug( "{} refreshes {} ({}) on {}{}. old_remains={} refresh_duration={} duration={}", *source, *this,
+                     stack, *target, current_action->dot_refreshable( this, duration ) ? " (no penalty)" : "",
+                     remaining_duration, duration, current_duration );
 
   // Ensure that the ticker is running when dots are refreshed. It is possible
   // that a specialized dot handling cancels the ticker when there's no time to
@@ -1110,11 +1083,9 @@ void dot_t::refresh( timespan_t duration )
   {
     event_t::cancel( tick_event );
     tick_event = make_event<dot_tick_event_t>( sim, this, next_tick_in );
-    if ( sim.debug )
-      sim.out_debug.printf(
-        "%s reschedules next tick (was a partial) for dot %s (%d) on %s to happen in %.3f at %.3f.",
-        source->name(), name(), stack, target->name(),
-        next_tick_in.total_seconds(), next_tick_at.total_seconds() );
+
+    sim.print_debug( "{} reschedules next tick (was a partial) for {} ({}) on {} to happen in {} at {}.", *source,
+                     *this, stack, *target, next_tick_in, next_tick_at );
   }
 }
 
@@ -1264,9 +1235,8 @@ dot_t::dot_tick_event_t::dot_tick_event_t(dot_t* d, timespan_t time_to_tick) :
   event_t(*d -> source, time_to_tick),
   dot(d)
 {
-  if (sim().debug)
-    sim().out_debug.printf("New DoT Tick Event: %s %s %d-of-%d %.4f",
-      d->source->name(), dot->name(), dot->current_tick + 1, dot->num_ticks, time_to_tick.total_seconds());
+  sim().print_debug( "New DoT Tick Event: {} {} tick {}-of{} time_to_tick={}", *d->source, *dot, dot->current_tick + 1,
+                     dot->num_ticks, time_to_tick );
 }
 
 
@@ -1313,9 +1283,7 @@ dot_t::dot_end_event_t::dot_end_event_t(dot_t* d, timespan_t time_to_end) :
   event_t(*d -> source, time_to_end),
   dot(d)
 {
-  if (sim().debug)
-    sim().out_debug.printf("New DoT End Event: %s %s %.3f",
-      d->source->name(), dot->name(), time_to_end.total_seconds());
+  sim().print_debug( "New DoT End Event: {} {} time_to_end={}", *d->source, *dot, time_to_end );
 }
 
 void dot_t::dot_end_event_t::execute()

--- a/engine/action/sc_spell.cpp
+++ b/engine/action/sc_spell.cpp
@@ -86,7 +86,7 @@ result_e spell_base_t::calculate_result( action_state_t* s ) const
     }
   }
 
-  sim->print_debug("{} result for {} is {}.", player -> name(), name(), util::result_type_string( result ) );
+  sim->print_debug("{} result for {} is {}.", *player, *this, result );
 
   return result;
 }

--- a/engine/action/variable.cpp
+++ b/engine/action/variable.cpp
@@ -208,7 +208,7 @@ void variable_t::reset()
     {
       sim->print_debug("{} removing variable action {} from APL because the variable value is "
         "constant (value={})",
-        player->name(), signature_str, var->current_value_);
+        *player, signature_str, var->current_value_);
 
       action_list->foreground_action_list.erase(it);
     }

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -7207,9 +7207,8 @@ struct adaptive_swarm_t : public druid_spell_t
 
         if ( it2 != swarm_tracker.end() )
         {
-          if ( druid->sim->debug )
-            druid->sim->print_debug( "Adaptive Swarm Handler: Merging {} stacks of {} on {} from #{} into #{}",
-                                     it2->stack, it2->swarm->name(), it2->swarm->target->name(), it2->UID, it->UID );
+          druid->sim->print_debug( "Adaptive Swarm Handler: Merging {} stacks of {} on {} from #{} into #{}",
+                                     it2->stack, *it2->swarm, *it2->swarm->target, it2->UID, it->UID );
 
           it->stack = std::min( max_stacks, it->stack + it2->stack );
           it2 = swarm_tracker.erase( it2 );
@@ -7222,8 +7221,7 @@ struct adaptive_swarm_t : public druid_spell_t
       auto it = range::find_if( swarm_tracker, [dot]( swarm_state_t s ) { return s.swarm == dot; } );
       if ( it != swarm_tracker.end() )
       {
-        if ( druid->sim->debug )
-          druid->sim->print_debug( "Adaptive Swarm Handler: Erasing swarm_state for:{} #{}.", dot->name(), it->UID );
+        druid->sim->print_debug( "Adaptive Swarm Handler: Erasing swarm_state for {} #{}.", *dot, it->UID );
 
         swarm_tracker.erase( it );
       }
@@ -7234,8 +7232,8 @@ struct adaptive_swarm_t : public druid_spell_t
       swarm_tracker.push_back( {dot, init_stacks, druid->sim->current_time()} );
 
       if ( druid->sim->debug )
-        druid->sim->print_debug( "Adaptive Swarm Handler: Creating new swarm_state for:{} #{} on {}", dot->name(),
-                                 swarm_tracker.back().UID, dot->target->name() );
+        druid->sim->print_debug( "Adaptive Swarm Handler: Creating new swarm_state for {} #{} on {}", *dot,
+                                 swarm_tracker.back().UID, *dot->target );
     }
 
     bool jump_swarm( dot_t* old_d, dot_t* new_d )
@@ -7244,9 +7242,8 @@ struct adaptive_swarm_t : public druid_spell_t
 
       if ( !sw )
       {
-        if ( druid->sim->debug )
-          druid->sim->print_debug( "Adaptive Swarm Handler: Attempting to jump {} on {} with no swarm_state!",
-                                   old_d->name(), old_d->target->name() );
+        druid->sim->print_debug( "Adaptive Swarm Handler: Attempting to jump {} on {} with no swarm_state!",
+                                   *old_d, *old_d->target );
 
         return false;
       }
@@ -7259,7 +7256,7 @@ struct adaptive_swarm_t : public druid_spell_t
 
       if ( druid->sim->debug )
         druid->sim->print_debug( "Adaptive Swarm Handler: Jumping #{} {} on {} ---> {} on {} with {} stacks.", sw->UID,
-                                 old_d->name(), old_d->target->name(), new_d->name(), new_d->target->name(),
+                                 *old_d, *old_d->target, *new_d, *new_d->target,
                                  sw->stack );
 
       sw->swarm = new_d;
@@ -7284,8 +7281,7 @@ struct adaptive_swarm_t : public druid_spell_t
 
       if ( !sw )
       {
-        if ( druid->sim->debug )
-          druid->sim->print_debug( "Adpative Swarm Handler: Unable to find swarm:{}!", dot->name() );
+        druid->sim->print_debug( "Adpative Swarm Handler: Unable to find swarm: {}!", *dot );
 
         return nullptr;
       }

--- a/engine/sim/sc_cooldown.cpp
+++ b/engine/sim/sc_cooldown.cpp
@@ -640,3 +640,8 @@ bool cooldown_t::is_ready() const
   // the player's (or default) cooldown tolerance for queueing.
   return queueable() <= sim.current_time();
 }
+
+void format_to( const cooldown_t& cooldown, fmt::format_context::iterator out )
+{
+  fmt::format_to( out, "Cooldown {}", cooldown.name_str );
+}

--- a/engine/sim/sc_cooldown.hpp
+++ b/engine/sim/sc_cooldown.hpp
@@ -9,6 +9,7 @@
 #include "util/timespan.hpp"
 #include "sc_enums.hpp"
 #include "util/string_view.hpp"
+#include "util/format.hpp"
 
 #include <string>
 #include <memory>
@@ -104,6 +105,8 @@ struct cooldown_t
   { return timespan_t::from_seconds( -60 * 60 ); }
 
   static timespan_t cooldown_duration( const cooldown_t* cd );
+
+  friend void format_to( const cooldown_t&, fmt::format_context::iterator );
 
 private:
   void adjust_remaining_duration( double delta ); // Modify the remaining duration of an ongoing cooldown.


### PR DESCRIPTION
Adjust log/debug calls in action/ classes.

Mostly making sure all those debug statements that I adjusted in the past to have no sim->debug check do no longer have function calls in them. (especially since player name() is virtual).