### PR TITLE
[Priest] Hungering Void Rework

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1503,6 +1503,11 @@ double priest_t::composite_player_target_multiplier( player_t* t, school_e schoo
     m *= 1.0 + target_data->buffs.schism->data().effectN( 2 ).percent();
   }
 
+  if ( hungering_void_active( t ) )
+  {
+    m *= ( 1 + talents.hungering_void_buff->effectN( 1 ).percent() );
+  }
+
   return m;
 }
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1194,8 +1194,6 @@ priest_td_t::priest_td_t( player_t* target, priest_t& p ) : actor_target_data_t(
   buffs.wrathful_faerie_fermata = make_buff( *this, "wrathful_faerie_fermata", p.find_spell( 345452 ) )
                                       ->set_cooldown( timespan_t::zero() )
                                       ->set_duration( priest().conduits.fae_fermata.time_value() );
-  buffs.hungering_void_tracking =
-      make_buff( *this, "hungering_void_tracking", p.talents.hungering_void )->set_quiet( true )->set_duration( 0_ms );
   buffs.hungering_void = make_buff( *this, "hungering_void", p.find_spell( 345219 ) );
 
   target->register_on_demise_callback( &p, [ this ]( player_t* ) { target_demise(); } );

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -591,6 +591,7 @@ public:
   void trigger_shadowy_apparitions( action_state_t* );
   void trigger_psychic_link( action_state_t* );
   bool hungering_void_active( player_t* target ) const;
+  void remove_hungering_void( player_t* target );
   void trigger_wrathful_faerie();
   void trigger_wrathful_faerie_fermata();
   void remove_wrathful_faerie();

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -84,7 +84,6 @@ public:
     propagate_const<buff_t*> shadow_crash_debuff;
     propagate_const<buff_t*> wrathful_faerie;
     propagate_const<buff_t*> wrathful_faerie_fermata;
-    propagate_const<buff_t*> hungering_void_tracking;
     propagate_const<buff_t*> hungering_void;
   } buffs;
 
@@ -243,6 +242,7 @@ public:
     const spell_data_t* void_torrent;
     // T50
     const spell_data_t* hungering_void;
+    const spell_data_t* hungering_void_buff;  // not linked from hungering void talent spell
     const spell_data_t* ancient_madness;
     const spell_data_t* surrender_to_madness;
   } talents;
@@ -595,7 +595,6 @@ public:
   void trigger_wrathful_faerie_fermata();
   void remove_wrathful_faerie();
   void remove_wrathful_faerie_fermata();
-  void remove_hungering_void_tracking();
   int shadow_weaving_active_dots( const player_t* target, const unsigned int spell_id ) const;
   double shadow_weaving_multiplier( const player_t* target, const unsigned int spell_id ) const;
   pets::fiend::base_fiend_pet_t* get_current_main_pet();
@@ -712,12 +711,9 @@ struct priest_pet_melee_t : public melee_attack_t
 struct priest_pet_spell_t : public spell_t
 {
   bool affected_by_shadow_weaving;
-  const spell_data_t* hungering_void_buff_spell;
 
   priest_pet_spell_t( priest_pet_t& p, util::string_view n )
-    : spell_t( n, &p, p.find_pet_spell( n ) ),
-      affected_by_shadow_weaving( false ),
-      hungering_void_buff_spell( p.o().find_spell( 345219 ) )
+    : spell_t( n, &p, p.find_pet_spell( n ) ), affected_by_shadow_weaving( false )
   {
     may_crit = true;
   }
@@ -746,11 +742,6 @@ struct priest_pet_spell_t : public spell_t
       tdm *= p().o().shadow_weaving_multiplier( t, id );
     }
 
-    if ( p().o().hungering_void_active( t ) )
-    {
-      tdm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
-    }
-
     return tdm;
   }
 
@@ -761,11 +752,6 @@ struct priest_pet_spell_t : public spell_t
     if ( affected_by_shadow_weaving )
     {
       ttm *= p().o().shadow_weaving_multiplier( t, id );
-    }
-
-    if ( p().o().hungering_void_active( t ) )
-    {
-      ttm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
     }
 
     return ttm;
@@ -1312,13 +1298,11 @@ struct priest_spell_t : public priest_action_t<spell_t>
 {
   bool affected_by_shadow_weaving;
   unsigned int mind_sear_id;
-  const spell_data_t* hungering_void_buff_spell;
 
   priest_spell_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
     : base_t( name, player, s ),
       affected_by_shadow_weaving( false ),
-      mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() ),
-      hungering_void_buff_spell( priest().find_spell( 345219 ) )
+      mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() )
   {
     weapon_multiplier = 0.0;
   }
@@ -1395,11 +1379,6 @@ struct priest_spell_t : public priest_action_t<spell_t>
       tdm *= priest().shadow_weaving_multiplier( t, id );
     }
 
-    if ( priest().hungering_void_active( t ) )
-    {
-      tdm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
-    }
-
     return tdm;
   }
 
@@ -1410,11 +1389,6 @@ struct priest_spell_t : public priest_action_t<spell_t>
     if ( affected_by_shadow_weaving )
     {
       ttm *= priest().shadow_weaving_multiplier( t, id );
-    }
-
-    if ( priest().hungering_void_active( t ) )
-    {
-      ttm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
     }
 
     return ttm;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -712,9 +712,12 @@ struct priest_pet_melee_t : public melee_attack_t
 struct priest_pet_spell_t : public spell_t
 {
   bool affected_by_shadow_weaving;
+  const spell_data_t* hungering_void_buff_spell;
 
   priest_pet_spell_t( priest_pet_t& p, util::string_view n )
-    : spell_t( n, &p, p.find_pet_spell( n ) ), affected_by_shadow_weaving( false )
+    : spell_t( n, &p, p.find_pet_spell( n ) ),
+      affected_by_shadow_weaving( false ),
+      hungering_void_buff_spell( p.o().find_spell( 345219 ) )
   {
     may_crit = true;
   }
@@ -745,7 +748,7 @@ struct priest_pet_spell_t : public spell_t
 
     if ( p().o().hungering_void_active( t ) )
     {
-      tdm *= ( 1 + p().o().talents.hungering_void->effectN( 2 ).percent() );
+      tdm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
     }
 
     return tdm;
@@ -762,7 +765,7 @@ struct priest_pet_spell_t : public spell_t
 
     if ( p().o().hungering_void_active( t ) )
     {
-      ttm *= ( 1 + p().o().talents.hungering_void->effectN( 2 ).percent() );
+      ttm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
     }
 
     return ttm;
@@ -1309,11 +1312,13 @@ struct priest_spell_t : public priest_action_t<spell_t>
 {
   bool affected_by_shadow_weaving;
   unsigned int mind_sear_id;
+  const spell_data_t* hungering_void_buff_spell;
 
   priest_spell_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
     : base_t( name, player, s ),
       affected_by_shadow_weaving( false ),
-      mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() )
+      mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() ),
+      hungering_void_buff_spell( priest().find_spell( 345219 ) )
   {
     weapon_multiplier = 0.0;
   }
@@ -1392,7 +1397,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
 
     if ( priest().hungering_void_active( t ) )
     {
-      tdm *= ( 1 + priest().talents.hungering_void->effectN( 2 ).percent() );
+      tdm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
     }
 
     return tdm;
@@ -1409,7 +1414,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
 
     if ( priest().hungering_void_active( t ) )
     {
-      ttm *= ( 1 + priest().talents.hungering_void->effectN( 2 ).percent() );
+      ttm *= ( 1 + hungering_void_buff_spell->effectN( 1 ).percent() );
     }
 
     return ttm;

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -2385,6 +2385,9 @@ bool priest_t::hungering_void_active( player_t* target ) const
 // ==========================================================================
 void priest_t::remove_hungering_void( player_t* target )
 {
+  if ( !talents.hungering_void->ok() )
+    return;
+
   for ( priest_td_t* priest_td : _target_data.get_entries() )
   {
     if ( priest_td && ( priest_td->target != target ) && priest_td->buffs.hungering_void->check() )

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -2016,6 +2016,7 @@ void priest_t::init_spells_shadow()
   // T50
   talents.ancient_madness      = find_talent_spell( "Ancient Madness" );
   talents.hungering_void       = find_talent_spell( "Hungering Void" );
+  talents.hungering_void_buff  = find_spell( 345219 );
   talents.surrender_to_madness = find_talent_spell( "Surrender to Madness" );
 
   // General Spells
@@ -2377,24 +2378,4 @@ bool priest_t::hungering_void_active( player_t* target ) const
 
   return td->buffs.hungering_void->check();
 }
-
-// ==========================================================================
-// Helper function to expire all tracking debuffs after Voidform expires
-// ==========================================================================
-void priest_t::remove_hungering_void_tracking()
-{
-  if ( !talents.hungering_void->ok() )
-  {
-    return;
-  }
-
-  for ( priest_td_t* priest_td : _target_data.get_entries() )
-  {
-    if ( priest_td && priest_td->buffs.hungering_void_tracking->check() )
-    {
-      priest_td->buffs.hungering_void_tracking->expire();
-    }
-  }
-}
-
 }  // namespace priestspace

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1211,11 +1211,11 @@ struct void_bolt_t final : public priest_spell_t
       void_bolt_extension->schedule_execute();
     }
 
-    if ( priest().talents.hungering_void->ok() && priest().buffs.voidform->check() )
+    if ( priest().talents.hungering_void->ok() )
     {
       priest_td_t& td = get_td( s->target );
       // Check if this buff is active, every Void Bolt after the first should get this
-      if ( td.buffs.hungering_void->up() )
+      if ( td.buffs.hungering_void->up() && priest().buffs.voidform->check() )
       {
         timespan_t seconds_to_add_to_voidform =
             s->result == RESULT_CRIT ? hungering_void_crit_duration : hungering_void_base_duration;

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1223,6 +1223,7 @@ struct void_bolt_t final : public priest_spell_t
         // TODO: add some type of tracking for this increase
         priest().buffs.voidform->extend_duration( player, seconds_to_add_to_voidform );
       }
+      priest().remove_hungering_void( s->target );
       td.buffs.hungering_void->trigger();
     }
   }
@@ -2377,5 +2378,19 @@ bool priest_t::hungering_void_active( player_t* target ) const
     return false;
 
   return td->buffs.hungering_void->check();
+}
+
+// ==========================================================================
+// Remove Hungering Void on any targets that don't match
+// ==========================================================================
+void priest_t::remove_hungering_void( player_t* target )
+{
+  for ( priest_td_t* priest_td : _target_data.get_entries() )
+  {
+    if ( priest_td && ( priest_td->target != target ) && priest_td->buffs.hungering_void->check() )
+    {
+      priest_td->buffs.hungering_void->expire();
+    }
+  }
 }
 }  // namespace priestspace


### PR DESCRIPTION
resolves https://github.com/WarcraftPriests/sl-shadow-priest/issues/84

the spell has been reworked:
  - no longer amps Void Bolt damage
  - moved damage increase to the buff spell
  - damage increase affects all priest spells, including trinkets, but nothing to do with pets
  - voidform extension on crits stored by itself as 2, no need to add 1+1
  - buff tracking was no longer needed, it now just always triggers the buff on every void bolt cast
  - added support for max targets