### PR TITLE
Add Blessing of the Seasons buffs for all classes

### DIFF
--- a/engine/class_modules/class_module.hpp
+++ b/engine/class_modules/class_module.hpp
@@ -35,6 +35,9 @@ struct module_t
   virtual void register_hotfixes() const
   {
   }
+  virtual void create_actions( player_t* ) const
+  {
+  }
   virtual void combat_begin( sim_t* ) const = 0;
   virtual void combat_end( sim_t* ) const   = 0;
 

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -152,7 +152,6 @@ public:
     action_t* necrolord_shield_of_the_righteous;
     action_t* divine_toll;
     action_t* seasons[NUM_SEASONS];
-    action_t* blessing_of_summer_proc;
 
     // Conduit stuff
     action_t* virtuous_command;
@@ -209,10 +208,6 @@ public:
 
     // Covenants
     buff_t* vanquishers_hammer;
-    buff_t* blessing_of_summer;
-    buff_t* blessing_of_autumn;
-    buff_t* blessing_of_winter;
-    buff_t* blessing_of_spring;
 
     // Legendaries
     buff_t* vanguards_momentum;
@@ -532,7 +527,6 @@ public:
 
   // player stat functions
   virtual double    composite_player_multiplier( school_e ) const override;
-  virtual double    composite_player_heal_multiplier( const action_state_t* s ) const override;
   virtual double    composite_attribute_multiplier( attribute_e attr ) const override;
   virtual double    composite_attack_power_multiplier() const override;
   virtual double    composite_bonus_armor() const override;
@@ -564,7 +558,6 @@ public:
 
   // combat outcome functions
   virtual void      assess_damage( school_e, result_amount_type, action_state_t* ) override;
-  virtual void      assess_heal( school_e, result_amount_type, action_state_t* ) override;
   virtual void      target_mitigation( school_e, result_amount_type, action_state_t* ) override;
 
   virtual void      invalidate_cache( cache_e ) override;
@@ -890,19 +883,6 @@ public:
 
             p() -> active.reckoning -> set_target( s -> target );
             p() -> active.reckoning -> schedule_execute();
-          }
-        }
-
-        if ( ab::callbacks && p() -> buffs.blessing_of_summer -> up() )
-        {
-          if ( p() -> rng().roll( p() -> buffs.blessing_of_summer -> data().proc_chance() ) )
-          {
-            double amt = s -> result_amount;
-            double multiplier = p() -> buffs.blessing_of_summer -> data().effectN( 1 ).percent();
-            amt *= multiplier;
-            p() -> active.blessing_of_summer_proc -> base_dd_max = p() -> active.blessing_of_summer_proc -> base_dd_min = amt;
-            p() -> active.blessing_of_summer_proc -> set_target( s -> target );
-            p() -> active.blessing_of_summer_proc -> schedule_execute();
           }
         }
       }

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -4628,10 +4628,10 @@ void player_t::combat_begin()
 
   add_timed_buff_triggers( external_buffs.power_infusion, buffs.power_infusion );
   add_timed_buff_triggers( external_buffs.benevolent_faerie, buffs.benevolent_faerie );
-  add_timed_buff_triggers( external_buffs.blessing_of_summer, buffs.blessing_of_summer); // TODO: Add a way to specify different durations (The Long Summer conduit).
-  add_timed_buff_triggers( external_buffs.blessing_of_autumn, buffs.blessing_of_autumn);
-  add_timed_buff_triggers( external_buffs.blessing_of_winter, buffs.blessing_of_winter);
-  add_timed_buff_triggers( external_buffs.blessing_of_spring, buffs.blessing_of_spring);
+  add_timed_buff_triggers( external_buffs.blessing_of_summer, buffs.blessing_of_summer ); // TODO: Add a way to specify different durations (The Long Summer conduit).
+  add_timed_buff_triggers( external_buffs.blessing_of_autumn, buffs.blessing_of_autumn );
+  add_timed_buff_triggers( external_buffs.blessing_of_winter, buffs.blessing_of_winter );
+  add_timed_buff_triggers( external_buffs.blessing_of_spring, buffs.blessing_of_spring );
 
   if ( buffs.windfury_totem )
   {
@@ -11212,10 +11212,10 @@ void player_t::create_options()
 
   add_option( opt_external_buff_times( "external_buffs.power_infusion", external_buffs.power_infusion ) );
   add_option( opt_external_buff_times( "external_buffs.benevolent_faerie", external_buffs.benevolent_faerie ) );
-  add_option( opt_external_buff_times( "external_buffs.blessing_of_summer", external_buffs.blessing_of_summer) );
-  add_option( opt_external_buff_times( "external_buffs.blessing_of_autumn", external_buffs.blessing_of_autumn) );
-  add_option( opt_external_buff_times( "external_buffs.blessing_of_winter", external_buffs.blessing_of_winter) );
-  add_option( opt_external_buff_times( "external_buffs.blessing_of_spring", external_buffs.blessing_of_spring) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_summer", external_buffs.blessing_of_summer ) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_autumn", external_buffs.blessing_of_autumn ) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_winter", external_buffs.blessing_of_winter ) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_spring", external_buffs.blessing_of_spring ) );
 
   // Azerite options
   if ( ! is_enemy() && ! is_pet() )

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -4028,7 +4028,12 @@ double player_t::composite_player_target_multiplier( player_t* target, school_e 
 
 double player_t::composite_player_heal_multiplier( const action_state_t* ) const
 {
-  return 1.0;
+  double m = 1.0;
+
+  if ( buffs.blessing_of_spring->up() )
+    m *= 1.0 + buffs.blessing_of_spring->data().effectN( 1 ).percent();
+
+  return m;
 }
 
 double player_t::composite_player_th_multiplier( school_e /* school */ ) const
@@ -4623,6 +4628,10 @@ void player_t::combat_begin()
 
   add_timed_buff_triggers( external_buffs.power_infusion, buffs.power_infusion );
   add_timed_buff_triggers( external_buffs.benevolent_faerie, buffs.benevolent_faerie );
+  add_timed_buff_triggers( external_buffs.blessing_of_summer, buffs.blessing_of_summer); // TODO: Add a way to specify different durations (The Long Summer conduit).
+  add_timed_buff_triggers( external_buffs.blessing_of_autumn, buffs.blessing_of_autumn);
+  add_timed_buff_triggers( external_buffs.blessing_of_winter, buffs.blessing_of_winter);
+  add_timed_buff_triggers( external_buffs.blessing_of_spring, buffs.blessing_of_spring);
 
   if ( buffs.windfury_totem )
   {
@@ -6854,6 +6863,9 @@ void player_t::assess_heal( school_e, result_amount_type, action_state_t* s )
   // and other effects based on raw healing.
   if ( buffs.guardian_spirit->up() )
     s->result_total *= 1.0 + buffs.guardian_spirit->data().effectN( 1 ).percent();
+
+  if ( buffs.blessing_of_spring->up() )
+    s->result_total *= 1.0 + buffs.blessing_of_spring->data().effectN( 2 ).percent();
 
   // process heal
   s->result_amount = resource_gain( RESOURCE_HEALTH, s->result_total, nullptr, s->action );
@@ -11200,6 +11212,10 @@ void player_t::create_options()
 
   add_option( opt_external_buff_times( "external_buffs.power_infusion", external_buffs.power_infusion ) );
   add_option( opt_external_buff_times( "external_buffs.benevolent_faerie", external_buffs.benevolent_faerie ) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_summer", external_buffs.blessing_of_summer) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_autumn", external_buffs.blessing_of_autumn) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_winter", external_buffs.blessing_of_winter) );
+  add_option( opt_external_buff_times( "external_buffs.blessing_of_spring", external_buffs.blessing_of_spring) );
 
   // Azerite options
   if ( ! is_enemy() && ! is_pet() )

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -507,6 +507,10 @@ struct player_t : public actor_t
 
     // 9.0 class covenant buffs
     buff_t* benevolent_faerie; // Night Fae Priest spell
+    buff_t* blessing_of_summer; // Night Fae Paladin spell
+    buff_t* blessing_of_autumn; // Night Fae Paladin spell
+    buff_t* blessing_of_winter; // Night Fae Paladin spell
+    buff_t* blessing_of_spring; // Night Fae Paladin spell
 
     // 9.0 Soulbinds
     buff_t* wild_hunt_tactics;  // night_fae/korayn - dummy buff used to quickly check if soulbind is enabled
@@ -541,6 +545,10 @@ struct player_t : public actor_t
     bool focus_magic;
     std::vector<timespan_t> power_infusion;
     std::vector<timespan_t> benevolent_faerie;
+    std::vector<timespan_t> blessing_of_summer;
+    std::vector<timespan_t> blessing_of_autumn;
+    std::vector<timespan_t> blessing_of_winter;
+    std::vector<timespan_t> blessing_of_spring;
   } external_buffs;
 
   struct gains_t

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -2492,6 +2492,13 @@ void sim_t::init_actor( player_t* p )
     // First, create all the action objects and set up action lists properly
     p -> create_actions();
 
+    // More initilization of class modules. Needed to create shared actions provided by a class.
+    for ( player_e i = PLAYER_NONE; i < PLAYER_MAX; ++i )
+    {
+      const module_t* m = module_t::get( i );
+      if ( m ) m -> create_actions( p );
+    }
+
     // Create persistent actors from dynamic spawners
     spawner::create_persistent_actors( *p );
 


### PR DESCRIPTION
To support keeping most of this in the paladin module, I added module_t::create_actions. I'm not sure if this is the best name for what is essentially a second init; maybe there is a better name?

From initial testing, this seems to sim about the same for Paladins. Differences in the spell implementations are:
* Blessing of Summer procs on all damage, not just Paladin spells, so this should slightly increase the value of items/enchants that do damage for Paladins.
* Blessing of Autumn does not double dip in flat reductions and now uses label 16 to find the spells it affects instead of the old guess we had for which class actions to adjust.
* Blessing of Winter seems to crit in logs, so I added that behavior.
* Blessing of Spring was not changed other than moving everything into player_t.

Minor issues to fix at some point:
* The assessor implementation for Blessing of Summer is needed to get it to proc on all of the damage events it should proc on, but there may be some that it shouldn't proc on. For example, Druids use a similar assessor-based implementation for Kindred Empowerment that could result in procs that won't happen in game. However, since Blessing of Summer has a 40% proc chance, this shouldn't crash sims or do anything too horrible. At most it may let Druids use slightly more of their Kindred Empowerment pool than they would be able to otherwise.
* Paladins have a Conduit that increases the duration of Blessing of Summer. The option for adding Blessing of Summer should somehow allow this to be configured.