### PR TITLE
CI: test json3 output and restrict log_debug sim length

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
           - type: spell_query
             simc_flags: spell_query=spell > /dev/null
           - type: log_debug
-            simc_flags: $SIMC_PROFILE log=1 debug=1
+            simc_flags: $SIMC_PROFILE log=1 debug=1 max_time=100
           - type: patchwerk
             simc_flags: $SIMC_PROFILE iterations=10 cleanup_threads=1
           - type: dungeon_slice
@@ -152,7 +152,7 @@ jobs:
       - name: Run
         env:
           UBSAN_OPTIONS: print_stacktrace=1
-        run: ${{ runner.workspace }}/b/ninja/simc output=/dev/null html=/dev/null json2=/dev/null ${{ matrix.simc_flags }}
+        run: ${{ runner.workspace }}/b/ninja/simc output=/dev/null html=/dev/null json2=/dev/null json3=/dev/null ${{ matrix.simc_flags }}
 
 
   build-docker:


### PR DESCRIPTION
log_debug test is starting to take a really long time with all the reactivated profiles. it is just quite slow in debug mode. Restrict to 100s fight length to get it somewhat down.

Add json3= alongside json2= output.