### PR TITLE
[Priest] rework Devouring Plague

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -2211,6 +2211,7 @@ double priest_t::shadow_weaving_multiplier( const player_t* target ) const
 
   if ( mastery_spells.shadow_weaving->ok() )
   {
+    // TODO: add logic to auto give mastery benefit if you are casting a DoT
     auto dots = shadow_weaving_active_dots( target );
 
     if ( dots > 0 )

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1032,12 +1032,12 @@ struct void_tendril_mind_flay_t final : public priest_pet_spell_t
     return base_tick_time;
   }
 
-  void impact( action_state_t* s ) override
+  void tick( dot_t* d ) override
   {
-    priest_pet_spell_t::impact( s );
+    priest_pet_spell_t::tick( d );
 
     p().o().generate_insanity( void_tendril_insanity->effectN( 1 ).base_value(),
-                               p().o().gains.insanity_eternal_call_to_the_void_mind_flay, s->action );
+                               p().o().gains.insanity_eternal_call_to_the_void_mind_flay, d->state->action );
   }
 };
 

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1031,24 +1031,19 @@ struct devouring_plague_t final : public priest_spell_t
       double old_multiplier   = cast_state( old_s )->rolling_multiplier;
 
       // figure out how many old ticks to roll over
-      int num_full_ticks      = as<int>( std::floor( ( old_remains - time_to_tick ) / old_tick ) );
-      double tick_coefficient = dot->current_action->spell_tick_power_coefficient( old_s ) * old_multiplier;
+      int num_full_ticks = as<int>( std::floor( ( old_remains - time_to_tick ) / old_tick ) );
 
       // find number of ticks in new DP
-      double new_num_ticks        = new_remains / new_tick;
-      double new_tick_coefficient = dot->current_action->spell_tick_power_coefficient( new_s );
+      double new_num_ticks = new_remains / new_tick;
 
-      sim->print_debug(
-          "{} {} calculations - num_full_ticks: {}, tick_coefficient: {}, new_num_ticks: {}, "
-          "new_tick_coefficient: {}",
-          *player, *this, num_full_ticks, tick_coefficient, new_num_ticks, new_tick_coefficient );
+      sim->print_debug( "{} {} calculations - num_full_ticks: {}, new_num_ticks: {}", *player, *this, num_full_ticks,
+                        new_num_ticks );
 
       // figure out the increase for each new tick of DP
-      double total_coefficient = num_full_ticks * tick_coefficient;
+      double total_coefficient     = num_full_ticks * old_multiplier;
       double increase_per_new_tick = total_coefficient / new_num_ticks;
-      double increase_ratio = increase_per_new_tick / new_tick_coefficient;
 
-      multiplier = 1 + increase_ratio;
+      multiplier = 1 + increase_per_new_tick;
 
       sim->print_debug( "{} {} modifier updated per tick from previous dot. Modifier per tick went from {} to {}.",
                         *player, *this, old_multiplier, multiplier );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -991,6 +991,17 @@ struct devouring_plague_t final : public priest_spell_t
     return priest_spell_t::cost();
   }
 
+  void impact( action_state_t* s ) override
+  {
+    priest_spell_t::impact( s );
+
+    // Damnation does not trigger a SA - 2020-08-08
+    if ( casted )
+    {
+      priest().trigger_shadowy_apparitions( s );
+    }
+  }
+
   // TODO override refresh duration to match in-game refresh
 
   void snapshot_state( action_state_t* s, result_amount_type rt ) override

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -976,13 +976,15 @@ struct devouring_plague_dot_t final : public priest_spell_t
   void append_damage( player_t* target )
   {
     dot_t* dot = get_dot( target );
+    assert( dot && dot->state && "Cannot append damage without active dot" );
     // get remaining full ticks left (not partials, these will be rolled over)
     // calculate total damage
     timespan_t remaining_dot = dot->remains();                                       // 2.5s
     remaining_dot            = remaining_dot - dot->time_to_next_tick();             // 2.5 - .5s = 2s
     int num_full_ticks = as<int>( std::ceil( remaining_dot / dot->time_to_tick ) );  // 2s / ~1.5 = 1.3 = 1 full tick
+    auto calculated_tick_amount = dot->current_action->calculate_tick_amount( dot->state, 1.0 );
 
-    double total_damage = priest().tick_damage_over_time( num_full_ticks * dot->time_to_tick, dot );
+    double total_damage = num_full_ticks * calculated_tick_amount;
     double total_ticks  = dot->duration() / dot->time_to_tick;
     if ( dot->time_to_next_tick() > timespan_t::from_seconds( 0 ) )
     {


### PR DESCRIPTION
resolves https://github.com/WarcraftPriests/sl-shadow-priest/issues/86
resolves https://github.com/WarcraftPriests/sl-shadow-priest/issues/80
resolves https://github.com/WarcraftPriests/sl-shadow-priest/issues/91

Early DP implementation.

Certainties:
- When you cast DP with a DP already up, it will preserve Time to Next Tick and the Partial Tick and add it to the duration of the new dot
- Remaining ticks get added to the damage of the new DP

Assumptions:
- Damage added by extra ticks is divided evenly between ticks and partial ticks at the moment of application.