### PR TITLE
[Death Knight] Obliterate KM rank2 mastery + razorice support

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5629,6 +5629,32 @@ struct obliterate_strike_t : public death_knight_melee_attack_t
     }
   }
 
+  double composite_da_multiplier( const action_state_t* state ) const override
+  {
+    double m = death_knight_melee_attack_t::composite_da_multiplier( state );
+    // Obliterate does not list Frozen Heart in it's list of affecting spells.  So mastery does not get applied automatically.
+    if ( p() -> spec.killing_machine_2 -> ok() && p() -> buffs.killing_machine -> up() )
+    {
+      m *= 1.0 + p() -> cache.mastery_value();
+    }
+
+    return m;
+  }
+
+  double composite_target_multiplier( player_t* target ) const override
+  {
+    double m = death_knight_melee_attack_t::composite_target_multiplier( target );
+
+    death_knight_td_t* td = p() -> get_target_data( target );
+    // Obliterate does not list razorice in it's list of affecting spells, so debuff does not get applied automatically.
+    if ( p() -> spec.killing_machine_2 -> ok() && p() -> buffs.killing_machine -> up() )
+    {
+      m *= 1.0 + td -> debuff.razorice -> check_stack_value();
+    }
+
+    return m;
+  }
+
   double composite_crit_chance() const override
   {
     double cc = death_knight_melee_attack_t::composite_crit_chance();


### PR DESCRIPTION
Finally got beta and was able to start testing with known good data.

Obliterate damage for KM rank 2 was looking a lot lower than it should have, upon investigation, it looks like it was caused by obliterate not having razorice and frozen heart listed in the affected by spells.

Baseline Rune of the fallen Crusader (no fix applied)
```
hit	45.32%	38.41	18	61	1060.64	975	1429	1060.63	988	1132	40739	58191	29.99%
crit	54.68%	46.35	25	70	3392.64	1950	4164	3395.02	3004	3750	157237	161832	2.81%
```
No Enchant (Frozen Heart only)
```
hit	45.31%	38.39	18	61	983.67	975	1263	983.66	975	1023	37759	53935	29.99%
crit	54.69%	46.34	24	70	3975.90	1950	4719	3979.71	3503	4396	184250	188508	2.24%
```
Rune of the fallen Crusader (Frozen Heart only)
```
hit	45.32%	38.41	16	61	1060.69	975	1429	1060.68	980	1129	40740	58193	29.99%
crit	54.68%	46.34	26	71	4290.34	1950	5346	4294.17	3715	4824	198817	203414	2.25%
```
Razorice (Frozen Heart + Razorice)
```
hit	45.31%	38.39	18	62	983.70	975	1263	983.69	975	1030	37768	53947	29.99%
crit	54.69%	46.35	25	69	4533.83	1950	5427	4538.52	3909	5006	210146	214403	1.98%
```