### PR TITLE
[Priest] add bugged behavior into simc for HV

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1179,9 +1179,8 @@ priest_td_t::priest_td_t( player_t* target, priest_t& p ) : actor_target_data_t(
   buffs.wrathful_faerie_fermata = make_buff( *this, "wrathful_faerie_fermata", p.find_spell( 345452 ) )
                                       ->set_cooldown( timespan_t::zero() )
                                       ->set_duration( priest().conduits.fae_fermata.time_value() );
-  buffs.hungering_void_tracking = make_buff( *this, "hungering_void_tracking", p.talents.hungering_void )
-                                      ->set_quiet( true )
-                                      ->set_duration( timespan_t::from_seconds( 99 ) );
+  buffs.hungering_void_tracking =
+      make_buff( *this, "hungering_void_tracking", p.talents.hungering_void )->set_quiet( true )->set_duration( 0_ms );
   buffs.hungering_void = make_buff( *this, "hungering_void", p.find_spell( 345219 ) );
 
   target->register_on_demise_callback( &p, [ this ]( player_t* ) { target_demise(); } );

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -593,6 +593,7 @@ public:
   void trigger_wrathful_faerie_fermata();
   void remove_wrathful_faerie();
   void remove_wrathful_faerie_fermata();
+  void remove_hungering_void_tracking();
   int shadow_weaving_active_dots( const player_t* target, const unsigned int spell_id ) const;
   double shadow_weaving_multiplier( const player_t* target, const unsigned int spell_id ) const;
   pets::fiend::base_fiend_pet_t* get_current_main_pet();


### PR DESCRIPTION
- rename hungering void variables to be more accurate
- add in bugged behavior and normal behavior for expiring the tracking debuff, currently in game it never "expires" although it is hidden so hard to check. That means every Void Bolt after the first will get the benefit and it never resets