### PR TITLE
Expressions: factor out the lexer

### DIFF
--- a/engine/dbc/sc_spell_data.cpp
+++ b/engine/dbc/sc_spell_data.cpp
@@ -1143,10 +1143,6 @@ std::unique_ptr<spell_data_expr_t> spell_data_expr_t::parse( sim_t* sim, util::s
 
   if ( sim -> debug ) expression::print_tokens( tokens, sim );
 
-  expression::convert_to_unary( tokens );
-
-  if ( sim -> debug ) expression::print_tokens( tokens, sim );
-
   if ( ! expression::convert_to_rpn( tokens ) )
   {
     throw std::invalid_argument(fmt::format("Unable to convert '{}' into RPN.", expr_str ));

--- a/engine/sim/sc_expressions.cpp
+++ b/engine/sim/sc_expressions.cpp
@@ -104,6 +104,7 @@ struct lexer_t
       case '*': return yield_token( TOK_MULT );
       case '%':
       {
+        // as '/' is taken by option separators we use '%' as division and '%%' as modulus
         if ( match( '%' ) )
           return yield_token( TOK_MOD );
         return yield_token( TOK_DIV );

--- a/engine/sim/sc_expressions.cpp
+++ b/engine/sim/sc_expressions.cpp
@@ -1060,22 +1060,16 @@ std::vector<expr_token_t> parse_tokens( action_t* action, util::string_view expr
 
 // print_tokens =============================================================
 
-void print_tokens( std::vector<expr_token_t>& tokens, sim_t* sim )
+void print_tokens( util::span<const expr_token_t> tokens, sim_t* sim )
 {
-  std::string str;
-  if ( !tokens.empty() )
-    str += "tokens: ";
+  if ( tokens.empty() )
+    return;
 
-  for ( size_t i = 0; i < tokens.size(); i++ )
-  {
-    expr_token_t& t = tokens[ i ];
-    auto labels = fmt::format("{:2d} '{}'", t.type, t.label );
-    str += labels;
-    if ( i < tokens.size() - 1 )
-      str += " | ";
-  }
+  std::vector<std::string> strings;
+  for ( const expr_token_t& token : tokens )
+    strings.push_back( fmt::format("{:2d} '{}'", token.type, token.label ) );
 
-  sim->out_debug << str;
+  sim->out_debug.print( "{}", fmt::join( strings, " | " ) );
 }
 
 // convert_to_rpn ===========================================================

--- a/engine/sim/sc_expressions.hpp
+++ b/engine/sim/sc_expressions.hpp
@@ -55,7 +55,8 @@ enum token_e
   TOK_FLOOR,
   TOK_CEIL,
   TOK_MAX,
-  TOK_MIN
+  TOK_MIN,
+  TOK_EOF, // "end of stream"
 };
 
 struct expr_token_t
@@ -66,10 +67,8 @@ struct expr_token_t
 
 bool is_unary( token_e );
 bool is_binary( token_e );
-std::vector<expr_token_t> parse_tokens( action_t* action,
-                                        util::string_view expr_str );
+std::vector<expr_token_t> parse_tokens( action_t* action, util::string_view expr_str );
 void print_tokens( std::vector<expr_token_t>& tokens, sim_t* sim );
-void convert_to_unary( std::vector<expr_token_t>& tokens );
 bool convert_to_rpn( std::vector<expr_token_t>& tokens );
 std::unique_ptr<expr_t> build_player_expression_tree(
     player_t& player, std::vector<expression::expr_token_t>& tokens,
@@ -173,7 +172,7 @@ private:
   Should return null if no improved version can be built.
   */
   virtual std::unique_ptr<expr_t> build_optimized_expression( int /* spacing */ )
-  { 
+  {
     return {};
   }
 #if !defined( NDEBUG )

--- a/engine/sim/sc_expressions.hpp
+++ b/engine/sim/sc_expressions.hpp
@@ -68,7 +68,7 @@ struct expr_token_t
 bool is_unary( token_e );
 bool is_binary( token_e );
 std::vector<expr_token_t> parse_tokens( action_t* action, util::string_view expr_str );
-void print_tokens( std::vector<expr_token_t>& tokens, sim_t* sim );
+void print_tokens( util::span<const expr_token_t> tokens, sim_t* sim );
 bool convert_to_rpn( std::vector<expr_token_t>& tokens );
 std::unique_ptr<expr_t> build_player_expression_tree(
     player_t& player, std::vector<expression::expr_token_t>& tokens,


### PR DESCRIPTION
Refactor expression tokenization by factoring out a lexer to make it
easier to follow.

The lexer is non-allocating - tokens contain views into the input
string view.

Drop an intermidate `convert_to_unary()` step as the lexer produces
unary tokens for plus/minus, so we need to convert to binary, and it's
actually easier to do that right inside `parse_tokens()`. We never use
non-converted token streams anyway.

---

Plus a smol cleanup of token printing on top.