### PR TITLE
Add player_t::find_target_data

### DIFF
--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -54,6 +54,11 @@ paladin_t::paladin_t( sim_t* sim, util::string_view name, race_e r ) :
   resource_regeneration = regen_type::DYNAMIC;
 }
 
+const paladin_td_t* paladin_t::find_target_data( const player_t* target ) const
+{
+  return target_data[ target ];
+}
+
 paladin_td_t* paladin_t::get_target_data( player_t* target ) const
 {
   paladin_td_t*& td = target_data[ target ];

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -583,6 +583,7 @@ public:
 
   target_specific_t<paladin_td_t> target_data;
 
+  virtual const paladin_td_t* find_target_data( const player_t* target ) const override;
   virtual paladin_td_t* get_target_data( player_t* target ) const override;
 
   cooldown_waste_data_t* get_cooldown_waste_data( cooldown_t* cd, cooldown_waste_data_t *(*factory)(cooldown_t*) = nullptr )

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -2041,6 +2041,11 @@ void priest_t::create_apl_default()
   def->add_action( this, "Smite" );
 }
 
+const priest_td_t* priest_t::find_target_data( const player_t* target ) const
+{
+  return _target_data[ target ];
+}
+
 /**
  * Obtain target_data for given target.
  * Always returns non-null targetdata pointer

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -545,6 +545,7 @@ public:
   void init_action_list() override;
   void combat_begin() override;
   void init_rng() override;
+  const priest_td_t* find_target_data( const player_t* target ) const override;
   priest_td_t* get_target_data( player_t* target ) const override;
   std::unique_ptr<expr_t> create_expression( util::string_view name_str ) override;
   void arise() override;
@@ -604,10 +605,6 @@ public:
   int shadow_weaving_active_dots( const player_t* target, const unsigned int spell_id ) const;
   double shadow_weaving_multiplier( const player_t* target, const unsigned int spell_id ) const;
   pets::fiend::base_fiend_pet_t* get_current_main_pet();
-  const priest_td_t* find_target_data( const player_t* target ) const
-  {
-    return _target_data[ target ];
-  }
 
   std::string default_potion() const override;
   std::string default_flask() const override;

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -1121,6 +1121,11 @@ public:
 
   target_specific_t<death_knight_td_t> target_data;
 
+  const death_knight_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   death_knight_td_t* get_target_data( player_t* target ) const override
   {
     death_knight_td_t*& td = target_data[ target ];
@@ -2576,6 +2581,11 @@ struct magus_pet_t : public death_knight_pet_t
   };
 
   target_specific_t<magus_td_t> target_data;
+
+  const magus_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
 
   magus_td_t* get_target_data( player_t* target ) const override
   {

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -651,6 +651,7 @@ public:
   // overridden player_t combat functions
   void assess_damage( school_e, result_amount_type, action_state_t* s ) override;
   void combat_begin() override;
+  const demon_hunter_td_t* find_target_data( const player_t* target ) const override;
   demon_hunter_td_t* get_target_data( player_t* target ) const override;
   void interrupt() override;
   void regen( timespan_t periodicity ) override;
@@ -6617,6 +6618,11 @@ std::unique_ptr<expr_t> actions::demon_hunter_sigil_t::create_sigil_expression( 
   }
 
   return {};
+}
+
+const demon_hunter_td_t* demon_hunter_t::find_target_data( const player_t* target ) const
+{
+  return _target_data[ target ];
 }
 
 /* Always returns non-null targetdata pointer

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -1002,6 +1002,7 @@ public:
   void recalculate_resource_max( resource_e, gain_t* g = nullptr ) override;
   void create_options() override;
   std::string create_profile( save_e type ) override;
+  const druid_td_t* find_target_data( const player_t* target ) const override;
   druid_td_t* get_target_data( player_t* target ) const override;
   void copy_from( player_t* ) override;
   void output_json_report( js::JsonOutput& /* root */ ) const override;
@@ -10604,6 +10605,14 @@ void druid_t::shapeshift( form_e f )
   }
 
   form = f;
+}
+
+// druid_t::find_target_data ================================================
+
+const druid_td_t* druid_t::find_target_data( const player_t* target ) const
+{
+  assert( target );
+  return target_data[ target ];
 }
 
 // druid_t::get_target_data =================================================

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -721,16 +721,16 @@ public:
 
   target_specific_t<hunter_td_t> target_data;
 
+  const hunter_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   hunter_td_t* get_target_data( player_t* target ) const override
   {
     hunter_td_t*& td = target_data[target];
     if ( !td ) td = new hunter_td_t( target, const_cast<hunter_t*>( this ) );
     return td;
-  }
-
-  const hunter_td_t* find_target_data( const player_t* target ) const
-  {
-    return target_data[ target ];
   }
 
   std::vector<action_t*> background_actions;
@@ -1585,17 +1585,17 @@ struct hunter_main_pet_t final : public hunter_main_pet_base_t
 
   target_specific_t<hunter_main_pet_td_t> target_data;
 
+  const hunter_main_pet_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   hunter_main_pet_td_t* get_target_data( player_t* target ) const override
   {
     hunter_main_pet_td_t*& td = target_data[target];
     if ( !td )
       td = new hunter_main_pet_td_t( target, const_cast<hunter_main_pet_t*>( this ) );
     return td;
-  }
-
-  const hunter_main_pet_td_t* find_target_data( const player_t* target ) const
-  {
-    return target_data[ target ];
   }
 
   resource_e primary_resource() const override

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -862,6 +862,11 @@ public:
 
   target_specific_t<mage_td_t> target_data;
 
+  const mage_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   mage_td_t* get_target_data( player_t* target ) const override
   {
     mage_td_t*& td = target_data[ target ];

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -1020,6 +1020,10 @@ public:
   void activate() override;
   void collect_resource_timeline_information() override;
   std::unique_ptr<expr_t> create_expression( util::string_view name_str ) override;
+  const monk_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
   monk_td_t* get_target_data( player_t* target ) const override
   {
     monk_td_t*& td = target_data[ target ];
@@ -2137,6 +2141,11 @@ public:
   const monk_t* o() const
   {
     return debug_cast<const monk_t*>( owner );
+  }
+
+  const sef_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
   }
 
   sef_td_t* get_target_data( player_t* target ) const override

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -820,6 +820,11 @@ public:
 
   target_specific_t<rogue_td_t> target_data;
 
+  const rogue_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   rogue_td_t* get_target_data( player_t* target ) const override
   {
     rogue_td_t*& td = target_data[ target ];

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -897,6 +897,11 @@ public:
 
   target_specific_t<shaman_td_t> target_data;
 
+  const shaman_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   shaman_td_t* get_target_data( player_t* target ) const override
   {
     shaman_td_t*& td = target_data[ target ];

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -673,6 +673,11 @@ public:
 
   target_specific_t<warrior_td_t> target_data;
 
+  const warrior_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   warrior_td_t* get_target_data( player_t* target ) const override
   {
     warrior_td_t*& td = target_data[ target ];

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -645,6 +645,11 @@ public:
 
   target_specific_t<warlock_td_t> target_data;
 
+  const warlock_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   warlock_td_t* get_target_data( player_t* target ) const override
   {
     warlock_td_t*& td = target_data[ target ];

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -69,6 +69,11 @@ struct warlock_pet_t : public pet_t
 
   target_specific_t<warlock_pet_td_t> target_data;
 
+  const warlock_pet_td_t* find_target_data( const player_t* target ) const override
+  {
+    return target_data[ target ];
+  }
+
   warlock_pet_td_t* get_target_data( player_t* target ) const override
   {
     warlock_pet_td_t*& td = target_data[ target ];

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -5666,7 +5666,8 @@ struct reaping_flames_t : public azerite_essence_major_t
 
         target->register_on_demise_callback( player, [ this ] ( player_t* enemy )
         {
-          if ( player->get_target_data( enemy )->debuff.reaping_flames_tracker->check() )
+          auto td = player->find_target_data( enemy );
+          if ( td && td->debuff.reaping_flames_tracker->check() )
           {
             cooldown->adjust( timespan_t::from_seconds( cd_reset ) - cooldown->duration );
             damage_buff->trigger();

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -117,7 +117,7 @@ double pet_t::composite_player_target_multiplier( player_t* target, school_e sch
 {
   double m = player_t::composite_player_target_multiplier( target, school );
 
-  if ( auto td = owner->get_target_data( target ) )
+  if ( auto td = owner->find_target_data( target ) )
   {
     m *= 1.0 + td->debuff.condensed_lifeforce->check_value();
 

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -4123,7 +4123,7 @@ double player_t::composite_player_target_multiplier( player_t* target, school_e 
   if ( buffs.wild_hunt_tactics && target->health_percentage() > 75.0 )
     m *= 1.0 + buffs.wild_hunt_tactics->default_value;
 
-  auto td = get_target_data( target );
+  auto td = find_target_data( target );
   if ( td )
   {
     m *= 1.0 + td->debuff.condensed_lifeforce->check_value();
@@ -4154,7 +4154,7 @@ double player_t::composite_player_target_crit_chance( player_t* target ) const
 {
   double c = 0.0;
 
-  if ( actor_target_data_t* td = get_owner_or_self()->get_target_data( target ) )
+  if ( const actor_target_data_t* td = get_owner_or_self()->find_target_data( target ) )
   {
     // Essence: Blood of the Enemy Major debuff
     c += td->debuff.blood_of_the_enemy->check_stack_value();

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -1081,6 +1081,9 @@ public:
   virtual bool has_t18_class_trinket() const;
 
   // Targetdata stuff
+  virtual const actor_target_data_t* find_target_data( const player_t* /* target */ ) const
+  { return nullptr; }
+
   virtual actor_target_data_t* get_target_data( player_t* /* target */ ) const
   { return nullptr; }
 

--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -395,8 +395,8 @@ void dauntless_duelist( special_effect_t& effect )
       if ( p->sim->event_mgr.canceled )
         return;
 
-      auto td = p->get_target_data( t );
-      if ( td->debuff.adversary->check() )
+      auto td = p->find_target_data( t );
+      if ( td && td->debuff.adversary->check() )
         cb->activate();
     } );
   } );

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -1665,9 +1665,9 @@ void items::briny_barnacle( special_effect_t& effect )
         return;
       }
 
-      auto td = p->get_target_data( target );
+      auto td = p->find_target_data( target );
 
-      if ( td->debuff.choking_brine->up() )
+      if ( td && td->debuff.choking_brine->up() )
       {
         target->sim->print_log( "Enemy {} dies while afflicted by Choking Brine, applying debuff on all neaby enemies",
                                 target->name_str );
@@ -4427,11 +4427,9 @@ void items::dribbling_inkpod( special_effect_t& effect )
 
     void trigger( action_t* a, action_state_t* s ) override
     {
-      auto td = listener->get_target_data( s->target );
-      assert( td );
-      assert( td->debuff.conductive_ink );
+      auto td = listener->find_target_data( s->target );
 
-      if ( td->debuff.conductive_ink->check() && s->target->health_percentage() <= hp_pct )
+      if ( td && td->debuff.conductive_ink->check() && s->target->health_percentage() <= hp_pct )
       {
         dbc_proc_callback_t::trigger( a, s );
       }
@@ -4439,11 +4437,11 @@ void items::dribbling_inkpod( special_effect_t& effect )
 
     void execute( action_t* a, action_state_t* s ) override
     {
-      auto td = listener->get_target_data( s->target );
+      auto td = listener->find_target_data( s->target );
 
       // Simultaneous attacks that hit at once can all count as the damage to burst the debuff, triggering the callback
       // multiple times. Ensure the event-scheduled callback execute checks for the debuff so we don't get multiple hits
-      if ( td->debuff.conductive_ink->check() )
+      if ( td && td->debuff.conductive_ink->check() )
       {
         dbc_proc_callback_t::execute( a, s );
       }
@@ -5698,9 +5696,8 @@ struct shredded_psyche_cb_t : public dbc_proc_callback_t
       return;
     }
 
-    auto td        = a->player->get_target_data( target );
-    buff_t* debuff = td->debuff.psyche_shredder;
-    if ( !debuff->check() )
+    auto td = a->player->find_target_data( target );
+    if ( !td || !td->debuff.psyche_shredder->check() )
       return;
 
     dbc_proc_callback_t::trigger( a, state );

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -1915,7 +1915,8 @@ struct shadow_blade_t : public proc_spell_t
   {
     double ctm = proc_spell_t::composite_target_multiplier( target );
 
-    ctm *= 1.0 + player -> get_target_data( target ) -> debuff.shadow_blades -> check_stack_value();
+    if ( auto td = player -> find_target_data( target ) )
+      ctm *= 1.0 + td -> debuff.shadow_blades -> check_stack_value();
 
     return ctm;
   }
@@ -2669,7 +2670,7 @@ struct haymaker_driver_t : public dbc_proc_callback_t
     if ( trigger_state -> result_amount <= 0 )
       return;
 
-    actor_target_data_t* td = effect.player -> get_target_data( trigger_state -> target );
+    const actor_target_data_t* td = effect.player -> find_target_data( trigger_state -> target );
 
     if ( td && td -> debuff.brutal_haymaker -> check() )
       accumulator -> damage += trigger_state -> result_amount * multiplier;


### PR DESCRIPTION
Since we're forced to use get_target_data in player_t::composite_player_target_multiplier, target data will be created for every target. This attempts to fix that issue by introducing find_target_data, which doesn't force the creation of the target data object.