### PR TITLE
(Priest) Fix Mindblast Dark Thoughts Bug

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -74,44 +74,45 @@ public:
 
   bool ready() override
   {
-    if ( only_cwc )
+    // Check conditions that do NOT pertain to the target before cycle_targets
+    if ( cooldown->is_ready() == false && !priest().buffs.dark_thoughts->check() )
+      return false;
+
+    if ( internal_cooldown->down() && !priest().buffs.dark_thoughts->check() )
+      return false;
+
+    if ( only_cwc && (!priest().buffs.dark_thoughts->check() || player->channeling == nullptr || player->channeling->data().id() != mind_flay_spell->id() &&
+         player->channeling->data().id() != mind_sear_spell->id() ))
+      return false;
+
+    if ( player->is_moving() && !usable_moving() )
+      return false;
+
+    auto resource = current_resource();
+    if ( resource != RESOURCE_NONE && !player->resource_available( resource, cost() ) )
     {
-      if ( !priest().buffs.dark_thoughts->check() )
-        return false;
+      if ( starved_proc )
+        starved_proc->occur();
+      return false;
+    }
 
-      if ( player->channeling == nullptr )
-        return false;
-
-      if ( player->channeling->data().id() != mind_flay_spell->id() &&
-           player->channeling->data().id() != mind_sear_spell->id() )
-        return false;
-
-      if ( player->is_moving() && !usable_moving() )
-        return false;
-
-      auto resource = current_resource();
-      if ( resource != RESOURCE_NONE && !player->resource_available( resource, cost() ) )
+    if ( usable_while_casting )
+    {
+      if ( execute_time() > timespan_t::zero() )
       {
-        if ( starved_proc )
-          starved_proc->occur();
         return false;
       }
-
-      if ( execute_time() > timespan_t::zero() )
-        return false;
 
       // Don't allow cast-while-casting spells that trigger the GCD to be ready if the GCD is still
       // ongoing (during the cast)
       if ( ( player->executing || player->channeling ) && gcd() > timespan_t::zero() &&
            player->gcd_ready > sim->current_time() )
+      {
         return false;
+      }
+    }
 
-      return true;
-    }
-    else
-    {
-      return priest_spell_t::ready();
-    }
+    return true;
   }
 
   double composite_energize_amount( const action_state_t* s ) const override

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -88,6 +88,14 @@ public:
     if ( player->is_moving() && !usable_moving() )
       return false;
 
+    if ( priest().specialization() == PRIEST_SHADOW && priest().talents.surrender_to_madness->ok() )
+    {
+      if ( priest().buffs.surrender_to_madness_death->check() )
+      {
+        return false;
+      }
+    }
+
     auto resource = current_resource();
     if ( resource != RESOURCE_NONE && !player->resource_available( resource, cost() ) )
     {

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1869,16 +1869,6 @@ struct dark_thoughts_t final : public priest_buff_t<buff_t>
     this->reactable = true;
   }
 
-  /*bool trigger( int stacks, double value, double chance, timespan_t duration ) override
-  {
-    bool r = base_t::trigger( stacks, value, chance, duration );
-
-    // Currently dark thoughts also resets your mind blast.
-    priest().cooldowns.mind_blast->reset( true, 1 );
-
-    return r;
-  }*/
-
   void expire_override( int expiration_stacks, timespan_t remaining_duration ) override
   {
     if ( remaining_duration == timespan_t::zero() )


### PR DESCRIPTION
resolves https://github.com/WarcraftPriests/sl-shadow-priest/issues/35

This does two things.
A> Change Dark Thoughts to no longer reset Mind blast, as per the in game change.
B> Fix the ready condition on mind blast to support casting the spell if the dark thoughts buff is up as the current implementation sidesteps the Mind Blast cooldown during a dark thoughts proc. This was previously bypassed by Mind Blast always resetting cooldown from a dark thoughts proc.
The ready override is based off of the implementation in action_t::ready, if any changes are made to action_t::ready or if anything is added to priest_spell_t::ready that are important they will need to be manually added in the future.