### PR TITLE
[Death Knight]: Fix player damage multiplier bug with frenzied monstrosity

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9124,7 +9124,8 @@ void death_knight_t::create_buffs()
 
   // Legendaries
   buffs.frenzied_monstrosity = make_buff( this, "frenzied_monstrosity", find_spell ( 334896 ) )
-    -> add_invalidate( CACHE_ATTACK_SPEED );
+    -> add_invalidate( CACHE_ATTACK_SPEED )
+    -> add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
 }
 
 // death_knight_t::init_gains ===============================================


### PR DESCRIPTION
Taez noticed an issue with the player damage multiplier not working properly with Frenzied Monstrosity, and I learned I need to invalidate caches for any buff effects not just stats.  He sent me some profiles to run and we carefully validated the results together.