### PR TITLE
[shaman] Add default_temporary_enchant

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -861,6 +861,7 @@ public:
   std::string default_flask() const override;
   std::string default_food() const override;
   std::string default_rune() const override;
+  std::string default_temporary_enchant() const override;
 
   void init_rng() override;
   void init_special_effects() override;
@@ -8856,6 +8857,22 @@ std::string shaman_t::default_rune() const
                                  : ( true_level >= 50 ) ? "battle_scarred" : "disabled";
 
   return specialization() == SHAMAN_ENHANCEMENT ? enhance_rune : elemental_rune;
+}
+
+// shaman_t::default_temporary_enchant ======================================
+
+std::string shaman_t::default_temporary_enchant() const
+{
+  switch ( specialization() )
+  {
+    case SHAMAN_ELEMENTAL:
+      if ( true_level >= 60 )
+        return "main_hand:shadowcore_oil";
+    case SHAMAN_ENHANCEMENT:
+    case SHAMAN_RESTORATION:
+    default:
+      return "disabled";
+  }
 }
 
 // shaman_t::init_action_list_elemental =====================================

--- a/profiles/PreRaids/PR_Shaman_Elemental.simc
+++ b/profiles/PreRaids/PR_Shaman_Elemental.simc
@@ -14,6 +14,7 @@ potion=potion_of_spectral_intellect
 flask=spectral_flask_of_power
 food=feast_of_gluttonous_hedonism
 augmentation=veiled
+temporary_enchant=main_hand:shadowcore_oil
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,
@@ -146,7 +147,7 @@ legs=lichbone_legguards,id=178778,bonus_id=6807/1498/6646
 feet=striders_of_restless_malice,id=178745,bonus_id=6807/1498/6646
 finger1=stitchfleshs_misplaced_signet,id=178736,bonus_id=6807/1498/6646,enchant=tenet_of_versatility
 finger2=ritual_bone_band,id=178870,bonus_id=6807/1498/6646,enchant=tenet_of_versatility
-trinket1=darkmoon_deck_putrescence,id=173069,enchant=shadowcore_oil
+trinket1=darkmoon_deck_putrescence,id=173069
 trinket2=soulletting_ruby,id=178809,bonus_id=6807/1498/6646
 main_hand=fleshcrafters_knife,id=178789,bonus_id=6807/1498/6646,enchant=sinful_revelation
 off_hand=encrusted_canopic_lid,id=178750,bonus_id=6807/1498/6646

--- a/profiles/PreRaids/PR_Shaman_Enhancement.simc
+++ b/profiles/PreRaids/PR_Shaman_Enhancement.simc
@@ -14,6 +14,7 @@ potion=potion_of_spectral_agility
 flask=spectral_flask_of_power
 food=feast_of_gluttonous_hedonism
 augmentation=veiled
+temporary_enchant=disabled
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,

--- a/profiles/PreRaids/PR_Shaman_Enhancement_VDW.simc
+++ b/profiles/PreRaids/PR_Shaman_Enhancement_VDW.simc
@@ -14,6 +14,7 @@ potion=potion_of_spectral_agility
 flask=spectral_flask_of_power
 food=feast_of_gluttonous_hedonism
 augmentation=veiled
+temporary_enchant=disabled
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,

--- a/profiles/Tier26/T26_Shaman_Elemental.simc
+++ b/profiles/Tier26/T26_Shaman_Elemental.simc
@@ -14,6 +14,7 @@ potion=potion_of_spectral_intellect
 flask=spectral_flask_of_power
 food=feast_of_gluttonous_hedonism
 augmentation=veiled
+temporary_enchant=main_hand:shadowcore_oil
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,

--- a/profiles/Tier26/T26_Shaman_Enhancement.simc
+++ b/profiles/Tier26/T26_Shaman_Enhancement.simc
@@ -14,6 +14,7 @@ potion=potion_of_spectral_agility
 flask=spectral_flask_of_power
 food=feast_of_gluttonous_hedonism
 augmentation=veiled
+temporary_enchant=disabled
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,

--- a/profiles/Tier26/T26_Shaman_Enhancement_VDW.simc
+++ b/profiles/Tier26/T26_Shaman_Enhancement_VDW.simc
@@ -14,6 +14,7 @@ potion=potion_of_spectral_agility
 flask=spectral_flask_of_power
 food=feast_of_gluttonous_hedonism
 augmentation=veiled
+temporary_enchant=disabled
 
 # This default action priority list is automatically created based on your character.
 # It is a attempt to provide you with a action list that is both simple and practicable,

--- a/profiles/generators/PreRaids/PR_Generate_Shaman.simc
+++ b/profiles/generators/PreRaids/PR_Generate_Shaman.simc
@@ -20,7 +20,7 @@ legs=lichbone_legguards,id=178778,bonus_id=6807/1498/6646
 feet=striders_of_restless_malice,id=178745,bonus_id=6807/1498/6646
 finger1=stitchfleshs_misplaced_signet,id=178736,bonus_id=6807/1498/6646,enchant=tenet_of_versatility
 finger2=ritual_bone_band,id=178870,bonus_id=6807/1498/6646,enchant=tenet_of_versatility
-trinket1=darkmoon_deck_putrescence,id=173069,enchant=shadowcore_oil
+trinket1=darkmoon_deck_putrescence,id=173069
 trinket2=soulletting_ruby,id=178809,bonus_id=6807/1498/6646
 main_hand=fleshcrafters_knife,id=178789,bonus_id=6807/1498/6646,enchant=sinful_revelation
 off_hand=encrusted_canopic_lid,id=178750,bonus_id=6807/1498/6646


### PR DESCRIPTION
This sets the weapon oil or other default enchant string.

* For now, only set Elemental to use shadowcore oil.
* I'm sure Enhance may need something special for their weapon enchants.
* Resto is probably going to use shadowcore oil for dps too but I'll let
  someone keen on Resto DPS sims worry about that.