### PR TITLE
Precombat adjustments

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -300,6 +300,7 @@ action_t::action_t( action_e ty, util::string_view token, player_t* p, const spe
     harmful( true ),
     proc(),
     is_interrupt( false ),
+    is_precombat(),
     initialized(),
     may_hit( true ),
     may_miss(),
@@ -940,7 +941,7 @@ double action_t::base_cost() const
  */
 double action_t::cost() const
 {
-  if ( !harmful && !player->in_combat )
+  if ( !harmful && is_precombat )
     return 0;
 
   resource_e cr = current_resource();
@@ -992,7 +993,7 @@ double action_t::cost_per_tick( resource_e r ) const
 
 timespan_t action_t::gcd() const
 {
-  if ( ( !harmful && !player->in_combat ) || trigger_gcd == timespan_t::zero() )
+  if ( trigger_gcd == timespan_t::zero() )
     return timespan_t::zero();
 
   timespan_t gcd_ = trigger_gcd;
@@ -2588,6 +2589,9 @@ void action_t::init_finished()
             option.cancel_if_expr_str ) );
     }
   }
+
+  if ( action_list && action_list->name_str == "precombat" )
+    is_precombat = true;
 }
 
 void action_t::reset()
@@ -3825,7 +3829,7 @@ void action_t::trigger_dot( action_state_t* s )
 
   // To simulate precasting HoTs, remove one tick worth of duration if precombat.
   // We also add a fake zero_tick in dot_t::check_tick_zero().
-  if ( !harmful && !player->in_combat && !tick_zero && !tick_on_application )
+  if ( !harmful && is_precombat && !tick_zero && !tick_on_application )
     duration -= tick_time( s );
 
   dot_t* dot = get_dot( s->target );

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -169,6 +169,9 @@ public:
   /// Whether or not the action is an interrupt (specifically triggers PF2_CAST_INTERRUPT callbacks)
   bool is_interrupt;
 
+  /// Whether the action is used from the precombat action list. Will be set up automatically by action_t::init_finished
+  bool is_precombat;
+
   /// Is the action initialized? (action_t::init ran successfully)
   bool initialized;
 

--- a/engine/action/sc_attack.cpp
+++ b/engine/action/sc_attack.cpp
@@ -46,9 +46,6 @@ timespan_t attack_t::execute_time() const
   if ( base_execute_time == timespan_t::zero() )
     return timespan_t::zero();
 
-  if ( !harmful && !player->in_combat )
-    return timespan_t::zero();
-
   return base_execute_time * player->cache.attack_speed();
 }
 

--- a/engine/action/sc_dot.cpp
+++ b/engine/action/sc_dot.cpp
@@ -881,7 +881,7 @@ void dot_t::check_tick_zero( bool start )
   // by using a first tick.
   // We also reduce the duration by one tick interval in
   // action_t::trigger_dot().
-  bool fake_first_tick = !current_action->harmful && !current_action->player->in_combat;
+  bool fake_first_tick = !current_action->harmful && current_action->is_precombat;
 
   if ( ( current_action->tick_zero || ( current_action->tick_on_application && start ) ) ||
        fake_first_tick )

--- a/engine/action/sc_spell.cpp
+++ b/engine/action/sc_spell.cpp
@@ -43,9 +43,6 @@ spell_base_t::spell_base_t( action_e at,
 
 timespan_t spell_base_t::execute_time() const
 {
-  if ( ! harmful && ! player -> in_combat )
-    return timespan_t::zero();
-
   timespan_t t = base_execute_time;
 
   if ( t <= timespan_t::zero() ) {

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -936,9 +936,6 @@ struct fiend_melee_t : public priest_pet_melee_t
     if ( base_execute_time == timespan_t::zero() )
       return timespan_t::zero();
 
-    if ( !harmful && !player->in_combat )
-      return timespan_t::zero();
-
     return base_execute_time * player->cache.spell_speed();
   }
 

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -7619,11 +7619,9 @@ struct lights_judgment_t : public racial_spell_t
   };
 
   action_t* damage;
-  bool precombat;
 
   lights_judgment_t( player_t* p, util::string_view options_str ) :
-    racial_spell_t( p, "lights_judgment", p->find_racial_spell( "Light's Judgment" ) ),
-    precombat()
+    racial_spell_t( p, "lights_judgment", p->find_racial_spell( "Light's Judgment" ) )
   {
     parse_options( options_str );
     // The cast doesn't trigger combat
@@ -7636,18 +7634,11 @@ struct lights_judgment_t : public racial_spell_t
     add_child( damage );
   }
 
-  void init_finished() override
-  {
-    racial_spell_t::init_finished();
-
-    precombat =  action_list -> name_str == "precombat";
-  }
-
   void execute() override
   {
     racial_spell_t::execute();
     // Reduce the cooldown by the player's gcd when used during precombat
-    if ( ! player -> in_combat && precombat )
+    if ( ! player -> in_combat && is_precombat )
     {
       cooldown -> adjust( - player -> base_gcd );
 
@@ -7660,7 +7651,7 @@ struct lights_judgment_t : public racial_spell_t
   timespan_t travel_time() const override
   {
     // Reduce the delay before the hit by the player's gcd when used during precombat
-    if ( ! player -> in_combat && precombat )
+    if ( ! player -> in_combat && is_precombat )
       return timespan_t::from_seconds( travel_speed ) - player -> base_gcd;
 
     return timespan_t::from_seconds( travel_speed );


### PR DESCRIPTION
Fixes APL loops caused by `harmful = false` actions and various other weird interactions by restricting the precombat stuff to the precombat action list.