### PR TITLE
[BrM] improved Angry Dave APL

### DIFF
--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -194,7 +194,7 @@ void brewmaster( player_t* p )
       def->add_action( racial_actions[ i ] );
   }
 
-  def->add_action( p, monk->spec.invoke_niuzao, "invoke_niuzao_the_black_ox", "if=target.time_to_die>25" );
+  def->add_action( p, monk->spec.invoke_niuzao, "invoke_niuzao_the_black_ox", "if=target.time_to_die>6&cooldown.purifying_brew.charges_fractional<2" );
   def->add_action( p, "Touch of Death", "if=target.health.pct<=15" );
 
   // Covenant Abilities
@@ -203,7 +203,9 @@ void brewmaster( player_t* p )
   def->add_action( "bonedust_brew" );
 
   // Purifying Brew
-  def->add_action( p, "Purifying Brew" );
+  def->add_action( p, "Purifying Brew", "if=stagger.amounttototalpct>=0.7&(cooldown.invoke_niuzao_the_black_ox.remains<5|buff.invoke_niuzao_the_black_ox.up)", "Cast PB during the Niuzao window, but only if recently hit." );
+  def->add_action( p, "Purifying Brew", "if=buff.invoke_niuzao_the_black_ox.up&buff.invoke_niuzao_the_black_ox.remains<8", "Dump PB charges towards the end of Niuzao: anything is better than nothing." );
+  def->add_action( p, "Purifying Brew", "if=cooldown.purifying_brew.charges_fractional>=1.8&(cooldown.invoke_niuzao_the_black_ox.remains>10|buff.invoke_niuzao_the_black_ox.up)", "Avoid capping charges, but pool charges shortly before Niuzao comes up and allow dumping to avoid capping during Niuzao." );
 
   // Black Ox Brew
   def->add_talent( p, "Black Ox Brew", "if=cooldown.purifying_brew.charges_fractional<0.5",

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -6177,7 +6177,9 @@ void monk_t::create_buffs()
   buff.gift_of_the_ox = new buffs::gift_of_the_ox_buff_t( *this, "gift_of_the_ox", find_spell( 124503 ) );
 
   buff.invoke_niuzao =
-      make_buff( this, "invoke_niuzao_the_black_ox", spec.invoke_niuzao )->set_default_value_from_effect( 2 );
+      make_buff( this, "invoke_niuzao_the_black_ox", spec.invoke_niuzao )
+        ->set_default_value_from_effect( 2 )
+        ->set_cooldown( timespan_t::zero() );
 
   buff.purified_chi = make_buff( this, "purified_chi", find_spell( 325092 ) )->set_default_value_from_effect( 1 );
 

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -1202,10 +1202,10 @@ private:
 
       auto purify_amount = o()->buff.recent_purifies->value();
       auto actual_damage = purify_amount * o()->spec.invoke_niuzao_2->effectN( 1 ).percent();
-      b += actual_damage;
-      o()->sim->print_debug( "applying bonus purify damage (original: {}, reduced: {})", purify_amount, actual_damage );
+      double res = b + actual_damage;
+      o()->sim->print_debug( "applying bonus purify damage (base stomp: {}, original: {}, reduced: {})", b, purify_amount, actual_damage );
 
-      return b;
+      return res;
     }
 
     double action_multiplier() const override


### PR DESCRIPTION
this results in a small improvement in overall DPS, but is mostly being
done because it prevents haste breakpoints from (incorrectly) appearing
due to the fact that the old APL didn't pool charges, didn't wait for
damage to have been purified before casting Invoke Niuzao, and didn't
wait to be hit before casting PB.

Those factors could interact to cause the sim to "lose" PB casts during
Invoke Niuzao, which then created haste breakpoints by recovering the
"lost" PB casts. By preventing the loss of those casts in the first
place, the breakpoints are eliminated.

this also fixes a bug where the buff wasn't applying to the second cast due to CDR. The buff doesn't *do* anything but is used for tracking in the updated APL.