### PR TITLE
[Generator] Whitelist Volatile Solvent sub-buffs for dbc

### DIFF
--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -1232,6 +1232,7 @@ class SpellDataGenerator(DataGenerator):
          321524, # Niya's Tools: Poison (night fae/niya)
          320130, 320212, # Social Butterfly vers buff (night fae/dreamweaver)
          332525, 341163, 341165, 332526, # Bron's Call to Action (kyrian/mikanikos)
+         323491, 323498, 323502, 323504, 323506, # Volatile Solvent's different buff variations
         ),
 
         # Warrior:


### PR DESCRIPTION
Adding the IDs for Volatile Solvent's various DPS oriented sub-buffs.  