### PR TITLE
[Death Knight] Fix FC Heal so it applies to the actor, not the target

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -6914,6 +6914,14 @@ void runeforge::fallen_crusader( special_effect_t& effect )
         callbacks = may_crit = false;
         base_pct_heal = data -> effectN( 2 ).percent();
       }
+
+      // Procs by default target the target of the action that procced them.
+      void execute() override
+      {
+        target = player;
+
+        death_knight_heal_t::execute();
+      }
     };
 
     p -> active_spells.unholy_strength = new fallen_crusader_heal_t( p, p -> find_spell( effect.spell_id ) -> effectN( 1 ).trigger() );


### PR DESCRIPTION
dbc_proc_callback_t seems to be setting the target to be the players target, rather than the player as specified in the constructor.  It looks like older versions addressed this behavior via the execute method setting the target, so this re-adds that section of code.