### PR TITLE
[Dockerfile] Change to release build, so march=native isn't set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,10 @@ RUN apk --no-cache add --virtual build_dependencies \
     make && \
     if [ $NONETWORKING -eq 0 ] ; then \
         echo "Building networking version" && \
-        make -C /app/SimulationCraft/engine optimized -j $THREADS LTO=1 OPTS+="-Os -mtune=native" SC_DEFAULT_APIKEY=${APIKEY} ;  \
+        make -C /app/SimulationCraft/engine release -j $THREADS LTO=1 OPTS+="-Os -march=x86-64 -mtune=generic" SC_DEFAULT_APIKEY=${APIKEY} ;  \
     else \
         echo "Building no-networking version" && \
-        make -C /app/SimulationCraft/engine optimized -j $THREADS LTO=1 SC_NO_NETWORKING=1 OPTS+="-Os -mtune=native" SC_DEFAULT_APIKEY=${APIKEY} ; \
+        make -C /app/SimulationCraft/engine release -j $THREADS LTO=1 SC_NO_NETWORKING=1 OPTS+="-Os -march=x86-64 -mtune=generic" SC_DEFAULT_APIKEY=${APIKEY} ; \
     fi && \
     apk del build_dependencies
 


### PR DESCRIPTION
If we want to have a compatible container, it should be built with x86-64 so that it runs on most machines.  optimized adds in -march=native so whatever the build machine cpu is is at least haswell or newer.  I had an old sandy bridge linux machine that I managed to reproduce the issue on.

Either that or a min processor age should be decided on, and march set to that instruction set.

@Bloodmallet 