### PR TITLE
[Warlock] Fix Malefic Rapture consuming two shards

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -547,6 +547,7 @@ struct malefic_rapture_t : public affliction_spell_t
         aoe = 1;
         background = true;
         spell_power_mod.direct = data().effectN( 1 ).sp_coeff();
+        base_costs[ RESOURCE_SOUL_SHARD ] = 0;
 
         p->spells.malefic_rapture_aoe = this;
       }


### PR DESCRIPTION
Malefic rapture was consuming two shards. One from `malefic_rapture_t` and `malefic_rapture_damage_instance_t`. Stopped the damage instance from consuming a shard. 