### PR TITLE
allow boss melees to be dodged/parried/blocked

### DIFF
--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -412,6 +412,7 @@ struct melee_t : public enemy_action_t<melee_attack_t>
     base_dd_min       = 1040;
     base_execute_time = timespan_t::from_seconds( 1.5 );
     may_crit = background = repeating = true;
+    may_dodge = may_parry = may_block = true;
     special                           = false;
 
     parse_options( options_str );


### PR DESCRIPTION
Right now, this matters for exactly Brewmaster because of how much of our potential damage comes from the Rank 2 effect of Invoke Niuzao, the Black Ox.

Currently, autos cannot be dodged and are set to heroic Sludgefist levels by default. This changes the boss autos to be dodgeable, which cuts incoming damage for Brewmasters by about half and brings Niuzao closer to actual values without further adjustments for boss uptime.

# Before
![Screenshot from 2020-12-19 12-26-31](https://user-images.githubusercontent.com/4909458/102695448-76271d80-41f5-11eb-96bb-6466c65c8953.png)

![image](https://user-images.githubusercontent.com/4909458/102695456-87702a00-41f5-11eb-9dce-886a2ec81fc9.png)

# After

![image](https://user-images.githubusercontent.com/4909458/102695471-948d1900-41f5-11eb-876b-f815f2dbb4d5.png)

![image](https://user-images.githubusercontent.com/4909458/102695475-9f47ae00-41f5-11eb-94b6-ffe3832876bf.png)
