### PR TITLE
Tests: properly quote simc arguments

### DIFF
--- a/engine/item/item.cpp
+++ b/engine/item/item.cpp
@@ -625,12 +625,12 @@ void item_t::parse_options()
   std::string DUMMY_REFORGE; // TODO-WOD: Remove once profiles update
   std::string DUMMY_CONTEXT; // not used by simc but used by 3rd parties (raidbots)
 
-  auto splits = util::string_split_allow_quotes(options_str, ",");
-  option_name_str = splits[0];
-  splits.erase(splits.begin());
-  if (!splits.empty())
+  std::string::size_type cut_pt = options_str.find_first_of( "," );
+
+  if ( cut_pt != options_str.npos )
   {
-    remainder = util::string_join(splits, ",");
+    remainder       = options_str.substr( cut_pt + 1 );
+    option_name_str = options_str.substr( 0, cut_pt );
   }
 
   std::array<std::unique_ptr<option_t>, 32> options { {

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,4 +1,4 @@
-import sys, os, shutil, subprocess, re, signal
+import sys, os, shutil, subprocess, re, signal, shlex
 from pathlib import Path
 
 def __error_status(code):
@@ -66,9 +66,9 @@ class Test(object):
         args.append(self._profile)
         for arg in self._args:
             if isinstance(arg, tuple):
-                args.append('{}={}'.format(*arg))
+                args.append(shlex.quote('{}={}'.format(*arg)))
             else:
-                args.append(str(arg))
+                args.append(shlex.quote(str(arg)))
         return args
 
 SIMC_WALL_SECONDS_RE = re.compile('WallSeconds\\s*=\\s*([0-9\\.]+)')

--- a/tests/run.py
+++ b/tests/run.py
@@ -73,7 +73,7 @@ def test_trinkets(klass: str, path: str):
     tests.append(grp)
     for trinket in trinkets:
         Test('{} ({})'.format(trinket.name, trinket.item_id), group=grp, args=[
-            ('trinket1', '"{}",id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
+            ('trinket1', '{},id={},ilevel={}'.format(trinket.name, trinket.item_id, trinket.min_itemlevel))])
 
 
 def test_legendaries(klass: str, path: str):
@@ -85,7 +85,7 @@ def test_legendaries(klass: str, path: str):
         tests.append(grp)
         for legendary in legendaries:
             Test('{} ({} / {})'.format(legendary.full_name, legendary.id, legendary.bonus_id), group=grp, args=[
-                ('trinket1', '"{}",bonus_id={}'.format(legendary.full_name, legendary.bonus_id))])
+                ('trinket1', '{},bonus_id={}'.format(legendary.full_name, legendary.bonus_id))])
 
 
 def test_soulbinds(klass: str, path: str):


### PR DESCRIPTION
We have to properly shell-quote simc option arguments as they can
contain characters (like whitespace, `;` or `&`) that would break shell
argument parsing.

Option parsing in files natively supports option values with whitespaces
as long as the whole option value is quoted. In case of options passed
on a command line they simply should be properly shell-quoted. Trying to
special case items by allowing separately quoted item names just brings
a lot of problems.

Right now, as `util::string_split_allow_quotes()` skips empty substrings
we get crashes for input like `off_hand=","` (because there are 0
splits).
For input without item name (like `=",id=ID"`) we either don't get an
item at all or we "lose" the first option, because it gets parsed as an
item name.

While we could theoretically fix that and allow separately quoting item
names, just revert it back to what it was and rely on full option value
quoting/shell arguemnt quoting to support whitespace.

Effectively revert
  5523e63 Escape item names and fix SimC to allow quoted item names.
  4b4cb8e Try to fix item option parsing.