### PR TITLE
Fix Pelagos Soulbind Combat Meditation

### DIFF
--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -560,16 +560,13 @@ void combat_meditation( special_effect_t& effect )
       set_refresh_behavior( buff_refresh_behavior::EXTEND );
       set_duration_multiplier( duration_mod );
 
-      triggered_times = 0;
       ext_dur = duration_mod * timespan_t::from_seconds( p->find_spell( 328913 )->effectN( 2 ).base_value() );
 
       // TODO: add more faithful simulation of delay/reaction needed from player to walk into the sorrowful memories
       set_tick_callback( [ this ]( buff_t*, int, timespan_t ) {
-        if ( this->triggered_times++ < 3 && rng().roll( sim->shadowlands_opts.combat_meditation_extend_chance ) )
+        if ( current_tick <= 3 && rng().roll( sim->shadowlands_opts.combat_meditation_extend_chance ) )
           extend_duration( player, ext_dur );
       } );
-
-      set_stack_change_callback( [ this ]( buff_t*, int, int ) { triggered_times = 0; } );
     }
   };
 

--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -553,7 +553,6 @@ void combat_meditation( special_effect_t& effect )
   struct combat_meditation_buff_t : public stat_buff_t
   {
     timespan_t ext_dur;
-    int triggered_times;
     combat_meditation_buff_t( player_t* p, double duration_mod, bool icd_enabled ) : stat_buff_t( p, "combat_meditation", p->find_spell( 328908 ) )
     {
       set_cooldown( icd_enabled ? data().effectN( 3 ).trigger()->duration() : 0_ms );

--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -343,7 +343,7 @@ struct sim_t : private sc_thread_t
   {
     /// Chance to catch each expelled sorrowful memory to extend the buff duration
     /// TODO: Set this to a reasonable value
-    double combat_meditation_extend_chance = 1;
+    double combat_meditation_extend_chance = 1.0;
     /// Number of nearby allies & enemies for the pointed courage soulbind
     unsigned pointed_courage_nearby = 5;
     /// Number of nearby allies when you proc lead by example

--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -343,7 +343,7 @@ struct sim_t : private sc_thread_t
   {
     /// Chance to catch each expelled sorrowful memory to extend the buff duration
     /// TODO: Set this to a reasonable value
-    double combat_meditation_extend_chance = 0.5;
+    double combat_meditation_extend_chance = 1;
     /// Number of nearby allies & enemies for the pointed courage soulbind
     unsigned pointed_courage_nearby = 5;
     /// Number of nearby allies when you proc lead by example


### PR DESCRIPTION
Limit combat meditation to three extensions per ability use.
Change default orb pickup chance to 100%
