### PR TITLE
[Priest] add damage and healing reversal effects for Mindgames

### DIFF
--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -1441,6 +1441,7 @@ class SpellDataGenerator(DataGenerator):
             ( 344753, 0 ),          # Eternal Call to the Void Parent spell
             ( 336373, 0 ),          # Cauterizing Shadows heal spell
             ( 323707, 0 ),          # Mindgames Healing reversal Damage spell
+            ( 323706, 0 ),          # Mindgames Damage reversal Healing spell
             # Holy Priest
             ( 196809, 5 ),          # Healing Light (Divine Image legendary pet spell)
             ( 196810, 5 ),          # Dazzling Light (Divine Image legendary pet spell)

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -559,8 +559,7 @@ struct mindgames_t final : public priest_spell_t
       insanity += insanity_gain;
       if ( !ignore_healing )
       {
-        child_mindgames_healing_reversal->target = player;
-        child_mindgames_healing_reversal->execute();
+        child_mindgames_damage_reversal->execute();
       }
     }
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -470,11 +470,9 @@ struct unholy_nova_t final : public priest_spell_t
 // ==========================================================================
 struct mindgames_healing_reversal_t final : public priest_spell_t
 {
-  mindgames_healing_reversal_t( priest_t& p, util::string_view options_str )
+  mindgames_healing_reversal_t( priest_t& p)
     : priest_spell_t( "mindgames_healing_reversal", p, p.covenant.mindgames_healing_reversal )
   {
-    parse_options( options_str );
-
     background        = true;
     may_crit          = false;
     energize_type     = action_energize::NONE;  // disable insanity gain (parent spell covers this)
@@ -490,11 +488,9 @@ struct mindgames_healing_reversal_t final : public priest_spell_t
 
 struct mindgames_damage_reversal_t final : public priest_heal_t
 {
-  mindgames_damage_reversal_t( priest_t& p, util::string_view options_str )
+  mindgames_damage_reversal_t( priest_t& p )
     : priest_heal_t( "mindgames_damage_reversal", p, p.covenant.mindgames_damage_reversal )
   {
-    parse_options( options_str );
-
     background        = true;
     harmful           = false;
     may_crit          = false;
@@ -532,9 +528,9 @@ struct mindgames_t final : public priest_spell_t
       base_dd_multiplier *= ( 1.0 + priest().conduits.shattered_perceptions.percent() );
     }
 
-    child_mindgames_healing_reversal = new mindgames_healing_reversal_t( priest(), options_str );
+    child_mindgames_healing_reversal = new mindgames_healing_reversal_t( priest() );
     add_child( child_mindgames_healing_reversal );
-    child_mindgames_damage_reversal = new mindgames_damage_reversal_t( priest(), options_str );
+    child_mindgames_damage_reversal = new mindgames_damage_reversal_t( priest() );
     add_child( child_mindgames_damage_reversal );
   }
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -542,14 +542,14 @@ struct mindgames_t final : public priest_spell_t
     // 10 if the targets heals enough to break the shield
     double insanity = 0;
     // Healing reversal creates damage
-    if ( priest().options.priest_mindgames_healing_insanity )
+    if ( priest().options.priest_mindgames_healing_reversal )
     {
       insanity += insanity_gain;
       child_mindgames_healing_reversal->target = s->target;
       child_mindgames_healing_reversal->execute();
     }
     // Damage reversal creates healing
-    if ( priest().options.priest_mindgames_damage_insanity )
+    if ( priest().options.priest_mindgames_damage_reversal )
     {
       insanity += insanity_gain;
       trigger_heal();
@@ -1739,8 +1739,8 @@ void priest_t::create_options()
   add_option( opt_int( "priest_set_voidform_duration", options.priest_set_voidform_duration ) );
   add_option( opt_bool( "priest_use_ascended_nova", options.priest_use_ascended_nova ) );
   add_option( opt_bool( "priest_use_ascended_eruption", options.priest_use_ascended_eruption ) );
-  add_option( opt_bool( "priest_mindgames_healing_insanity", options.priest_mindgames_healing_insanity ) );
-  add_option( opt_bool( "priest_mindgames_damage_insanity", options.priest_mindgames_damage_insanity ) );
+  add_option( opt_bool( "priest_mindgames_healing_reversal", options.priest_mindgames_healing_reversal ) );
+  add_option( opt_bool( "priest_mindgames_damage_reversal", options.priest_mindgames_damage_reversal ) );
   add_option( opt_bool( "priest_self_power_infusion", options.priest_self_power_infusion ) );
   add_option( opt_bool( "priest_self_benevolent_faerie", options.priest_self_benevolent_faerie ) );
   add_option(

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -564,10 +564,7 @@ struct mindgames_t final : public priest_spell_t
       }
     }
 
-    if ( priest().specialization() == PRIEST_SHADOW )
-    {
-      priest().generate_insanity( insanity, priest().gains.insanity_mindgames, s->action );
-    }
+    priest().generate_insanity( insanity, priest().gains.insanity_mindgames, s->action );
   }
 };
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1085,7 +1085,6 @@ void priest_t::create_gains()
   gains.insanity_pet                  = get_gain( "Insanity Gained from Shadowfiend" );
   gains.insanity_surrender_to_madness = get_gain( "Insanity Gained from Surrender to Madness" );
   gains.mindbender                    = get_gain( "Mana Gained from Mindbender" );
-  gains.mindgames_health              = get_gain( "Health from Mindgames damage reversal" );
   gains.painbreaker_psalm             = get_gain( "Insanity Gained from Painbreaker Psalm" );
   gains.power_word_solace             = get_gain( "Mana Gained from Power Word: Solace" );
   gains.shadow_word_death_self_damage = get_gain( "Shadow Word: Death self inflicted damage" );

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -446,6 +446,7 @@ public:
     // Venthyr
     const spell_data_t* mindgames;
     const spell_data_t* mindgames_healing_reversal;
+    const spell_data_t* mindgames_damage_reversal;
     // Kyrian
     const spell_data_t* boon_of_the_ascended;
   } covenant;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -164,8 +164,8 @@ public:
     // T30
     const spell_data_t* power_word_solace;
     // T40
-    const spell_data_t* sins_of_the_many; // assumes 0 atonment targets
-    const spell_data_t* shadow_covenant;  // healing not fully implemented, only dmg/healing buff
+    const spell_data_t* sins_of_the_many;  // assumes 0 atonment targets
+    const spell_data_t* shadow_covenant;   // healing not fully implemented, only dmg/healing buff
     // T45
     const spell_data_t* purge_the_wicked;
     // T50
@@ -218,7 +218,7 @@ public:
     const spell_data_t* shadow_word_death;
 
     // Discipline
-    const spell_data_t* discipline_priest; // General discipline data
+    const spell_data_t* discipline_priest;       // General discipline data
     const spell_data_t* power_of_the_dark_side;  // For buffing the damage of penance
 
     // Holy
@@ -231,9 +231,9 @@ public:
     const spell_data_t* dark_thoughts;  // Passive effect
     const spell_data_t* dispersion;
     const spell_data_t* mind_flay;
-    const spell_data_t* shadow_priest;  // General shadow data
-    const spell_data_t* shadowy_apparition; // Damage event
-    const spell_data_t* shadowy_apparitions; // Passive effect
+    const spell_data_t* shadow_priest;        // General shadow data
+    const spell_data_t* shadowy_apparition;   // Damage event
+    const spell_data_t* shadowy_apparitions;  // Passive effect
     const spell_data_t* shadowform;
     const spell_data_t* silence;
     const spell_data_t* vampiric_embrace;
@@ -299,7 +299,6 @@ public:
     propagate_const<gain_t*> insanity_pet;
     propagate_const<gain_t*> insanity_surrender_to_madness;
     propagate_const<gain_t*> mindbender;
-    propagate_const<gain_t*> mindgames_health;
     propagate_const<gain_t*> painbreaker_psalm;
     propagate_const<gain_t*> power_of_the_dark_side;
     propagate_const<gain_t*> power_word_solace;
@@ -771,13 +770,6 @@ struct priest_heal_t : public priest_action_t<heal_t>
   priest_heal_t( util::string_view name, priest_t& player, const spell_data_t* s = spell_data_t::nil() )
     : base_t( name, player, s )
   {
-  }
-
-  void execute() override
-  {
-    base_t::execute();
-
-    may_crit = true;
   }
 
   void impact( action_state_t* s ) override

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -379,8 +379,8 @@ public:
     // Add in options to override insanity gained
     // Mindgames gives 20 insanity from the healing and 20 from damage dealt
     // For most content the healing part won't proc, only default damage dealt
-    bool priest_mindgames_healing_insanity = false;
-    bool priest_mindgames_damage_insanity  = true;
+    bool priest_mindgames_healing_reversal = false;
+    bool priest_mindgames_damage_reversal  = true;
 
     // Fae Blessings CDR can be given to another player, but you can still get the insanity gen
     bool priest_self_benevolent_faerie = true;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -299,6 +299,7 @@ public:
     propagate_const<gain_t*> insanity_pet;
     propagate_const<gain_t*> insanity_surrender_to_madness;
     propagate_const<gain_t*> mindbender;
+    propagate_const<gain_t*> mindgames_health;
     propagate_const<gain_t*> painbreaker_psalm;
     propagate_const<gain_t*> power_of_the_dark_side;
     propagate_const<gain_t*> power_word_solace;
@@ -444,6 +445,7 @@ public:
     const spell_data_t* unholy_nova;
     // Venthyr
     const spell_data_t* mindgames;
+    const spell_data_t* mindgames_healing_reversal;
     // Kyrian
     const spell_data_t* boon_of_the_ascended;
   } covenant;


### PR DESCRIPTION
Mindgames has two variable formulas to calculate the healing and damage reversal parts of the spell. By default in SimC we only have `priest_mindgames_damage_insanity` enabled by default.

From this refactor I changed the options to reflect the whole reversal instead, they will create the proper healing and/or damage events based on the reversal options set.

Specifically activating `priest_mindgames_healing_reversal=1` create a child damage action on Mindgames that does the reversal damage. `priest_mindgames_damage_reversal=1` create a healing event that heals the actor. Both of these follow specific formulas for the damage/healing found in the parent spell.