### PR TITLE
[shaman] Fix Earthquake spell modifier on PTR

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -5131,7 +5131,19 @@ struct earthquake_damage_t : public shaman_spell_t
     aoe        = -1;
     ground_aoe = background = true;
     school                  = SCHOOL_PHYSICAL;
-    spell_power_mod.direct  = 0.23;  // still cool to hardcode the SP% into tooltip
+
+    // Earthquake modifier is hardcoded rather than using effects, so we set the modifier here
+    if ( player->dbc->ptr )
+    {
+      // TODO: remove this conditional once 9.0.5 is live
+      // PTR for 9.0.5 buffed EQ by 70%,
+      // https://us.forums.blizzard.com/en/wow/t/905-ptr-changes-updated-february-23/875072/1
+      spell_power_mod.direct = 0.391;
+    }
+    else
+    {
+      spell_power_mod.direct = 0.23;
+    }
   }
 
   double composite_target_armor( player_t* ) const override


### PR DESCRIPTION
PTR for 9.0.5 buffs Earthquake by 70%. Unfortunately, for technical
reasons the %SP modifier is neither set directly on the spell in the
spell database, nor is it attached to an effect on the spell, meaning we
have to hardcode this.

ref:

* https://us.forums.blizzard.com/en/wow/t/905-ptr-changes-updated-february-23/875072/1
* https://ptr.wowhead.com/spell=61882/earthquake