### PR TITLE
Manual override of Death Knight Night Fae ability lookup

### DIFF
--- a/engine/player/covenant.cpp
+++ b/engine/player/covenant.cpp
@@ -574,6 +574,8 @@ covenant_ability_cast_cb_t::covenant_ability_cast_cb_t( player_t* p, const speci
   // Manual overrides for covenant abilities that don't utilize the spells found in __covenant_ability_data dbc table
   if ( p->type == DRUID && p->covenant->type() == covenant_e::KYRIAN )
     class_ability = 326446;
+  if ( p->type == DEATH_KNIGHT && p->covenant->type() == covenant_e::NIGHT_FAE )
+    class_ability = 324128;
 }
 
 void covenant_ability_cast_cb_t::initialize()


### PR DESCRIPTION
manually add deaths due covenant ability so that soulbind callbacks can correctly locate it.

dbc/generated/covenant_data.inc and dbc/generated/covenant_data_ptr.inc have 0 in the field meant for class for Death's Due, when the value should be 6.  As a result, we are not able to automatically detect the DK covenant ability, so callbacks from the various soulbinds do not work.

This manually sets it, allowing callbacks to correctly trigger.