### PR TITLE
[Priest] fix unfurling darkness calculation

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -1404,7 +1404,15 @@ struct priest_spell_t : public priest_action_t<spell_t>
 
     if ( affected_by_shadow_weaving )
     {
-      tdm *= priest().shadow_weaving_multiplier( t, id );
+      // Guarding against Unfurling Darkness, it does not get the mastery benefit
+      unsigned int spell_id = id;
+      if ( energize_type == action_energize::NONE && background == true )
+      {
+        sim->print_debug( "{} {} cast does not benefit from Mastery automatically.", *player, name_str );
+        spell_id = 1;
+      }
+
+      tdm *= priest().shadow_weaving_multiplier( t, spell_id );
     }
 
     return tdm;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -1320,11 +1320,13 @@ struct priest_heal_t : public priest_action_t<heal_t>
 struct priest_spell_t : public priest_action_t<spell_t>
 {
   bool affected_by_shadow_weaving;
+  bool ignores_automatic_mastery;
   unsigned int mind_sear_id;
 
   priest_spell_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
     : base_t( name, player, s ),
       affected_by_shadow_weaving( false ),
+      ignores_automatic_mastery( false ),
       mind_sear_id( priest().find_class_spell( "Mind Sear" )->effectN( 1 ).trigger()->id() )
   {
     weapon_multiplier = 0.0;
@@ -1406,7 +1408,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
     {
       // Guarding against Unfurling Darkness, it does not get the mastery benefit
       unsigned int spell_id = id;
-      if ( energize_type == action_energize::NONE && background == true )
+      if ( ignores_automatic_mastery )
       {
         sim->print_debug( "{} {} cast does not benefit from Mastery automatically.", *player, name_str );
         spell_id = 1;

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -877,6 +877,7 @@ struct vampiric_touch_t final : public priest_spell_t
     if ( priest().talents.unfurling_darkness->ok() )
     {
       child_ud = new unfurling_darkness_t( priest() );
+      add_child( child_ud );
     }
   }
 
@@ -910,7 +911,6 @@ struct vampiric_touch_t final : public priest_spell_t
     {
       child_ud->target = s->target;
       child_ud->execute();
-      add_child( child_ud );
       priest().buffs.unfurling_darkness->expire();
     }
     else

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -837,6 +837,8 @@ struct unfurling_darkness_t final : public priest_spell_t
     energize_amount            = 0;
     energize_resource          = RESOURCE_NONE;
 
+    ignores_automatic_mastery = 1;
+
     // Since we are re-using the Vampiric Touch spell disable the DoT
     dot_duration       = timespan_t::from_seconds( 0 );
     base_td_multiplier = spell_power_mod.tick = 0;
@@ -901,12 +903,6 @@ struct vampiric_touch_t final : public priest_spell_t
   {
     trigger_heal( s );
 
-    if ( child_swp )
-    {
-      child_swp->target = s->target;
-      child_swp->execute();
-    }
-
     if ( priest().buffs.unfurling_darkness->check() )
     {
       child_ud->target = s->target;
@@ -921,6 +917,13 @@ struct vampiric_touch_t final : public priest_spell_t
         // The CD Starts as soon as the buff is applied
         priest().buffs.unfurling_darkness_cd->trigger();
       }
+    }
+
+    // Trigger SW:P after UD since it does not benefit from the automatic Mastery benefit
+    if ( child_swp )
+    {
+      child_swp->target = s->target;
+      child_swp->execute();
     }
 
     priest_spell_t::impact( s );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -836,8 +836,7 @@ struct unfurling_darkness_t final : public priest_spell_t
     energize_type              = action_energize::NONE;  // no insanity gain
     energize_amount            = 0;
     energize_resource          = RESOURCE_NONE;
-
-    ignores_automatic_mastery = 1;
+    ignores_automatic_mastery  = 1;
 
     // Since we are re-using the Vampiric Touch spell disable the DoT
     dot_duration       = timespan_t::from_seconds( 0 );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -796,8 +796,7 @@ struct shadow_word_pain_t final : public priest_spell_t
   {
     priest_spell_t::impact( s );
 
-    // Only applied if you hard cast SW:P, Misery and Damnation do not trigger this
-    if ( casted && result_is_hit( s->result ) )
+    if ( result_is_hit( s->result ) )
     {
       if ( priest().buffs.fae_guardians->check() )
       {
@@ -829,10 +828,16 @@ struct shadow_word_pain_t final : public priest_spell_t
 // ==========================================================================
 struct unfurling_darkness_t final : public priest_spell_t
 {
-  unfurling_darkness_t( priest_t& p ) : priest_spell_t( "unfurling_darkness", p, p.find_spell( 34914 ) )
+  unfurling_darkness_t( priest_t& p )
+    : priest_spell_t( "unfurling_darkness", p, p.find_class_spell( "Vampiric Touch" ) )
   {
     background                 = true;
     affected_by_shadow_weaving = true;
+    energize_type              = action_energize::NONE;  // no insanity gain
+
+    // Since we are re-using the Vampiric Touch spell disable the DoT
+    dot_duration       = timespan_t::from_seconds( 0 );
+    base_td_multiplier = spell_power_mod.tick = 0;
   }
 };
 
@@ -1630,7 +1635,7 @@ struct damnation_t final : public priest_spell_t
 
   damnation_t( priest_t& p, util::string_view options_str )
     : priest_spell_t( "damnation", p, p.find_talent_spell( "Damnation" ) ),
-      child_swp( new shadow_word_pain_t( priest(), false ) ),
+      child_swp( new shadow_word_pain_t( priest(), true ) ), // Damnation still triggers SW:P as if it was hard casted
       child_vt( new vampiric_touch_t( priest(), false ) ),
       child_dp( new devouring_plague_t( priest(), false ) )
   {

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -486,7 +486,7 @@ struct shadow_word_death_t final : public priest_spell_t
 
         // Right now in-game this is not using the spell data value
         if ( priest().bugs )
-        { 
+        {
           insanity_per_dot = 5;
         }
         double insanity_gain = dots * insanity_per_dot;
@@ -829,14 +829,9 @@ struct shadow_word_pain_t final : public priest_spell_t
 // ==========================================================================
 struct unfurling_darkness_t final : public priest_spell_t
 {
-  double vampiric_touch_sp;
-
-  unfurling_darkness_t( priest_t& p )
-    : priest_spell_t( "unfurling_darkness", p, p.find_talent_spell( "Unfurling Darkness" ) ),
-      vampiric_touch_sp( p.find_spell( 34914 )->effectN( 4 ).sp_coeff() )
+  unfurling_darkness_t( priest_t& p ) : priest_spell_t( "unfurling_darkness", p, p.find_spell( 34914 ) )
   {
     background                 = true;
-    spell_power_mod.direct     = vampiric_touch_sp;
     affected_by_shadow_weaving = true;
   }
 };
@@ -860,6 +855,9 @@ struct vampiric_touch_t final : public priest_spell_t
     casted                     = _casted;
     may_crit                   = false;
     affected_by_shadow_weaving = true;
+
+    // Disable initial hit damage
+    base_dd_min = base_dd_max = spell_power_mod.direct = 0;
 
     if ( priest().talents.misery->ok() && casted )
     {
@@ -909,6 +907,7 @@ struct vampiric_touch_t final : public priest_spell_t
     {
       child_ud->target = s->target;
       child_ud->execute();
+      add_child( child_ud );
       priest().buffs.unfurling_darkness->expire();
     }
     else


### PR DESCRIPTION
VT spell data auto triggered the direct hit damage on every VT, and we just added more if using VT. This disables that completely and refactors UD to hit for the correct amount as a child action.