### PR TITLE
[Soulbinds] Handle 0-enchant edge case for Forgeborne Reveries

### DIFF
--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -1070,6 +1070,15 @@ void forgeborne_reveries( special_effect_t& effect )
     }
   }
 
+  if ( count == 0 ) {
+    // no enchants are applied, do not apply the buff
+    //
+    // this is done because the buff code replaces a multiplier of 0 with the
+    // default value from the spelldata---which in this case is 1, or a 100%
+    // increase in stats
+    return;
+  }
+
   auto buff = buff_t::find( effect.player, "forgeborne_reveries" );
   if ( !buff )
   {


### PR DESCRIPTION
Currently, when forgeborne reveries is simmed with no enchants applied, a multiplier of 0 is passed to `set_default_value_from_effect`. However, when this occurs that method replaces the multiplier with the default value from the spelldata (see `sc_buff.cpp` lines 961-962)---which is 1 (i.e. 100%). This results in no enchants dramatically oversimming due to doubled mainstat.

This fix just exits the initialization early if no enchants are applied.