### PR TITLE
[Priest] use correct spell references where possible

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -31,8 +31,8 @@ private:
   bool only_cwc;
 
 public:
-  mind_blast_t( priest_t& player, util::string_view options_str )
-    : priest_spell_t( "mind_blast", player, player.find_class_spell( "Mind Blast" ) ),
+  mind_blast_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "mind_blast", p, p.find_class_spell( "Mind Blast" ) ),
       mind_blast_insanity( priest().find_spell( 137033 )->effectN( 12 ).resource( RESOURCE_INSANITY ) ),
       whispers_of_the_damned_value( priest().azerite.whispers_of_the_damned.value( 2 ) ),
       harvested_thoughts_value( priest().azerite.thought_harvester.value( 1 ) ),
@@ -44,8 +44,8 @@ public:
                                    .trigger()
                                    ->effectN( 1 )
                                    .resource( RESOURCE_INSANITY ) ),
-      mind_flay_spell( player.find_specialization_spell( "Mind Flay" ) ),
-      mind_sear_spell( player.find_class_spell( "Mind Sear" ) ),
+      mind_flay_spell( p.find_specialization_spell( "Mind Flay" ) ),
+      mind_sear_spell( p.find_class_spell( "Mind Sear" ) ),
       only_cwc( false )
   {
     add_option( opt_bool( "only_cwc", only_cwc ) );
@@ -57,7 +57,7 @@ public:
     energize_amount = mind_blast_insanity;
     energize_amount *= 1 + priest().talents.fortress_of_the_mind->effectN( 2 ).percent();
 
-    spell_power_mod.direct *= 1.0 + player.talents.fortress_of_the_mind->effectN( 4 ).percent();
+    spell_power_mod.direct *= 1.0 + p.talents.fortress_of_the_mind->effectN( 4 ).percent();
 
     if ( priest().conduits.mind_devourer->ok() )
     {
@@ -70,7 +70,7 @@ public:
     base_dd_adder += whispers_of_the_damned_value;
 
     // Cooldown reduction
-    apply_affecting_aura( player.find_rank_spell( "Mind Blast", "Rank 2", PRIEST_SHADOW ) );
+    apply_affecting_aura( p.find_rank_spell( "Mind Blast", "Rank 2", PRIEST_SHADOW ) );
   }
 
   void reset() override
@@ -505,8 +505,8 @@ struct shadow_word_death_t final : public priest_spell_t
 // ==========================================================================
 struct dispersion_t final : public priest_spell_t
 {
-  dispersion_t( priest_t& player, util::string_view options_str )
-    : priest_spell_t( "dispersion", player, player.find_class_spell( "Dispersion" ) )
+  dispersion_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "dispersion", p, p.find_class_spell( "Dispersion" ) )
   {
     parse_options( options_str );
 
@@ -565,8 +565,8 @@ struct shadowform_t final : public priest_spell_t
 // ==========================================================================
 struct silence_t final : public priest_spell_t
 {
-  silence_t( priest_t& player, util::string_view options_str )
-    : priest_spell_t( "silence", player, player.find_class_spell( "Silence" ) )
+  silence_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "silence", p, p.find_class_spell( "Silence" ) )
   {
     parse_options( options_str );
     may_miss = may_crit   = false;
@@ -704,7 +704,7 @@ struct shadowy_apparition_damage_t final : public priest_spell_t
 
 struct shadowy_apparition_spell_t final : public priest_spell_t
 {
-  shadowy_apparition_spell_t( priest_t& p ) : priest_spell_t( "shadowy_apparitions", p, p.find_spell( 78203 ) )
+  shadowy_apparition_spell_t( priest_t& p ) : priest_spell_t( "shadowy_apparitions", p, p.specs.shadowy_apparitions )
   {
     background   = true;
     proc         = false;
@@ -1109,12 +1109,12 @@ struct void_bolt_t final : public priest_spell_t
   {
     timespan_t dot_extension;
 
-    void_bolt_extension_t( priest_t& player, const spell_data_t* rank2_spell )
-      : priest_spell_t( "void_bolt_extension", player, rank2_spell )
+    void_bolt_extension_t( priest_t& p, const spell_data_t* rank2_spell )
+      : priest_spell_t( "void_bolt_extension", p, rank2_spell )
     {
       dot_extension = data().effectN( 1 ).time_value();
       aoe           = -1;
-      radius        = player.find_spell( 234746 )->effectN( 1 ).radius();
+      radius        = p.find_spell( 234746 )->effectN( 1 ).radius();
       may_miss      = false;
       background = dual = true;
       energize_type     = action_energize::ON_CAST;
@@ -1138,11 +1138,11 @@ struct void_bolt_t final : public priest_spell_t
   timespan_t hungering_void_base_duration;
   timespan_t hungering_void_crit_duration;
 
-  void_bolt_t( priest_t& player, util::string_view options_str )
-    : priest_spell_t( "void_bolt", player, player.find_spell( 205448 ) ),
+  void_bolt_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "void_bolt", p, p.find_spell( 205448 ) ),
       void_bolt_extension( nullptr ),
-      shadowfiend_cooldown( player.get_cooldown( "mindbender" ) ),
-      mindbender_cooldown( player.get_cooldown( "shadowfiend" ) ),
+      shadowfiend_cooldown( p.get_cooldown( "mindbender" ) ),
+      mindbender_cooldown( p.get_cooldown( "shadowfiend" ) ),
       hungering_void_base_duration(
           timespan_t::from_seconds( priest().talents.hungering_void->effectN( 3 ).base_value() ) ),
       hungering_void_crit_duration(
@@ -1154,10 +1154,10 @@ struct void_bolt_t final : public priest_spell_t
     cooldown->hasted           = true;
     affected_by_shadow_weaving = true;
 
-    auto rank2 = player.find_rank_spell( "Void Bolt", "Rank 2" );
+    auto rank2 = p.find_rank_spell( "Void Bolt", "Rank 2" );
     if ( rank2->ok() )
     {
-      void_bolt_extension = new void_bolt_extension_t( player, rank2 );
+      void_bolt_extension = new void_bolt_extension_t( p, rank2 );
     }
 
     if ( priest().conduits.dissonant_echoes->ok() )
@@ -1356,8 +1356,7 @@ struct surrender_to_madness_t final : public priest_spell_t
 // ==========================================================================
 struct mind_bomb_t final : public priest_spell_t
 {
-  mind_bomb_t( priest_t& player, util::string_view options_str )
-    : priest_spell_t( "mind_bomb", player, player.talents.mind_bomb )
+  mind_bomb_t( priest_t& p, util::string_view options_str ) : priest_spell_t( "mind_bomb", p, p.talents.mind_bomb )
   {
     parse_options( options_str );
     may_miss = may_crit   = false;
@@ -1373,8 +1372,8 @@ struct mind_bomb_t final : public priest_spell_t
 // ==========================================================================
 struct psychic_horror_t final : public priest_spell_t
 {
-  psychic_horror_t( priest_t& player, util::string_view options_str )
-    : priest_spell_t( "psychic_horror", player, player.talents.psychic_horror )
+  psychic_horror_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "psychic_horror", p, p.talents.psychic_horror )
   {
     parse_options( options_str );
     may_miss = may_crit   = false;
@@ -1434,7 +1433,7 @@ struct void_torrent_t final : public priest_spell_t
 // ==========================================================================
 struct psychic_link_t final : public priest_spell_t
 {
-  psychic_link_t( priest_t& p ) : priest_spell_t( "psychic_link", p, p.find_spell( 199486 ) )
+  psychic_link_t( priest_t& p ) : priest_spell_t( "psychic_link", p, p.talents.psychic_link )
   {
     background = true;
     may_crit   = false;
@@ -1524,7 +1523,7 @@ struct searing_nightmare_t final : public priest_spell_t
   const spell_data_t* mind_sear_spell;
 
   searing_nightmare_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "searing_nightmare", p, p.find_talent_spell( "Searing Nightmare" ) ),
+    : priest_spell_t( "searing_nightmare", p, p.talents.searing_nightmare ),
       child_swp( new shadow_word_pain_t( priest(), false ) ),
       mind_sear_spell( p.find_class_spell( "Mind Sear" ) )
   {
@@ -1578,7 +1577,7 @@ struct damnation_t final : public priest_spell_t
   propagate_const<devouring_plague_t*> child_dp;
 
   damnation_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "damnation", p, p.find_talent_spell( "Damnation" ) ),
+    : priest_spell_t( "damnation", p, p.talents.damnation ),
       child_swp( new shadow_word_pain_t( priest(), true ) ),  // Damnation still triggers SW:P as if it was hard casted
       child_vt( new vampiric_touch_t( priest(), false ) ),
       child_dp( new devouring_plague_t( priest(), false ) )
@@ -1752,7 +1751,7 @@ struct death_and_madness_buff_t final : public priest_buff_t<buff_t>
 // ==========================================================================
 struct ancient_madness_t final : public priest_buff_t<buff_t>
 {
-  ancient_madness_t( priest_t& p ) : base_t( p, "ancient_madness", p.find_talent_spell( "Ancient Madness" ) )
+  ancient_madness_t( priest_t& p ) : base_t( p, "ancient_madness", p.talents.ancient_madness )
   {
     if ( !data().ok() )
       return;


### PR DESCRIPTION
- always use `p` instead of `player`
- remove most duplicate `find_spell` entries
- fix error with incorrect Shadowy Apparition data ([causes a simc crash at low level](https://www.raidbots.com/simbot/report/jwS5FZg4GKYMmz6NjLsnmf/))