### PR TITLE
Priest ecttv refactor

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1004,10 +1004,10 @@ struct void_tendril_mind_flay_t final : public priest_pet_spell_t
         if ( stats == first_pet_action->stats )
         {
           // This is the first pet created. Add its stat as a child to priest mind_flay
-          auto owner_mind_flay_action = p.o().find_action( "mind_flay" );
-          if ( owner_mind_flay_action )
+          auto owner_ecttv_action = p.o().find_action( "eternal_call_to_the_void" );
+          if ( owner_ecttv_action )
           {
-            owner_mind_flay_action->add_child( this );
+            owner_ecttv_action->add_child( this );
           }
         }
         if ( !sim->report_pets_separately )
@@ -1103,10 +1103,10 @@ struct void_lasher_mind_sear_t final : public priest_pet_spell_t
         if ( stats == first_pet_action->stats )
         {
           // This is the first pet created. Add its stat as a child to priest mind_sear
-          auto owner_mind_sear_action = p.o().find_action( "mind_sear" );
-          if ( owner_mind_sear_action )
+          auto owner_ecttv_action = p.o().find_action( "eternal_call_to_the_void" );
+          if ( owner_ecttv_action )
           {
-            owner_mind_sear_action->add_child( this );
+            owner_ecttv_action->add_child( this );
           }
         }
         if ( !sim->report_pets_separately )

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -39,6 +39,7 @@ struct ascended_eruption_t;
 struct wrathful_faerie_t;
 struct wrathful_faerie_fermata_t;
 struct psychic_link_t;
+struct eternal_call_to_the_void_t;
 }  // namespace spells
 namespace heals
 {
@@ -374,6 +375,7 @@ public:
     propagate_const<actions::spells::wrathful_faerie_t*> wrathful_faerie;
     propagate_const<actions::spells::wrathful_faerie_fermata_t*> wrathful_faerie_fermata;
     propagate_const<actions::spells::ascended_eruption_t*> ascended_eruption;
+    propagate_const<actions::spells::eternal_call_to_the_void_t*> eternal_call_to_the_void;
   } background_actions;
 
   // Items

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1286,6 +1286,18 @@ struct psychic_horror_t final : public priest_spell_t
 };
 
 // ==========================================================================
+// Eternal Call to the Void (Shadowlands Legendary)
+// ==========================================================================
+struct eternal_call_to_the_void_t final : public priest_spell_t
+{
+  eternal_call_to_the_void_t( priest_t& p, util::string_view options_str )
+    : priest_spell_t( "eternal_call_to_the_void", p, p.find_spell( 344753 ) )
+  {
+    parse_options( options_str );
+  }
+};
+
+// ==========================================================================
 // Void Torrent
 // ==========================================================================
 struct void_torrent_t final : public priest_spell_t

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1293,6 +1293,7 @@ struct eternal_call_to_the_void_t final : public priest_spell_t
   eternal_call_to_the_void_t( priest_t& p )
     : priest_spell_t( "eternal_call_to_the_void", p, p.find_spell( p.legendary.eternal_call_to_the_void->id() ) )
   {
+    background = true;
   }
 };
 

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1290,10 +1290,8 @@ struct psychic_horror_t final : public priest_spell_t
 // ==========================================================================
 struct eternal_call_to_the_void_t final : public priest_spell_t
 {
-  eternal_call_to_the_void_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "eternal_call_to_the_void", p, p.find_spell( 344753 ) )
+  eternal_call_to_the_void_t( priest_t& p ) : priest_spell_t( "eternal_call_to_the_void", p, p.find_spell( 344753 ) )
   {
-    parse_options( options_str );
   }
 };
 
@@ -2119,6 +2117,11 @@ void priest_t::init_background_actions_shadow()
   if ( talents.psychic_link->ok() )
   {
     background_actions.psychic_link = new actions::spells::psychic_link_t( *this );
+  }
+
+  if ( legendary.eternal_call_to_the_void->ok() )
+  {
+    background_actions.eternal_call_to_the_void = new actions::spells::eternal_call_to_the_void_t( *this );
   }
 }
 

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1290,7 +1290,8 @@ struct psychic_horror_t final : public priest_spell_t
 // ==========================================================================
 struct eternal_call_to_the_void_t final : public priest_spell_t
 {
-  eternal_call_to_the_void_t( priest_t& p ) : priest_spell_t( "eternal_call_to_the_void", p, p.find_spell( 344753 ) )
+  eternal_call_to_the_void_t( priest_t& p )
+    : priest_spell_t( "eternal_call_to_the_void", p, p.find_spell( p.legendary.eternal_call_to_the_void->id() ) )
   {
   }
 };


### PR DESCRIPTION
The current implementation just tosses the leggo effects under the spells that proc it, rather than under a EcttV action like WCL does. This should make it easier to distinguish the power of the legendary by looking at the result table.

![new ecttv](https://user-images.githubusercontent.com/10604059/102413580-c5353e80-3fba-11eb-9540-e515cf2d82cc.png)
