### PR TITLE
[Shaman] Updated resto racial APL

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8974,11 +8974,11 @@ void shaman_t::init_action_list_restoration_dps()
   def->add_action( this, "Earth Elemental" );
 
   // Racials
-  def->add_action( "blood_fury,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50" );
-  def->add_action( "berserking,if=!talent.ascendance.enabled|buff.ascendance.up" );
-  def->add_action( "fireblood,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50" );
-  def->add_action( "ancestral_call,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50" );
-  def->add_action( "bag_of_tricks,if=!talent.ascendance.enabled|!buff.ascendance.up" );
+  def->add_action( "blood_fury" );
+  def->add_action( "berserking" );
+  def->add_action( "fireblood" );
+  def->add_action( "ancestral_call" );
+  def->add_action( "bag_of_tricks" );
 
   // Covenants
   def->add_action( "chain_harvest,if=covenant.venthyr" );


### PR DESCRIPTION
Removed ascendance checking from the racial usage as resto shaman since it gives no value to dps