### PR TITLE
[Priest] make mind sear and mind flay spec spells

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1736,6 +1736,10 @@ void priest_t::init_spells()
   init_spells_discipline();
   init_spells_holy();
 
+  // Generic Spells
+  specs.mind_flay = find_specialization_spell( "Mind Flay" );
+  specs.mind_sear = find_class_spell( "Mind Sear" );
+
   // Class passives
   specs.priest     = dbc::get_class_passive( *this, SPEC_NONE );
   specs.holy       = dbc::get_class_passive( *this, PRIEST_HOLY );
@@ -2187,8 +2191,8 @@ void priest_t::trigger_shadowflame_prism( player_t* target )
 // Legendary Eternal Call to the Void trigger
 void priest_t::trigger_eternal_call_to_the_void( action_state_t* s )
 {
-  auto mind_sear_id = find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id();
-  auto mind_flay_id = find_specialization_spell( "Mind Flay" )->id();
+  auto mind_sear_id = specs.mind_sear->effectN( 1 ).trigger()->id();
+  auto mind_flay_id = specs.mind_flay->id();
   auto action_id    = s->action->id;
   if ( !legendary.eternal_call_to_the_void->ok() )
     return;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -251,6 +251,7 @@ public:
   struct
   {
     const spell_data_t* priest;  // General priest data
+    const spell_data_t* mind_sear;
 
     // Discipline
     const spell_data_t* discipline;  // General discipline data
@@ -279,6 +280,7 @@ public:
     const spell_data_t* void_eruption;
     const spell_data_t* shadow_priest;
     const spell_data_t* dark_thoughts;
+    const spell_data_t* mind_flay;
   } specs;
 
   // DoT Spells
@@ -1305,12 +1307,9 @@ struct priest_heal_t : public priest_action_t<heal_t>
 struct priest_spell_t : public priest_action_t<spell_t>
 {
   bool affected_by_shadow_weaving;
-  unsigned int mind_sear_id;
 
   priest_spell_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
-    : base_t( name, player, s ),
-      affected_by_shadow_weaving( false ),
-      mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() )
+    : base_t( name, player, s ), affected_by_shadow_weaving( false )
   {
     weapon_multiplier = 0.0;
   }
@@ -1445,7 +1444,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
 
     // Currently Mind-Sear has half the proc rate of Mind Flay
     // https://github.com/WarcraftPriests/sl-shadow-priest/issues/101
-    if ( priest().bugs && action_id == mind_sear_id )
+    if ( priest().bugs && action_id == priest().specs.mind_sear->effectN( 1 ).trigger()->id() )
     {
       dark_thoughts_proc_percent /= 2;
     }

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -1307,9 +1307,12 @@ struct priest_heal_t : public priest_action_t<heal_t>
 struct priest_spell_t : public priest_action_t<spell_t>
 {
   bool affected_by_shadow_weaving;
+  unsigned int mind_sear_id;
 
   priest_spell_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
-    : base_t( name, player, s ), affected_by_shadow_weaving( false )
+    : base_t( name, player, s ),
+      affected_by_shadow_weaving( false ),
+      mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() )
   {
     weapon_multiplier = 0.0;
   }
@@ -1444,7 +1447,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
 
     // Currently Mind-Sear has half the proc rate of Mind Flay
     // https://github.com/WarcraftPriests/sl-shadow-priest/issues/101
-    if ( priest().bugs && action_id == priest().specs.mind_sear->effectN( 1 ).trigger()->id() )
+    if ( priest().bugs && action_id == mind_sear_id )
     {
       dark_thoughts_proc_percent /= 2;
     }

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -26,8 +26,6 @@ private:
   double whispers_of_the_damned_value;
   double harvested_thoughts_value;
   double whispers_bonus_insanity;
-  const spell_data_t* mind_flay_spell;
-  const spell_data_t* mind_sear_spell;
   bool only_cwc;
   cooldown_t* dark_thought_dummy_cooldown;
   cooldown_t* action_cooldown;
@@ -46,8 +44,6 @@ public:
                                    .trigger()
                                    ->effectN( 1 )
                                    .resource( RESOURCE_INSANITY ) ),
-      mind_flay_spell( player.find_specialization_spell( "Mind Flay" ) ),
-      mind_sear_spell( player.find_class_spell( "Mind Sear" ) ),
       only_cwc( false ),
       dark_thought_dummy_cooldown( player.get_cooldown( "dark_thought_dummy_cooldown" ) ),
       action_cooldown( player.get_cooldown( "mind_blast" ) )
@@ -110,8 +106,8 @@ public:
         return false;
       if ( player->channeling == nullptr )
         return false;
-      if ( player->channeling->data().id() == mind_flay_spell->id() ||
-           player->channeling->data().id() == mind_sear_spell->id() )
+      if ( player->channeling->data().id() == priest().specs.mind_flay->id() ||
+           player->channeling->data().id() == priest().specs.mind_sear->id() )
         return priest_spell_t::ready();
       return false;
     }
@@ -1597,12 +1593,10 @@ struct shadow_crash_t final : public priest_spell_t
 struct searing_nightmare_t final : public priest_spell_t
 {
   propagate_const<shadow_word_pain_t*> child_swp;
-  const spell_data_t* mind_sear_spell;
 
   searing_nightmare_t( priest_t& p, util::string_view options_str )
     : priest_spell_t( "searing_nightmare", p, p.find_talent_spell( "Searing Nightmare" ) ),
-      child_swp( new shadow_word_pain_t( priest(), false ) ),
-      mind_sear_spell( p.find_class_spell( "Mind Sear" ) )
+      child_swp( new shadow_word_pain_t( priest(), false ) )
   {
     parse_options( options_str );
     child_swp->background = true;
@@ -1616,7 +1610,7 @@ struct searing_nightmare_t final : public priest_spell_t
 
   bool ready() override
   {
-    if ( player->channeling == nullptr || player->channeling->data().id() != mind_sear_spell->id() )
+    if ( player->channeling == nullptr || player->channeling->data().id() != priest().specs.mind_sear->id() )
       return false;
     return priest_spell_t::ready();
   }

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -26,6 +26,8 @@ private:
   double whispers_of_the_damned_value;
   double harvested_thoughts_value;
   double whispers_bonus_insanity;
+  const spell_data_t* mind_flay_spell;
+  const spell_data_t* mind_sear_spell;
   bool only_cwc;
   cooldown_t* dark_thought_dummy_cooldown;
   cooldown_t* action_cooldown;
@@ -44,6 +46,8 @@ public:
                                    .trigger()
                                    ->effectN( 1 )
                                    .resource( RESOURCE_INSANITY ) ),
+      mind_flay_spell( player.find_specialization_spell( "Mind Flay" ) ),
+      mind_sear_spell( player.find_class_spell( "Mind Sear" ) ),
       only_cwc( false ),
       dark_thought_dummy_cooldown( player.get_cooldown( "dark_thought_dummy_cooldown" ) ),
       action_cooldown( player.get_cooldown( "mind_blast" ) )
@@ -106,8 +110,8 @@ public:
         return false;
       if ( player->channeling == nullptr )
         return false;
-      if ( player->channeling->data().id() == priest().specs.mind_flay->id() ||
-           player->channeling->data().id() == priest().specs.mind_sear->id() )
+      if ( player->channeling->data().id() == mind_flay_spell->id() ||
+           player->channeling->data().id() == mind_sear_spell->id() )
         return priest_spell_t::ready();
       return false;
     }
@@ -1593,10 +1597,12 @@ struct shadow_crash_t final : public priest_spell_t
 struct searing_nightmare_t final : public priest_spell_t
 {
   propagate_const<shadow_word_pain_t*> child_swp;
+  const spell_data_t* mind_sear_spell;
 
   searing_nightmare_t( priest_t& p, util::string_view options_str )
     : priest_spell_t( "searing_nightmare", p, p.find_talent_spell( "Searing Nightmare" ) ),
-      child_swp( new shadow_word_pain_t( priest(), false ) )
+      child_swp( new shadow_word_pain_t( priest(), false ) ),
+      mind_sear_spell( p.find_class_spell( "Mind Sear" ) )
   {
     parse_options( options_str );
     child_swp->background = true;
@@ -1610,7 +1616,7 @@ struct searing_nightmare_t final : public priest_spell_t
 
   bool ready() override
   {
-    if ( player->channeling == nullptr || player->channeling->data().id() != priest().specs.mind_sear->id() )
+    if ( player->channeling == nullptr || player->channeling->data().id() != mind_sear_spell->id() )
       return false;
     return priest_spell_t::ready();
   }


### PR DESCRIPTION
Fixes some performance issues with calling `find_spell` in combat, and makes Mind Flay and Mind Sear priest spec spells so we can reduce some bloat we have in a few places.