### PR TITLE
[Death Knight] Phearomones

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -501,6 +501,7 @@ public:
 
     // Legendaries
     buff_t* frenzied_monstrosity;
+    buff_t* death_turf;
   } buffs;
 
   struct runeforge_t {
@@ -956,7 +957,7 @@ public:
   struct legendary_t
   { // Commented out = NYI                        // bonus ID
     // Shared
-    // item_runeforge_t phearomones; // 6954
+    item_runeforge_t phearomones; // 6954
     item_runeforge_t superstrain; // 6953
 
     // Blood
@@ -1658,6 +1659,30 @@ struct death_knight_pet_t : public pet_t
     }
 
     return m;
+  }
+
+  double composite_melee_haste() const override
+  {
+    double haste = pet_t::composite_melee_haste();
+
+    if (o() -> legendary.phearomones -> ok())
+    {
+      haste *= 1.0 / (1.0 + o() -> buffs.death_turf -> check_value());
+    }
+
+    return haste;
+  }
+
+  double composite_spell_haste() const override
+  {
+    double haste = pet_t::composite_spell_haste();
+
+    if (o() -> legendary.phearomones -> ok())
+    {
+      haste *= 1.0 / (1.0 + o() -> buffs.death_turf -> check_value());
+    }
+
+    return haste;
   }
 };
 
@@ -4478,6 +4503,12 @@ struct death_and_decay_base_t : public death_knight_spell_t
     {
       p() -> active_spells.bone_spike_graveyard -> set_target( execute_state ->target );
       p() -> active_spells.bone_spike_graveyard -> execute();
+    }
+
+    if ( p() -> legendary.phearomones -> ok() )
+    {
+      p() -> buffs.death_turf -> trigger();
+      p() -> buffs.death_turf -> set_duration(data().duration() + 500_ms);
     }
 
     make_event<ground_aoe_event_t>( *sim, player, ground_aoe_params_t()
@@ -8393,6 +8424,11 @@ double death_knight_t::composite_melee_haste() const
     haste *= buffs.bone_shield -> value();
   }
 
+  if ( legendary.phearomones -> ok() )
+  {
+    haste *= 1.0 / ( 1.0 + buffs.death_turf -> check_value() );
+  }
+
   return haste;
 }
 
@@ -8409,6 +8445,11 @@ double death_knight_t::composite_spell_haste() const
   if ( buffs.bone_shield -> up() && spec.marrowrend_2 -> ok() )
   {
     haste *= buffs.bone_shield -> value();
+  }
+
+  if ( legendary.phearomones -> ok() )
+  {
+    haste *= 1.0 / ( 1.0 + buffs.death_turf -> check_value() );
   }
 
   return haste;
@@ -8757,7 +8798,7 @@ void death_knight_t::init_spells()
   // Legendary Items
 
   // Shared
-  // legendary.phearomones = find_runeforge_legendary( "Phearomones" );
+  legendary.phearomones = find_runeforge_legendary( "Phearomones" );
   legendary.superstrain = find_runeforge_legendary( "Superstrain" );
 
   // Blood
@@ -9449,6 +9490,10 @@ void death_knight_t::create_buffs()
   buffs.frenzied_monstrosity = make_buff( this, "frenzied_monstrosity", find_spell ( 334896 ) )
     -> add_invalidate( CACHE_ATTACK_SPEED )
     -> add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
+
+  buffs.death_turf = make_buff( this, "death_turf", find_spell ( 335180) )
+    -> set_default_value( specialization() == DEATH_KNIGHT_BLOOD ? find_spell( 335180 ) -> effectN(1).percent() / 2 : find_spell( 335180 ) -> effectN(1).percent() )
+    -> add_invalidate( CACHE_HASTE );
 }
 
 // death_knight_t::init_gains ===============================================

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9484,7 +9484,9 @@ void death_knight_t::create_buffs()
   buffs.death_turf = make_buff( this, "death_turf", find_spell ( 335180) )
     -> set_default_value_from_effect( 1 )
     -> set_pct_buff_type( STAT_PCT_BUFF_HASTE );
-  if ( specialization() == DEATH_KNIGHT_BLOOD ) {
+// According to tooltip data and ingame testing, the buff's value is halved for blood
+  if ( specialization() == DEATH_KNIGHT_BLOOD ) 
+  {
     buffs.death_turf -> default_value /= 2;
   }
 }

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -6765,14 +6765,6 @@ struct unholy_blight_dot_t : public death_knight_spell_t
 
     p() -> active_spells.virulent_plague -> set_target( state -> target );
     p() -> active_spells.virulent_plague -> execute();
-
-    if ( p() -> legendary.superstrain -> ok() )
-    {
-      p() -> active_spells.frost_fever -> set_target( state -> target );
-      p() -> active_spells.frost_fever -> execute();
-      p() -> active_spells.blood_plague -> set_target( state -> target );
-      p() -> active_spells.blood_plague -> execute();
-    }
   }
 };
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -6119,8 +6119,6 @@ struct virulent_plague_t : public death_knight_spell_t
   virulent_plague_t( death_knight_t* p ) :
     death_knight_spell_t( "virulent_plague", p, p -> spell.virulent_plague )
   {
-    aoe = -1;
-
     base_tick_time *= 1.0 + p -> talent.ebon_fever -> effectN( 1 ).percent();
 
     // Order of operation matters for dot_duration.  lingering plague gives you an extra 3 seconds, or 1 tick of the dot
@@ -6155,6 +6153,8 @@ struct outbreak_t : public death_knight_spell_t
   {
     parse_options( options_str );
     add_child( vp );
+
+    aoe = -1;
   }
 
   void impact( action_state_t* s ) override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9162,6 +9162,7 @@ void death_knight_t::default_apl_unholy()
   // Maintain Virulent Plague
   def -> add_action( this, "Outbreak", "if=dot.virulent_plague.refreshable&!talent.unholy_blight.enabled&!raid_event.adds.exists", "Maintaining Virulent Plague is a priority" );
   def -> add_action( this, "Outbreak", "if=dot.virulent_plague.refreshable&(!talent.unholy_blight.enabled|talent.unholy_blight.enabled&cooldown.unholy_blight.remains)&active_enemies>=2" );
+  def -> add_action( this, "Outbreak", "if=runeforge.superstrain.equipped&(dot.frost_fever.refreshable|dot.blood_plague.refreshable)" );
 
   // Action Lists
   // def -> add_action( "call_action_list,name=covenants" );


### PR DESCRIPTION
Confirmed with Taez that pets double dip on the haste.  I'm not 100% on the way I set the default value.  It works properly for each spec, but its a bit ugly and uses the same magic number id 3 times.  

Made a couple of assumptions:

- We don't care about modeling the CC effect

- The player will always be standing in their DnD.  This means instead of trying to turn the buff on and off based on in_death_and_decay() I just gave the buff the same duration as DnD

Included is a fix for Outbreak not acting as a proper AoE spell.   It was causing an issue with Superstrain if you didn't have Unholy Blight talented where only the main target got all 3 dots.  With Outbreak reworked to behave similar to Howling Blast I moved the aoe flag to Outbreak instead of having VP apply the other 2 dots itself.  