### PR TITLE
[Death Knight] Unholy blight dot no longer pandemics

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -7098,6 +7098,12 @@ struct unholy_blight_dot_t : public death_knight_spell_t
     aoe = -1;
   }
 
+  timespan_t calculate_dot_refresh_duration( const dot_t* dot, timespan_t triggered_duration ) const override
+  {
+    // No longer pandemics
+    return triggered_duration;
+  }
+
   void impact(action_state_t* state) override
   {
     death_knight_spell_t::impact( state );


### PR DESCRIPTION
the unholy blight dot damage portion no longer pandemics, virulent still does.

Is there a better way to do this?  The other refresh options for dot's didn't seem to match what I needed for behavior.