### PR TITLE
[Death Knight] Epidemic fixes

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5070,6 +5070,12 @@ struct epidemic_damage_main_t : public death_knight_spell_t
     death_knight_spell_t( "epidemic_main", p, p -> find_spell( 212739 ) )
   {
     background = true;
+    // "Max targets" is '7' in spelldata, but that probably accounts for the main enemy that triggers the aoe
+    // In-game testing shows that it doesn't hit more than 6 enemies
+    // This value is what is used for epidemic_damage_aoe_t, as the impact action for epidemic_damage_main_t
+    // is set to the impact action from epidemic_damage_aoe_t
+    // Number of targets for hit for this spell is controlled by epidemic_t spell_data
+    aoe = aoe - 1;
   }
 };
 
@@ -5079,9 +5085,9 @@ struct epidemic_damage_aoe_t : public death_knight_spell_t
     death_knight_spell_t( "epidemic_aoe", p, p -> find_spell( 215969 ) )
   {
     background = true;
-    // "Max targets" is '7' in spelldata, but that probably accounts for the main enemy that triggers the aoe
-    // In-game testing shows that it doesn't hit more than 6 enemies
-    aoe = aoe - 1;
+    // Since we set epidemic_damage_main_t's impact action to be the impact action from this spell, we end up using
+    // the aoe value from that spell, instead of this one
+    aoe = 0;
   }
 
   size_t available_targets( std::vector< player_t* >& tl ) const override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5070,14 +5070,21 @@ struct epidemic_damage_main_t : public death_knight_spell_t
     death_knight_spell_t( "epidemic_main", p, p -> find_spell( 212739 ) )
   {
     background = true;
-    // "Max targets" is '7' in spelldata, but that probably accounts for the main enemy that triggers the aoe
-    // In-game testing shows that it doesn't hit more than 6 enemies
-    // This value is what is used for epidemic_damage_aoe_t, as the impact action for epidemic_damage_main_t
-    // is set to the impact action from epidemic_damage_aoe_t
-    // Number of targets for hit for this spell is controlled by epidemic_t spell_data
-    aoe = aoe - 1;
+    // Ignore spelldata for max targets for the main spell, as it is single target only
+    aoe = 0;
     // this spell has both coefficients in it, and it seems like it is reading #2, the aoe portion, instead of #1
     attack_power_mod.direct = data().effectN( 1 ).ap_coeff();
+  }
+};
+
+struct epidemic_damage_aoe_t : public death_knight_spell_t
+{
+  epidemic_damage_aoe_t( death_knight_t* p ) :
+    death_knight_spell_t( "epidemic_aoe", p, p -> find_spell( 215969 ) )
+  {
+    background = true;
+    // Main is one target, aoe is the other targets, so we take 1 off the max targets
+    aoe = aoe - 1;
   }
 
   size_t available_targets( std::vector< player_t* >& tl ) const override
@@ -5091,18 +5098,6 @@ struct epidemic_damage_main_t : public death_knight_spell_t
     }
 
     return tl.size();
-  }
-};
-
-struct epidemic_damage_aoe_t : public death_knight_spell_t
-{
-  epidemic_damage_aoe_t( death_knight_t* p ) :
-    death_knight_spell_t( "epidemic_aoe", p, p -> find_spell( 215969 ) )
-  {
-    background = true;
-    // Since we set epidemic_damage_main_t's impact action to be the impact action from this spell, we end up using
-    // the aoe value from that spell, instead of this one
-    aoe = 0;
   }
 };
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5079,18 +5079,6 @@ struct epidemic_damage_main_t : public death_knight_spell_t
     // this spell has both coefficients in it, and it seems like it is reading #2, the aoe portion, instead of #1
     attack_power_mod.direct = data().effectN( 1 ).ap_coeff();
   }
-};
-
-struct epidemic_damage_aoe_t : public death_knight_spell_t
-{
-  epidemic_damage_aoe_t( death_knight_t* p ) :
-    death_knight_spell_t( "epidemic_aoe", p, p -> find_spell( 215969 ) )
-  {
-    background = true;
-    // Since we set epidemic_damage_main_t's impact action to be the impact action from this spell, we end up using
-    // the aoe value from that spell, instead of this one
-    aoe = 0;
-  }
 
   size_t available_targets( std::vector< player_t* >& tl ) const override
   {
@@ -5103,6 +5091,18 @@ struct epidemic_damage_aoe_t : public death_knight_spell_t
     }
 
     return tl.size();
+  }
+};
+
+struct epidemic_damage_aoe_t : public death_knight_spell_t
+{
+  epidemic_damage_aoe_t( death_knight_t* p ) :
+    death_knight_spell_t( "epidemic_aoe", p, p -> find_spell( 215969 ) )
+  {
+    background = true;
+    // Since we set epidemic_damage_main_t's impact action to be the impact action from this spell, we end up using
+    // the aoe value from that spell, instead of this one
+    aoe = 0;
   }
 };
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5076,6 +5076,8 @@ struct epidemic_damage_main_t : public death_knight_spell_t
     // is set to the impact action from epidemic_damage_aoe_t
     // Number of targets for hit for this spell is controlled by epidemic_t spell_data
     aoe = aoe - 1;
+    // this spell has both coefficients in it, and it seems like it is reading #2, the aoe portion, instead of #1
+    attack_power_mod.direct = data().effectN( 1 ).ap_coeff();
   }
 };
 


### PR DESCRIPTION
### Target cap Issue

Epidemic is capped at 20 targets, with the secondary eruption capped at 6 targets.  Spell data for the main spell, 207317, shows 20 max targets, and spell data for the child spell(s) both show 7 targets.  A change in SL shows that the first child spell, 212739, had a secondary spell effect added to it, that has matching coefficient with the other child spell, 215969.  Main spell still refers to both of them in the tool tip.  Testing has shown that the splash damage only hits 6 targets.

109 casts * 20 = 2180 main target hits
2180 main target hits * 6 = 13080 secondary splash hits
2180 main target hits * 7 = 15260 secondary splash hits

### Damage Issue

Epidemic was also using the wrong coefficient for epidemic_main.  a_mod was being set to 0.08 for both main, and aoe.  It should be 0.20 for main, and 0.08 for aoe.  In 212739 since it has both coefficients in it, it looks like it was using effect 2 coefficient, which is 0.08 instead of reading it from effect 1 which has 0.20.

#### Profile
```
./simc ../profiles/Tier25/T25_Death_Knight_Unholy.simc enemy=t1 enemy=t2 enemy=t3 enemy=4 enemy=5 enemy=6 enemy=7 enemy=8 enemy=9 enemy=10 enemy=11 enemy=12 enemy=13 enemy=14 enemy=15 enemy=16 enemy=17 enemy=18 enemy=19 enemy=20 enemy=21 enemy=22 enemy=23 enemy=24 enemy=25 enemy=26 enemy=27 enemy=28 enemy=29 enemy=30
```

#### Test Results
```
Original

    epidemic                   Count= 109.0|  2.698sec  DPE=126044| 0.00%  DPET=136432  DPR= 5493  pDPS=    0
    epidemic_aoe               Count=15258.3|  2.698sec  DPE=   600|44.10%  DPET=     0  DPR=    0  pDPS=30546  Miss= 0.00%  Hit=   222|   132|   395  Crit=   446|   264|   789|34.84%
    epidemic_main              Count=2179.8|  2.698sec  DPE=  2101|22.05%  DPET=     0  DPR=    0  pDPS=15272  Miss= 0.00%  Hit=   222|   132|   395  Crit=   446|   264|   789|34.83%

Post Fix
    epidemic                   Count= 108.6|  2.700sec  DPE=126129| 0.00%  DPET=136521  DPR= 5496  pDPS=    0
    epidemic_aoe               Count=13030.8|  2.700sec  DPE=   300|18.89%  DPET=     0  DPR=    0  pDPS=13107  Miss= 0.00%  Hit=   222|   132|   395  Crit=   446|   264|   791|34.84%
    epidemic_main              Count=2171.8|  2.700sec  DPE=  4505|47.23%  DPET=     0  DPR=    0  pDPS=32767  Miss= 0.00%  Hit=   556|   330|   988  Crit=  1116|   659|  1977|34.83%
```