### PR TITLE
[Soulbind] Volatile Solvent fixes

### DIFF
--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -965,7 +965,7 @@ void volatile_solvent( special_effect_t& effect )
                   ->set_pct_buff_type( STAT_PCT_BUFF_INTELLECT )
                   ->set_pct_buff_type( STAT_PCT_BUFF_STRENGTH )
                   ->set_pct_buff_type( STAT_PCT_BUFF_AGILITY )
-                  ->set_default_value_from_effect_type( A_MOD_PERCENT_STAT );
+                  ->set_default_value_from_effect_type( A_MOD_TOTAL_STAT_PERCENTAGE );
         }
         break;
 
@@ -985,7 +985,8 @@ void volatile_solvent( special_effect_t& effect )
         {
           buff = make_buff( effect.player, "volatile_solvent_elemental", effect.player->find_spell( 323504 ) )
                   ->set_default_value_from_effect_type( A_MOD_DAMAGE_PERCENT_DONE )
-                  ->set_schools_from_effect( 1 );
+                  ->set_schools_from_effect( 1 )
+                  ->add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
         }
         effect.player->buffs.volatile_solvent_damage = buff;
         break;
@@ -996,7 +997,8 @@ void volatile_solvent( special_effect_t& effect )
         {
           buff = make_buff( effect.player, "volatile_solvent_giant", effect.player->find_spell( 323506 ) )
                   ->set_default_value_from_effect_type( A_MOD_DAMAGE_PERCENT_DONE )
-                  ->set_schools_from_effect( 2 );
+                  ->set_schools_from_effect( 2 )
+                  ->add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
         }
         effect.player->buffs.volatile_solvent_damage = buff;
         break;


### PR DESCRIPTION
Fix affect type for beast (primary stat)
Invalidate caches for giant (physical) and elemental (magic) damage