### PR TITLE
[Frost DK] Remaining Conduits and bug fixes

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4632,7 +4632,7 @@ struct empower_rune_weapon_buff_t : public buff_t
     cooldown -> duration = 0_ms; // Handled in the action
     set_period( p -> spec.empower_rune_weapon -> effectN( 1 ).period() );
     set_trigger_spell( p -> spec.empower_rune_weapon );
-    set_default_value( p -> spec.empower_rune_weapon -> effectN( 3 ).percent() + ( p -> conduits.accelerated_cold->ok() ? p -> conduits.accelerated_cold.percent() : 0 ));
+    set_default_value( p -> spec.empower_rune_weapon -> effectN( 3 ).percent() + p -> conduits.accelerated_cold.percent());
     add_invalidate( CACHE_HASTE );
     set_refresh_behavior( buff_refresh_behavior::EXTEND);
     set_tick_behavior( buff_tick_behavior::REFRESH );

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -8703,6 +8703,7 @@ void death_knight_t::create_buffs()
   buffs.icy_talons = make_buff( this, "icy_talons", talent.icy_talons -> effectN( 1 ).trigger() )
         -> add_invalidate( CACHE_ATTACK_SPEED )
         -> set_default_value( talent.icy_talons -> effectN( 1 ).trigger() -> effectN( 1 ).percent() )
+        -> set_cooldown( talent.icy_talons->internal_cooldown() )
         -> set_trigger_spell( talent.icy_talons );
 
   buffs.inexorable_assault = make_buff( this, "inexorable_assault", find_spell( 253595 ) )

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -8780,7 +8780,8 @@ void death_knight_t::create_buffs()
   // Conduits
   buffs.eradicating_blow = make_buff( this, "eradicating_blow", find_spell( 337936 ) )
         -> set_default_value( conduits.eradicating_blow.percent() )
-        -> set_trigger_spell( conduits.eradicating_blow );
+        -> set_trigger_spell( conduits.eradicating_blow )
+        -> set_cooldown( conduits.eradicating_blow -> internal_cooldown() );
 
   buffs.unleashed_frenzy = make_buff( this, "unleashed_frenzy", conduits.unleashed_frenzy->effectN( 1 ).trigger() )
         -> add_invalidate( CACHE_STRENGTH )

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4674,11 +4674,18 @@ struct empower_rune_weapon_t : public death_knight_spell_t
 
     cooldown -> duration *= 1.0 + p -> vision_of_perfection_minor_cdr;
     cooldown -> duration += p -> spec.empower_rune_weapon_2->effectN( 1 ).time_value();
-    if ( p -> conduits.accelerated_cold->ok() )
+  }
+
+  double recharge_multiplier( const cooldown_t& cd ) const override
+  {
+    double m = death_knight_spell_t::recharge_multiplier( cd );
+
+    if ( p() -> conduits.accelerated_cold->ok() )
     {
-      cooldown -> duration *= 1.0 + p -> conduits.accelerated_cold->effectN( 2 ).percent();
+      m *= 1.0 + p()->conduits.accelerated_cold->effectN( 2 ).percent();
     }
 
+    return m;
   }
 
   void execute() override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5016,7 +5016,9 @@ struct frost_strike_strike_t : public death_knight_melee_attack_t
     trigger_icecap( execute_state );
 
     if ( p() -> conduits.unleashed_frenzy->ok() )
+    {
       p() -> buffs.unleashed_frenzy->trigger();
+    }
 
   }
 
@@ -5553,7 +5555,9 @@ struct obliterate_strike_t : public death_knight_melee_attack_t
     trigger_icecap( execute_state );
 
     if ( p() -> conduits.eradicating_blow->ok() )
+    {
       p() -> buffs.eradicating_blow -> trigger();
+    }
 
     if ( p() -> azerite.icy_citadel.enabled() && p() -> buffs.pillar_of_frost -> up() && execute_state -> result == RESULT_CRIT )
     {

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -8778,7 +8778,7 @@ void death_knight_t::create_buffs()
         -> set_default_value( conduits.eradicating_blow.percent() )
         -> set_trigger_spell( conduits.eradicating_blow );
 
-  buffs.unleashed_frenzy = make_buff( this, "unleashed_frenzy", find_spell( 338501 ) )
+  buffs.unleashed_frenzy = make_buff( this, "unleashed_frenzy", conduits.unleashed_frenzy->effectN( 1 ).trigger() )
         -> add_invalidate( CACHE_STRENGTH )
         -> set_default_value( conduits.unleashed_frenzy.percent() );
 }


### PR DESCRIPTION
- add in accelerated_cold conduit
- add in unleashed_frenzy conduit, can proc from both hands, as per archerus
- add conduit_id comments
- move eradicating blow trigger calls to the strike action, as it seems to also proc from both hands, but does have a 0.5s ICD
- Wrap eradicating_blow trigger calls in ->ok() checks to clean up the dynamic buffs list.

Please review the below change in more detail:
- Line: 8772 Update eradicating_blow set_trigger_spell from spec.obliterate to conduits.eradicating_blow.  Eradicating blow has a 0.5s ICD.  Through debug output it does look like it's working as expected, but if this is the incorrect way to handle it, or there is a better way, please let me know.

Various test output for accelerated_cold and unleashed_frenzy follows:

#### Accelerated Cold
Baseline
```
  Dynamic Buffs:
    blood_fury               : start=  2.0 refresh=  0.0 interval=226.7 trigger=226.7 duration= 15.0 uptime= 10.13%
    bloodlust                : start=  1.0 refresh=  0.0 interval=  0.0 trigger=  0.0 duration= 40.0 uptime= 13.52%
    empower_rune_weapon      : start=  3.4 refresh=  0.0 interval=105.4 trigger=105.4 duration= 19.5 uptime= 21.84%
    eradicating_blow         : start= 66.4 refresh= 25.9 interval=  4.5 trigger=  3.2 duration=  2.5 uptime= 54.67%  benefit= 76.33%
    gathering_storm          : start= 15.1 refresh= 80.0 interval= 20.3 trigger=  3.1 duration= 11.5 uptime= 57.78%  benefit= 83.67%
    inexorable_assault       : start= 37.2 refresh=  1.3 interval=  8.2 trigger=  8.0 duration=  2.2 uptime= 27.80%  benefit= 45.39%
    killing_machine          : start= 46.3 refresh=  8.0 interval=  6.4 trigger=  5.4 duration=  1.7 uptime= 25.98%  benefit= 36.65%
    pillar_of_frost          : start=  7.1 refresh=  0.0 interval= 45.4 trigger= 45.4 duration= 14.7 uptime= 34.71%  benefit= 34.26%
    pillar_of_frost_bonus    : start=  7.0 refresh= 48.5 interval= 45.5 trigger=  5.3 duration= 13.7 uptime= 32.30%  benefit= 32.15%
    potion_of_unbridled_fury : start=  1.3 refresh=  0.0 interval=319.0 trigger=  0.0 duration= 48.8 uptime= 21.65%
    power_overwhelming       : start=  3.7 refresh=  0.0 interval= 90.7 trigger= 90.7 duration= 14.7 uptime= 18.31%
    remorseless_winter       : start= 15.2 refresh=  0.0 interval= 20.3 trigger= 20.3 duration= 13.1 uptime= 66.54%
    rime                     : start= 39.5 refresh=  2.3 interval=  7.5 trigger=  7.1 duration=  1.9 uptime= 24.38%  benefit= 97.12%
    unholy_strength          : start=  8.5 refresh= 12.0 interval= 35.6 trigger= 14.2 duration= 23.4 uptime= 66.52%  benefit= 66.19%

1.327 Player 'PR_Death_Knight_Frost_2H' schedules execute for Action empower_rune_weapon
1.327 Add Event: core_event_t(#32) time=1.327 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 7 scheduled events
1.327 New Action Execute Event: Player 'PR_Death_Knight_Frost_2H' Action empower_rune_weapon time_to_execute=0.000 (target=Fluffy_Pillow, marker=0)
1.327 Executing event: Action-Execute(#31)
1.327 Player 'PR_Death_Knight_Frost_2H' performs Action potion_of_unbridled_fury (10.0)
1.327 Player 'PR_Death_Knight_Frost_2H' result for Action potion_of_unbridled_fury is hit.
1.327 Player 'PR_Death_Knight_Frost_2H' direct amount for Action potion_of_unbridled_fury: amount=430.63649991565876 initial_amount=430.63649991565876 weapon=0.0 base=378.0 s_mod=0.0 s_power=0.0 a_mod=0.0 a_power=0.0 mult=1.139249999776875 w_mult=0.0 w_slot_mod=1.0 bonus_da=0.0
1.327 PR_Death_Knight_Frost_2H potion_of_unbridled_fury Fluffy_Pillow: snapshot_flags={ CRIT|VERS|MUL_DA|MUL_PER|TGT_CRIT|TGT_MUL_DA } update_flags={ CRIT|VERS|MUL_DA|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA } result=hit type=direct_damage proc_type=MagicHarmfulSpell exec_proc_type=Impact impact_proc_type=HitAmount n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=430.636 total_amount=430.636 mitigated_amount=0 absorbed_amount=0 crit_bonus=0 actual_amount=430.636 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1.085 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1.05 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=0
1.327 Player Fluffy_Pillow loses 0.00 (430.64) health. pct=0.00% (0.00/0.00)
1.327 PR_Death_Knight_Frost_2H potion_of_unbridled_fury Fluffy_Pillow: snapshot_flags={ CRIT|VERS|MUL_DA|MUL_PER|TGT_CRIT|TGT_MUL_DA } update_flags={ CRIT|VERS|MUL_DA|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA } result=hit type=direct_damage proc_type=MagicHarmfulSpell exec_proc_type=Impact impact_proc_type=HitAmount n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=430.636 total_amount=430.636 mitigated_amount=430.636 absorbed_amount=430.636 crit_bonus=1 actual_amount=430.636 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1.085 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1.05 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=0
1.327 Player 'PR_Death_Knight_Frost_2H' potion_of_unbridled_fury hits Player 'Fluffy_Pillow' for 430.63649991565876 fire damage (hit)
1.327 Executing event: Action-Execute(#32)
1.327 Player 'PR_Death_Knight_Frost_2H' performs Action empower_rune_weapon (10.0)
1.327 Player 'PR_Death_Knight_Frost_2H' result for Action empower_rune_weapon is hit.
1.327 PR_Death_Knight_Frost_2H empower_rune_weapon Fluffy_Pillow: snapshot_flags={ CRIT|TGT_CRIT|TGT_ARMOR } update_flags={ CRIT|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA|TGT_ARMOR } result=hit type=direct_damage proc_type=MeleeAbility exec_proc_type=Unknown impact_proc_type=Unknown n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=0 total_amount=0 mitigated_amount=0 absorbed_amount=0 crit_bonus=0 actual_amount=0 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=1071
1.327 Player 'PR_Death_Knight_Frost_2H' schedules travel (1.250) for Action empower_rune_weapon
1.327 Add Event: core_event_t(#33) time=2.577 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Stateless Action Travel Event: Player 'PR_Death_Knight_Frost_2H' Action empower_rune_weapon 1.250
1.327 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action empower_rune_weapon (Cooldown empower_rune_weapon, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 106.327
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for attack_haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for attack_speed.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for rppm_haste_coeff.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for spell_haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for spell_speed.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for rppm_haste_coeff.
1.327 Player 'PR_Death_Knight_Frost_2H' gains empower_rune_weapon_1 (value=0.15)
1.327 Rune-Regen-Event coefficient change, remains=5.69 old_coeff=0.6787330318919833 new_coeff=0.5902026364278117 ratio=0.8695652173913045 new_remains=4.947
1.327 Add Event: Rune-Regen-Event(#34) time=6.274 reschedule=0.000
1.327 Haste change, reschedule Action auto_attack_mh from 1.345 to 1.168 (speed 0.6787330318919833 -> 0.5902026364278117, remains 1.345)
1.327 Add Event: core_event_t(#35) time=2.495 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Action Execute Event: Player 'PR_Death_Knight_Frost_2H' Action auto_attack_mh time_to_execute=1.168 (target=Fluffy_Pillow, marker=0)
```

Rank 1:
```
  Dynamic Buffs:
    blood_fury               : start=  2.0 refresh=  0.0 interval=189.5 trigger=189.5 duration= 15.0 uptime= 10.07%
    bloodlust                : start=  1.0 refresh=  0.0 interval=  0.0 trigger=  0.0 duration= 40.0 uptime= 13.43%
    empower_rune_weapon      : start=  3.7 refresh=  0.0 interval= 94.8 trigger= 94.8 duration= 19.5 uptime= 23.59%
    eradicating_blow         : start= 67.8 refresh= 26.4 interval=  4.4 trigger=  3.2 duration=  2.4 uptime= 54.60%  benefit= 76.36%
    gathering_storm          : start= 15.2 refresh= 83.1 interval= 20.3 trigger=  3.0 duration= 11.6 uptime= 58.63%  benefit= 83.88%
    inexorable_assault       : start= 37.4 refresh=  1.2 interval=  8.2 trigger=  8.0 duration=  2.2 uptime= 27.31%  benefit= 44.79%
    killing_machine          : start= 47.6 refresh=  8.3 interval=  6.2 trigger=  5.3 duration=  1.6 uptime= 25.85%  benefit= 36.85%
    pillar_of_frost          : start=  7.1 refresh=  0.0 interval= 45.3 trigger= 45.3 duration= 14.7 uptime= 34.74%  benefit= 34.35%
    pillar_of_frost_bonus    : start=  7.1 refresh= 50.7 interval= 45.5 trigger=  5.1 duration= 13.7 uptime= 32.13%  benefit= 32.09%
    potion_of_unbridled_fury : start=  1.0 refresh=  0.0 interval=  0.0 trigger=  0.0 duration= 58.0 uptime= 19.48%
    power_overwhelming       : start=  3.7 refresh=  0.0 interval= 90.6 trigger= 90.6 duration= 14.8 uptime= 18.36%
    remorseless_winter       : start= 15.3 refresh=  0.0 interval= 20.3 trigger= 20.3 duration= 13.3 uptime= 67.22%
    rime                     : start= 40.3 refresh=  2.2 interval=  7.4 trigger=  7.0 duration=  1.8 uptime= 23.82%  benefit= 97.21%
    unholy_strength          : start=  8.5 refresh= 12.5 interval= 36.0 trigger= 14.0 duration= 24.1 uptime= 67.61%  benefit= 67.36%
1.327 Player 'PR_Death_Knight_Frost_2H' schedules execute for Action empower_rune_weapon
1.327 Add Event: core_event_t(#32) time=1.327 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 7 scheduled events
1.327 New Action Execute Event: Player 'PR_Death_Knight_Frost_2H' Action empower_rune_weapon time_to_execute=0.000 (target=Fluffy_Pillow, marker=0)
1.327 Executing event: Action-Execute(#31)
1.327 Player 'PR_Death_Knight_Frost_2H' performs Action potion_of_unbridled_fury (10.0)
1.327 Player 'PR_Death_Knight_Frost_2H' result for Action potion_of_unbridled_fury is crit.
1.327 Player 'PR_Death_Knight_Frost_2H' direct amount for Action potion_of_unbridled_fury: amount=430.63649991565876 initial_amount=430.63649991565876 weapon=0.0 base=378.0 s_mod=0.0 s_power=0.0 a_mod=0.0 a_power=0.0 mult=1.139249999776875 w_mult=0.0 w_slot_mod=1.0 bonus_da=0.0
1.327 PR_Death_Knight_Frost_2H potion_of_unbridled_fury Fluffy_Pillow: snapshot_flags={ CRIT|VERS|MUL_DA|MUL_PER|TGT_CRIT|TGT_MUL_DA } update_flags={ CRIT|VERS|MUL_DA|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA } result=crit type=direct_damage proc_type=MagicHarmfulSpell exec_proc_type=Impact impact_proc_type=CritAmount n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=430.636 total_amount=430.636 mitigated_amount=0 absorbed_amount=0 crit_bonus=0 actual_amount=430.636 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1.085 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1.05 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=0
1.327 Player 'PR_Death_Knight_Frost_2H' crit_bonus for Action potion_of_unbridled_fury: total=1.0 base=1.0 mult_buffed=1.0 damage_bonus_mult=1.0
1.327 Player Fluffy_Pillow loses 0.00 (861.27) health. pct=0.00% (0.00/0.00)
1.327 PR_Death_Knight_Frost_2H potion_of_unbridled_fury Fluffy_Pillow: snapshot_flags={ CRIT|VERS|MUL_DA|MUL_PER|TGT_CRIT|TGT_MUL_DA } update_flags={ CRIT|VERS|MUL_DA|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA } result=crit type=direct_damage proc_type=MagicHarmfulSpell exec_proc_type=Impact impact_proc_type=CritAmount n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=430.636 total_amount=861.273 mitigated_amount=861.273 absorbed_amount=861.273 crit_bonus=1 actual_amount=861.273 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1.085 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1.05 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=0
1.327 Player 'PR_Death_Knight_Frost_2H' potion_of_unbridled_fury hits Player 'Fluffy_Pillow' for 861.2729998313175 fire damage (crit)
1.327 Executing event: Action-Execute(#32)
1.327 Player 'PR_Death_Knight_Frost_2H' performs Action empower_rune_weapon (10.0)
1.327 Player 'PR_Death_Knight_Frost_2H' result for Action empower_rune_weapon is hit.
1.327 PR_Death_Knight_Frost_2H empower_rune_weapon Fluffy_Pillow: snapshot_flags={ CRIT|TGT_CRIT|TGT_ARMOR } update_flags={ CRIT|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA|TGT_ARMOR } result=hit type=direct_damage proc_type=MeleeAbility exec_proc_type=Unknown impact_proc_type=Unknown n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=0 total_amount=0 mitigated_amount=0 absorbed_amount=0 crit_bonus=0 actual_amount=0 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=1071
1.327 Player 'PR_Death_Knight_Frost_2H' schedules travel (1.250) for Action empower_rune_weapon
1.327 Add Event: core_event_t(#33) time=2.577 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Stateless Action Travel Event: Player 'PR_Death_Knight_Frost_2H' Action empower_rune_weapon 1.250
1.327 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action empower_rune_weapon (Cooldown empower_rune_weapon, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 95.827
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for attack_haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for attack_speed.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for rppm_haste_coeff.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for spell_haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for spell_speed.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for rppm_haste_coeff.
1.327 Player 'PR_Death_Knight_Frost_2H' gains empower_rune_weapon_1 (value=0.2)
1.327 Rune-Regen-Event coefficient change, remains=5.69 old_coeff=0.6787330318919833 new_coeff=0.5656108599099862 ratio=0.8333333333333335 new_remains=4.741
1.327 Add Event: Rune-Regen-Event(#34) time=6.068 reschedule=0.000
1.327 Haste change, reschedule Action auto_attack_mh from 1.345 to 1.119 (speed 0.6787330318919833 -> 0.5656108599099862, remains 1.345)
1.327 Add Event: core_event_t(#35) time=2.446 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Action Execute Event: Player 'PR_Death_Knight_Frost_2H' Action auto_attack_mh time_to_execute=1.119 (target=Fluffy_Pillow, marker=0)
```

Rank 15:
```
  Dynamic Buffs:
    blood_fury               : start=  2.0 refresh=  0.0 interval=189.8 trigger=189.8 duration= 15.0 uptime= 10.12%
    bloodlust                : start=  1.0 refresh=  0.0 interval=  0.0 trigger=  0.0 duration= 40.0 uptime= 13.50%
    empower_rune_weapon      : start=  3.6 refresh=  0.0 interval= 94.9 trigger= 94.9 duration= 19.5 uptime= 23.51%
    eradicating_blow         : start= 69.4 refresh= 27.2 interval=  4.3 trigger=  3.1 duration=  2.4 uptime= 54.71%  benefit= 76.64%
    gathering_storm          : start= 14.3 refresh= 87.1 interval= 21.6 trigger=  2.9 duration= 12.6 uptime= 59.81%  benefit= 84.56%
    inexorable_assault       : start= 37.4 refresh=  1.1 interval=  8.1 trigger=  8.0 duration=  2.1 uptime= 26.76%  benefit= 43.56%
    killing_machine          : start= 49.2 refresh=  8.5 interval=  6.0 trigger=  5.1 duration=  1.6 uptime= 25.88%  benefit= 37.05%
    pillar_of_frost          : start=  7.1 refresh=  0.0 interval= 45.4 trigger= 45.4 duration= 14.7 uptime= 34.69%  benefit= 34.54%
    pillar_of_frost_bonus    : start=  7.0 refresh= 52.7 interval= 45.7 trigger=  4.9 duration= 13.7 uptime= 32.22%  benefit= 32.56%
    potion_of_unbridled_fury : start=  1.0 refresh=  0.0 interval=  0.0 trigger=  0.0 duration= 58.0 uptime= 19.57%
    power_overwhelming       : start=  3.7 refresh=  0.0 interval= 90.9 trigger= 90.9 duration= 14.8 uptime= 18.30%
    remorseless_winter       : start= 14.4 refresh=  0.9 interval= 21.6 trigger= 20.3 duration= 14.2 uptime= 68.15%
    rime                     : start= 41.1 refresh=  2.4 interval=  7.2 trigger=  6.8 duration=  1.7 uptime= 23.95%  benefit= 97.26%
    unholy_strength          : start=  8.5 refresh= 12.8 interval= 36.0 trigger= 13.8 duration= 24.1 uptime= 68.23%  benefit= 68.13%

1.327 Player 'PR_Death_Knight_Frost_2H' schedules execute for Action empower_rune_weapon
1.327 Add Event: core_event_t(#30) time=1.327 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Action Execute Event: Player 'PR_Death_Knight_Frost_2H' Action empower_rune_weapon time_to_execute=0.000 (target=Fluffy_Pillow, marker=0)
1.327 Executing event: Action-Execute(#30)
1.327 Player 'PR_Death_Knight_Frost_2H' performs Action empower_rune_weapon (10.0)
1.327 Player 'PR_Death_Knight_Frost_2H' result for Action empower_rune_weapon is hit.
1.327 PR_Death_Knight_Frost_2H empower_rune_weapon Fluffy_Pillow: snapshot_flags={ CRIT|TGT_CRIT|TGT_ARMOR } update_flags={ CRIT|TGT_CRIT|TGT_MUL_DA|TGT_MUL_TA|TGT_ARMOR } result=hit type=direct_damage proc_type=MeleeAbility exec_proc_type=Unknown impact_proc_type=Unknown n_targets=1 chain_target=0 original_x=0 original_y=0 raw_amount=0 total_amount=0 mitigated_amount=0 absorbed_amount=0 crit_bonus=0 actual_amount=0 only_blocked_damage=0 self_absorbed_damage=0 ap=0 sp=0 haste=1 crit=0.2623 tgt_crit=0 versatility=1 da_mul=1 ta_mul=1 per_mul=1 tgt_da_mul=1 tgt_ta_mul=1 tgt_mitg_da_mul=1 tgt_mitg_ta_mul=1 target_armor=1071
1.327 Player 'PR_Death_Knight_Frost_2H' schedules travel (1.250) for Action empower_rune_weapon
1.327 Add Event: core_event_t(#31) time=2.577 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Stateless Action Travel Event: Player 'PR_Death_Knight_Frost_2H' Action empower_rune_weapon 1.250
1.327 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action empower_rune_weapon (Cooldown empower_rune_weapon, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 95.827
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for attack_haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for attack_speed.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for rppm_haste_coeff.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for spell_haste.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for spell_speed.
1.327 Player 'PR_Death_Knight_Frost_2H' invalidates stat cache for rppm_haste_coeff.
1.327 Player 'PR_Death_Knight_Frost_2H' gains empower_rune_weapon_1 (value=0.3)
1.327 Rune-Regen-Event coefficient change, remains=5.69 old_coeff=0.6787330318919833 new_coeff=0.5221023322246025 ratio=0.769230769230769 new_remains=4.376
1.327 Add Event: Rune-Regen-Event(#32) time=5.703 reschedule=0.000
1.327 Haste change, reschedule Action auto_attack_mh from 1.345 to 1.034 (speed 0.6787330318919833 -> 0.5221023322246025, remains 1.345)
1.327 Add Event: core_event_t(#33) time=2.361 reschedule=0.000
1.327 Actor PR_Death_Knight_Frost_2H has 6 scheduled events
1.327 New Action Execute Event: Player 'PR_Death_Knight_Frost_2H' Action auto_attack_mh time_to_execute=1.034 (target=Fluffy_Pillow, marker=0)
```


#### Unleashed Frenzy
Rank1:
```
2.217 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_1 (value=0.01)
8.217 Player 'PR_Death_Knight_Frost_2H' loses unleashed_frenzy
10.221 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_1 (value=0.01)
11.999 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_2 (value=0.01)
11.999 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_2 (value=0.01, duration=6.000)
13.778 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_3 (value=0.01)
13.778 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_3 (value=0.01, duration=6.000)
17.337 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_4 (value=0.01)
17.337 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_4 (value=0.01, duration=6.000)
18.225 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_5 (value=0.01)
18.225 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
20.006 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
20.894 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
26.894 Player 'PR_Death_Knight_Frost_2H' loses unleashed_frenzy
27.919 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_1 (value=0.01)
29.965 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_2 (value=0.01)
29.965 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_2 (value=0.01, duration=6.000)
34.059 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_3 (value=0.01)
34.059 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_3 (value=0.01, duration=6.000)
35.082 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_4 (value=0.01)
35.082 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_4 (value=0.01, duration=6.000)
39.173 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_5 (value=0.01)
39.173 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
40.194 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
41.218 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
46.530 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
51.841 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
54.498 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
57.154 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
59.807 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
63.876 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
66.533 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
69.189 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.01, duration=6.000)
75.189 Player 'PR_Death_Knight_Frost_2H' loses unleashed_frenzy
76.171 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_1 (value=0.01)
77.498 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_2 (value=0.01)
77.498 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_2 (value=0.01, duration=6.000)
81.754 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_3 (value=0.01)
81.754 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_3 (value=0.01, duration=6.000)
86.338 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_4 (value=0.01)
86.338 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_4 (value=0.01, duration=6.000)
```
Rank 15:
```
2.218 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_1 (value=0.045)
3.995 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_2 (value=0.045)
3.995 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_2 (value=0.045, duration=6.000)
7.555 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_3 (value=0.045)
7.555 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_3 (value=0.045, duration=6.000)
9.333 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_4 (value=0.045)
9.333 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_4 (value=0.045, duration=6.000)
14.672 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_5 (value=0.045)
14.672 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
18.228 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
20.007 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
20.896 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
26.896 Player 'PR_Death_Knight_Frost_2H' loses unleashed_frenzy
27.925 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_1 (value=0.045)
29.968 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_2 (value=0.045)
29.968 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_2 (value=0.045, duration=6.000)
32.011 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_3 (value=0.045)
32.011 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_3 (value=0.045, duration=6.000)
35.083 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_4 (value=0.045)
35.083 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_4 (value=0.045, duration=6.000)
37.129 Player 'PR_Death_Knight_Frost_2H' gains unleashed_frenzy_5 (value=0.045)
37.129 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
40.195 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
41.219 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
46.530 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
49.186 Player 'PR_Death_Knight_Frost_2H' refreshes unleashed_frenzy_5 (value=0.045, duration=6.000)
```