### PR TITLE
Fix for mind blast with dark thought up ignoring its own cooldown.

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1867,16 +1867,6 @@ struct dark_thoughts_t final : public priest_buff_t<buff_t>
     this->reactable = true;
   }
 
-  bool trigger( int stacks, double value, double chance, timespan_t duration ) override
-  {
-    bool r = base_t::trigger( stacks, value, chance, duration );
-
-    // Currently dark thoughts also resets your mind blast.
-    priest().cooldowns.mind_blast->reset( true, 1 );
-
-    return r;
-  }
-
   void expire_override( int expiration_stacks, timespan_t remaining_duration ) override
   {
     if ( remaining_duration == timespan_t::zero() )


### PR DESCRIPTION
resolves https://github.com/WarcraftPriests/sl-shadow-priest/issues/35