### PR TITLE
[Frost DK] Rage of the Frozen Champion Legendary

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4871,12 +4871,8 @@ struct festering_strike_t : public death_knight_melee_attack_t
 
 struct frostscythe_t : public death_knight_melee_attack_t
 {
-  double rime_proc_chance;
-
   frostscythe_t( death_knight_t* p, const std::string& options_str ) :
-    death_knight_melee_attack_t( "frostscythe", p, p -> talent.frostscythe ),
-    rime_proc_chance( ( p -> spec.rime -> effectN( 2 ).percent() +
-                        p -> legendary.rage_of_the_frozen_champion -> effectN( 1 ).percent() ) / 2.0 )
+    death_knight_melee_attack_t( "frostscythe", p, p -> talent.frostscythe )
   {
     parse_options( options_str );
 
@@ -4905,7 +4901,7 @@ struct frostscythe_t : public death_knight_melee_attack_t
     }
 
     // Frostscythe procs rime at half the chance of Obliterate
-    p() -> buffs.rime -> trigger( 1, buff_t::DEFAULT_VALUE(), rime_proc_chance );
+    p() -> buffs.rime -> trigger( 1, buff_t::DEFAULT_VALUE(), (p() -> buffs.rime->manual_chance / 2.0) );
   }
 
   double composite_crit_chance() const override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4363,7 +4363,6 @@ struct death_coil_t : public death_knight_spell_t
     // Reduces the cooldown Dark Transformation by 1s
     p() -> cooldown.dark_transformation -> adjust( -timespan_t::from_seconds(
       p() -> spec.death_coil -> effectN( 2 ).base_value() ) );
-    printf("DEBUGME: %f\n", p() -> spec.death_coil -> effectN( 2 ).base_value() / 10);
 
     // Reduce the cooldown on Apocalypse and Army of the Dead if Army of the Damned is talented
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -576,6 +576,7 @@ public:
     gain_t* koltiras_favor;
     gain_t* murderous_efficiency;
     gain_t* obliteration;
+    gain_t* rage_of_the_frozen_champion;
     gain_t* runic_attenuation;
     gain_t* runic_empowerment;
 
@@ -765,6 +766,7 @@ public:
     const spell_data_t* frost_fever;
     const spell_data_t* inexorable_assault_damage;
     const spell_data_t* murderous_efficiency_gain;
+    const spell_data_t* rage_of_the_frozen_champion;
 
     // Unholy
     const spell_data_t* death_coil_damage;
@@ -894,8 +896,9 @@ public:
 
     // Blood
 
-    // Frost
-    item_runeforge_t koltiras_favor;  // 6944
+    // Frost                                      // bonus_id
+    item_runeforge_t koltiras_favor;              // 6944
+    item_runeforge_t rage_of_the_frozen_champion; // 7160
 
     // Unholy
   } legendary;
@@ -4360,6 +4363,7 @@ struct death_coil_t : public death_knight_spell_t
     // Reduces the cooldown Dark Transformation by 1s
     p() -> cooldown.dark_transformation -> adjust( -timespan_t::from_seconds(
       p() -> spec.death_coil -> effectN( 2 ).base_value() ) );
+    printf("DEBUGME: %f\n", p() -> spec.death_coil -> effectN( 2 ).base_value() / 10);
 
     // Reduce the cooldown on Apocalypse and Army of the Dead if Army of the Damned is talented
 
@@ -4868,8 +4872,12 @@ struct festering_strike_t : public death_knight_melee_attack_t
 
 struct frostscythe_t : public death_knight_melee_attack_t
 {
+  double rime_proc_chance;
+
   frostscythe_t( death_knight_t* p, const std::string& options_str ) :
-    death_knight_melee_attack_t( "frostscythe", p, p -> talent.frostscythe )
+    death_knight_melee_attack_t( "frostscythe", p, p -> talent.frostscythe ),
+    rime_proc_chance( ( p -> spec.rime -> effectN( 2 ).percent() +
+                        p -> legendary.rage_of_the_frozen_champion -> effectN( 1 ).percent() ) / 2.0 )
   {
     parse_options( options_str );
 
@@ -4898,7 +4906,7 @@ struct frostscythe_t : public death_knight_melee_attack_t
     }
 
     // Frostscythe procs rime at half the chance of Obliterate
-    p() -> buffs.rime -> trigger( 1, buff_t::DEFAULT_VALUE(), p() -> spec.rime -> effectN( 2 ).percent() / 2.0 );
+    p() -> buffs.rime -> trigger( 1, buff_t::DEFAULT_VALUE(), rime_proc_chance );
   }
 
   double composite_crit_chance() const override
@@ -5379,6 +5387,13 @@ struct howling_blast_t : public death_knight_spell_t
     {
       echoing_howl -> set_target( execute_state -> target );
       echoing_howl -> execute();
+    }
+
+    if ( p() -> buffs.rime -> check() && p() -> legendary.rage_of_the_frozen_champion->ok() )
+    {
+      p() -> resource_gain( RESOURCE_RUNIC_POWER,
+                            p() -> spell.rage_of_the_frozen_champion -> effectN( 1 ).resource( RESOURCE_RUNIC_POWER ),
+                            p() -> gains.rage_of_the_frozen_champion );
     }
 
     p() -> buffs.rime -> decrement();
@@ -7983,6 +7998,7 @@ void death_knight_t::init_spells()
   spell.frost_fever               = find_spell( 55095 );
   spell.inexorable_assault_damage = find_spell( 253597 );
   spell.murderous_efficiency_gain = find_spell( 207062 );
+  spell.rage_of_the_frozen_champion = find_spell( 341725 );
 
   // Unholy
   spell.bursting_sores         = find_spell( 207267 );
@@ -8077,6 +8093,7 @@ void death_knight_t::init_spells()
   // Blood
   // Frost
   legendary.koltiras_favor       = find_runeforge_legendary( "Koltira's Favor" );
+  legendary.rage_of_the_frozen_champion = find_runeforge_legendary( "Rage of the Frozen Champion" );
   // Unholy
 }
 
@@ -8692,7 +8709,7 @@ void death_knight_t::create_buffs()
 
   buffs.rime = make_buff( this, "rime", spec.rime -> effectN( 1 ).trigger() )
         -> set_trigger_spell( spec.rime )
-        -> set_chance( spec.rime -> effectN( 2 ).percent() );
+        -> set_chance( spec.rime -> effectN( 2 ).percent() + legendary.rage_of_the_frozen_champion ->effectN( 1 ).percent() );
 
   // Unholy
   buffs.dark_transformation = make_buff( this, "dark_transformation", spec.dark_transformation )
@@ -8788,6 +8805,7 @@ void death_knight_t::init_gains()
   gains.horn_of_winter                   = get_gain( "Horn of Winter" );
   gains.murderous_efficiency             = get_gain( "Murderous Efficiency" );
   gains.obliteration                     = get_gain( "Obliteration" );
+  gains.rage_of_the_frozen_champion      = get_gain( "Rage of the Frozen Champion" );
   gains.runic_attenuation                = get_gain( "Runic Attenuation" );
   gains.runic_empowerment                = get_gain( "Runic Empowerment" );
   gains.koltiras_favor                   = get_gain( "Koltira's Favor" );

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4901,7 +4901,7 @@ struct frostscythe_t : public death_knight_melee_attack_t
     }
 
     // Frostscythe procs rime at half the chance of Obliterate
-    p() -> buffs.rime -> trigger( 1, buff_t::DEFAULT_VALUE(), (p() -> buffs.rime->manual_chance / 2.0) );
+    p() -> buffs.rime -> trigger( 1, buff_t::DEFAULT_VALUE(), p() -> buffs.rime->manual_chance / 2.0 );
   }
 
   double composite_crit_chance() const override


### PR DESCRIPTION
A few people mentioned that it does work with frostscythe, so it appears to be pretty close to a copy/paste of the legion T19 set bonus.  I pulled the majority of the code from the legion version, with the exception of the runic power generation.

#### Legion SpellData
```
SimulationCraft 901-01 for World of Warcraft 9.0.2.35854 shadowlands-BETA (hotfix 2020-09-14/35854, git build rage_of_the_frozen_champion ab2771d5b0)

Name             : Item - Death Knight T19 Frost 2P Bonus (id=211042) [Spell Family (15), Passive, Hidden]
School           : Physical
Spell Type       : None
Attributes       : ......xx ........ ........ ........   ........ ........ ........ ........
                 : ........ x....... ........ ........   ........ ........ ........ ........
                 : ........ ........ x....... ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ .x...... ........   ........ ........ ........ ........
                 : ........ ........ ........ ........
                 : Passive (6), Hidden (7)
Effects          :
#1 (id=312604)   : Apply Aura (6) | Add Flat Modifier (107): Spell Proc Chance (18)
                   Base Value: 20 | Scaled Value: 20 | PvP Coefficient: 1.00000 | Misc Value: 18 | Target: Self (1)
                   Affected Spells: Rime (59057)
                   Family Flags: 3
Description      : Obliterate has a $s1% increased chance to trigger Rime.


SimulationCraft 901-01 for World of Warcraft 9.0.2.35854 shadowlands-BETA (hotfix 2020-09-14/35854, git build rage_of_the_frozen_champion ab2771d5b0)

Name             : Item - Death Knight T19 Frost 4P Bonus (id=211045) [Spell Family (15), Passive, Hidden]
School           : Physical
Spell Type       : None
Attributes       : ......xx ........ ........ ........   ........ ........ ........ ........
                 : ........ x....... ........ ........   ........ ........ ........ ........
                 : ........ ........ x....... ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ .x...... ........   ........ ........ ........ ........
                 : ........ ........ ........ ........
                 : Passive (6), Hidden (7)
Effects          :
#1 (id=312607)   : Apply Aura (6) | Add Flat Modifier (107): Spell Effect 3 (23)
                   Base Value: 60 | Scaled Value: 60 | PvP Coefficient: 1.00000 | Misc Value: 23 | Target: Self (1)
                   Affected Spells: Rime (59052)
                   Family Flags: 82
Description      : Howling Blast now generates ${$m1/100*10} Runic Power while Rime is active.
```
#### SL Lego SpellData
```
SimulationCraft 901-01 for World of Warcraft 9.0.2.35854 shadowlands-BETA (hotfix 2020-09-14/35854, git build rage_of_the_frozen_champion ab2771d5b0)

Name             : Rage of the Frozen Champion (id=341724) [Spell Family (15), Passive]
School           : Physical
Spell Type       : None
Proc Chance      : 101%
Attributes       : ......x. ........ ........ ........   ........ ........ ........ ........
                 : ........ x....... ........ ........   ........ ........ ........ ..x.....
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........
                 : Passive (6)
Effects          :
#1 (id=842305)   : Apply Aura (6) | Add Flat Modifier (107): Spell Effect 2 (12)
                   Base Value: 15 | Scaled Value: 15 | PvP Coefficient: 1.00000 | Misc Value: 12 | Target: Self (1)
                   Affected Spells: Rime (59057)
                   Family Flags: 3
Description      : Obliterate has a $s1% increased chance to trigger Rime and Howling Blast generates ${$341725s1/10} Runic Power while Rime is active.

Name             : Rage of the Frozen Champion (id=341725) [Spell Family (15)]
School           : Physical
Spell Type       : Magic
Attributes       : ........ ........ ..x..... ........   ........ ........ ........ ........
                 : ........ x....... ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ....x... ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........   ........ ........ ........ ........
                 : ........ ........ ........ ........
Effects          :
#1 (id=842306)   : Energize Power (30)
                   Base Value: 80 | Scaled Value: 80 | PvP Coefficient: 1.00000 | Misc Value: runic_power | Target: Self (1)
Description      : $@spelldesc341724
```
### Test data
#### Without Lego
```
    obliterate                           Count=  85.0|  3.483sec  DPE=2537| 0.00%  DPET=2069  DPR=  0  pDPS=  0
    obliterate_2h                        Count=  85.0|  3.483sec  DPE=2537|35.55%  DPET=   0  DPR=  0  pDPS=721  Miss= 0.00%  Hit=  1110|  1017|  1590  Crit=  3582|  2035|  4617|57.72%

    rime                     : start= 36.6 refresh=  1.7 interval=  8.1 trigger=  7.7 duration=  1.8 uptime= 22.33%  benefit= 96.53%

  Gains:
        12.6 : howling_blast        (runic_power)
       149.6 : remorseless_winter   (runic_power)
      1692.6 : obliterate           (runic_power)
        94.8 : Rune Regeneration    (rune)
        68.9 : Empower Rune Weapon  (runic_power)    (overflow=2.60%)
        14.0 : Empower Rune Weapon  (rune)
       147.5 : Frost Fever          (runic_power)
        21.5 : Murderous Efficiency (rune)
        11.7 : Obliteration         (rune)           (overflow=1.70%)
        40.1 : Runic Empowerment    (rune)
  Waiting:  9.21%
```

#### With Lego
```
   obliterate                           Count=  84.2|  3.570sec  DPE=2648| 0.00%  DPET=2151  DPR=  0  pDPS=  0
    obliterate_2h                        Count=  84.2|  3.570sec  DPE=2648|34.79%  DPET=   0  DPR=  0  pDPS=743  Miss= 0.00%  Hit=  1101|  1017|  1484  Crit=  3617|  2035|  4617|61.47%

   rime                     : start= 44.3 refresh=  6.1 interval=  6.7 trigger=  5.9 duration=  2.1 uptime= 31.65%  benefit= 97.69%

  Gains:
        10.2 : howling_blast               (runic_power)
       144.9 : remorseless_winter          (runic_power)    (overflow=4.97%)
      1635.8 : obliterate                  (runic_power)    (overflow=2.84%)
        86.9 : Rune Regeneration           (rune)
        64.1 : Empower Rune Weapon         (runic_power)    (overflow=9.45%)
        14.0 : Empower Rune Weapon         (rune)           (overflow=1.27%)
       142.0 : Frost Fever                 (runic_power)    (overflow=5.06%)
        23.2 : Murderous Efficiency        (rune)
        12.6 : Obliteration                (rune)           (overflow=2.12%)
       337.5 : Rage of the Frozen Champion (runic_power)    (overflow=4.12%)
        44.3 : Runic Empowerment           (rune)           (overflow=2.06%)
  Waiting:  2.34%
```