### PR TITLE
[shaman] Hotfix PTR Chain Lightning SP coefficient

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9879,6 +9879,12 @@ struct shaman_module_t : public module_t
 
   void register_hotfixes() const override
   {
+    hotfix::register_effect( "Shaman", "2021-02-24", "Chain Lightning Spell Power Modifier was accidentally missed",
+                             275203, hotfix::HOTFIX_FLAG_PTR )
+        .field( "sp_coefficient" )
+        .operation( hotfix::HOTFIX_SET )
+        .modifier( 0.635 )
+        .verification_value( 0.47 );
   }
 
   void combat_begin( sim_t* ) const override


### PR DESCRIPTION
Despite being in the patch notes and despite Chain Lightning
Overload, Lava Beam, and Lava Beam Overload all being correctly updated,
somehow the base Chain Lightning spell power modifier was missed.

This fixes that omission with a PTR-only hotfix.

ref:

* https://ptr.wowhead.com/spell=188443/chain-lightning
* https://ptr.wowhead.com/spell=45297/chain-lightning-overload
* https://us.forums.blizzard.com/en/wow/t/905-ptr-changes-updated-february-23/875072