### PR TITLE
Update gear for Elemental PreRaid profile

### DIFF
--- a/profiles/PreRaids/PR_Shaman_Elemental.simc
+++ b/profiles/PreRaids/PR_Shaman_Elemental.simc
@@ -10,10 +10,10 @@ covenant=necrolord
 soulbind=emeni,lead_by_example/call_of_flame:4
 
 # Default consumables
-potion=disabled
-flask=disabled
-food=disabled
-augmentation=disabled
+potion=potion_of_spectral_intellect
+flask=spectral_flask_of_power
+food=feast_of_gluttonous_hedonism
+augmentation=veiled
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,
@@ -25,9 +25,13 @@ augmentation=disabled
 actions.precombat=flask
 actions.precombat+=/food
 actions.precombat+=/augmentation
+actions.precombat+=/earth_elemental,if=!talent.primal_elementalist.enabled
 actions.precombat+=/potion
+actions.precombat+=/elemental_blast,if=talent.elemental_blast.enabled
+actions.precombat+=/lava_burst,if=!talent.elemental_blast.enabled
 # Snapshot raid buffed stats before combat begins and pre-potting is done.
 actions.precombat+=/snapshot_stats
+actions.precombat+=/potion
 
 # Executed every time the actor is available.
 # Interrupt of casts.
@@ -129,29 +133,29 @@ actions.single_target+=/flame_shock,moving=1,if=movement.distance>6
 actions.single_target+=/frost_shock,moving=1
 
 head=nathrian_usurpers_mask,id=178816,bonus_id=6807/1498
-neck=sin_stained_pendant,id=178827,bonus_id=6807/1498
+neck=azurevenom_choker,id=180115,bonus_id=6807/1498
 shoulders=boneshatter_pauldrons,id=172327,bonus_id=6647/6649/6716/6991/1487
 back=blighted_margraves_cloak,id=178755,bonus_id=6807/1498
 chest=harness_of_twisted_whims,id=179353,bonus_id=6807/1498,enchant=eternal_insight
 wrists=fallen_paragons_armguards,id=180114,bonus_id=6807/1498,enchant=eternal_intellect
-hands=absonant_constructs_handguards,id=180105,bonus_id=6807/1498
-waist=executors_prideful_girdle,id=178843,bonus_id=6807/1498
+hands=grips_of_overwhelming_beatings,id=178798,bonus_id=6807/1498
+waist=belt_of_wretched_manipulations,id=178932,bonus_id=6807/1498
 legs=lichbone_legguards,id=178778,bonus_id=6807/1498
-feet=primeval_souls_ankleguards,id=179352,bonus_id=6807/1498
+feet=striders_of_restless_malice,id=178745,bonus_id=6807/1498
 finger1=stitchfleshs_misplaced_signet,id=178736,bonus_id=6807/1498,enchant=tenet_of_versatility
 finger2=ritual_bone_band,id=178870,bonus_id=6807/1498,enchant=tenet_of_versatility
 trinket1=darkmoon_deck_putrescence,id=173069
-trinket2=satchel_of_misbegotten_minions,id=178772,bonus_id=6807/1498
+trinket2=soulletting_ruby,id=178809,bonus_id=6807/1498
 main_hand=fleshcrafters_knife,id=178789,bonus_id=6807/1498,enchant=sinful_revelation
-off_hand=acidslough_bulwark,id=178712,bonus_id=6807/1498
+off_hand=encrusted_canopic_lid,id=178750,bonus_id=6807/1498
 
 # Gear Summary
 # gear_ilvl=185.38
 # gear_strength=27
 # gear_stamina=857
 # gear_intellect=785
-# gear_crit_rating=120
-# gear_haste_rating=589
-# gear_mastery_rating=170
-# gear_versatility_rating=489
-# gear_armor=1187
+# gear_crit_rating=354
+# gear_haste_rating=412
+# gear_mastery_rating=45
+# gear_versatility_rating=558
+# gear_armor=1211

--- a/profiles/generators/PreRaids/PR_Generate_Shaman.simc
+++ b/profiles/generators/PreRaids/PR_Generate_Shaman.simc
@@ -9,21 +9,21 @@ covenant=necrolord
 soulbind=emeni,lead_by_example/call_of_flame:4
 
 head=nathrian_usurpers_mask,id=178816,bonus_id=6807/1498
-neck=sin_stained_pendant,id=178827,bonus_id=6807/1498
+neck=azurevenom_choker,id=180115,bonus_id=6807/1498
 shoulder=boneshatter_pauldrons,id=172327,bonus_id=6647/6649/6716/6991/1487
 back=blighted_margraves_cloak,id=178755,bonus_id=6807/1498
 chest=harness_of_twisted_whims,id=179353,bonus_id=6807/1498,enchant=eternal_insight
-wrists=fallen_paragons_armguards,id=180114,bonus_id=6807/1498,enchant=eternal_intellect
-hands=absonant_constructs_handguards,id=180105,bonus_id=6807/1498
-waist=executors_prideful_girdle,id=178843,bonus_id=6807/1498
+wrist=fallen_paragons_armguards,id=180114,bonus_id=6807/1498,enchant=eternal_intellect
+hands=grips_of_overwhelming_beatings,id=178798,bonus_id=6807/1498
+waist=belt_of_wretched_manipulations,id=178932,bonus_id=6807/1498
 legs=lichbone_legguards,id=178778,bonus_id=6807/1498
-feet=primeval_souls_ankleguards,id=179352,bonus_id=6807/1498
+feet=striders_of_restless_malice,id=178745,bonus_id=6807/1498
 finger1=stitchfleshs_misplaced_signet,id=178736,bonus_id=6807/1498,enchant=tenet_of_versatility
 finger2=ritual_bone_band,id=178870,bonus_id=6807/1498,enchant=tenet_of_versatility
 trinket1=darkmoon_deck_putrescence,id=173069
-trinket2=satchel_of_misbegotten_minions,id=178772,bonus_id=6807/1498
+trinket2=soulletting_ruby,id=178809,bonus_id=6807/1498
 main_hand=fleshcrafters_knife,id=178789,bonus_id=6807/1498,enchant=sinful_revelation
-off_hand=acidslough_bulwark,id=178712,bonus_id=6807/1498
+off_hand=encrusted_canopic_lid,id=178750,bonus_id=6807/1498
 
 save=PR_Shaman_Elemental.simc
 


### PR DESCRIPTION
Approx a 7% DPS increase over the current profile (after the recent
consumable fixes).

* Adjust stats for several slots to cater to where EotGS shoulders
perform best
* Fix boots to be mail instead of leather.
* Update trinkets


before: https://www.raidbots.com/simbot/report/siqiuH9CwGN4DfYRVx6hML

after: https://www.raidbots.com/simbot/report/5UdcEjwR3Gfyt6MbUBW5kP