### PR TITLE
[Feral Druid] Fix Bloodtalons

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -1586,7 +1586,7 @@ struct bt_dummy_buff_t : public druid_buff_t<buff_t>
 
   bool trigger( int s, double v, double c, timespan_t d ) override
   {
-    if ( !p().talent.bloodtalons->ok() || p().buff.bloodtalons->check() )
+    if ( !p().talent.bloodtalons->ok() )
       return false;
 
     if ( p().buff.bt_rake->check() + p().buff.bt_shred->check() + p().buff.bt_swipe->check() +

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -1590,7 +1590,7 @@ struct bt_dummy_buff_t : public druid_buff_t<buff_t>
       return false;
 
     if ( p().buff.bt_rake->check() + p().buff.bt_shred->check() + p().buff.bt_swipe->check() +
-         p().buff.bt_thrash->check() + p().buff.bt_moonfire->check() + p().buff.bt_brutal_slash->check() + 1 < count )
+         p().buff.bt_thrash->check() + p().buff.bt_moonfire->check() + p().buff.bt_brutal_slash->check() + !this->check() < count )
     {
       return druid_buff_t<buff_t>::trigger( s, v, c, d );
     }


### PR DESCRIPTION
There was an issue with Bloodtalons triggering even without meeting all
the conditions. e.g.

Rake -> Shred -> Shred

Issue is that the trigger function is called each time we give dummy bt_
buff. Using example above following would happen:

Rake -> trigger is called, we don't have any buffs so if condition
evaluates to true (1 < 3)

Shred -> trigger is called, we have bt_rake from previous rake but
condition still evaluates to true (2 < 3)

Shred -> trigger is called, we have bt_rake, and bt_shred from previous
shred so condition now evaluates to false (3 < 3) giving us bloodtalons

This change will fix that by adding one to the entire expresion only if
we already don't have the buff that triggered the call. Credit goes to
Melekus for suggesting the fix.