### PR TITLE
Add log_debug overload for const char* to reduce overhead for construction of not needed string_view

### DIFF
--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -697,6 +697,15 @@ struct sim_t : private sc_thread_t
     out_debug.print( format, std::forward<Args>(args)... );
   }
 
+  template <typename... Args>
+  void print_debug( const char* format, Args&&... args )
+  {
+    if ( !debug )
+      return;
+
+    out_debug.print( util::string_view( format ), std::forward<Args>( args )... );
+  }
+
   /**
    * Convenient log function using python-like formatting.
    *


### PR DESCRIPTION
**Description**
In this pull request small change, that improves overall performance of simc.
The issue is in explicit (char*) constructor for string_view parameter used in log_debug. It takes char pointer and uses strlen to determine length of a string. As log_debug function is used heavy, this strlen creates additional overhead.
Most of time simc->debug is false, therefore construction of string_view is unnecessary.
I've added overload for log_debug that takes const char* and constructs string_view only if simc->debug is true.
The change reduces overhead only for non-debug simc runs. But there is possibility to also improve debug run, using some macro that substitutes string len during compile time, though it would need to change all log_debug occurrences.

**Proofing**
To prove of change I've took the utility BenchmarkDotnet. It is designed for microbenchmarking, but in my experience, it also works good with not-so-micro benchmarks.
There is three items in the report: Base - simc without the change; Simc - simc with the change; Minimal - simc without the change but with iteration count = 1, to determine overhead of process start, character parsing, reporting and so on what happens in a simc process, but not during simulation itself.
All processes was run using MediumRun(IterationCount=15, LaunchCount=2, WarmupCount=10)
simc input, taken from raidbots:
```
# armory and name omitted

potion="disabled"
food="disabled"
flask="disabled"
augmentation="disabled"

# Simulation Configs
iterations="100000"
fight_style="Patchwerk"
desired_targets="1"
max_time="60"
calculate_scale_factors="0"
scale_only="strength,intellect,agility,crit,mastery,vers,haste,weapon_dps,weapon_offhand_dps"
override.bloodlust="0"
override.arcane_intellect="0"
override.power_word_fortitude="0"
override.battle_shout="0"
override.mystic_touch="0"
override.chaos_brand="0"
override.bleeding="0"
report_details="1"
single_actor_batch="1"
optimize_expressions="1"
deterministic="1"
```
And as I said minimal config is the same, except iterations = 1

**Results**
``` ini

OS=Windows 10.0.19042
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28316 for x64

Job=MediumRun  IterationCount=15  LaunchCount=2  
WarmupCount=10  

```
|  Method |        Mean |     Error |    StdDev |
|-------- |------------:|----------:|----------:|
|    Simc | 12,163.3 ms | 396.37 ms | 581.00 ms |
|    Base | 13,034.4 ms | 315.23 ms | 441.91 ms |
| Minimal |    631.0 ms |  14.13 ms |  21.15 ms |

```
Simc: ConfidenceInterval = [11.767 s; 12.560 s] (CI 99.9%), Margin = 0.396 s (3.26% of Mean)
Base: ConfidenceInterval = [12.719 s; 13.350 s] (CI 99.9%), Margin = 0.315 s (2.42% of Mean)
Mini: ConfidenceInterval = [616.844 ms; 645.111 ms] (CI 99.9%), Margin = 14.134 ms (2.24% of Mean)
```

Approx overall improve:
```
1 - (12163.3 - 631 / 13034.4 - 631) = (1 - 11532.3 / 12403.4) = 7%
```