### PR TITLE
Updating Demonology APL for more damage

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1321,6 +1321,7 @@ void warlock_t::create_apl_demonology()
   action_priority_list_t* sum    = get_action_priority_list( "summon_tyrant" );
   action_priority_list_t* ogcd   = get_action_priority_list( "off_gcd" );
   action_priority_list_t* cov    = get_action_priority_list( "covenant" );
+  action_priority_list_t* bshard = get_action_priority_list( "build_shard" );
 
   def->add_action( "call_action_list,name=off_gcd" );
   def->add_action( "run_action_list,name=tyrant_prep,if=cooldown.summon_demonic_tyrant.remains<4&!variable.tyrant_ready" );
@@ -1330,8 +1331,8 @@ void warlock_t::create_apl_demonology()
   def->add_action( "doom,if=refreshable" );
   def->add_action( "demonic_strength" );
   def->add_action( "bilescourge_bombers" );
-  def->add_action( "implosion,if=active_enemies>1&!talent.sacrificed_souls.enabled&buff.wild_imps.stack>=8&buff.tyrant.down&cooldown.summon_demonic_tyrant.remains>5" );
-  def->add_action( "implosion,if=active_enemies>2&buff.wild_imps.stack>=8&buff.tyrant.down" );
+  def->add_action( "implosion,if=active_enemies>1&!talent.sacrificed_souls.enabled&buff.wild_imps.stack>=6&buff.tyrant.down&cooldown.summon_demonic_tyrant.remains>5" );
+  def->add_action( "implosion,if=active_enemies>2&buff.wild_imps.stack>=6&buff.tyrant.down" );
   def->add_action( "hand_of_guldan,if=soul_shard=5|buff.nether_portal.up" );
   def->add_action( "hand_of_guldan,if=soul_shard>=3&cooldown.summon_demonic_tyrant.remains>20&(cooldown.summon_vilefiend.remains>5|!talent.summon_vilefiend.enabled)&cooldown.call_dreadstalkers.remains>2" );
   def->add_action( "call_action_list,name=covenant,if=(covenant.necrolord|covenant.night_fae)&!talent.nether_portal.enabled" );
@@ -1357,6 +1358,8 @@ void warlock_t::create_apl_demonology()
   sum->add_action( "hand_of_guldan,if=soul_shard=5,line_cd=20" );
   sum->add_action( "demonbolt,if=buff.demonic_core.up&(talent.demonic_consumption.enabled|buff.nether_portal.down),line_cd=20" );
   sum->add_action( "shadow_bolt,if=buff.wild_imps.stack+incoming_imps<4&(talent.demonic_consumption.enabled|buff.nether_portal.down),line_cd=20" );
+  sum->add_action( "grimoire_felguard" );
+  sum->add_action( "summon_vilefiend" );
   sum->add_action( "call_dreadstalkers" );
   sum->add_action( "hand_of_guldan" );
   sum->add_action( "demonbolt,if=buff.demonic_core.up&buff.nether_portal.up&((buff.vilefiend.remains>5|!talent.summon_vilefiend.enabled)&(buff.grimoire_felguard.remains>5|buff.grimoire_felguard.down))" );
@@ -1364,7 +1367,7 @@ void warlock_t::create_apl_demonology()
   sum->add_action( "shadow_bolt,if=buff.nether_portal.up&((buff.vilefiend.remains>5|!talent.summon_vilefiend.enabled)&(buff.grimoire_felguard.remains>5|buff.grimoire_felguard.down))" );
   sum->add_action( "variable,name=tyrant_ready,value=!cooldown.summon_demonic_tyrant.ready" );
   sum->add_action( "summon_demonic_tyrant" );
-  sum->add_action( "shadow_bolt" );
+  sum->add_action( "run_action_list,name=build_shard" );
 
   ogcd->add_action( "berserking,if=pet.demonic_tyrant.active" );
   ogcd->add_action( "potion,if=buff.berserking.up|pet.demonic_tyrant.active&!race.troll" );
@@ -1376,5 +1379,8 @@ void warlock_t::create_apl_demonology()
   cov->add_action( "scouring_tithe,if=!talent.sacrificed_souls.enabled&active_enemies<4" );
   cov->add_action( "soul_rot" );
   cov->add_action( "decimating_bolt" );
+
+  bshard->add_action( "soul_strike" );
+  bshard->add_action( "shadow_bolt" );
 }
 }  // namespace warlock

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1366,6 +1366,7 @@ void warlock_t::create_apl_demonology()
   sum->add_action( "shadow_bolt,if=buff.nether_portal.up&((buff.vilefiend.remains>5|!talent.summon_vilefiend.enabled)&(buff.grimoire_felguard.remains>5|buff.grimoire_felguard.down))" );
   sum->add_action( "variable,name=tyrant_ready,value=!cooldown.summon_demonic_tyrant.ready" );
   sum->add_action( "summon_demonic_tyrant" );
+  sum->add_action( "shadow_bolt" );
 
   ogcd->add_action( "berserking,if=pet.demonic_tyrant.active" );
   ogcd->add_action( "potion,if=buff.berserking.up|pet.demonic_tyrant.active&!race.troll" );

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1321,7 +1321,6 @@ void warlock_t::create_apl_demonology()
   action_priority_list_t* sum    = get_action_priority_list( "summon_tyrant" );
   action_priority_list_t* ogcd   = get_action_priority_list( "off_gcd" );
   action_priority_list_t* cov    = get_action_priority_list( "covenant" );
-  action_priority_list_t* bshard = get_action_priority_list( "build_shard" );
 
   def->add_action( "call_action_list,name=off_gcd" );
   def->add_action( "run_action_list,name=tyrant_prep,if=cooldown.summon_demonic_tyrant.remains<4&!variable.tyrant_ready" );
@@ -1367,7 +1366,6 @@ void warlock_t::create_apl_demonology()
   sum->add_action( "shadow_bolt,if=buff.nether_portal.up&((buff.vilefiend.remains>5|!talent.summon_vilefiend.enabled)&(buff.grimoire_felguard.remains>5|buff.grimoire_felguard.down))" );
   sum->add_action( "variable,name=tyrant_ready,value=!cooldown.summon_demonic_tyrant.ready" );
   sum->add_action( "summon_demonic_tyrant" );
-  sum->add_action( "run_action_list,name=build_shard" );
 
   ogcd->add_action( "berserking,if=pet.demonic_tyrant.active" );
   ogcd->add_action( "potion,if=buff.berserking.up|pet.demonic_tyrant.active&!race.troll" );
@@ -1379,8 +1377,5 @@ void warlock_t::create_apl_demonology()
   cov->add_action( "scouring_tithe,if=!talent.sacrificed_souls.enabled&active_enemies<4" );
   cov->add_action( "soul_rot" );
   cov->add_action( "decimating_bolt" );
-
-  bshard->add_action( "soul_strike" );
-  bshard->add_action( "shadow_bolt" );
 }
 }  // namespace warlock


### PR DESCRIPTION
### Notes on Demonology changes I made:

**Why change Imploding at 6 Imps instead of 8?**
It sims better.  6 seems to be the magic number when I simmed Imploding 3 imps iterating up to 12 imps.

**Why did I add `-- grimoire_felguard` and `-- summon_vilefiend` to SummonTyrant() function?**
When actually playing and you are moving from pack to pack / get interrupted etc, often it will run TyrantPrep, but you won't actually use your tyrant.  Moving to next pack while not exiting combat has been enough time for those two cooldowns to come back up.  Both pets considerably boost your tyrants damage with consumption.  If you were to follow APL as written, it would cast both those pets after Tyrant was summoned instead of before in that situation.

**Why remove `-- demonic_strength,if=!talent.demonic_consumption.enabled` from TyrantPrep()?**
There is no reason to cast demonic strength before your Tyrant as the damage boost is huge after Tyrant.  This doesn't matter if you are running demonic consumption or not.  Also casting demonic strength uses a valuable GCD while using nether portal / performing consumption prep.

**What is the BuildShard() function and why is it needed?**
When running Soul Strike, this is a handy tool for building up your shards during Tyrant prep phase or any time you would normally use Shadow Bolt.  There is no downside to using Soul Strike on CD and it should be utilized as soon as it is able to be cast.  Changing this improved damage sims when talented into Soul Strike.  Much smoother openers as well within M+ where the environment is fast paced.

### Simulations for APL Comparisons

**Patchwork Single Target APL Comparisons:**
https://www.raidbots.com/simbot/report/mxcpMZ7uuu1TCvA14khr6S

**Patchwork 3 Target APL Comparisons:**
https://www.raidbots.com/simbot/report/88pBfKJhfjCVJm2mTUk33f

**Dungeon Slice APL Comparisons:**
https://www.raidbots.com/simbot/report/nJhntPeFXtFnPrr6bHngbL
