### PR TITLE
[Warrior] Added HR rage gain to Shield Slam

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -4054,6 +4054,7 @@ struct shield_slam_t : public warrior_attack_t
   {
     parse_options( options_str );
     energize_type = action_energize::NONE;
+    rage_gain += p->talents.heavy_repercussions->effectN( 2 ).resource( RESOURCE_RAGE );
   }
 
   double action_multiplier() const override


### PR DESCRIPTION
When HR is talented Shield Slam generates 3 extra Rage.