### PR TITLE
Buff initial stacks

### DIFF
--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -707,16 +707,13 @@ buff_t* buff_t::set_max_stack( int max_stack )
   {
     if ( data().ok() )
     {
-      // NOTE: buffs can have negative stacks in the data, which can indicate special handling. We do NOT guard for it
-      // here, and instead will assert() out if such a buff is trigger'd/execute'd without explicitly setting a positive
-      // stack in the buff construction or explicitly passing a stack amount.
       if ( data().max_stacks() != 0 )
       {
         _max_stack = data().max_stacks();
       }
       else if ( data().initial_stacks() != 0 )
       {
-        _max_stack = data().initial_stacks();
+        _max_stack = std::abs( data().initial_stacks() );
       }
       else
       {
@@ -731,15 +728,14 @@ buff_t* buff_t::set_max_stack( int max_stack )
   else
   {
     _max_stack = max_stack;
-
-    if ( _max_stack < 1 )
-    {
-      sim->error( "{} initialized with max_stack < 1 ({}). Setting max_stack to 1.\n", *this, _max_stack );
-      _max_stack = 1;
-    }
   }
 
-  if ( _max_stack > 999 )
+  if ( _max_stack < 1 )
+  {
+    sim->error( "{} initialized with max_stack < 1 ({}). Setting max_stack to 1.\n", *this, _max_stack );
+    _max_stack = 1;
+  }
+  else if ( _max_stack > 999 )
   {
     sim->error( "{} initialized with max_stack > 999. Setting max_stack to 999.\n", *this );
     _max_stack = 999;

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -803,6 +803,7 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
 
 buff_t* buff_t::modify_initial_stack( int initial_stack )
 {
+  assert( _initial_stack > 0 && "Attempting to modify negative initial stack. Use set_initial_stack() with a postive value.");
   set_initial_stack( _initial_stack + initial_stack );
   return this;
 }

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -763,7 +763,7 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
   {
     if ( data().ok() && data().initial_stacks() )
     {
-      _initial_stack = data().initial_stacks();
+      _initial_stack = std::abs( data().initial_stacks() );
     }
     else
     {
@@ -1694,13 +1694,13 @@ void buff_t::execute( int stacks, double value, timespan_t duration )
   // ticking buffs, we treat executes as another "normal trigger", which
   // refreshes the buff
   if ( tick_event )
-    increment( stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks, value, duration );
+    increment( stacks < 0 ? ( reverse ? _max_stack : _initial_stack * std::abs( stacks ) ) : stacks, value, duration );
   else
   {
     if ( reverse && current_stack > 0 )
-      decrement( stacks == -1 ? 1 : stacks, value );
+      decrement( std::abs( stacks ), value );
     else
-      increment( stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks, value, duration );
+      increment( stacks < 0 ? ( reverse ? _max_stack : _initial_stack * std::abs( stacks ) ) : stacks, value, duration );
   }
 
   // new buff cooldown impl

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -1188,9 +1188,14 @@ buff_t* buff_t::apply_affecting_effect( const spelleffect_data_t& effect )
         }
         break;
 
+      case P_STACK:
+        modify_initial_stack( as<int>( effect.base_value() ) );
+        sim->print_debug( "{} initial stacks modified by {} to {}", *this, effect.base_value(), initial_stack() );
+        break;
+
       case P_MAX_STACKS:
         modify_max_stack( as<int>( effect.base_value() ) );
-        sim->print_debug( "{} maximum stacks modified by {}", *this, effect.base_value() );
+        sim->print_debug( "{} maximum stacks modified by {} to {}", *this, effect.base_value(), max_stack() );
         break;
 
       case P_EFFECT_1:

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -780,16 +780,17 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
     sim->error( "{} initialized with initial_stack < 1 ({}). Setting initial_stack to 1.\n", *this, _initial_stack );
     _initial_stack = 1;
   }
-  else if ( _initial_stack > _max_stack )
-  {
-    sim->error( "{} initalized with initial_stack ({}) > max_stack ({}). Setting initial_stack to {}.\n", *this,
-                _initial_stack, _max_stack, _max_stack );
-    _initial_stack = _max_stack;
-  }
   else if ( _initial_stack > 999 )
   {
     _initial_stack = 999;
     sim->error( "{} initialized with initial_stack > 999. Setting initial_stack to 999.\n", *this );
+  }
+
+  if ( _initial_stack > _max_stack )
+  {
+    sim->print_debug( "{} initalized with initial_stack ({}) > max_stack ({}). Setting max_stack to {}.\n", *this,
+                      _initial_stack, _max_stack, _initial_stack );
+    _max_stack = _initial_stack;
   }
 
   return this;
@@ -798,6 +799,14 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
 buff_t* buff_t::modify_initial_stack( int initial_stack )
 {
   set_initial_stack( _initial_stack + initial_stack );
+
+  if ( _initial_stack > _max_stack )
+  {
+    sim->print_debug( "{} modified to initial_stack ({}) > max_stack ({}). Setting max_stack to {}.\n", *this,
+                      _initial_stack, _max_stack, _initial_stack );
+    _max_stack = _initial_stack;
+  }
+
   return this;
 }
 

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -801,14 +801,6 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
 buff_t* buff_t::modify_initial_stack( int initial_stack )
 {
   set_initial_stack( _initial_stack + initial_stack );
-
-  if ( _initial_stack > _max_stack )
-  {
-    sim->print_debug( "{} modified to initial_stack ({}) > max_stack ({}). Setting max_stack to {}.\n", *this,
-                      _initial_stack, _max_stack, _initial_stack );
-    _max_stack = _initial_stack;
-  }
-
   return this;
 }
 
@@ -1660,7 +1652,7 @@ bool buff_t::trigger( int stacks, double value, double chance, timespan_t durati
   if ( ( !activated || stack_behavior == buff_stack_behavior::ASYNCHRONOUS ) && player && player->in_combat &&
        sim->default_aura_delay > timespan_t::zero() )
   {
-    // Since we're storing stacks as value in buff_delay_t, resolve default values first
+    // Since we're storing stacks as value in buff_delay_t, _resolve default values first
     if ( reverse && current_stack > 0 )
     {
       // Expected behavior of a default value (-1) call on an existing reversible buff is `decrement( 1 )`
@@ -1704,7 +1696,7 @@ void buff_t::execute( int stacks, double value, timespan_t duration )
   }
 
   // For cases where the buff trigger hasn't been processed through buff_delay_t, or where buff_t::execute() is called
-  // directly, default value remains -1, so it needs to get _resolve()'d
+  // directly, default value remains -1, so it needs to get _resolve'd
 
   // If the buff has a tick event ongoing, the rules change a bit for ongoing ticking buffs, we treat executes as
   // another "normal trigger", which refreshes the buff

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -803,7 +803,7 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
 
 buff_t* buff_t::modify_initial_stack( int initial_stack )
 {
-  assert( _initial_stack > 0 && "Attempting to modify negative initial stack. Use set_initial_stack() with a postive value.");
+  assert( _initial_stack > 0 && "Cannot modify invalid initial stack. Use set_initial_stack() with a postive value.");
   set_initial_stack( _initial_stack + initial_stack );
   return this;
 }
@@ -1597,7 +1597,7 @@ bool buff_t::remains_lt( timespan_t time ) const
 int buff_t::_resolve_stacks( int stacks )
 {
   int ret = stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks;
-  assert( ret > 0 && "Stacks must be positive. If spell data has negative stacks, you must explicitly set them. " );
+  assert( ret > 0 && "Stacks must be positive. set_initial_stack() must be used if spell data is negative." );
   return ret;
 }
 

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -235,6 +235,7 @@ public:
   bool remains_gt( timespan_t time ) const;
   bool remains_lt( timespan_t time ) const;
   bool at_max_stacks( int mod = 0 ) const { return check() + mod >= max_stack(); }
+  int _resolve_stacks( int stacks ) { return stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks; }
   bool trigger( action_t*, int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
   bool trigger( timespan_t duration );
   bool trigger( int stacks, timespan_t duration );

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -237,7 +237,7 @@ public:
   bool at_max_stacks( int mod = 0 ) const { return check() + mod >= max_stack(); }
   // For trigger()/execute(), default value of stacks is -1, since we want to allow for explicit calls of stacks=1 to
   // override using buff_t::_initial_stack
-  int _resolve_stacks( int stacks ) { return stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks; }
+  int _resolve_stacks( int stacks );
   bool trigger( action_t*, int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
   bool trigger( timespan_t duration );
   bool trigger( int stacks, timespan_t duration );

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -143,9 +143,9 @@ public:
 
   virtual ~buff_t() {}
 
-  buff_t(actor_pair_t q, util::string_view name);
+  buff_t( actor_pair_t q, util::string_view name );
   buff_t( actor_pair_t q, util::string_view name, const spell_data_t*, const item_t* item = nullptr );
-  buff_t(sim_t* sim, util::string_view name);
+  buff_t( sim_t* sim, util::string_view name );
   buff_t( sim_t* sim, util::string_view name, const spell_data_t*, const item_t* item = nullptr );
 protected:
   buff_t( sim_t* sim, player_t* target, player_t* source, util::string_view name, const spell_data_t*, const item_t* item );
@@ -287,7 +287,7 @@ public:
 
   static double DEFAULT_VALUE() { return -std::numeric_limits< double >::min(); }
   static buff_t* find( util::span<buff_t* const>, util::string_view name, player_t* source = nullptr );
-  static buff_t* find(    sim_t*, util::string_view name );
+  static buff_t* find( sim_t*, util::string_view name );
   static buff_t* find( player_t*, util::string_view name, player_t* source = nullptr );
   static buff_t* find_expressable( util::span<buff_t* const>, util::string_view name, player_t* source = nullptr );
 
@@ -295,8 +295,7 @@ public:
   util::string_view source_name() const;
   int max_stack() const { return _max_stack; }
   int initial_stack() const { return _initial_stack; }
-  const spell_data_t* get_trigger_data() const
-  { return trigger_data; }
+  const spell_data_t* get_trigger_data() const { return trigger_data; }
 
   rng::rng_t& rng();
 
@@ -335,14 +334,10 @@ public:
   buff_t* set_affects_regen( bool state );
   buff_t* set_refresh_behavior( buff_refresh_behavior );
   buff_t* set_refresh_duration_callback( buff_refresh_duration_callback_t );
-  buff_t* set_tick_zero( bool v )
-  { tick_zero = v; return this; }
-  buff_t* set_tick_on_application( bool v )
-  { tick_on_application = v; return this; }
-  buff_t* set_partial_tick( bool v )
-  { partial_tick = v; return this; }
-  buff_t* set_tick_time_behavior( buff_tick_time_behavior b )
-  { tick_time_behavior = b; return this; }
+  buff_t* set_tick_zero( bool v ) { tick_zero = v; return this; }
+  buff_t* set_tick_on_application( bool v ) { tick_on_application = v; return this; }
+  buff_t* set_partial_tick( bool v ) { partial_tick = v; return this; }
+  buff_t* set_tick_time_behavior( buff_tick_time_behavior b ) { tick_time_behavior = b; return this; }
   buff_t* set_rppm( rppm_scale_e scale = RPPM_NONE, double freq = -1, double mod = -1);
   buff_t* set_trigger_spell( const spell_data_t* s );
   buff_t* set_stack_change_callback( const buff_stack_change_callback_t& cb );

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -235,7 +235,7 @@ public:
   bool remains_gt( timespan_t time ) const;
   bool remains_lt( timespan_t time ) const;
   bool at_max_stacks( int mod = 0 ) const { return check() + mod >= max_stack(); }
-  // For trigger()/execute(), default value of stacks is -1, since we want to allow for explicitly calls of stacks=1 to
+  // For trigger()/execute(), default value of stacks is -1, since we want to allow for explicit calls of stacks=1 to
   // override using buff_t::_initial_stack
   int _resolve_stacks( int stacks ) { return stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks; }
   bool trigger( action_t*, int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -74,6 +74,7 @@ private: // private because changing max_stacks requires resizing some stack-dep
   const spell_data_t* trigger_data;
 
 public:
+  int _initial_stack;
   double default_value;
   size_t default_value_effect_idx;
   double default_value_effect_multiplier;
@@ -231,22 +232,22 @@ public:
   timespan_t elapsed( timespan_t t ) const { return t - last_start; }
   timespan_t last_trigger_time() const { return last_trigger; }
   timespan_t last_expire_time() const { return last_expire; }
-  bool   remains_gt( timespan_t time ) const;
-  bool   remains_lt( timespan_t time ) const;
-  bool   at_max_stacks( int mod = 0 ) const { return check() + mod >= max_stack(); }
-  bool   trigger  ( action_t*, int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
-  bool   trigger  ( timespan_t duration );
-  bool   trigger  ( int stacks, timespan_t duration );
-  virtual bool   trigger  ( int stacks = 1, double value = DEFAULT_VALUE(), double chance = -1.0, timespan_t duration = timespan_t::min() );
-  virtual void   execute ( int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
-  virtual void   increment( int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
-  virtual void   decrement( int stacks = 1, double value = DEFAULT_VALUE() );
-  virtual void   extend_duration( player_t* p, timespan_t seconds );
-  virtual void   extend_duration_or_trigger( timespan_t duration = timespan_t::min(), player_t* p = nullptr );
+  bool remains_gt( timespan_t time ) const;
+  bool remains_lt( timespan_t time ) const;
+  bool at_max_stacks( int mod = 0 ) const { return check() + mod >= max_stack(); }
+  bool trigger( action_t*, int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
+  bool trigger( timespan_t duration );
+  bool trigger( int stacks, timespan_t duration );
+  virtual bool trigger( int stacks = -1, double value = DEFAULT_VALUE(), double chance = -1.0, timespan_t duration = timespan_t::min() );
+  virtual void execute( int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
+  virtual void increment( int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
+  virtual void decrement( int stacks = 1, double value = DEFAULT_VALUE() );
+  virtual void extend_duration( player_t* p, timespan_t seconds );
+  virtual void extend_duration_or_trigger( timespan_t duration = timespan_t::min(), player_t* p = nullptr );
 
-  virtual void start    ( int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
-  virtual void refresh  ( int stacks = 0, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
-  virtual void bump     ( int stacks = 1, double value = DEFAULT_VALUE() );
+  virtual void start( int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
+  virtual void refresh( int stacks = 0, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
+  virtual void bump( int stacks = 1, double value = DEFAULT_VALUE() );
   virtual void override_buff ( int stacks = 1, double value = DEFAULT_VALUE() );
   virtual bool may_react( int stacks = 1 );
   virtual int stack_react();
@@ -293,6 +294,7 @@ public:
   const char* name() const { return name_str.c_str(); }
   util::string_view source_name() const;
   int max_stack() const { return _max_stack; }
+  int initial_stack() const { return _initial_stack; }
   const spell_data_t* get_trigger_data() const
   { return trigger_data; }
 
@@ -306,6 +308,8 @@ public:
   buff_t* set_duration_multiplier( double );
   buff_t* set_max_stack( int max_stack );
   buff_t* modify_max_stack( int max_stack );
+  buff_t* set_initial_stack( int initial_stack );
+  buff_t* modify_initial_stack( int initial_stack );
   buff_t* set_cooldown( timespan_t duration );
   buff_t* modify_cooldown( timespan_t duration );
   buff_t* set_period( timespan_t );

--- a/engine/buff/sc_buff.hpp
+++ b/engine/buff/sc_buff.hpp
@@ -71,10 +71,10 @@ public:
   // static values
 private: // private because changing max_stacks requires resizing some stack-dependant vectors
   int _max_stack;
+  int _initial_stack;
   const spell_data_t* trigger_data;
 
 public:
-  int _initial_stack;
   double default_value;
   size_t default_value_effect_idx;
   double default_value_effect_multiplier;
@@ -235,12 +235,16 @@ public:
   bool remains_gt( timespan_t time ) const;
   bool remains_lt( timespan_t time ) const;
   bool at_max_stacks( int mod = 0 ) const { return check() + mod >= max_stack(); }
+  // For trigger()/execute(), default value of stacks is -1, since we want to allow for explicitly calls of stacks=1 to
+  // override using buff_t::_initial_stack
   int _resolve_stacks( int stacks ) { return stacks == -1 ? ( reverse ? _max_stack : _initial_stack ) : stacks; }
   bool trigger( action_t*, int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
   bool trigger( timespan_t duration );
   bool trigger( int stacks, timespan_t duration );
   virtual bool trigger( int stacks = -1, double value = DEFAULT_VALUE(), double chance = -1.0, timespan_t duration = timespan_t::min() );
   virtual void execute( int stacks = -1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
+  // For increment()/decrement(), default value of stack is 1, since expectation when calling these with default value
+  // is that the stack count will be adjusted by a single stack, regardless of buff_t::_initial_stack
   virtual void increment( int stacks = 1, double value = DEFAULT_VALUE(), timespan_t duration = timespan_t::min() );
   virtual void decrement( int stacks = 1, double value = DEFAULT_VALUE() );
   virtual void extend_duration( player_t* p, timespan_t seconds );

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -1678,7 +1678,7 @@ struct bt_dummy_buff_t : public druid_buff_t<buff_t>
     p().buff.bt_moonfire->expire();
     p().buff.bt_brutal_slash->expire();
 
-    p().buff.bloodtalons->trigger( p().buff.bloodtalons->max_stack() );
+    p().buff.bloodtalons->trigger();
 
     return true;
   }
@@ -4702,7 +4702,7 @@ struct tigers_fury_t : public cat_attack_t
     p()->buff.tigers_fury->trigger( duration );
 
     if ( p()->legendary.eye_of_fearful_symmetry->ok() )
-      p()->buff.eye_of_fearful_symmetry->trigger( p()->legendary.eye_of_fearful_symmetry->initial_stacks() );
+      p()->buff.eye_of_fearful_symmetry->trigger();
 
     // p()->buff.jungle_fury->trigger( 1, buff_t::DEFAULT_VALUE(), 1.0, duration );
   }
@@ -7133,7 +7133,7 @@ struct warrior_of_elune_t : public druid_spell_t
 
     p()->cooldown.warrior_of_elune->reset( false );
 
-    p()->buff.warrior_of_elune->trigger( p()->talent.warrior_of_elune->initial_stacks() );
+    p()->buff.warrior_of_elune->trigger();
   }
 
   bool ready() override

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -1678,7 +1678,7 @@ struct bt_dummy_buff_t : public druid_buff_t<buff_t>
     p().buff.bt_moonfire->expire();
     p().buff.bt_brutal_slash->expire();
 
-    p().buff.bloodtalons->trigger();
+    p().buff.bloodtalons->trigger( p().buff.bloodtalons->max_stack() );
 
     return true;
   }
@@ -4702,7 +4702,7 @@ struct tigers_fury_t : public cat_attack_t
     p()->buff.tigers_fury->trigger( duration );
 
     if ( p()->legendary.eye_of_fearful_symmetry->ok() )
-      p()->buff.eye_of_fearful_symmetry->trigger();
+      p()->buff.eye_of_fearful_symmetry->trigger( p()->legendary.eye_of_fearful_symmetry->initial_stacks() );
 
     // p()->buff.jungle_fury->trigger( 1, buff_t::DEFAULT_VALUE(), 1.0, duration );
   }
@@ -7133,7 +7133,7 @@ struct warrior_of_elune_t : public druid_spell_t
 
     p()->cooldown.warrior_of_elune->reset( false );
 
-    p()->buff.warrior_of_elune->trigger();
+    p()->buff.warrior_of_elune->trigger( p()->talent.warrior_of_elune->initial_stacks() );
   }
 
   bool ready() override

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -6559,6 +6559,7 @@ rogue_td_t::rogue_td_t( player_t* target, rogue_t* source ) :
     ->set_default_value_from_effect_type( A_MOD_CRIT_CHANCE_FROM_CASTER )
     ->set_cooldown( timespan_t::zero() );
   debuffs.flagellation = make_buff( *this, "flagellation", source->covenant.flagellation )
+    ->set_initial_stack( 1 )
     ->set_refresh_behavior( buff_refresh_behavior::DISABLED )
     ->set_cooldown( timespan_t::zero() )
     ->set_stack_change_callback( [ source ]( buff_t*, int, int new_ ) {


### PR DESCRIPTION
Implement parsing spell data for initial stack of buffs, and applying that number of stacks by default when the buff is called via trigger() or execute() with no explicit stack value.

For reverse buffs, behavior remains unchanged where a default value call will results in decrement(1).
Similarly, decrement() and increment() remain unchanged as expected behavior when those are called with default value is that the buff is adjusted by a single stack each time.

* buff_t::set_initial_stack( int ) and buff_t::modify_initial_stack( int ) can be used to explicitly set/modify the initial stacks, overriding what's read off the spell data. Can be chained at buff construction like the *_max_stack() counterparts.
* buff_t::initial_stack() will return the _initial_stack value.