### PR TITLE
[Brewmaster] Invoke Niuzao R2 + Misc fixes

### DIFF
--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -2645,6 +2645,16 @@ private:
       range                                                 = radius;
       radius                                                = 0;
       cooldown->duration                                    = timespan_t::zero();
+      // technically the base damage doesn't split. practically, the base damage
+      // is ass and totally irrelevant. the r2 hot trub effect (which does
+      // split) is by far the dominating factor in any aoe sim.
+      //
+      // if i knew more about simc, i'd implement a separate effect for that,
+      // but i'm not breaking something that (mostly) works in pursuit of that
+      // goal.
+      //
+      //  - emallson
+      split_aoe_damage = true;
     }
 
     double bonus_da( const action_state_t* s ) const override

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -3514,17 +3514,17 @@ public:
       if ( owner->legendary.stormstouts_last_keg->ok() )
         am *= 1 + owner->legendary.stormstouts_last_keg->effectN( 1 ).percent();
 
+      if ( owner->conduit.scalding_brew->ok() )
+        {
+          if ( owner->get_target_data( player->target )->dots.breath_of_fire->is_ticking() )
+            am *= 1 + owner->conduit.scalding_brew.percent();
+        }
+
       return am;
     }
 
     void impact( action_state_t* s ) override
     {
-      if ( owner->conduit.scalding_brew->ok() )
-      {
-        if ( owner->get_target_data( s->target )->dots.breath_of_fire->is_ticking() )
-          s->result_amount *= 1 + owner->conduit.scalding_brew.percent();
-      }
-
       melee_attack_t::impact( s );
 
       owner->get_target_data( s->target )->debuff.fallen_monk_keg_smash->trigger();
@@ -6425,6 +6425,12 @@ struct keg_smash_t : public monk_melee_attack_t
     if ( p()->legendary.stormstouts_last_keg->ok() )
       am *= 1 + p()->legendary.stormstouts_last_keg->effectN( 1 ).percent();
 
+    if ( p()->conduit.scalding_brew->ok() )
+    {
+      if ( td( p()->target )->dots.breath_of_fire->is_ticking() )
+        am *= 1 + p()->conduit.scalding_brew.percent();
+    }
+
     return am;
   }
 
@@ -6449,12 +6455,6 @@ struct keg_smash_t : public monk_melee_attack_t
 
   void impact( action_state_t* s ) override
   {
-    if ( p()->conduit.scalding_brew->ok() )
-    {
-      if ( td( s->target )->dots.breath_of_fire->is_ticking() )
-        s->result_amount *= 1 + p()->conduit.scalding_brew.percent();
-    }
-
     monk_melee_attack_t::impact( s );
 
     td( s->target )->debuff.keg_smash->trigger();

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -8025,9 +8025,6 @@ struct faeline_stomp_t : public monk_spell_t
       }
       case MONK_BREWMASTER:
       {
-        p()->active_actions.breath_of_fire->target = s->target;
-        p()->active_actions.breath_of_fire->execute();
-
         p()->buff.faeline_stomp_brm->trigger();
         break;
       }

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -2665,6 +2665,17 @@ private:
 
       return b;
     }
+
+    double action_multiplier() const override
+    {
+      double am = melee_attack_t::action_multiplier();
+      niuzao_pet_t* p = static_cast<niuzao_pet_t*>( player );
+
+      if ( p->o()->conduit.walk_with_the_ox->ok() )
+        am *= 1 + p->o()->conduit.walk_with_the_ox.percent();
+
+      return am;
+    }
   };
 
   struct stomp_t : public spell_t
@@ -2749,9 +2760,6 @@ public:
     double cpm = pet_t::composite_player_multiplier( school );
 
     cpm *= 1 + o()->spec.brewmaster_monk->effectN( 3 ).percent();
-
-    if ( o()->conduit.walk_with_the_ox->ok() )
-      cpm *= 1 + o()->conduit.walk_with_the_ox.percent();
 
     return cpm;
   }

--- a/engine/class_modules/sc_monk.cpp
+++ b/engine/class_modules/sc_monk.cpp
@@ -7529,6 +7529,8 @@ struct purifying_brew_t : public monk_spell_t
 
     harmful     = false;
 
+    cooldown->charges += (int)p.spec.purifying_brew_2->effectN( 1 ).base_value();
+
     if ( p.talent.light_brewing->ok() )
       cooldown->duration *= 1 + p.talent.light_brewing->effectN( 2 ).percent(); // -20
 


### PR DESCRIPTION
This PR includes:

- implementation of Invoke Niuzao's Rank 2 effect that turns purified damage into stomp damage (with help from @Hinalover)
- implementation of rank 2 of Purifying Brew (adds a 2nd charge, this was previously baseline)
- a fix for Walk with the Ox (the conduit now correctly applies to only stomp damage)
- a fix for Scalding Brew (the previous calculation occurred after damage was applied)
- a fix for BrM's Faeline Stomp (it no longer applies BoF)

the bulk of the code changes are related to Invoke Niuzao r2.