### PR TITLE
Windows platform: Convert the environment string's encoding to utf8 when using io::ofstream.

### DIFF
--- a/engine/interfaces/bcp_api.cpp
+++ b/engine/interfaces/bcp_api.cpp
@@ -104,9 +104,13 @@ std::vector<std::string> token_paths()
 
   if ( const char* home_drive = getenv( "HOMEDRIVE" ) )
   {
-    if ( const char* home_path = getenv( "HOMEPATH" ) )
+    if ( const char* home_path_ansi = getenv( "HOMEPATH" ) )
     {
-      paths.push_back( std::string( home_drive ) + std::string( home_path ) + "/simc-apitoken" );
+      std::string home_path = std::string( home_drive ) + std::string( home_path_ansi ) + "/simc-apitoken";
+#ifdef SC_WINDOWS
+      home_path = io::ansi_to_utf8( home_path.c_str() );
+#endif
+      paths.push_back( home_path );
     }
   }
 

--- a/engine/util/io.cpp
+++ b/engine/util/io.cpp
@@ -181,6 +181,23 @@ utf8_args::utf8_args( int, char** )
   LocalFree( wargv );
 }
 
+std::string ansi_to_utf8( const char* src )
+{
+  int len = MultiByteToWideChar( CP_ACP, 0, src, -1, NULL, 0 );
+  wchar_t* wstr = new wchar_t[ len + 1 ];
+  memset( wstr, 0, len + 1 );
+  MultiByteToWideChar( CP_ACP, 0, src, -1, wstr, len );
+  len = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL );
+  char* str = new char[ len + 1 ];
+  memset( str, 0, len + 1 );
+  WideCharToMultiByte( CP_UTF8, 0, wstr, -1, str, len, NULL, NULL );
+  std::string strTemp = str;
+  if ( wstr )
+    delete[] wstr;
+  if ( str )
+    delete[] str;
+  return strTemp;
+}
 #else
 
 utf8_args::utf8_args( int argc, char** argv ) :

--- a/engine/util/io.hpp
+++ b/engine/util/io.hpp
@@ -108,6 +108,8 @@ public:
 #ifndef SC_WINDOWS
 inline FILE* fopen( const std::string& filename, const char* mode )
 { return std::fopen( filename.c_str(), mode ); }
+#else
+std::string ansi_to_utf8( const char* src );
 #endif
 
 inline int fclose( cfile& file ) { file.close(); return 0; }


### PR DESCRIPTION
#5586 
In io::ofstream, the path is always converted from UTF-8, but in the function token_paths(), obtained text encoding is ANSI.