### PR TITLE
Update Warlock APL to prevent PS issue

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -1046,7 +1046,7 @@ void warlock_t::create_apl_affliction()
   action_priority_list_t* item  = get_action_priority_list( "item" );
 
   def->add_action( "call_action_list,name=aoe,if=active_enemies>3" );
-  def->add_action( "phantom_singularity,if=time>30" );
+  def->add_action( "phantom_singularity,if=time>30&cooldown.summon_darkglare.remains>15" );
 
   def->add_action( "call_action_list,name=darkglare_prep,if=covenant.venthyr&dot.impending_catastrophe_dot.ticking&cooldown.summon_darkglare.remains<2&(dot.phantom_singularity.remains>2|!talent.phantom_singularity.enabled)" );
   def->add_action( "call_action_list,name=darkglare_prep,if=covenant.night_fae&dot.soul_rot.ticking&cooldown.summon_darkglare.remains<2&(dot.phantom_singularity.remains>2|!talent.phantom_singularity.enabled)" );
@@ -1102,6 +1102,7 @@ void warlock_t::create_apl_affliction()
   def->add_action( "shadow_bolt" );
 
   prep->add_action( "vile_taint,if=cooldown.summon_darkglare.remains<2" );
+  prep->add_action( "phantom_singularity" );
   prep->add_action( "dark_soul" );
   prep->add_action( "potion" );
   prep->add_action( "fireblood" );


### PR DESCRIPTION
Currently PS will accidentally be used just after Darkglare, waiting for it for 15 seconds max completly prevents this issue. And then calling it in the Darkglare prep. Depending on haste it may or may not occur with a 5min sim. Here is a comparison on a 10min 2t. 

https://www.raidbots.com/simbot/report/7f6uhMWwk6GFZTX96mkiXh

https://www.raidbots.com/simbot/report/iRZk4rpC9SiY5wRzS4Ddvn

1t:

https://www.raidbots.com/simbot/report/bWKc6JE1pZxezRs7Ezw8YS

https://www.raidbots.com/simbot/report/ozq7Jnr4csNgWKEEn3yG1Q