### PR TITLE
[WARLOCK] Implement Corrupting Leer Conduit

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -948,6 +948,14 @@ void warlock_t::darkglare_extension_helper( warlock_t* p, timespan_t darkglare_e
   }
 }
 
+void warlock_t::malignancy_reduction_helper()
+{
+  if ( rng().roll( conduit.corrupting_leer.percent() ) )
+  {
+    cooldowns.darkglare->adjust( -5.0_s );  // Value is in the description so had to hardcode it
+  }
+}
+
 // Function for returning the the number of imps that will spawn in a specified time period.
 int warlock_t::imps_spawned_during( timespan_t period )
 {

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -659,6 +659,8 @@ void warlock_t::init_procs()
   procs.portal_summon   = get_proc( "portal_summon" );
   procs.demonic_calling = get_proc( "demonic_calling" );
   procs.soul_conduit    = get_proc( "soul_conduit" );
+  procs.corrupting_leer = get_proc( "corrupting_leer" );
+
 }
 
 void warlock_t::init_base_stats()
@@ -952,6 +954,7 @@ void warlock_t::malignancy_reduction_helper()
 {
   if ( rng().roll( conduit.corrupting_leer.percent() ) )
   {
+    procs.corrupting_leer->occur();
     cooldowns.darkglare->adjust( -5.0_s );  // Value is in the description so had to hardcode it
   }
 }

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -516,6 +516,7 @@ public:
     proc_t* soul_conduit;
     // aff
     proc_t* nightfall;
+    proc_t* corrupting_leer;
     // demo
     proc_t* demonic_calling;
     proc_t* souls_consumed;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -568,6 +568,7 @@ public:
   void vision_of_perfection_proc_aff();
   void vision_of_perfection_proc_demo();
   void darkglare_extension_helper( warlock_t* p, timespan_t darkglare_extension );
+  void malignancy_reduction_helper();
   action_t* create_action( util::string_view name, const std::string& options ) override;
   pet_t* create_pet( util::string_view name, util::string_view type = "" ) override;
   void create_pets() override;

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -910,6 +910,7 @@ void warlock_t::init_rng_affliction()
 void warlock_t::init_procs_affliction()
 {
   procs.nightfall = get_proc( "nightfall" );
+  procs.corrupting_leer = get_proc( "corrupting_leer" );
 }
 
 void warlock_t::create_apl_affliction()

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -250,10 +250,7 @@ struct agony_t : public affliction_spell_t
       p()->buffs.inevitable_demise->trigger();
     }
 
-    if (p()->rng().roll( p()->conduit.corrupting_leer.percent() ))
-    {
-      p()->cooldowns.darkglare->adjust( -5.0_s ); // Value is in the description so had to hardcode it
-    }
+    p()->malignancy_reduction_helper();
 
     affliction_spell_t::tick( d );
   }
@@ -362,9 +359,16 @@ struct unstable_affliction_t : public affliction_spell_t
 
     p()->ua_target = nullptr;
   }
+
+  void tick( dot_t* d ) override
+  {
+    p()->malignancy_reduction_helper();
+
+    affliction_spell_t::tick( d );
+  }
 };
 
-struct summon_darkglare_t : public affliction_spell_t
+struct summon_darkglare_t : public affliction_spell_t   
 {
   summon_darkglare_t( warlock_t* p, util::string_view options_str )
     : affliction_spell_t( "summon_darkglare", p, p->spec.summon_darkglare )

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -250,6 +250,11 @@ struct agony_t : public affliction_spell_t
       p()->buffs.inevitable_demise->trigger();
     }
 
+    if (p()->rng().roll( p()->conduit.corrupting_leer.percent() ))
+    {
+      p()->cooldowns.darkglare->adjust( -5.0_s ); // Value is in the description so had to hardcode it
+    }
+
     affliction_spell_t::tick( d );
   }
 };


### PR DESCRIPTION
Created helper function that's used in UA and Agony ticks. Added proc tracker for Corrupting Leer. 

Side note - Hard coded the 5s CDR in helper function as the CDR value is in the description of Corrupting Leer.