### PR TITLE
Shadowcore Oil Fix

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8902,6 +8902,8 @@ std::string shaman_t::default_temporary_enchant() const
       if ( true_level >= 60 )
         return "main_hand:shadowcore_oil";
     case SHAMAN_ENHANCEMENT:
+      if ( true_level >= 60 )
+        return "disabled";
     case SHAMAN_RESTORATION:
       if ( true_level >= 60 )
         return "main_hand:shadowcore_oil";


### PR DESCRIPTION
Shadowcore oil damage is being applied to Enhancement Shaman simulations even though it's impossible to stack both weapon imbues (Windfury/Flametongue) with shadowcore oil.

![Problem](https://user-images.githubusercontent.com/74802218/101934767-0b019980-3bac-11eb-8a54-dd6fd43a025a.PNG)


![Fix](https://user-images.githubusercontent.com/74802218/101934774-0ccb5d00-3bac-11eb-8f9a-13b7c25d6d8a.PNG)

