### PR TITLE
fixing NF frost buff

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -5770,7 +5770,7 @@ struct obliterate_strike_t : public death_knight_melee_attack_t
   void impact( action_state_t* state ) override
   {
     death_knight_melee_attack_t::impact( state );
-    if ( p() -> covenant.deaths_due && p() -> in_death_and_decay() )
+    if ( p() -> covenant.deaths_due -> ok() && p() -> in_death_and_decay() )
     {
       p() -> buffs.deaths_due->trigger();
     }


### PR DESCRIPTION
fixes an issue that causes non- night fae frost dks to get the deaths due buff 