### PR TITLE
[shaman] Add High Voltage conduit

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -388,6 +388,13 @@ public:
     const spell_data_t* night_fae; // Fae Transfusion
   } covenant;
 
+  // Conduits
+  struct conduit_t
+  {
+    // Elemental
+    conduit_data_t high_voltage;
+  } conduit;
+
   // Gains
   struct
   {
@@ -567,6 +574,7 @@ public:
       buff(),
       cooldown(),
       covenant(),
+      conduit( conduit_t() ),
       gain(),
       proc(),
       spec(),
@@ -4087,6 +4095,16 @@ struct lightning_bolt_t : public shaman_spell_t
     }
   }
 
+  double composite_maelstrom_gain_coefficient( const action_state_t* state ) const override
+  {
+    double coeff = shaman_spell_t::composite_maelstrom_gain_coefficient( state );
+
+    if ( p()->conduit.high_voltage->ok() && rng().roll( p()->conduit.high_voltage.percent() ) )
+      coeff *= 2.0;
+
+    return coeff;
+  }
+
   double overload_chance( const action_state_t* s ) const override
   {
     double chance = shaman_spell_t::overload_chance( s );
@@ -6032,6 +6050,9 @@ void shaman_t::init_spells()
   // Covenants
   covenant.necrolord = find_covenant_spell( "Primordial Wave" );
   covenant.night_fae = find_covenant_spell( "Fae Transfusion" );
+
+  // Conduits
+  conduit.high_voltage = find_conduit_spell( "High Voltage" );
 
   //
   // Misc spells

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -400,6 +400,7 @@ public:
   struct
   {
     gain_t* aftershock;
+    gain_t* high_voltage;
     gain_t* ascendance;
     gain_t* resurgence;
     gain_t* feral_spirit;
@@ -4110,15 +4111,14 @@ struct lightning_bolt_t : public shaman_spell_t
     }
   }
 
-  double composite_maelstrom_gain_coefficient( const action_state_t* state ) const override
-  {
-    double coeff = shaman_spell_t::composite_maelstrom_gain_coefficient( state );
-
-    if ( p()->conduit.high_voltage->ok() && rng().roll( p()->conduit.high_voltage.percent() ) )
-      coeff *= 2.0;
-
-    return coeff;
-  }
+  // TODO: once bug is fixed, uncomment this
+  // double composite_maelstrom_gain_coefficient( const action_state_t* state ) const override
+  // {
+  //   double coeff = shaman_spell_t::composite_maelstrom_gain_coefficient( state );
+  //   if ( p()->conduit.high_voltage->ok() && rng().roll( p()->conduit.high_voltage.percent() ) )
+  //     coeff *= 2.0;
+  //   return coeff;
+  // }
 
   double overload_chance( const action_state_t* s ) const override
   {
@@ -4215,6 +4215,12 @@ struct lightning_bolt_t : public shaman_spell_t
   void execute() override
   {
     shaman_spell_t::execute();
+
+    // TODO: remove this when the high voltage bug is fixed and it properly generates double instead of 5
+    if ( p()->conduit.high_voltage->ok() && rng().roll( p()->conduit.high_voltage.percent() ) )
+    {
+      p()->trigger_maelstrom_gain( 5.0, p()->gain.high_voltage );
+    }
 
     if ( p()->specialization() == SHAMAN_ENHANCEMENT && p()->covenant.necrolord->ok() && p()->buff.primordial_wave->up() )
     {
@@ -6589,6 +6595,7 @@ void shaman_t::init_gains()
   player_t::init_gains();
 
   gain.aftershock              = get_gain( "Aftershock" );
+  gain.high_voltage            = get_gain( "High Voltage" );
   gain.ascendance              = get_gain( "Ascendance" );
   gain.resurgence              = get_gain( "resurgence" );
   gain.feral_spirit            = get_gain( "Feral Spirit" );


### PR DESCRIPTION
Reference spell: https://shadowlands.wowhead.com/spell=338131/high-voltage

* Gives Lightning Bolt an N% chance to gain double maelstrom.
* Based on in-game testing, this _only_ effects the main spell (not overloads)

cc @Bloodmallet 