### PR TITLE
[Frost DK] Add Biting cold Legendary

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5462,7 +5462,7 @@ struct howling_blast_t : public death_knight_spell_t
       echoing_howl -> execute();
     }
 
-    if ( p() -> buffs.rime -> check() && p() -> legendary.rage_of_the_frozen_champion->ok() )
+    if ( p() -> buffs.rime -> check() && p() -> legendary.rage_of_the_frozen_champion.ok() )
     {
       p() -> resource_gain( RESOURCE_RUNIC_POWER,
                             p() -> spell.rage_of_the_frozen_champion -> effectN( 1 ).resource( RESOURCE_RUNIC_POWER ),
@@ -5594,7 +5594,7 @@ struct obliterate_strike_t : public death_knight_melee_attack_t
     {
       base_multiplier *= 1.0 + p -> spec.might_of_the_frozen_wastes -> effectN( 1 ).percent();
     }
-    if ( p -> legendary.koltiras_favor-> ok() )
+    if ( p -> legendary.koltiras_favor.ok() )
     {
       base_multiplier *= 1.0 + p -> legendary.koltiras_favor -> effectN ( 2 ).percent();
     }
@@ -5630,7 +5630,7 @@ struct obliterate_strike_t : public death_knight_melee_attack_t
       p() -> buffs.icy_citadel_builder -> trigger();
     }
 
-    if ( p() -> legendary.koltiras_favor -> ok() )
+    if ( p() -> legendary.koltiras_favor.ok() )
     {
       if ( p() -> rng().roll(p() -> legendary.koltiras_favor->proc_chance()))
       {

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5962,6 +5962,7 @@ struct remorseless_winter_damage_t : public death_knight_spell_t
     if ( p -> legendary.biting_cold.ok() )
     {
       biting_cold_target_threshold = p -> legendary.biting_cold->effectN ( 1 ).base_value();
+      base_multiplier *= 1.0 + p -> legendary.biting_cold->effectN( 2 ).percent();
     }
   }
 
@@ -5970,11 +5971,6 @@ struct remorseless_winter_damage_t : public death_knight_spell_t
     double m = death_knight_spell_t::action_multiplier();
 
     m *= 1.0 + p() -> buffs.gathering_storm -> stack_value();
-
-    if ( p() -> legendary.biting_cold.ok() )
-    {
-      m *= 1.0 + p() -> legendary.biting_cold->effectN( 2 ).percent();
-    }
 
     return m;
   }


### PR DESCRIPTION
Fixed Frozen Tempest to also gain rime when hitting 3 enemies, it was using trigger, and I had previously used set_chance to set the proc rate, so it was not triggering properly.

In this merge I also moved all the legendaries to using .ok() instead of ->ok().  enabled() is also available, and ok() just calls enabled().  It looks like most azerite traits are using .enabled() within the file.  Is there a preference between the two for the class?  If we decide on one, I'll update them all prior to this being merged in.

#### No Legendary
```
   remorseless_winter                   Count=  15.1| 20.354sec  DPE=13507| 0.00%  DPET=10750  DPR=  0  pDPS=  0
    remorseless_winter_damage            Count= 201.7|  1.476sec  DPE= 1014|18.00%  DPET=   0  DPR=  0  pDPS=690  Miss= 0.00%  Hit=   243|   144|   461  Crit=   495|   289|   922|16.16%
   howling_blast                        Count=  36.4|  8.415sec  DPE= 8594| 9.88%  DPET=6943  DPR=  0  pDPS=377  Miss= 0.00%  Hit=   791|   120|  1865  Crit=  1646|   240|  3729|16.29%

   rime                     : start= 35.3 refresh=  0.9 interval=  8.4 trigger=  8.2 duration=  1.6 uptime= 19.09%  benefit= 96.34%
```
#### Biting Cold
```
    remorseless_winter                   Count=  15.2| 20.329sec  DPE=16615| 0.00%  DPET=13223  DPR=  0  pDPS=  0
    remorseless_winter_damage            Count= 207.7|  1.431sec  DPE= 1213|19.39%  DPET=   0  DPR=  0  pDPS=850  Miss= 0.00%  Hit=   289|   166|   533  Crit=   590|   332|  1066|16.22%
   howling_blast                        Count=  45.3|  6.595sec  DPE= 9375|11.99%  DPET=7556  DPR=  0  pDPS=525  Miss= 0.00%  Hit=   770|   294|  1865  Crit=  1596|   588|  3751|16.55%

   rime                     : start= 44.5 refresh=  3.2 interval=  6.6 trigger=  6.2 duration=  1.5 uptime= 22.09%  benefit= 97.67%
```

