### PR TITLE
[shaman] Add maelstrom back to Elemental

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1332,12 +1332,6 @@ public:
 
     // for benefit tracking purpose
     ab::p()->buff.spiritwalkers_grace->up();
-
-    if ( ab::p()->talent.aftershock->ok() && ab::current_resource() == RESOURCE_MAELSTROM &&
-         ab::last_resource_cost > 0 && ab::rng().roll( ab::p()->talent.aftershock->effectN( 1 ).percent() ) )
-    {
-      ab::p()->trigger_maelstrom_gain( ab::last_resource_cost, ab::p()->gain.aftershock );
-    }
   }
 };
 
@@ -4549,6 +4543,11 @@ struct earth_shock_t : public shaman_spell_t
   void execute() override
   {
     shaman_spell_t::execute();
+
+    if (p()->talent.aftershock->ok() && p()->rng().roll( p()->talent.aftershock->effectN( 1 ).percent() ) )
+    {
+      p()->trigger_maelstrom_gain( last_resource_cost, p()->gain.aftershock );
+    }
 
     if ( p()->talent.surge_of_power->ok() )
     {


### PR DESCRIPTION
The rework to Fulmination was abandoned and Elemental is once again
using maelstrom as a resource.

Of note in this change:

* The spell ID for maelstrom is now 343725, with the previous
  spell ID of 190493 still hanging around as Fulmination.
* Tooltips for Lava Beam are bugged and show incorrect values
* Tooltips are bugged for Icefury and don't show Frost Shock's
  maelstrom generation value at all, so it is hardcoded based
  on in-game testing on beta.
* Fix Aftershock to only work on Earth Shock

Note that the default APL is currently causing a segfault due to
some conditional hidden within there. I'm going to be sending
along a separate Pull Request shortly to remove all the APL
complexity from Elemental until we're ready to begin optimizing
when things are feature-complete.

cc @Rusah @HawkCorrigan @Bloodmallet 