### PR TITLE
Priest: Refactor option variables and use priest. prefix

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1775,12 +1775,12 @@ std::string priest_t::create_profile( save_e type )
   {
     if ( !options.autoUnshift )
     {
-      profile_str += fmt::format( "autounshift={}\n", options.autoUnshift );
+      profile_str += fmt::format( "priest.autounshift={}\n", options.autoUnshift );
     }
 
     if ( !options.fixed_time )
     {
-      profile_str += fmt::format( "priest_fixed_time={}\n", options.fixed_time );
+      profile_str += fmt::format( "priest.fixed_time={}\n", options.fixed_time );
     }
   }
 

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -365,31 +365,31 @@ public:
   struct
   {
     bool autoUnshift           = true;  // Shift automatically out of stance/form
-    bool priest_fixed_time     = true;
-    bool priest_ignore_healing = false;  // Remove Healing calculation codes
+    bool fixed_time     = true;
+    bool ignore_healing = false;  // Remove Healing calculation codes
 
     // Default param to set if you should cast Power Infusion on yourself
-    bool priest_self_power_infusion = true;
+    bool self_power_infusion = true;
 
     // Add in easy options to change if you are in range or not
-    bool priest_use_ascended_nova     = true;
-    bool priest_use_ascended_eruption = true;
+    bool use_ascended_nova     = true;
+    bool use_ascended_eruption = true;
 
     // Add in options to override insanity gained
     // Mindgames gives 20 insanity from the healing and 20 from damage dealt
     // For most content the healing part won't proc, only default damage dealt
-    bool priest_mindgames_healing_reversal = false;
-    bool priest_mindgames_damage_reversal  = true;
+    bool mindgames_healing_reversal = false;
+    bool mindgames_damage_reversal  = true;
 
     // Fae Blessings CDR can be given to another player, but you can still get the insanity gen
-    bool priest_self_benevolent_faerie = true;
+    bool self_benevolent_faerie = true;
 
     // Add "bugged" targets to Ascended Eruption for the SQRT calculation
     // Setting to 0 turns off the bug
-    int priest_ascended_eruption_additional_targets = 0;
+    int ascended_eruption_additional_targets = 0;
 
     // The amount of allies to assume for Cauterizing Shadows healing
-    int priest_cauterizing_shadows_allies = 3;
+    int cauterizing_shadows_allies = 3;
   } options;
 
   // Legendaries

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -639,7 +639,7 @@ struct shadow_word_pain_t final : public priest_spell_t
 
   shadow_word_pain_t( priest_t& p, bool _casted = false )
     : priest_spell_t( "shadow_word_pain", p, p.dot_spells.shadow_word_pain ),
-      ignore_healing( p.options.priest_ignore_healing )
+      ignore_healing( p.options.ignore_healing )
   {
     affected_by_shadow_weaving = true;
     casted                     = _casted;
@@ -673,7 +673,7 @@ struct shadow_word_pain_t final : public priest_spell_t
     }
 
     // Use a simple option to dictate how many "allies" this will heal. All healing will go to the actor
-    double amount_to_heal = priest().options.priest_cauterizing_shadows_allies * priest().intellect() *
+    double amount_to_heal = priest().options.cauterizing_shadows_allies * priest().intellect() *
                             priest().specs.cauterizing_shadows_health->effectN( 1 ).sp_coeff();
     priest().resource_gain( RESOURCE_HEALTH, amount_to_heal, priest().gains.cauterizing_shadows_health, this );
   }
@@ -760,7 +760,7 @@ struct vampiric_touch_t final : public priest_spell_t
     : priest_spell_t( "vampiric_touch", p, p.dot_spells.vampiric_touch ),
       child_swp( nullptr ),
       child_ud( nullptr ),
-      ignore_healing( p.options.priest_ignore_healing )
+      ignore_healing( p.options.ignore_healing )
   {
     casted                     = _casted;
     may_crit                   = false;
@@ -893,7 +893,7 @@ struct devouring_plague_t final : public priest_spell_t
 
   devouring_plague_t( priest_t& p, bool _casted = false )
     : priest_spell_t( "devouring_plague", p, p.dot_spells.devouring_plague ),
-      ignore_healing( p.options.priest_ignore_healing )
+      ignore_healing( p.options.ignore_healing )
   {
     casted                     = _casted;
     may_crit                   = true;
@@ -1240,7 +1240,7 @@ struct void_eruption_t final : public priest_spell_t
   {
     double m = priest_spell_t::recharge_multiplier( cd );
 
-    if ( &cd == cooldown && priest().buffs.fae_guardians->check() && priest().options.priest_self_benevolent_faerie )
+    if ( &cd == cooldown && priest().buffs.fae_guardians->check() && priest().options.self_benevolent_faerie )
     {
       m /= 1.0 + benevolent_faerie_rate;
     }


### PR DESCRIPTION
Makes options consistent with other modules (hunter, mage and others who have started switching to class name prefix), as well as with priest apl options (priest.self_power_infusion, priest.fiend, etc.)

Remove the priest_ prefix from variable names, since there really is no point of doing that. They are inside a option struct inside priest_t already.

cc @seriallos 