### PR TITLE
[Death Knight] Add deadliest coil legendary

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4539,7 +4539,7 @@ struct death_coil_t : public death_knight_spell_t
 
     if ( p() -> legendary.deadliest_coil.ok() )
     {
-      cost += (p() -> legendary.deadliest_coil->effectN( 1 ).base_value() / 10);
+      cost += (p() -> legendary.deadliest_coil->effectN( 1 ).resource( RESOURCE_RUNIC_POWER ) );
     }
 
     return cost;

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -952,7 +952,7 @@ public:
     item_runeforge_t rage_of_the_frozen_champion; // 7160
 
     // Unholy
-    // item_runeforge_t deadliest_coil; // 6952
+    item_runeforge_t deadliest_coil; // 6952
     // item_runeforge_t deaths_certainty; // 6951
     item_runeforge_t frenzied_monstrosity;        // 6950
     // item_runeforge_t reanimated_shambler; // 6949
@@ -4535,7 +4535,14 @@ struct death_coil_t : public death_knight_spell_t
     if ( p() -> buffs.sudden_doom -> check() )
       return 0;
 
-    return death_knight_spell_t::cost();
+    double cost = death_knight_spell_t::cost();
+
+    if ( p() -> legendary.deadliest_coil.ok() )
+    {
+      cost += (p() -> legendary.deadliest_coil->effectN( 1 ).base_value() / 10);
+    }
+
+    return cost;
   }
 
   void execute() override
@@ -4552,6 +4559,8 @@ struct death_coil_t : public death_knight_spell_t
 
     p() -> cooldown.army_of_the_dead -> adjust( -timespan_t::from_seconds(
       p() -> talent.army_of_the_damned -> effectN( 2 ).base_value() / 10 ) );
+
+    p() -> buffs.dark_transformation->extend_duration(p(), timespan_t::from_seconds(p() -> legendary.deadliest_coil -> effectN( 2 ).base_value()) );
 
     p() -> buffs.sudden_doom -> decrement();
   }
@@ -8434,7 +8443,7 @@ void death_knight_t::init_spells()
   legendary.rage_of_the_frozen_champion = find_runeforge_legendary( "Rage of the Frozen Champion" );
 
   // Unholy
-  // legendary.deadliest_coil = find_runeforge_legendary( "Deadliest Coil" );
+  legendary.deadliest_coil = find_runeforge_legendary( "Deadliest Coil" );
   // legendary.deaths_certainty = find_runeforge_legendary( "Death's Certainty" );
   legendary.frenzied_monstrosity = find_runeforge_legendary( "Frenzied Monstrosity" );
   // legendary.reanimated_shambler = find_runeforge_legendary( "Reanimated Shambler" );

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4560,7 +4560,10 @@ struct death_coil_t : public death_knight_spell_t
     p() -> cooldown.army_of_the_dead -> adjust( -timespan_t::from_seconds(
       p() -> talent.army_of_the_damned -> effectN( 2 ).base_value() / 10 ) );
 
-    p() -> buffs.dark_transformation->extend_duration(p(), timespan_t::from_seconds(p() -> legendary.deadliest_coil -> effectN( 2 ).base_value()) );
+    if ( p() -> buffs.dark_transformation -> up() && p() -> legendary.deadliest_coil.ok() )
+    {
+      p() -> buffs.dark_transformation->extend_duration(p(), timespan_t::from_seconds(p() -> legendary.deadliest_coil -> effectN( 2 ).base_value()) );
+    }
 
     p() -> buffs.sudden_doom -> decrement();
   }


### PR DESCRIPTION
B = Baseline profile
L = Legendary added as a bonus_id
```
B death_coil                 Count=  61.4|  4.714sec  DPE= 850|10.81%  DPET= 632  DPR=  29  pDPS=174  Miss= 0.00%  Hit=   763|   763|   763  Crit=  1526|  1526|  1526|11.49%
L death_coil                 Count=  75.8|  3.785sec  DPE= 852|12.59%  DPET= 633  DPR=  37  pDPS=216  Miss= 0.00%  Hit=   763|   763|   763  Crit=  1526|  1526|  1526|11.76%

B dark_transformation        Count=   6.4| 50.314sec  DPE= 755| 0.99%  DPET= 559  DPR=   0  pDPS= 16  Miss= 0.00%  Hit=   678|   678|   678  Crit=  1357|  1357|  1357|11.25%
L dark_transformation        Count=   6.7| 48.398sec  DPE= 753| 0.98%  DPET= 557  DPR=   0  pDPS= 17  Miss= 0.00%  Hit=   678|   678|   678  Crit=  1357|  1357|  1357|10.99%

B 0.78% : Runic Power Cap
L 1.91% : Runic Power Cap

B dark_transformation       : start=  6.4 refresh=  0.0 interval= 50.3 trigger= 50.3 duration= 14.7 uptime= 31.18%  benefit= 35.85%
L dark_transformation       : start=  6.7 refresh=  0.0 interval= 48.4 trigger= 48.4 duration= 19.3 uptime= 43.08%  benefit= 46.59%
```