### PR TITLE
[Death Knight] Updated Eternal Hunger to b36401

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9327,7 +9327,7 @@ void death_knight_t::create_buffs()
 
   // Unholy
   buffs.dark_transformation = make_buff( this, "dark_transformation", spec.dark_transformation )
-        -> set_duration( spec.dark_transformation->duration() + conduits.eternal_hunger.time_value() )
+        -> set_duration( spec.dark_transformation->duration() + conduits.eternal_hunger -> effectN( 2 ).time_value() )
         -> set_cooldown( 0_ms ); // Handled by the ability
 
   buffs.runic_corruption = new runic_corruption_buff_t( this );
@@ -9813,6 +9813,11 @@ double death_knight_t::composite_player_pet_damage_multiplier( const action_stat
   if ( mastery.dreadblade -> ok() )
   {
     m *= 1.0 + cache.mastery_value();
+  }
+
+  if ( conduits.eternal_hunger.ok() )
+  {
+    m *= 1.0 + conduits.eternal_hunger.percent();
   }
 
   m *= 1.0 + spec.blood_death_knight -> effectN( 14 ).percent();


### PR DESCRIPTION
Changed from increasing duration by conduit level, to a fixed duration increase + scaling minion damage

Tested on beta and works with ghoul, aotd, apoc, gargoyle

```
Effects          :
#1 (id=835368)   : Apply Aura (6) | Modify Pet Damage Done% (429)
                   Base Value: 3 | Scaled Value: 3 | PvP Coefficient: 1.00000 | Target: Self (1)
#2 (id=874420)   : Apply Aura (6) | Add Flat Modifier (107): Spell Duration (1)
                   Base Value: 3000 | Scaled Value: 3000 | PvP Coefficient: 1.00000 | Misc Value: 1 | Target: Self (1)
                   Affected Spells: Dark Transformation (63560)
                   Family Flags: 69
Description      : Dark Transformation's duration is increased by ${$s2/1000} sec and your Minion damage is increased by |cFFFFFFFF${$s1}.1%|r.
```

