### PR TITLE
Player: Change distance targeting initialization.

### DIFF
--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -57,6 +57,7 @@
 #include "util/util.hpp"
 
 #include <cerrno>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <cctype>
@@ -1210,8 +1211,8 @@ player_t::player_t( sim_t* s, player_e t, util::string_view n, race_e r )
     passive_modifier( 0 ),
     x_position( 0.0 ),
     y_position( 0.0 ),
-    default_x_position( 0.0 ),
-    default_y_position( 0.0 ),
+    default_x_position( std::numeric_limits<double>::lowest() ),
+    default_y_position( std::numeric_limits<double>::lowest() ),
     consumables(),
     buffs(),
     debuffs(),
@@ -5258,6 +5259,8 @@ void player_t::reset()
   off_hand_weapon.buff_value = 0;
   off_hand_weapon.bonus_dmg  = 0;
 
+  assert( default_x_position != std::numeric_limits<decltype(default_x_position)>::lowest() );
+  assert( default_y_position != std::numeric_limits<decltype(default_y_position)>::lowest() );
   x_position = default_x_position;
   y_position = default_y_position;
 
@@ -12967,7 +12970,14 @@ void player_t::init_distance_targeting()
   if (!sim->distance_targeting_enabled)
     return;
 
-  x_position = -1 * base.distance;
+  if (default_x_position == std::numeric_limits<decltype(default_x_position)>::lowest())
+  {
+    default_x_position = -1 * base.distance;
+  }
+  if (default_y_position == std::numeric_limits<decltype(default_y_position)>::lowest())
+  {
+    default_y_position = 0;
+  }
 }
 
 void format_to( const player_t& player, fmt::format_context::iterator out )

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -12967,9 +12967,6 @@ double player_t::get_ground_aoe_distance(const action_state_t& a) const
 
 void player_t::init_distance_targeting()
 {
-  if (!sim->distance_targeting_enabled)
-    return;
-
   if (default_x_position == std::numeric_limits<decltype(default_x_position)>::lowest())
   {
     default_x_position = -1 * base.distance;


### PR DESCRIPTION
Initialize option variable with double::lowest().

If not set by the users, initialize actual values used to x=base.distance; y=0;

This fixes the problem that all players where just set to 0,0 coordinates in player_t::reset(), no matter if coordinates were set through x/y_pos or through distance.