### PR TITLE
[Warlock] Implemented Conduits and added dot to Malefic Rapture

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -318,8 +318,10 @@ double warlock_t::composite_player_target_multiplier( player_t* target, school_e
   {
     if ( td->debuffs_haunt->check() )
       m *= 1.0 + td->debuffs_haunt->data().effectN( 2 ).percent();
-    if ( td->debuffs_shadow_embrace->check() )
-      m *= 1.0 + ( td->debuffs_shadow_embrace->data().effectN( 1 ).percent() * td->debuffs_shadow_embrace->check() );
+	  
+	  //TOCHECK 
+	  m *= 1.0 + ( ( td->debuffs_shadow_embrace->data().effectN( 1 ).percent() ) * ( 1 + conduit.cold_embrace.percent() )
+		  * td->debuffs_shadow_embrace->check() );
   }
 
   return m;

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -534,7 +534,7 @@ struct malefic_rapture_t : public affliction_spell_t
         if ( td->dots_corruption->is_ticking() )
           mult += 1.0;
 
-        if ( td->dots_unstable_affliction->is_ticking() )
+		if ( td->dots_unstable_affliction->is_ticking() )
           mult += 1.0;
 
         if ( td->dots_vile_taint->is_ticking() )
@@ -542,6 +542,9 @@ struct malefic_rapture_t : public affliction_spell_t
 
         if ( td->dots_siphon_life->is_ticking() )
           mult += 1.0;
+		
+		if ( td->dots_phantom_singularity->is_ticking() )
+		  mult += 1.0;
 
         return mult;
       }
@@ -550,6 +553,7 @@ struct malefic_rapture_t : public affliction_spell_t
       {
         double m = affliction_spell_t::composite_da_multiplier( s );
         m *= get_dots_ticking( s->target );
+		m *= 1 + p()->conduit.focused_malignancy.percent();
         return m;
       }
 

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -554,10 +554,10 @@ struct malefic_rapture_t : public affliction_spell_t
       {
         double m = affliction_spell_t::composite_da_multiplier( s );
         m *= get_dots_ticking( s->target );
-	if ( td( s->target )->dots_unstable_affliction->is_ticket() ) 
-	{
-	  m *= 1 + p()->conduit.focused_malignancy.percent(); 
-	}
+	    if ( td( s->target )->dots_unstable_affliction->is_ticking() ) 
+	    {
+	      m *= 1 + p()->conduit.focused_malignancy.percent(); 
+	    }
         return m;
       }
 

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -554,7 +554,10 @@ struct malefic_rapture_t : public affliction_spell_t
       {
         double m = affliction_spell_t::composite_da_multiplier( s );
         m *= get_dots_ticking( s->target );
-		m *= 1 + p()->conduit.focused_malignancy.percent();
+	if ( td( s->target )->dots_unstable_affliction->is_ticket() ) 
+	{
+	  m *= 1 + p()->conduit.focused_malignancy.percent(); 
+	}
         return m;
       }
 


### PR DESCRIPTION
Added Conduits : Cold Embrace ( modifying Shadow Embrace damage ) and Focused Malignancy ( increases Malefic Rapture DMG on targets affected by Unstable Affliction)

Added Phantom Singularity to Malefic Rapture Damage Calculation.