### PR TITLE
[Priest] Add support for prepatch sims and fix apl for priest_self_power_infusion

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1376,49 +1376,60 @@ std::unique_ptr<expr_t> priest_t::create_expression( util::string_view expressio
 
   auto splits = util::string_split<util::string_view>( expression_str, "." );
   // pet.fiend.X refers to either shadowfiend or mindbender
-  if ( splits.size() >= 2 && splits[ 0 ] == "pet" )
+  if ( splits.size() >= 2 )
   {
-    if ( util::str_compare_ci( splits[ 1 ], "fiend" ) )
+    if ( splits[ 0 ] == "pet" )
     {
-      pet_t* pet = get_current_main_pet();
-      if ( !pet )
+      if ( util::str_compare_ci( splits[ 1 ], "fiend" ) )
       {
-        throw std::invalid_argument( "Cannot find any summoned fiend (shadowfiend/mindbender) pet ." );
-      }
-      if ( splits.size() == 2 )
-      {
-        return expr_t::create_constant( "pet_index_expr", static_cast<double>( pet->actor_index ) );
-      }
-      // pet.foo.blah
-      else
-      {
-        if ( splits[ 2 ] == "active" )
+        pet_t* pet = get_current_main_pet();
+        if ( !pet )
         {
-          return make_fn_expr( expression_str, [ pet ] { return !pet->is_sleeping(); } );
+          throw std::invalid_argument( "Cannot find any summoned fiend (shadowfiend/mindbender) pet ." );
         }
-        else if ( splits[ 2 ] == "remains" )
+        if ( splits.size() == 2 )
         {
-          return make_fn_expr( expression_str, [ pet ] {
-            if ( pet->expiration && pet->expiration->remains() > timespan_t::zero() )
-            {
-              return pet->expiration->remains().total_seconds();
-            }
-            else
-            {
-              return 0.0;
-            };
-          } );
+          return expr_t::create_constant( "pet_index_expr", static_cast<double>( pet->actor_index ) );
         }
+        // pet.foo.blah
+        else
+        {
+          if ( splits[ 2 ] == "active" )
+          {
+            return make_fn_expr( expression_str, [ pet ] { return !pet->is_sleeping(); } );
+          }
+          else if ( splits[ 2 ] == "remains" )
+          {
+            return make_fn_expr( expression_str, [ pet ] {
+              if ( pet->expiration && pet->expiration->remains() > timespan_t::zero() )
+              {
+                return pet->expiration->remains().total_seconds();
+              }
+              else
+              {
+                return 0.0;
+              };
+            } );
+          }
 
-        // build player/pet expression from the tail of the expression string.
-        auto tail = expression_str.substr( splits[ 1 ].length() + 5 );
-        if ( auto e = pet->create_expression( tail ) )
-        {
-          return e;
-        }
+          // build player/pet expression from the tail of the expression string.
+          auto tail = expression_str.substr( splits[ 1 ].length() + 5 );
+          if ( auto e = pet->create_expression( tail ) )
+          {
+            return e;
+          }
 
-        throw std::invalid_argument( fmt::format( "Unsupported pet expression '{}'.", tail ) );
+          throw std::invalid_argument( fmt::format( "Unsupported pet expression '{}'.", tail ) );
+        }
       }
+    }
+    else if ( util::str_compare_ci( splits[ 0 ], "priest" ))
+    {
+      if ( util::str_compare_ci(splits[ 1 ], "self_power_infusion" ))
+      {
+        return expr_t::create_constant( "self_power_infusion", options.priest_self_power_infusion );
+      }
+      throw std::invalid_argument( fmt::format( "Unsupported priest expression '{}'.", splits[1] ) );
     }
   }
 
@@ -1655,10 +1666,9 @@ void priest_t::trigger_lucid_dreams( double cost )
     return;
 
   double multiplier  = azerite_essence.lucid_dreams->effectN( 1 ).percent();
-  double proc_chance = ( specialization() == PRIEST_SHADOW )
-                           ? options.priest_lucid_dreams_proc_chance_shadow
-                           : ( specialization() == PRIEST_HOLY ) ? options.priest_lucid_dreams_proc_chance_holy
-                                                                 : options.priest_lucid_dreams_proc_chance_disc;
+  double proc_chance = ( specialization() == PRIEST_SHADOW ) ? options.priest_lucid_dreams_proc_chance_shadow
+                       : ( specialization() == PRIEST_HOLY ) ? options.priest_lucid_dreams_proc_chance_holy
+                                                             : options.priest_lucid_dreams_proc_chance_disc;
 
   if ( rng().roll( proc_chance ) )
   {

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -2190,18 +2190,33 @@ void priest_t::generate_apl_shadow()
       "variable,name=all_dots_up,op=set,value="
       "dot.shadow_word_pain.ticking&dot.vampiric_touch.ticking&dot.devouring_plague.ticking" );
   default_list->add_action( "variable,name=searing_nightmare_cutoff,op=set,value=spell_targets.mind_sear>3" );
+  default_list->add_action(
+      "variable,name=pi_or_vf_sync_condition,op=set,value=(priest.self_power_infusion|runeforge.twins_of_the_sun_"
+      "priestess.equipped)&level>=58&cooldown.power_infusion.up|(level<58|!priest.self_power_infusion&!runeforge.twins_"
+      "of_the_sun_priestess.equipped)&cooldown.void_eruption.up",
+      "Variable to switch between syncing cooldown usage to Power Infusion or Void Eruption depenending whether "
+      "priest_self_power_infusion is in use or we don't have power infusion learned." );
 
   // Racials
   if ( race == RACE_DARK_IRON_DWARF )
-    default_list->add_action( "fireblood,if=buff.power_infusion.up" );
+    default_list->add_action(
+        "fireblood,if=(priest.self_power_infusion|runeforge.twins_of_the_sun_priestess."
+        "equipped)&level>=58&buff.power_infusion.up|(level<58|!priest.self_power_infusion&!runeforge.twins_of_the_"
+        "sun_priestess.equipped)&buff.voidform.up" );
   if ( race == RACE_TROLL )
-    default_list->add_action( "berserking,if=buff.power_infusion.up" );
+    default_list->add_action(
+        "berserking,if=(priest.self_power_infusion|runeforge.twins_of_the_sun_priestess."
+        "equipped)&level>=58&buff.power_infusion.up|(level<58|!priest.self_power_infusion&!runeforge.twins_of_the_"
+        "sun_priestess.equipped)&buff.voidform.up" );
   if ( race == RACE_LIGHTFORGED_DRAENEI )
     default_list->add_action(
         "lights_judgment,if=spell_targets.lights_judgment>=2|(!raid_event.adds.exists|raid_event.adds.in>75)",
         "Use Light's Judgment if there are 2 or more targets, or adds aren't spawning for more than 75s." );
   if ( race == RACE_MAGHAR_ORC )
-    default_list->add_action( "ancestral_call,if=buff.power_infusion.up" );
+    default_list->add_action(
+        "ancestral_call,if=(priest.self_power_infusion|runeforge.twins_of_the_sun_priestess."
+        "equipped)&level>=58&buff.power_infusion.up|(level<58|!priest.self_power_infusion&!runeforge.twins_of_the_"
+        "sun_priestess.equipped)&buff.voidform.up" );
 
   default_list->add_call_action_list( cwc );
   default_list->add_run_action_list( main );
@@ -2242,7 +2257,7 @@ void priest_t::generate_apl_shadow()
 
   // Cast While Casting actions. Set at higher priority to short circuit interrupt conditions on Mind Sear/Flay
   cwc->add_talent( this, "Searing Nightmare",
-                   "use_while_casting=1,target_if=(variable.searing_nightmare_cutoff&!cooldown.power_infusion.up)|("
+                   "use_while_casting=1,target_if=(variable.searing_nightmare_cutoff&!variable.pi_or_vf_sync_condition)|("
                    "dot.shadow_word_pain.refreshable&spell_targets.mind_sear>1)",
                    "Use Searing Nightmare if you will hit enough targets and Power Infusion and Voidform are not "
                    "ready, or to refresh SW:P on two or more targets." );
@@ -2255,7 +2270,7 @@ void priest_t::generate_apl_shadow()
 
   // Main APL, should cover all ranges of targets and scenarios
   main->add_call_action_list( this, covenant.boon_of_the_ascended, boon, "if=buff.boon_of_the_ascended.up" );
-  main->add_action( this, "Void Eruption", "if=cooldown.power_infusion.up&insanity>=40",
+  main->add_action( this, "Void Eruption", "if=variable.pi_or_vf_sync_condition&insanity>=40",
                     "Sync up Voidform and Power Infusion Cooldowns and of using LotV pool insanity before casting." );
   main->add_action( this, "Shadow Word: Pain", "if=buff.fae_guardians.up&!debuff.wrathful_faerie.up",
                     "Make sure you put up SW:P ASAP on the target if Wrathful Faerie isn't active." );
@@ -2267,7 +2282,7 @@ void priest_t::generate_apl_shadow()
   main->add_talent( this, "Damnation", "target_if=!variable.all_dots_up",
                     "Prefer to use Damnation ASAP if any DoT is not up." );
   main->add_action( this, "Devouring Plague",
-                    "target_if=(refreshable|insanity>75)&!cooldown.power_infusion.up&(!talent.searing_nightmare."
+                    "target_if=(refreshable|insanity>75)&!variable.pi_or_vf_sync_condition&(!talent.searing_nightmare."
                     "enabled|(talent.searing_nightmare.enabled&!variable.searing_nightmare_cutoff))",
                     "Don't use Devouring Plague if you can get into Voidform instead, or if Searing Nightmare is "
                     "talented and will hit enough targets." );


### PR DESCRIPTION
resolves WarcraftPriests/sl-shadow-priest#102
more feature complete version of simulationcraft/simc#5391

This also adds support for the priest_self_power_infusion option to be accessed from apl via priest.self_power_infusion and uses it to expand the condition @seanpeters86 used in simulationcraft/simc#5391 so that the APL functions properly when self PI is disabled.