### PR TITLE
Add trinket tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,9 @@ jobs:
             profiles
             tests
           key: ubuntu-clang-10-for_run-${{ github.sha }}
+          
+      - name: Install Python dependencies
+        run: pip install -r tests/requirements.txt
 
       - name: Run
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,9 +95,9 @@ jobs:
         run: cmake -H. -B'${{ runner.workspace }}/b/ninja' -GNinja -DBUILD_GUI=OFF
               -DCMAKE_BUILD_TYPE=Debug
               -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10
-              -DCMAKE_CXX_FLAGS="-ffile-prefix-map=${{ runner.workspace }}/=/
+              -DCMAKE_CXX_FLAGS="-Og -ffile-prefix-map=${{ runner.workspace }}/=/
                 -fno-omit-frame-pointer -fsanitize=address,undefined
-                -fsanitize-undefined-strip-path-components=$UBSAN_STRIP_COUNT -Og"
+                -fsanitize-undefined-strip-path-components=$UBSAN_STRIP_COUNT"
               -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -fsanitize=address,undefined"
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_C_COMPILER=clang-10
               -DCMAKE_CXX_FLAGS="-ffile-prefix-map=${{ runner.workspace }}/=/
                 -fno-omit-frame-pointer -fsanitize=address,undefined
-                -fsanitize-undefined-strip-path-components=$UBSAN_STRIP_COUNT"
+                -fsanitize-undefined-strip-path-components=$UBSAN_STRIP_COUNT -Og"
               -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -fsanitize=address,undefined"
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
           SIMC_PROFILE_DIR: ${{ github.workspace }}/profiles/${{ matrix.tier }}
           SIMC_THREADS: 2
           SIMC_ITERATIONS: 2
-        run: tests/run.py ${{ matrix.spec }}
+        run: tests/run.py ${{ matrix.spec }} --test-trinkets
 
   build-docker:
     name: docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,9 +184,9 @@ jobs:
             profiles
             tests
           key: ubuntu-clang-10-for_run-${{ github.sha }}
-          
+
       - name: Install Python dependencies
-        run: pip install -r tests/requirements.txt
+        run: pip3 install -r tests/requirements.txt
 
       - name: Run
         env:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,10 +13,10 @@ def __error_status(code):
 def __simc_cli_path(var):
     path = os.environ.get(var)
     if path is None:
-        sys.exit(1)
+        raise Exception("No SIMC_CLI_PATH environment variable set")
     path = shutil.which(path)
     if path is None:
-        sys.exit(1)
+        raise Exception("SIMC_CLI_PATH not valid")
     return str(Path(path).resolve())
 
 IN_CI = 'CI' in os.environ

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+simc-support

--- a/tests/run.py
+++ b/tests/run.py
@@ -12,11 +12,31 @@ COVENANTS = ('Kyrian', 'Venthyr', 'Night_Fae', 'Necrolord')
 parser = argparse.ArgumentParser(description='Run simc tests')
 parser.add_argument('specialization', metavar='spec', type=str,
                     help='Simc specialization in the form of CLASS_SPEC, eg. Priest_Shadow')
-parser.add_argument('--no-trinkets', default=False, action='store_true',
-                    help='Disable trinket tests. Trinket tests require simc-support library to be installed.')
+parser.add_argument('--test-trinkets', default=False, action='store_true',
+                    help='Test trinkets. Trinket tests require simc-support library to be installed.')
 parser.add_argument('--trinkets-fight-style', default='DungeonSlice', type=str,
                     help='Fight style used for trinket simulations.')
 args = parser.parse_args()
+
+def test_trinkets(klass : str, path : str):
+    if not args.test_trinkets:
+        return
+    try:
+        from simc_support.game_data.WowSpec import get_wow_spec_from_combined_simc_name
+        from simc_support.game_data.Trinket import get_trinkets_for_spec
+    except ImportError:
+        print("Error importing simc-support library for trinket test. Skipping test.")
+        return
+
+    trinkets = get_trinkets_for_spec(
+        get_wow_spec_from_combined_simc_name(klass))
+    fight_style = args.trinkets_fight_style
+    grp = TestGroup('{}/{}/trinkets'.format(profile, fight_style),
+                    fight_style=fight_style, profile=path)
+    tests.append(grp)
+    for trinket in trinkets:
+        Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
+                ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
 
 klass = args.specialization
 
@@ -43,18 +63,7 @@ for profile, path in profiles:
             Test(covenant, group=grp,
                  args=[('covenant', covenant.lower()), ('level', 60)])
 
-    if not args.no_trinkets:
-        from simc_support.game_data.WowSpec import get_wow_spec_from_combined_simc_name
-        from simc_support.game_data.Trinket import get_trinkets_for_spec
+    test_trinkets(klass, path)
 
-        trinkets = get_trinkets_for_spec(
-            get_wow_spec_from_combined_simc_name(klass))
-        fight_style = args.trinkets_fight_style
-        grp = TestGroup('{}/{}/trinkets'.format(profile, fight_style),
-                        fight_style=fight_style, profile=path)
-        tests.append(grp)
-        for trinket in trinkets:
-            Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
-                    ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
 
 sys.exit(run(tests))

--- a/tests/run.py
+++ b/tests/run.py
@@ -23,7 +23,11 @@ klass = args.specialization
 print(' '.join(klass.split('_')))
 
 tests = []
-for profile, path in find_profiles(klass):
+profiles = list(find_profiles(klass))
+if len(profiles) == 0:
+    print("No profile found for {}".format(klass))
+
+for profile, path in profiles:
     for fight_style in FIGHT_STYLES:
         grp = TestGroup('{}/{}/talents'.format(profile, fight_style),
                         fight_style=fight_style, profile=path)
@@ -52,7 +56,5 @@ for profile, path in find_profiles(klass):
         for trinket in trinkets:
             Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
                     ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
-else:
-    print("No profile found for {}".format(klass))
 
 sys.exit(run(tests))

--- a/tests/run.py
+++ b/tests/run.py
@@ -6,8 +6,8 @@ import argparse
 from helper import Test, TestGroup, run, find_profiles
 from talent_options import talent_combinations
 
-FIGHT_STYLES = ( 'Patchwerk', 'DungeonSlice', 'HeavyMovement' )
-COVENANTS = ( 'Kyrian', 'Venthyr', 'Night_Fae', 'Necrolord' )
+FIGHT_STYLES = ('Patchwerk', 'DungeonSlice', 'HeavyMovement')
+COVENANTS = ('Kyrian', 'Venthyr', 'Night_Fae', 'Necrolord')
 
 parser = argparse.ArgumentParser(description='Run simc tests')
 parser.add_argument('specialization', metavar='spec', type=str,
@@ -27,7 +27,7 @@ for profile, path in find_profiles(klass):
                         fight_style=fight_style, profile=path)
         tests.append(grp)
         for talents in talent_combinations(klass):
-            Test(talents, group=grp, args=[ ('talents', talents) ])
+            Test(talents, group=grp, args=[('talents', talents)])
 
     for fight_style in FIGHT_STYLES:
         grp = TestGroup('{}/{}/covenants'.format(profile, fight_style),
@@ -35,8 +35,8 @@ for profile, path in find_profiles(klass):
         tests.append(grp)
         for covenant in COVENANTS:
             Test(covenant, group=grp,
-                 args=[ ('covenant', covenant.lower()), ('level', 60) ])
-    
+                 args=[('covenant', covenant.lower()), ('level', 60)])
+
     if not args.no_trinkets:
         from simc_support.game_data.WowSpec import get_wow_spec
         from simc_support.game_data.Trinket import get_trinkets_for_spec
@@ -48,6 +48,7 @@ for profile, path in find_profiles(klass):
                             fight_style=fight_style, profile=path)
             tests.append(grp)
             for trinket in trinkets:
-                Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[ ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel)) ])
+                Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
+                     ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
 
-sys.exit( run(tests) )
+sys.exit(run(tests))

--- a/tests/run.py
+++ b/tests/run.py
@@ -12,8 +12,8 @@ COVENANTS = ( 'Kyrian', 'Venthyr', 'Night_Fae', 'Necrolord' )
 parser = argparse.ArgumentParser(description='Run simc tests')
 parser.add_argument('specialization', metavar='spec', type=str,
                     help='Simc specialization in the form of CLASS_SPEC, eg. Priest_Shadow')
-parser.add_argument('--no-trinkets', default=False,action="store_true",
-                    help='Disable trinket tests. Requires simc-support dependency to be installed')
+parser.add_argument('--no-trinkets', default=False, action='store_true',
+                    help='Disable trinket tests. Trinket tests require simc-support library to be installed.')
 args = parser.parse_args()
 
 klass = args.specialization

--- a/tests/run.py
+++ b/tests/run.py
@@ -14,6 +14,8 @@ parser.add_argument('specialization', metavar='spec', type=str,
                     help='Simc specialization in the form of CLASS_SPEC, eg. Priest_Shadow')
 parser.add_argument('--no-trinkets', default=False, action='store_true',
                     help='Disable trinket tests. Trinket tests require simc-support library to be installed.')
+parser.add_argument('--trinkets-fight-style', default='DungeonSlice', type=str,
+                    help='Fight style used for trinket simulations.')
 args = parser.parse_args()
 
 klass = args.specialization
@@ -38,17 +40,19 @@ for profile, path in find_profiles(klass):
                  args=[('covenant', covenant.lower()), ('level', 60)])
 
     if not args.no_trinkets:
-        from simc_support.game_data.WowSpec import get_wow_spec
+        from simc_support.game_data.WowSpec import get_wow_spec_from_combined_simc_name
         from simc_support.game_data.Trinket import get_trinkets_for_spec
 
-        wow_class, wow_spec = klass.split('_')
-        trinkets = get_trinkets_for_spec(get_wow_spec(wow_class, wow_spec))
-        for fight_style in FIGHT_STYLES:
-            grp = TestGroup('{}/{}/trinkets'.format(profile, fight_style),
-                            fight_style=fight_style, profile=path)
-            tests.append(grp)
-            for trinket in trinkets:
-                Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
-                     ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
+        trinkets = get_trinkets_for_spec(
+            get_wow_spec_from_combined_simc_name(klass))
+        fight_style = args.trinkets_fight_style
+        grp = TestGroup('{}/{}/trinkets'.format(profile, fight_style),
+                        fight_style=fight_style, profile=path)
+        tests.append(grp)
+        for trinket in trinkets:
+            Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
+                    ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
+else:
+    print("No profile found for {}".format(klass))
 
 sys.exit(run(tests))


### PR DESCRIPTION
Use argparse for run.py since I was not happy with the silent fail when invoking it without arguments.

simc-support is a helper library written by Bloodmallet which contains various game data as json and is easily accessible with python. It is a outside dependency, but I thought it was worth the effort. Can be disabled with --no-trinkets option.