### PR TITLE
[ci] fix 2019 smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
             platform: x64
             configuration: Debug-NoNetworking
             projectFile: vs/simc_vs2019.vcxproj
-            executable: vs\x64\Debug-NoNetworking\simc_vs2019.exe
+            executable: simc_vs2019.exe
             runSmokeTest: true
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
             platform: x64
             configuration: Debug-NoNetworking
             projectFile: vs/simc_vs2019.vcxproj
-            executable: simc_vs2019.exe
+            executable: ./simc_vs2019.exe
             runSmokeTest: true
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
             platform: x64
             configuration: Debug-NoNetworking
             projectFile: vs/simc_vs2019.vcxproj
-            executable: ./simc_vs2019.exe
+            executable: vs\x64\Debug-NoNetworking\simc_vs2019.exe
             runSmokeTest: true
 
     steps:

--- a/vs/simc_vs2019.vcxproj
+++ b/vs/simc_vs2019.vcxproj
@@ -38,7 +38,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <!-- <Import Project="OutputDirectories.props" /> -->
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/vs/simc_vs2019.vcxproj
+++ b/vs/simc_vs2019.vcxproj
@@ -38,7 +38,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="OutputDirectories.props" />
+    <!-- <Import Project="OutputDirectories.props" /> -->
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
I added the copy command back in for vs2019 https://github.com/simulationcraft/simc/commit/aff4ef8687a86c6bc968eebd6f93b87af7f8d1f5 and this commit broke the smoke tests for the solution