### PR TITLE
[Brewmaster] Reset Keg Smash cooldown on WoO cast

### DIFF
--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -7813,6 +7813,9 @@ struct weapons_of_order_t : public monk_spell_t
   void execute() override
   {
     p()->buff.weapons_of_order->trigger();
+    if ( p()->specialization() == MONK_BREWMASTER ) {
+      p()->cooldown.keg_smash->reset( true );
+    }
     monk_spell_t::execute();
   }
 };

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -6254,7 +6254,7 @@ struct melee_t : public monk_melee_attack_t
 
     if ( player->main_hand_weapon.group() == WEAPON_1H )
     {
-      if ( !player->specialization() == MONK_MISTWEAVER )
+      if ( player->specialization() != MONK_MISTWEAVER )
         base_hit -= 0.19;
     }
   }

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -7814,7 +7814,7 @@ struct weapons_of_order_t : public monk_spell_t
   {
     p()->buff.weapons_of_order->trigger();
     if ( p()->specialization() == MONK_BREWMASTER ) {
-      p()->cooldown.keg_smash->reset( true );
+      p()->cooldown.keg_smash->reset( true, 1 );
     }
     monk_spell_t::execute();
   }


### PR DESCRIPTION
[Weapons of Order](https://www.wowhead.com/spell=310454/weapons-of-order) resets the cooldown of Keg Smash when cast. This change makes it reset the cooldown (or, with Stormstout's Last Keg, refund a charge).

There is also an unrelated change fixing an incorrect condition for hit % modification. This is a no-op change for brewmaster and windwalker, since the condition was previously always false---but it eliminates several warnings.