### PR TITLE
Change to Race for VDW

### DIFF
--- a/profiles/generators/Tier26/T26_Generate_Shaman.simc
+++ b/profiles/generators/Tier26/T26_Generate_Shaman.simc
@@ -90,7 +90,7 @@ save=T26_Shaman_Enhancement.simc
 
 shaman="T26_Shaman_Enhancement_VDW"
 level=60
-race=goblin
+race=troll
 spec=enhancement
 role=attack
 position=back


### PR DESCRIPTION
Since both troll outsims goblin in all the sims I've run (standard patchwerk, patchwerk 3 targets, hectic add cleave, dungeon slice) I suggest changing the default race to troll.