### PR TITLE
[shaman] Implement Chains of Devastation legendary

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -329,6 +329,8 @@ public:
     buff_t* vesper_totem;
 
     // Legendaries
+    buff_t* chains_of_devastation_chain_heal;
+    buff_t* chains_of_devastation_chain_lightning;
     buff_t* echoes_of_great_sundering;
 
     // Elemental, Restoration
@@ -416,7 +418,7 @@ public:
   {
     // Shared
     item_runeforge_t ancestral_reminder;     // NYI
-    item_runeforge_t chains_of_devastation;  // NYI
+    item_runeforge_t chains_of_devastation;
     item_runeforge_t deeptremor_stone;       // NYI
     item_runeforge_t deeply_rooted_elements; // NYI
 
@@ -3642,6 +3644,11 @@ struct chain_lightning_t : public chained_base_t
       t *= 1 + p()->talent.stormkeeper->effectN( 1 ).percent();
     }
 
+    if ( p()->buff.chains_of_devastation_chain_lightning->up() )
+    {
+      return timespan_t::zero();
+    }
+
     return t;
   }
 
@@ -3680,6 +3687,12 @@ struct chain_lightning_t : public chained_base_t
   void execute() override
   {
     chained_base_t::execute();
+
+    if ( p()->legendary.chains_of_devastation->ok() )
+    {
+      p()->buff.chains_of_devastation_chain_heal->trigger();
+      p()->buff.chains_of_devastation_chain_lightning->expire();
+    }
 
     // Storm Elemental Wind Gust passive buff trigger
     if ( p()->talent.storm_elemental->ok() )
@@ -5031,6 +5044,27 @@ struct chain_heal_t : public shaman_heal_t
       m *= 1.0 + p()->spec.riptide->effectN( 3 ).percent();
 
     return m;
+  }
+
+  timespan_t execute_time() const override
+  {
+    if ( p()->buff.chains_of_devastation_chain_heal->up() )
+    {
+      return timespan_t::zero();
+    }
+
+    return shaman_heal_t::execute_time();
+  }
+
+  void execute() override
+  {
+    shaman_heal_t::execute();
+
+    if ( p()->legendary.chains_of_devastation->ok() )
+    {
+      p()->buff.chains_of_devastation_chain_lightning->trigger();
+      p()->buff.chains_of_devastation_chain_heal->expire();
+    }
   }
 };
 
@@ -6822,6 +6856,9 @@ void shaman_t::create_buffs()
 
   buff.echoes_of_great_sundering = make_buff( this, "echoes_of_great_sundering", find_spell( 336217 ) )
                                      ->set_default_value( find_spell(336217)->effectN( 2 ).percent() );
+  
+  buff.chains_of_devastation_chain_heal      = make_buff( this, "chains_of_devastation_chain_heal", find_spell( 329772 ) );
+  buff.chains_of_devastation_chain_lightning = make_buff( this, "chains_of_devastation_chain_lightning", find_spell( 329771 ) );
 
   // PvP
   buff.thundercharge = make_buff( this, "thundercharge", find_spell( 204366 ) )

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -3646,7 +3646,7 @@ struct chain_lightning_t : public chained_base_t
 
     if ( p()->buff.chains_of_devastation_chain_lightning->up() )
     {
-      return timespan_t::zero();
+      t *= 1 + p()->buff.chains_of_devastation_chain_lightning->data().effectN( 1 ).percent();
     }
 
     return t;
@@ -5048,12 +5048,14 @@ struct chain_heal_t : public shaman_heal_t
 
   timespan_t execute_time() const override
   {
+    timespan_t t = shaman_heal_t::execute_time();
+
     if ( p()->buff.chains_of_devastation_chain_heal->up() )
     {
-      return timespan_t::zero();
+      t *= 1 + p()->buff.chains_of_devastation_chain_heal->data().effectN( 1 ).percent();
     }
 
-    return shaman_heal_t::execute_time();
+    return t;
   }
 
   void execute() override


### PR DESCRIPTION

Upon casting Chain Lighting, the player gets a buff that makes the
next Chain Heal instant cast.

Upon casting Chain Heal, the player gets a buff that makes the
next Chain Lightning instant cast.

I'm not able to test this on beta/PTR at the moment, so spell IDs
on the buffs are sourced from wowhead and should be confirmed first.