### PR TITLE
[Priest] standardize shadow find_spell calls

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1701,8 +1701,9 @@ void priest_t::init_spells()
   init_spells_holy();
 
   // Generic Spells
-  specs.mind_flay = find_specialization_spell( "Mind Flay" );
   specs.mind_sear = find_class_spell( "Mind Sear" );
+  specs.mind_blast = find_class_spell( "Mind Blast" );
+  specs.shadow_word_death = find_class_spell( "Shadow Word: Death" );
 
   // Class passives
   specs.priest     = dbc::get_class_passive( *this, SPEC_NONE );
@@ -1727,18 +1728,18 @@ void priest_t::init_spells()
   legendary.kiss_of_death    = find_runeforge_legendary( "Kiss of Death" );
   legendary.the_penitent_one = find_runeforge_legendary( "The Penitent One" );
   // Shadow Legendaries
+  legendary.eternal_call_to_the_void = find_runeforge_legendary( "Eternal Call to the Void" );
   legendary.painbreaker_psalm        = find_runeforge_legendary( "Painbreaker Psalm" );
   legendary.shadowflame_prism        = find_runeforge_legendary( "Shadowflame Prism" );
-  legendary.eternal_call_to_the_void = find_runeforge_legendary( "Eternal Call to the Void" );
   legendary.talbadars_stratagem      = find_runeforge_legendary( "Talbadar's Stratagem" );
 
   // Generic Conduits
   conduits.power_unto_others = find_conduit_spell( "Power Unto Others" );
   // Shadow Conduits
   conduits.dissonant_echoes     = find_conduit_spell( "Dissonant Echoes" );
+  conduits.haunting_apparitions = find_conduit_spell( "Haunting Apparitions" );
   conduits.mind_devourer        = find_conduit_spell( "Mind Devourer" );
   conduits.rabid_shadows        = find_conduit_spell( "Rabid Shadows" );
-  conduits.haunting_apparitions = find_conduit_spell( "Haunting Apparitions" );
   // Covenant Conduits
   conduits.courageous_ascension  = find_conduit_spell( "Courageous Ascension" );
   conduits.festering_transfusion = find_conduit_spell( "Festering Transfusion" );
@@ -1746,10 +1747,10 @@ void priest_t::init_spells()
   conduits.shattered_perceptions = find_conduit_spell( "Shattered Perceptions" );
 
   // Covenant Abilities
-  covenant.fae_guardians        = find_covenant_spell( "Fae Guardians" );
-  covenant.unholy_nova          = find_covenant_spell( "Unholy Nova" );
-  covenant.mindgames            = find_covenant_spell( "Mindgames" );
   covenant.boon_of_the_ascended = find_covenant_spell( "Boon of the Ascended" );
+  covenant.fae_guardians        = find_covenant_spell( "Fae Guardians" );
+  covenant.mindgames            = find_covenant_spell( "Mindgames" );
+  covenant.unholy_nova          = find_covenant_spell( "Unholy Nova" );
 }
 
 void priest_t::create_buffs()

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1701,9 +1701,10 @@ void priest_t::init_spells()
   init_spells_holy();
 
   // Generic Spells
-  specs.mind_sear = find_class_spell( "Mind Sear" );
-  specs.mind_blast = find_class_spell( "Mind Blast" );
-  specs.shadow_word_death = find_class_spell( "Shadow Word: Death" );
+  specs.mind_blast         = find_class_spell( "Mind Blast" );
+  specs.mind_sear          = find_class_spell( "Mind Sear" );
+  specs.mind_sear_insanity = find_spell( 208232 );  // Insanity is stored here, not in any spell triggers
+  specs.shadow_word_death  = find_class_spell( "Shadow Word: Death" );
 
   // Class passives
   specs.priest     = dbc::get_class_passive( *this, SPEC_NONE );
@@ -1712,9 +1713,9 @@ void priest_t::init_spells()
   specs.shadow     = dbc::get_class_passive( *this, PRIEST_SHADOW );
 
   // DoT Spells
+  dot_spells.devouring_plague = find_class_spell( "Devouring Plague" );
   dot_spells.shadow_word_pain = find_class_spell( "Shadow Word: Pain" );
   dot_spells.vampiric_touch   = find_class_spell( "Vampiric Touch" );
-  dot_spells.devouring_plague = find_class_spell( "Devouring Plague" );
 
   // Mastery Spells
   mastery_spells.grace          = find_mastery_spell( PRIEST_DISCIPLINE );
@@ -1749,6 +1750,7 @@ void priest_t::init_spells()
   // Covenant Abilities
   covenant.boon_of_the_ascended = find_covenant_spell( "Boon of the Ascended" );
   covenant.fae_guardians        = find_covenant_spell( "Fae Guardians" );
+  covenant.benevolent_faerie    = find_spell( 327710 );
   covenant.mindgames            = find_covenant_spell( "Mindgames" );
   covenant.unholy_nova          = find_covenant_spell( "Unholy Nova" );
 }

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -249,6 +249,7 @@ public:
   {
     const spell_data_t* mind_blast;
     const spell_data_t* mind_sear;
+    const spell_data_t* mind_sear_insanity;
     const spell_data_t* priest;  // General priest data
     const spell_data_t* shadow_word_death;
 
@@ -273,16 +274,24 @@ public:
     const spell_data_t* holy_priest;
 
     // Shadow
-    const spell_data_t* shadow;  // General shadow data
-    const spell_data_t* shadowy_apparitions;
-    const spell_data_t* voidform;
-    const spell_data_t* void_eruption;
-    const spell_data_t* shadow_priest;
     const spell_data_t* dark_thought;   // Actual buff, holds proc rate
     const spell_data_t* dark_thoughts;  // Passive effect
+    const spell_data_t* dispersion;
     const spell_data_t* mind_flay;
+    const spell_data_t* shadow;  // General shadow data
+    const spell_data_t* shadowy_apparition; // Damage event
+    const spell_data_t* shadowy_apparitions; // Passive effect
+    const spell_data_t* shadow_priest; // Passive spell, holds lots of random things
     const spell_data_t* shadowform;
+    const spell_data_t* silence;
     const spell_data_t* vampiric_embrace;
+    const spell_data_t* void_bolt;
+    const spell_data_t* voidform;
+    const spell_data_t* void_eruption;
+    const spell_data_t* void_eruption_damage;
+    
+    // Legendary Effects
+    const spell_data_t* painbreaker_psalm_insanity;
   } specs;
 
   // DoT Spells
@@ -473,9 +482,14 @@ public:
   // Covenants
   struct
   {
+    // Night Fae
+    const spell_data_t* benevolent_faerie;
     const spell_data_t* fae_guardians;
+    // Necrolord
     const spell_data_t* unholy_nova;
+    // Venthyr
     const spell_data_t* mindgames;
+    // Kyrian
     const spell_data_t* boon_of_the_ascended;
   } covenant;
 

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -186,9 +186,9 @@ public:
     // T45
     const spell_data_t* purge_the_wicked;
     // T50
-    const spell_data_t* lenience;     // not fully implemented
-    const spell_data_t* spirit_shell;     // not fully implemented
-    const spell_data_t* evangelism;     // not fully implemented
+    const spell_data_t* lenience;      // not fully implemented
+    const spell_data_t* spirit_shell;  // not fully implemented
+    const spell_data_t* evangelism;    // not fully implemented
 
     // Holy
     // T15
@@ -218,6 +218,7 @@ public:
     // T15
     const spell_data_t* fortress_of_the_mind;
     const spell_data_t* death_and_madness;
+    const spell_data_t* death_and_madness_insanity;
     const spell_data_t* unfurling_darkness;
     // T25
     const spell_data_t* sanlayn;        // NYI
@@ -246,8 +247,10 @@ public:
   // Specialization Spells
   struct
   {
-    const spell_data_t* priest;  // General priest data
+    const spell_data_t* mind_blast;
     const spell_data_t* mind_sear;
+    const spell_data_t* priest;  // General priest data
+    const spell_data_t* shadow_word_death;
 
     // Discipline
     const spell_data_t* discipline;  // General discipline data
@@ -275,8 +278,11 @@ public:
     const spell_data_t* voidform;
     const spell_data_t* void_eruption;
     const spell_data_t* shadow_priest;
-    const spell_data_t* dark_thoughts;
+    const spell_data_t* dark_thought;   // Actual buff, holds proc rate
+    const spell_data_t* dark_thoughts;  // Passive effect
     const spell_data_t* mind_flay;
+    const spell_data_t* shadowform;
+    const spell_data_t* vampiric_embrace;
   } specs;
 
   // DoT Spells

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -172,7 +172,7 @@ struct mind_sear_tick_t final : public priest_spell_t
   double insanity_gain;
 
   mind_sear_tick_t( priest_t& p, const spell_data_t* s )
-    : priest_spell_t( "mind_sear_tick", p, s ), insanity_gain( p.find_spell( 208232 )->effectN( 1 ).percent() )
+    : priest_spell_t( "mind_sear_tick", p, s ), insanity_gain( p.specs.mind_sear_insanity->effectN( 1 ).percent() )
   {
     affected_by_shadow_weaving = true;
     background                 = true;
@@ -325,7 +325,7 @@ struct shadow_word_death_t final : public priest_spell_t
     : priest_spell_t( "shadow_word_death", p, p.specs.shadow_word_death ),
       execute_percent( data().effectN( 2 ).base_value() ),
       execute_modifier( data().effectN( 3 ).percent() ),
-      insanity_per_dot( p.find_spell( 336167 )->effectN( 2 ).base_value() /
+      insanity_per_dot( p.specs.painbreaker_psalm_insanity->effectN( 2 ).base_value() /
                         10 )  // Spell Data stores this as 100 not 1000 or 10
   {
     parse_options( options_str );
@@ -422,8 +422,7 @@ struct shadow_word_death_t final : public priest_spell_t
 // ==========================================================================
 struct dispersion_t final : public priest_spell_t
 {
-  dispersion_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "dispersion", p, p.find_class_spell( "Dispersion" ) )
+  dispersion_t( priest_t& p, util::string_view options_str ) : priest_spell_t( "dispersion", p, p.specs.dispersion )
   {
     parse_options( options_str );
 
@@ -481,8 +480,7 @@ struct shadowform_t final : public priest_spell_t
 // ==========================================================================
 struct silence_t final : public priest_spell_t
 {
-  silence_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "silence", p, p.find_class_spell( "Silence" ) )
+  silence_t( priest_t& p, util::string_view options_str ) : priest_spell_t( "silence", p, p.specs.silence )
   {
     parse_options( options_str );
     may_miss = may_crit   = false;
@@ -539,7 +537,7 @@ struct silence_t final : public priest_spell_t
 struct vampiric_embrace_t final : public priest_spell_t
 {
   vampiric_embrace_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "vampiric_embrace", p, p.find_class_spell( "Vampiric Embrace" ) )
+    : priest_spell_t( "vampiric_embrace", p, p.specs.vampiric_embrace )
   {
     parse_options( options_str );
 
@@ -576,7 +574,7 @@ struct shadowy_apparition_damage_t final : public priest_spell_t
   double insanity_gain;
 
   shadowy_apparition_damage_t( priest_t& p )
-    : priest_spell_t( "shadowy_apparition", p, p.find_spell( 148859 ) ),
+    : priest_spell_t( "shadowy_apparition", p, p.specs.shadowy_apparition ),
       insanity_gain( priest().talents.auspicious_spirits->effectN( 2 ).percent() )
   {
     affected_by_shadow_weaving = true;
@@ -640,7 +638,7 @@ struct shadow_word_pain_t final : public priest_spell_t
   bool casted;
 
   shadow_word_pain_t( priest_t& p, bool _casted = false )
-    : priest_spell_t( "shadow_word_pain", p, p.find_class_spell( "Shadow Word: Pain" ) )
+    : priest_spell_t( "shadow_word_pain", p, p.dot_spells.shadow_word_pain )
   {
     affected_by_shadow_weaving = true;
     casted                     = _casted;
@@ -706,7 +704,8 @@ struct shadow_word_pain_t final : public priest_spell_t
 struct unfurling_darkness_t final : public priest_spell_t
 {
   unfurling_darkness_t( priest_t& p )
-    : priest_spell_t( "unfurling_darkness", p, p.find_class_spell( "Vampiric Touch" ) )
+    : priest_spell_t( "unfurling_darkness", p,
+                      p.dot_spells.vampiric_touch )  // Damage value is stored in Vampiric Touch
   {
     background                 = true;
     affected_by_shadow_weaving = true;
@@ -732,7 +731,7 @@ struct vampiric_touch_t final : public priest_spell_t
   bool casted;
 
   vampiric_touch_t( priest_t& p, bool _casted = false )
-    : priest_spell_t( "vampiric_touch", p, p.find_class_spell( "Vampiric Touch" ) ),
+    : priest_spell_t( "vampiric_touch", p, p.dot_spells.vampiric_touch ),
       child_swp( nullptr ),
       child_ud( nullptr ),
       ignore_healing( p.options.priest_ignore_healing )
@@ -866,7 +865,7 @@ struct devouring_plague_t final : public priest_spell_t
   bool casted;
 
   devouring_plague_t( priest_t& p, bool _casted = false )
-    : priest_spell_t( "devouring_plague", p, p.find_class_spell( "Devouring Plague" ) )
+    : priest_spell_t( "devouring_plague", p, p.dot_spells.devouring_plague )
   {
     casted                     = _casted;
     may_crit                   = true;
@@ -1003,7 +1002,7 @@ struct void_bolt_t final : public priest_spell_t
     {
       dot_extension = data().effectN( 1 ).time_value();
       aoe           = -1;
-      radius        = p.find_spell( 234746 )->effectN( 1 ).radius();
+      radius        = p.specs.void_bolt->effectN( 1 ).trigger()->effectN( 1 ).radius_max();
       may_miss      = false;
       background = dual = true;
       energize_type     = action_energize::ON_CAST;
@@ -1028,7 +1027,7 @@ struct void_bolt_t final : public priest_spell_t
   timespan_t hungering_void_crit_duration;
 
   void_bolt_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "void_bolt", p, p.find_spell( 205448 ) ),
+    : priest_spell_t( "void_bolt", p, p.specs.void_bolt ),
       void_bolt_extension( nullptr ),
       shadowfiend_cooldown( p.get_cooldown( "mindbender" ) ),
       mindbender_cooldown( p.get_cooldown( "shadowfiend" ) ),
@@ -1133,7 +1132,7 @@ struct void_eruption_damage_t final : public priest_spell_t
   propagate_const<action_t*> void_bolt;
 
   void_eruption_damage_t( priest_t& p )
-    : priest_spell_t( "void_eruption_damage", p, p.find_spell( 228360 ) ), void_bolt( nullptr )
+    : priest_spell_t( "void_eruption_damage", p, p.specs.void_eruption_damage ), void_bolt( nullptr )
   {
     may_miss                   = false;
     background                 = true;
@@ -1158,8 +1157,8 @@ struct void_eruption_t final : public priest_spell_t
   double benevolent_faerie_rate;
 
   void_eruption_t( priest_t& p, util::string_view options_str )
-    : priest_spell_t( "void_eruption", p, p.find_spell( 228260 ) ),
-      benevolent_faerie_rate( priest().find_spell( 327710 )->effectN( 1 ).percent() )
+    : priest_spell_t( "void_eruption", p, p.specs.void_eruption ),
+      benevolent_faerie_rate( p.covenant.benevolent_faerie->effectN( 1 ).percent() )
   {
     parse_options( options_str );
 
@@ -1213,9 +1212,9 @@ struct void_eruption_stm_damage_t final : public priest_spell_t
   propagate_const<action_t*> void_bolt;
 
   void_eruption_stm_damage_t( priest_t& p )
-    : priest_spell_t( "void_eruption_stm_damage", p, p.find_spell( 228360 ) ), void_bolt( nullptr )
+    : priest_spell_t( "void_eruption_stm_damage", p, p.specs.void_eruption_damage ), void_bolt( nullptr )
   {
-    // This Void Eruption currently only hits a single target
+    // This Void Eruption only hits a single target
     may_miss                   = false;
     background                 = true;
     affected_by_shadow_weaving = true;
@@ -1521,7 +1520,7 @@ namespace buffs
 // ==========================================================================
 struct voidform_t final : public priest_buff_t<buff_t>
 {
-  voidform_t( priest_t& p ) : base_t( p, "voidform", p.find_spell( 194249 ) )
+  voidform_t( priest_t& p ) : base_t( p, "voidform", p.specs.voidform )
   {
     add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
     add_invalidate( CACHE_PLAYER_HEAL_MULTIPLIER );
@@ -1602,8 +1601,7 @@ struct shadowform_state_t final : public priest_buff_t<buff_t>
 // ==========================================================================
 struct dark_thought_t final : public priest_buff_t<buff_t>
 {
-  // TODO: fix this
-  dark_thought_t( priest_t& p ) : base_t( p, "dark_thought", p.find_spell( 341207 ) )
+  dark_thought_t( priest_t& p ) : base_t( p, "dark_thought", p.specs.dark_thought )
   {
     // Allow player to react to the buff being applied so they can cast Mind Blast.
     this->reactable = true;
@@ -1658,7 +1656,7 @@ struct ancient_madness_t final : public priest_buff_t<buff_t>
     add_invalidate( CACHE_CRIT_CHANCE );
     add_invalidate( CACHE_SPELL_CRIT_CHANCE );
 
-    set_duration( p.find_spell( 194249 )->duration() );
+    set_duration( p.specs.voidform->duration() );        // Uses the same duration as Voidform for tooltip
     set_default_value( data().effectN( 2 ).percent() );  // Each stack is worth 2% from effect 2
     set_max_stack( as<int>( data().effectN( 1 ).base_value() ) /
                    as<int>( data().effectN( 2 ).base_value() ) );  // Set max stacks to 30 / 2
@@ -1791,15 +1789,23 @@ void priest_t::init_spells_shadow()
   talents.surrender_to_madness = find_talent_spell( "Surrender to Madness" );
 
   // General Spells
-  specs.dark_thought        = find_specialization_spell( "Dark Thought" );
-  specs.dark_thoughts       = find_specialization_spell( "Dark Thoughts" );
-  specs.mind_flay           = find_specialization_spell( "Mind Flay" );
-  specs.shadowy_apparitions = find_specialization_spell( "Shadowy Apparitions" );
-  specs.shadow_priest       = find_specialization_spell( "Shadow Priest" );
-  specs.shadowform          = find_specialization_spell( "Shadowform" );
-  specs.vampiric_embrace    = find_specialization_spell( "Vampiric Embrace" );
-  specs.voidform            = find_specialization_spell( "Voidform" );
-  specs.void_eruption       = find_specialization_spell( "Void Eruption" );
+  specs.dark_thought         = find_spell( 341207 );
+  specs.dark_thoughts        = find_specialization_spell( "Dark Thoughts" );
+  specs.dispersion           = find_specialization_spell( "Dispersion" );
+  specs.mind_flay            = find_specialization_spell( "Mind Flay" );
+  specs.shadowy_apparition   = find_spell( 148859 );
+  specs.shadowy_apparitions  = find_specialization_spell( "Shadowy Apparitions" );
+  specs.shadow_priest        = find_specialization_spell( "Shadow Priest" );
+  specs.shadowform           = find_specialization_spell( "Shadowform" );
+  specs.silence              = find_specialization_spell( "Silence" );
+  specs.vampiric_embrace     = find_specialization_spell( "Vampiric Embrace" );
+  specs.void_bolt            = find_spell( 205448 );
+  specs.voidform             = find_spell( 194249 );
+  specs.void_eruption        = find_specialization_spell( "Void Eruption" );
+  specs.void_eruption_damage = find_spell( 228360 );
+
+  // Legendary Effects
+  specs.painbreaker_psalm_insanity = find_spell( 336167 );
 }
 
 action_t* priest_t::create_action_shadow( util::string_view name, util::string_view options_str )


### PR DESCRIPTION
starts work on https://github.com/WarcraftPriests/sl-shadow-priest/issues/159

- order things alphabetically
- consistently use the `specs` struct where possible. We should not find `mind_flay` 3 times for example, just the one time.
- fix issue with Void Bolt Extension having infinite radius (needed `radius_max()` instead of `radius()`