### PR TITLE
Priest: Remove c++ if in the shadow APL code; merge disc/holy apls in…

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1940,6 +1940,16 @@ priest_td_t* priest_t::get_target_data( player_t* target ) const
 
 void priest_t::init_action_list()
 {
+    // 2020-12-31: Healing is outdated and not supported (both discipline and holy)
+  if ( !sim->allow_experimental_specializations && primary_role() == ROLE_HEAL )
+  {
+    if ( ! quiet )
+      sim -> error( "Role heal for priest '{}' is currently not supported.", name() );
+
+    quiet = true;
+    return;
+  }
+  
   if ( !action_list_str.empty() )
   {
     player_t::init_action_list();
@@ -1955,24 +1965,10 @@ void priest_t::init_action_list()
       generate_apl_shadow();
       break;
     case PRIEST_DISCIPLINE:
-      if ( primary_role() != ROLE_HEAL )
-      {
-        generate_apl_discipline_d();
-      }
-      else
-      {
-        generate_apl_discipline_h();
-      }
+        generate_apl_discipline();
       break;
     case PRIEST_HOLY:
-      if ( primary_role() != ROLE_HEAL )
-      {
-        generate_apl_holy_d();
-      }
-      else
-      {
-        generate_apl_holy_h();
-      }
+        generate_apl_holy();
       break;
     default:
       create_apl_default();

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -536,16 +536,14 @@ private:
   void init_rng_discipline();
 
   void init_background_actions_shadow();
-  void generate_apl_discipline_d();
-  void generate_apl_discipline_h();
+  void generate_apl_discipline();
   std::unique_ptr<expr_t> create_expression_discipline( action_t* a, const util::string_view name_str );
   action_t* create_action_discipline( util::string_view name, util::string_view options_str );
 
   void create_buffs_holy();
   void init_spells_holy();
   void init_rng_holy();
-  void generate_apl_holy_d();
-  void generate_apl_holy_h();
+  void generate_apl_holy();
   expr_t* create_expression_holy( action_t* a, util::string_view name_str );
   action_t* create_action_holy( util::string_view name, util::string_view options_str );
   target_specific_t<priest_td_t> _target_data;

--- a/engine/class_modules/priest/sc_priest_discipline.cpp
+++ b/engine/class_modules/priest/sc_priest_discipline.cpp
@@ -383,35 +383,8 @@ std::unique_ptr<expr_t> priest_t::create_expression_discipline( action_t*, util:
   return {};
 }
 
-void priest_t::generate_apl_discipline_h()
-{
-  action_priority_list_t* def = get_action_priority_list( "default" );
-
-  // DEFAULT
-  if ( sim->allow_potions )
-  {
-    def->add_action( "mana_potion,if=mana.pct<=75" );
-  }
-
-  if ( find_class_spell( "Shadowfiend" )->ok() )
-  {
-    def->add_action( this, "Shadowfiend" );
-  }
-
-  if ( race == RACE_TROLL )
-  {
-    def->add_action( "berserking" );
-  }
-  if ( race == RACE_BLOOD_ELF )
-  {
-    def->add_action( "arcane_torrent,if=mana.pct<=90" );
-  }
-  def->add_action( this, "Penance" );
-  def->add_action( this, "Shadow Mend" );
-}
-
 /** Discipline Damage Combat Action Priority List */
-void priest_t::generate_apl_discipline_d()
+void priest_t::generate_apl_discipline()
 {
   action_priority_list_t* def     = get_action_priority_list( "default" );
   action_priority_list_t* boon    = get_action_priority_list( "boon" );
@@ -424,11 +397,8 @@ void priest_t::generate_apl_discipline_d()
   def->add_action( "use_items", "Default fallback for usable items: Use on cooldown in order by trinket slot." );
 
   // Potions
-  if ( sim->allow_potions )
-  {
-    def->add_action( "potion,if=buff.bloodlust.react|buff.power_infusion.up|target.time_to_die<=40",
+  def->add_action( "potion,if=buff.bloodlust.react|buff.power_infusion.up|target.time_to_die<=40",
                      "Sync potion usage with Bloodlust or Power Infusion." );
-  }
 
   // Racials
   racials->add_action( "arcane_torrent,if=mana.pct<=95" );

--- a/engine/class_modules/priest/sc_priest_holy.cpp
+++ b/engine/class_modules/priest/sc_priest_holy.cpp
@@ -279,7 +279,7 @@ void priest_t::adjust_holy_word_serenity_cooldown()
 }
 
 /** Holy Damage Combat Action Priority List */
-void priest_t::generate_apl_holy_d()
+void priest_t::generate_apl_holy()
 {
   action_priority_list_t* default_list = get_action_priority_list( "default" );
   action_priority_list_t* precombat    = get_action_priority_list( "precombat" );
@@ -336,12 +336,6 @@ void priest_t::generate_apl_holy_d()
       this, "Divine Star",
       "if=(raid_event.adds.in>5|raid_event.adds.remains>2|raid_event.adds.duration<2)&spell_targets.divine_star>0" );
   default_list->add_action( this, "Holy Nova", "if=raid_event.movement.remains>gcd*0.3&spell_targets.holy_nova>0" );
-}
-
-/** Holy Heal Combat Action Priority List */
-void priest_t::generate_apl_holy_h()
-{
-  create_apl_default();
 }
 
 }  // namespace priestspace

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1974,15 +1974,12 @@ void priest_t::generate_apl_shadow()
                         "Default fallback for usable items: Use on cooldown in order by trinket slot." );
 
   // CDs
-  if ( options.priest_self_power_infusion )
-  {
-    cds->add_action( this, "Power Infusion",
-                     "if=buff.voidform.up|!soulbind.combat_meditation.enabled&cooldown.void_eruption.remains>=10|fight_"
-                     "remains<cooldown.void_eruption.remains",
-                     "Use Power Infusion with Voidform. Hold for Voidform comes off cooldown in the next 10 seconds "
-                     "otherwise use on cd unless the Pelagos Trait Combat Meditation is talented, or if there will not "
-                     "be another Void Eruption this fight." );
-  }
+  cds->add_action( this, "Power Infusion",
+                   "if=priest.self_power_infusion&(buff.voidform.up|!soulbind.combat_meditation.enabled&cooldown.void_"
+                   "eruption.remains>=10|fight_remains<cooldown.void_eruption.remains)",
+                   "Use Power Infusion with Voidform. Hold for Voidform comes off cooldown in the next 10 seconds "
+                   "otherwise use on cd unless the Pelagos Trait Combat Meditation is talented, or if there will not "
+                   "be another Void Eruption this fight." );
   cds->add_action( this, "Silence",
                    "target_if=runeforge.sephuzs_proclamation.equipped&(target.is_add|target.debuff.casting.react)",
                    "Use Silence on CD to proc Sephuz's Proclamation." );

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -3,6 +3,7 @@
 // Send questions to natehieter@gmail.com
 // ==========================================================================
 
+#include "sc_enums.hpp"
 #include "unique_gear.hpp"
 
 #include "unique_gear_shadowlands.hpp"
@@ -3543,6 +3544,11 @@ void generic::windfury_totem( special_effect_t& effect )
       atk->set_target( old_target );
     }
   };
+
+  if ( effect.player->is_enemy() || effect.player->type == HEALING_ENEMY )
+  {
+    return;
+  }
 
   // Apply rank 2 automatically
   effect.proc_chance_ = effect.driver()->proc_chance() +


### PR DESCRIPTION
…to dps only.

Disable healing role for priests. This will also disable default holy sims unless dps role is actively specified.

Disable windfury totem callback for (healing) enemy. This fixes the assert for holy priest and its associated healing enemy, which is only set to quiet even if disabled.