### PR TITLE
Add resource overflow tracking.

### DIFF
--- a/engine/player/player_collected_data.hpp
+++ b/engine/player/player_collected_data.hpp
@@ -58,7 +58,7 @@ struct player_collected_data_t
   extended_sample_data_t target_metric;
   mutex_t target_metric_mutex;
 
-  std::vector<simple_sample_data_t> resource_lost, resource_gained;
+  std::vector<simple_sample_data_t> resource_lost, resource_gained, resource_overflowed;
   struct resource_timeline_t
   {
     resource_e type;

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -319,7 +319,7 @@ struct player_t : public actor_t
   timespan_t iteration_fight_length;
   timespan_t iteration_waiting_time, iteration_pooling_time;
   int iteration_executed_foreground_actions;
-  std::array< double, RESOURCE_MAX > iteration_resource_lost, iteration_resource_gained;
+  std::array< double, RESOURCE_MAX > iteration_resource_lost, iteration_resource_gained, iteration_resource_overflowed;
   double rps_gain, rps_loss;
   std::string tmi_debug_file_str;
   double tmi_window;

--- a/engine/report/json/report_json.cpp
+++ b/engine/report/json/report_json.cpp
@@ -620,6 +620,8 @@ void collected_data_to_json( JsonOutput root, const ::report::json::report_confi
     // Rest of the resource summaries are printed only based on relevant resources
     range::for_each( relevant_resources, [ &root, &cd ]( resource_e r ) {
       root[ "resource_lost" ][ util::resource_type_string( r ) ] = cd.resource_lost[ r ];
+      
+      root[ "resource_overflowed" ][ util::resource_type_string( r ) ] = cd.resource_overflowed[ r ];
 
       if ( r < cd.combat_end_resource.size() )
       {

--- a/engine/report/sc_report_html_player.cpp
+++ b/engine/report/sc_report_html_player.cpp
@@ -2733,6 +2733,7 @@ void print_html_resource_changes_table( report::sc_html_stream& os, const player
      << "<th>Start</th>\n"
      << "<th>Gain/s</th>\n"
      << "<th>Loss/s</th>\n"
+     << "<th>Overflow (Total)</th>\n"
      << "<th>End (Avg)</th>\n"
      << "<th>Min</th>\n"
      << "<th>Max</th>\n"
@@ -2758,11 +2759,13 @@ void print_html_resource_changes_table( report::sc_html_stream& os, const player
                 "<td class=\"right\">%.1f</td>\n"
                 "<td class=\"right\">%.1f</td>\n"
                 "<td class=\"right\">%.1f</td>\n"
+                "<td class=\"right\">%.1f</td>\n"
                 "</tr>\n",
                 util::inverse_tokenize( util::resource_type_string( rt ) ),
                 p.collected_data.combat_start_resource[ rt ].mean(),
                 p.collected_data.resource_gained[ rt ].mean() / p.collected_data.fight_length.mean(),
                 p.collected_data.resource_lost[ rt ].mean() / p.collected_data.fight_length.mean(),
+                p.collected_data.resource_overflowed[ rt ].mean(),
                 p.collected_data.combat_end_resource[ rt ].mean(),
                 p.collected_data.combat_end_resource[ rt ].min(),
                 p.collected_data.combat_end_resource[ rt ].max() );


### PR DESCRIPTION
Collect cumulative overflow amount per resource per player, similar to resource gained and lost.

Requested by WarcraftPriests/sl-shadow-priest#155