### PR TITLE
[Priest] remove ignore_healing option

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -434,12 +434,9 @@ struct unholy_transfusion_t final : public priest_spell_t
 
 struct unholy_transfusion_healing_t final : public priest_heal_t
 {
-  bool ignore_healing;
-
   unholy_transfusion_healing_t( priest_t& p )
     : priest_heal_t( "unholy_transfusion_healing", p,
-                     p.covenant.unholy_nova->effectN( 2 ).trigger()->effectN( 2 ).trigger() ),
-      ignore_healing( p.options.ignore_healing )
+                     p.covenant.unholy_nova->effectN( 2 ).trigger()->effectN( 2 ).trigger() )
   {
     background = true;
     harmful    = false;
@@ -455,9 +452,6 @@ struct unholy_transfusion_healing_t final : public priest_heal_t
 
   void trigger()
   {
-    if ( ignore_healing )
-      return;
-
     execute();
   }
 };
@@ -579,7 +573,7 @@ struct mindgames_damage_reversal_t final : public priest_heal_t
     // $damage=${($SPS*$s2/100)*(1+$@versadmg)*$m3/100}
     spell_power_mod.direct = ( priest().covenant.mindgames->effectN( 2 ).base_value() / 100 ) *
                              ( priest().covenant.mindgames->effectN( 3 ).base_value() / 100 );
-                            
+
     if ( priest().conduits.shattered_perceptions->ok() )
     {
       base_dd_multiplier *= ( 1.0 + priest().conduits.shattered_perceptions.percent() );
@@ -591,14 +585,12 @@ struct mindgames_t final : public priest_spell_t
 {
   propagate_const<mindgames_healing_reversal_t*> child_mindgames_healing_reversal;
   propagate_const<mindgames_damage_reversal_t*> child_mindgames_damage_reversal;
-  bool ignore_healing;
   double insanity_gain;
 
   mindgames_t( priest_t& p, util::string_view options_str )
     : priest_spell_t( "mindgames", p, p.covenant.mindgames ),
       child_mindgames_healing_reversal( nullptr ),
       child_mindgames_damage_reversal( nullptr ),
-      ignore_healing( p.options.ignore_healing ),
       insanity_gain( p.find_spell( 323706 )->effectN( 2 ).base_value() )
   {
     parse_options( options_str );
@@ -640,10 +632,7 @@ struct mindgames_t final : public priest_spell_t
     if ( child_mindgames_damage_reversal )
     {
       insanity += insanity_gain;
-      if ( !ignore_healing )
-      {
-        child_mindgames_damage_reversal->execute();
-      }
+      child_mindgames_damage_reversal->execute();
     }
 
     priest().generate_insanity( insanity, priest().gains.insanity_mindgames, s->action );
@@ -1830,7 +1819,6 @@ void priest_t::create_options()
 
   add_option( opt_deprecated( "autounshift", "priest.autounshift" ) );
   add_option( opt_deprecated( "priest_fixed_time", "priest.fixed_time" ) );
-  add_option( opt_deprecated( "priest_ignore_healing", "priest.ignore_healing" ) );
   add_option( opt_deprecated( "priest_use_ascended_nova", "priest.use_ascended_nova" ) );
   add_option( opt_deprecated( "priest_use_ascended_eruption", "priest.use_ascended_eruption" ) );
   add_option( opt_deprecated( "priest_mindgames_healing_reversal", "priest.mindgames_healing_reversal" ) );
@@ -1843,7 +1831,6 @@ void priest_t::create_options()
 
   add_option( opt_bool( "priest.autounshift", options.autoUnshift ) );
   add_option( opt_bool( "priest.fixed_time", options.fixed_time ) );
-  add_option( opt_bool( "priest.ignore_healing", options.ignore_healing ) );
   add_option( opt_bool( "priest.use_ascended_nova", options.use_ascended_nova ) );
   add_option( opt_bool( "priest.use_ascended_eruption", options.use_ascended_eruption ) );
   add_option( opt_bool( "priest.mindgames_healing_reversal", options.mindgames_healing_reversal ) );

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -368,7 +368,6 @@ public:
   {
     bool autoUnshift           = true;  // Shift automatically out of stance/form
     bool fixed_time     = true;
-    bool ignore_healing = false;  // Remove Healing calculation codes
 
     // Default param to set if you should cast Power Infusion on yourself
     bool self_power_infusion = true;

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -634,12 +634,10 @@ struct shadowy_apparition_spell_t final : public priest_spell_t
 // ==========================================================================
 struct shadow_word_pain_t final : public priest_spell_t
 {
-  bool ignore_healing;
   bool casted;
 
   shadow_word_pain_t( priest_t& p, bool _casted = false )
-    : priest_spell_t( "shadow_word_pain", p, p.dot_spells.shadow_word_pain ),
-      ignore_healing( p.options.ignore_healing )
+    : priest_spell_t( "shadow_word_pain", p, p.dot_spells.shadow_word_pain )
   {
     affected_by_shadow_weaving = true;
     casted                     = _casted;
@@ -667,11 +665,6 @@ struct shadow_word_pain_t final : public priest_spell_t
 
   void trigger_heal()
   {
-    if ( ignore_healing )
-    {
-      return;
-    }
-
     // Use a simple option to dictate how many "allies" this will heal. All healing will go to the actor
     double amount_to_heal = priest().options.cauterizing_shadows_allies * priest().intellect() *
                             priest().specs.cauterizing_shadows_health->effectN( 1 ).sp_coeff();
@@ -753,14 +746,10 @@ struct vampiric_touch_t final : public priest_spell_t
 {
   propagate_const<shadow_word_pain_t*> child_swp;
   propagate_const<unfurling_darkness_t*> child_ud;
-  bool ignore_healing;
   bool casted;
 
   vampiric_touch_t( priest_t& p, bool _casted = false )
-    : priest_spell_t( "vampiric_touch", p, p.dot_spells.vampiric_touch ),
-      child_swp( nullptr ),
-      child_ud( nullptr ),
-      ignore_healing( p.options.ignore_healing )
+    : priest_spell_t( "vampiric_touch", p, p.dot_spells.vampiric_touch ), child_swp( nullptr ), child_ud( nullptr )
   {
     casted                     = _casted;
     may_crit                   = false;
@@ -789,11 +778,6 @@ struct vampiric_touch_t final : public priest_spell_t
 
   void trigger_heal( action_state_t* s )
   {
-    if ( ignore_healing )
-    {
-      return;
-    }
-
     double amount_to_heal = s->result_amount * data().effectN( 2 ).m_value();
     priest().resource_gain( RESOURCE_HEALTH, amount_to_heal, priest().gains.vampiric_touch_health, this );
   }
@@ -887,12 +871,10 @@ struct devouring_plague_dot_state_t : public action_state_t
 
 struct devouring_plague_t final : public priest_spell_t
 {
-  bool ignore_healing;
   bool casted;
 
   devouring_plague_t( priest_t& p, bool _casted = false )
-    : priest_spell_t( "devouring_plague", p, p.dot_spells.devouring_plague ),
-      ignore_healing( p.options.ignore_healing )
+    : priest_spell_t( "devouring_plague", p, p.dot_spells.devouring_plague )
   {
     casted                     = _casted;
     may_crit                   = true;
@@ -936,11 +918,6 @@ struct devouring_plague_t final : public priest_spell_t
 
   void trigger_heal( action_state_t* s )
   {
-    if ( ignore_healing )
-    {
-      return;
-    }
-
     double amount_to_heal = s->result_amount * data().effectN( 2 ).m_value();
     priest().resource_gain( RESOURCE_HEALTH, amount_to_heal, priest().gains.devouring_plague_health, this );
   }


### PR DESCRIPTION
@scamille did some tests and found that this option hardly affects performance at all (~`0.18%` diff). Due to this small of a change we opted to remove this option to make the code cleaner.