### PR TITLE
Fix gui.pro for MacOS Builds

### DIFF
--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -56,7 +56,7 @@ macx {
 
   Resources.files = ../Welcome.html ../Welcome.png ../Error.html
   Resources.path = Contents/Resources
-  Profiles.files =  ../profiles/PreRaids ../profiles/Tier22 ../profiles/Tier23 ../profiles/Tier24 ../profiles/Tier25 ../profiles/DungeonSlice
+  Profiles.files =  ../profiles/PreRaids ../profiles/Tier25 ../profiles/DungeonSlice
   Profiles.path = Contents/Resources/profiles
   Localization.files = ../locale/sc_de.qm ../locale/sc_it.qm ../locale/sc_cn.qm
   Localization.path = Contents/Resources/locale


### PR DESCRIPTION
Seems like this included some older references that aren’t used anymore.

Builds successfully after removing those:

![Screenshot 2020-10-06 at 13 50 41](https://user-images.githubusercontent.com/458591/95198413-1cf14580-07d3-11eb-82ce-81ad18a8546d.png)