### PR TITLE
 [Hunter] Update MM Opener APL

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -6334,13 +6334,14 @@ void hunter_t::apl_mm()
   action_priority_list_t* trickshots   = get_action_priority_list( "trickshots" );
 
   precombat -> add_action( "tar_trap,if=runeforge.soulforge_embers" );
-  precombat -> add_action( "double_tap,precast_time=10,if=!covenant.kyrian&(!talent.volley|active_enemies<2)" );
-  precombat -> add_action( "aimed_shot,if=active_enemies<3" );
-  precombat -> add_action( "steady_shot,if=active_enemies>2" );
+  precombat -> add_action( "double_tap,precast_time=10,if=active_enemies>1|!covenant.kyrian&!talent.volley" );
+  precombat -> add_action( "aimed_shot,if=active_enemies<3&(!covenant.kyrian&!talent.volley|active_enemies<2)" );
+  precombat -> add_action( "steady_shot,if=active_enemies>2|(covenant.kyrian|talent.volley)&active_enemies=2" );
 
   default_list -> add_action( "auto_shot" );
   default_list -> add_action( "counter_shot,line_cd=30,if=runeforge.sephuzs_proclamation|soulbind.niyas_tools_poison|(conduit.reversal_of_fortune&!runeforge.sephuzs_proclamation)" );
-  default_list -> add_action( "use_items" );
+  default_list -> add_action( "use_items,name=dreadfire_vessel" );
+  default_list -> add_action( "use_items,if=buff.trueshot.up|cooldown.trueshot.remains>59|target.time_to_die<20" );
   default_list -> add_action( "call_action_list,name=cds" );
   default_list -> add_action( "call_action_list,name=st,if=active_enemies<3" );
   default_list -> add_action( "call_action_list,name=trickshots,if=active_enemies>2" );
@@ -6358,7 +6359,7 @@ void hunter_t::apl_mm()
     * - check why Explo can't be executed in precombat (throws while it *should* have travel time)
     */
   trickshots -> add_action( "steady_shot,if=talent.steady_focus&in_flight&buff.steady_focus.remains<5" );
-  trickshots -> add_action( "double_tap,if=covenant.kyrian&cooldown.resonating_arrow.remains<gcd|cooldown.rapid_fire.remains<cooldown.aimed_shot.full_recharge_time|!(talent.streamline&runeforge.surging_shots)|!covenant.kyrian" );
+  trickshots -> add_action( "double_tap,if=covenant.kyrian&cooldown.resonating_arrow.remains<gcd|!covenant.kyrian&!covenant.night_fae|covenant.night_fae&(cooldown.wild_spirits.remains<gcd|cooldown.trueshot.remains>55)|target.time_to_die<10" );
   trickshots -> add_action( "tar_trap,if=runeforge.soulforge_embers&tar_trap.remains<gcd&cooldown.flare.remains<gcd" );
   trickshots -> add_action( "flare,if=tar_trap.up&runeforge.soulforge_embers" );
   trickshots -> add_action( "explosive_shot" );
@@ -6368,7 +6369,7 @@ void hunter_t::apl_mm()
   trickshots -> add_action( "barrage" );
   trickshots -> add_action( "trueshot" );
   trickshots -> add_action( "rapid_fire,if=buff.trick_shots.remains>=execute_time&runeforge.surging_shots&buff.double_tap.down" );
-  trickshots -> add_action( "aimed_shot,target_if=min:(dot.serpent_sting.remains<?action.serpent_sting.in_flight_to_target*dot.serpent_sting.duration),if=buff.trick_shots.remains>=execute_time&(buff.precise_shots.down|full_recharge_time<cast_time+gcd|buff.trueshot.up)" );
+  trickshots -> add_action( "aimed_shot,target_if=min:dot.serpent_sting.remains+action.serpent_sting.in_flight_to_target*99,if=buff.trick_shots.remains>=execute_time&(buff.precise_shots.down|full_recharge_time<cast_time+gcd|buff.trueshot.up)" );
   trickshots -> add_action( "death_chakram,if=focus+cast_regen<focus.max" );
   trickshots -> add_action( "rapid_fire,if=buff.trick_shots.remains>=execute_time" );
   trickshots -> add_action( "multishot,if=buff.trick_shots.down|buff.precise_shots.up&focus>cost+action.aimed_shot.cost&(!talent.chimaera_shot|active_enemies>3)" );
@@ -6382,18 +6383,18 @@ void hunter_t::apl_mm()
 
   st -> add_action( "steady_shot,if=talent.steady_focus&(prev_gcd.1.steady_shot&buff.steady_focus.remains<5|buff.steady_focus.down)" );
   st -> add_action( "kill_shot" );
-  st -> add_action( "double_tap,if=covenant.kyrian&cooldown.resonating_arrow.remains<gcd|!covenant.kyrian&(cooldown.aimed_shot.up|cooldown.rapid_fire.remains>cooldown.aimed_shot.remains)" );
+  st -> add_action( "double_tap,if=covenant.kyrian&cooldown.resonating_arrow.remains<gcd|!covenant.kyrian&!covenant.night_fae|covenant.night_fae&(cooldown.wild_spirits.remains<gcd|cooldown.trueshot.remains>55)|target.time_to_die<15" );
   st -> add_action( "flare,if=tar_trap.up&runeforge.soulforge_embers" );
   st -> add_action( "tar_trap,if=runeforge.soulforge_embers&tar_trap.remains<gcd&cooldown.flare.remains<gcd" );
   st -> add_action( "explosive_shot" );
   st -> add_action( "wild_spirits" );
   st -> add_action( "flayed_shot" );
   st -> add_action( "death_chakram,if=focus+cast_regen<focus.max" );
-  st -> add_action( "volley,if=buff.precise_shots.down|!talent.chimaera_shot|active_enemies<2" );
   st -> add_action( "a_murder_of_crows" );
   st -> add_action( "resonating_arrow" );
+  st -> add_action( "volley,if=buff.precise_shots.down|!talent.chimaera_shot|active_enemies<2" );
   st -> add_action( "trueshot,if=buff.precise_shots.down|buff.resonating_arrow.up|buff.wild_spirits.up|buff.volley.up&active_enemies>1" );
-  st -> add_action( "aimed_shot,target_if=min:(dot.serpent_sting.remains<?action.serpent_sting.in_flight_to_target*dot.serpent_sting.duration),if=buff.precise_shots.down|(buff.trueshot.up|full_recharge_time<gcd+cast_time)&(!talent.chimaera_shot|active_enemies<2)|buff.trick_shots.remains>execute_time&active_enemies>1" );
+  st -> add_action( "aimed_shot,target_if=min:dot.serpent_sting.remains+action.serpent_sting.in_flight_to_target*99,if=buff.precise_shots.down|(buff.trueshot.up|full_recharge_time<gcd+cast_time)&(!talent.chimaera_shot|active_enemies<2)|buff.trick_shots.remains>execute_time&active_enemies>1" );
   st -> add_action( "rapid_fire,if=focus+cast_regen<focus.max&(buff.trueshot.down|!runeforge.eagletalons_true_focus)&(buff.double_tap.down|talent.streamline)" );
   st -> add_action( "chimaera_shot,if=buff.precise_shots.up|focus>cost+action.aimed_shot.cost" );
   st -> add_action( "arcane_shot,if=buff.precise_shots.up|focus>cost+action.aimed_shot.cost" );

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -6340,7 +6340,7 @@ void hunter_t::apl_mm()
 
   default_list -> add_action( "auto_shot" );
   default_list -> add_action( "counter_shot,line_cd=30,if=runeforge.sephuzs_proclamation|soulbind.niyas_tools_poison|(conduit.reversal_of_fortune&!runeforge.sephuzs_proclamation)" );
-  default_list -> add_action( "use_items,name=dreadfire_vessel" );
+  default_list -> add_action( "use_item,name=dreadfire_vessel" );
   default_list -> add_action( "use_items,if=buff.trueshot.up|cooldown.trueshot.remains>59|target.time_to_die<20" );
   default_list -> add_action( "call_action_list,name=cds" );
   default_list -> add_action( "call_action_list,name=st,if=active_enemies<3" );


### PR DESCRIPTION
Specific updates for:
- Pair on-use trinkets with Trueshot.
- Pair Double Tap with Covenant abilities.
- Precast abilities for 1-3+ targets.
- Volley after Resonating Arrow.
- Slight Serpentstalker's Trickery optimization.