### PR TITLE
[Frost DK] Add Absolute Zero Legendary

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -909,6 +909,7 @@ public:
     // Frost                                      // bonus_id
     item_runeforge_t koltiras_favor;              // 6944
     item_runeforge_t rage_of_the_frozen_champion; // 7160
+    item_runeforge_t absolute_zero;               // 6946
 
     // Unholy
   } legendary;
@@ -5004,6 +5005,11 @@ struct frostwyrms_fury_t : public death_knight_spell_t
     damage( new frostwyrms_fury_damage_t( p ) )
   {
     parse_options( options_str );
+    if ( p -> legendary.absolute_zero -> ok() )
+    {
+      cooldown -> duration *= 1.0 + p -> legendary.absolute_zero->effectN( 1 ).percent();
+    }
+    // TODO Should we be implementing the stun here from the legendary? Doesn't look like other modules do.
   }
 
   void execute() override
@@ -8127,8 +8133,9 @@ void death_knight_t::init_spells()
   // Generic
   // Blood
   // Frost
-  legendary.koltiras_favor       = find_runeforge_legendary( "Koltira's Favor" );
+  legendary.koltiras_favor              = find_runeforge_legendary( "Koltira's Favor" );
   legendary.rage_of_the_frozen_champion = find_runeforge_legendary( "Rage of the Frozen Champion" );
+  legendary.absolute_zero               = find_runeforge_legendary( "Absolute Zero" );
   // Unholy
 }
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -907,9 +907,9 @@ public:
     // Blood
 
     // Frost                                      // bonus_id
+    item_runeforge_t absolute_zero;               // 6946
     item_runeforge_t koltiras_favor;              // 6944
     item_runeforge_t rage_of_the_frozen_champion; // 7160
-    item_runeforge_t absolute_zero;               // 6946
 
     // Unholy
   } legendary;
@@ -8133,9 +8133,9 @@ void death_knight_t::init_spells()
   // Generic
   // Blood
   // Frost
+  legendary.absolute_zero               = find_runeforge_legendary( "Absolute Zero" );
   legendary.koltiras_favor              = find_runeforge_legendary( "Koltira's Favor" );
   legendary.rage_of_the_frozen_champion = find_runeforge_legendary( "Rage of the Frozen Champion" );
-  legendary.absolute_zero               = find_runeforge_legendary( "Absolute Zero" );
   // Unholy
 }
 


### PR DESCRIPTION
The stun was not implemented for this legendary.  I was looking at other class files, and it doesn't look like stuns were implemented for them either.

#### No Legendary (180 sec cd)
```
16.587 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action frostwyrms_fury_driver (Cooldown frostwyrms_fury_driver, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 196.587
198.087 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action frostwyrms_fury_driver (Cooldown frostwyrms_fury_driver, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 378.087
```

#### Legendary (90 sec cd)
```
17.185 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action frostwyrms_fury_driver (Cooldown frostwyrms_fury_driver, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 107.185
108.370 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action frostwyrms_fury_driver (Cooldown frostwyrms_fury_driver, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 198.370
199.153 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action frostwyrms_fury_driver (Cooldown frostwyrms_fury_driver, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 289.153
289.930 Player 'PR_Death_Knight_Frost_2H' starts cooldown for Action frostwyrms_fury_driver (Cooldown frostwyrms_fury_driver, 1/1). Duration=-9223372036854776.000 Delay=0.000. Will be ready at 379.930
```