### PR TITLE
[Soulbind] Heirmir marrowed gemstone gains stacks from player/pet crits

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -3878,6 +3878,15 @@ void action_t::impact( action_state_t* s )
   {
     sim->print_log( "Target {} avoids {} {} ({})", *s->target, *player, *this, s->result );
   }
+
+  // Handle Heirmir Marrowed Gemstone Soulbind
+  if ( this -> player -> type == PLAYER_PET && s -> result == RESULT_CRIT )
+  {
+    auto counter_buff = buff_t::find( debug_cast<pet_t*>( this -> player ) -> owner, "marrowed_gemstone_charging" );
+    auto buff = buff_t::find( debug_cast<pet_t*>( this -> player ) -> owner, "marrowed_gemstone_enhancement" );
+    if ( buff && counter_buff && buff -> cooldown -> up() )
+      counter_buff -> trigger();
+  }
 }
 
 void action_t::trigger_dot( action_state_t* s )


### PR DESCRIPTION
### Issue
Marrowed gemstone will gain stacks from pet and player crits, but does not gain stacks from guardian crits.  Currently simc does not take any pet crits into account for gaining stacks of the buff.

### Info
Was initially tested on my dk, and I had a demo warlock from warlock discord help me test as well.  They saw the same behavior, pet crits caused the buff to stack, while guardian (like the imps) crits did not cause a stack.

DK module has been updated and all pets/guardians set appropriately.
I would have updated other guardians as well, but unfortunately lack the experience with the specs to know which should, or should not be set.

### TODO
I think animal companion and wild imp should be set as guardians, but I'm not 100% sure.

From what I can tell going through the modules, the classes are currently setup as follows:

Class | Pet | Type
-|-|-
Monk | All | Guardian
Priest | Shadowfiend | Pet
Priest | lasher/tendril | Guardian
Druid | Force of Nature | Guardian
Hunter | Dire Critter | Guardian
Hunter | Spitting Cobra | Guardian
Hunter | Animal Companion | Pet
Hunter | Main Pet | Pet
Mage | Mirror Image | Guardian
Mage | Water Elemental | Pet
Shaman | Wolf | Guardian
Shaman | Primal Elemental | Pet
Shaman | !Primal Elemental | Guardian
Shaman | Totem | Guardian
Warlock | Shivarra | Guardian
Warlock | darkhound | Guardian
Warlock | Bilescourge | Guardian
Warlock | Urzul | Guardian
Warlock | void_terror | Guardian
Warlock | wrathguard | Guardian
Warlock | viscious_hellhound | Guardian
Warlock | illidari_satyr | Guardian
Warlock | eyes_of_guldan | Guardian
Warlock | prince_malachezaar | Guardian
Warlock | felhunter | Pet
Warlock | imp | Pet
Warlock | succubus | Pet
Warlock | voidwalker | Pet
Warlock | felguard | Pet
Warlock | infernal | Pet
Warlock | dark_glare | Pet
Warlock | Wild Imp | Pet

### Test data
All tests were run with all t26 profiles setup to use necrolord, with heirmir as the soulbind, and target_error=0.05

#### Performance

 Field | Shadowlands | Heirmir Fix
-|-|-
RNG Engine | xoshiro256+ | xoshiro256+
Iterations | 36708 (9184, 9195, 9176, 9153) | 37209 (9326, 9287, 9326, 9270)
 TotalEvents   | 7029320005 | 7117870872
  MaxEventQueue | 1638 | 1652
  TargetHealth  | 76494326 | 77721686
  SimSeconds    | 11012533.104 | 11155861.578
  CpuSeconds    | 33803.5584395 | 31461.8128702
  WallSeconds   | 8457.5907515 | 7871.0757288
  InitSeconds   | 0.387363 | 0.3983161
  MergeSeconds  | 0.2005578 | 0.1513565
  AnalyzeSeconds | 0.6111223 | 0.5974017
  SpeedUp       | 326 | 355

#### DPS changes
Highlights:
Warlock Demo 5868 -> 5996
Warlock Aff 6159 -> 6171
Warlock Destro 6397 -> 6407
DK Unholy 6766 -> 6791
Hunter BM 6051 -> 6072

Profile | Shadowlands | Heirmir Fix
-|-|-
T26_Priest_Shadow_Necrolord |   7471 |  7472   
T26_Priest_Shadow |   7276  | 7272   
T26_Mage_Frost_FM_Trade |   7168   | 7165   
T26_Priest_Shadow_Venthyr |   7157 |   7158   
 T26_Priest_Shadow_Kyrian |  7156  | 7156   
 T26_Shaman_Enhancement |  7153  | 7151   
 T26_Rogue_Assassination |  7016 | 7015   
T26_Mage_Frost |  6929   | 6925   
T26_Shaman_Enhancement_VDW |   6880  | 6883   
T26_Rogue_Outlaw |   6872   | 6873   
T26_Druid_Feral_Owlweave |   6858  | 6858   
T26_Death_Knight_Frost |   6810 | 6809   
T26_Death_Knight_Unholy |   6766  | 6791   
T26_Shaman_Elemental |   6683 | 6682   
T26_Shaman_Elemental_NF |  6682  | 6681   
 T26_Druid_Feral |  6625  | 6625   
T26_Mage_Fire |   6611 | 6611   
T26_Rogue_Subtlety |   6578 | 6577   
T26_Druid_Balance |   6503 | 6502   
T26_Warlock_Destruction |   6397 | 6407   
 T26_Death_Knight_Frost_2H |  6380 | 6380   
T26_Demon_Hunter_Havoc_Momentum |   6380  | 6380   
T26_Paladin_Retribution_Venthyr |   6338 | 6340   
T26_Demon_Hunter_Havoc |   6293 | 6292   
T26_Paladin_Retribution |   6164  | 6166   
T26_Warlock_Affliction |   6159  | 6171   
T26_Warrior_Fury |  6151 | 6150   
T26_Hunter_Marksmanship |   6147   | 6148   
T26_Mage_Arcane |   6140  | 6140   
T26_Hunter_Beast_Mastery |   6051   | 6072   
T26_Warrior_Arms |   5899  | 5899   
T26_Monk_Windwalker |   5870  | 5871   
T26_Warlock_Demonology |   5868  | 5996   
T26_Hunter_Survival |   5803   | 5806   
T26_Monk_Windwalker_Serenity |   5740  | 5742   
T26_Paladin_Protection |   4906  | 4907   
T26_Monk_Brewmaster |   4224   | 4224   
T26_Druid_Guardian |   4172   | 4172   
T26_Death_Knight_Blood |   3621 | 3621   
T26_Warrior_Protection |   3596 | 3596   
T26_Demon_Hunter_Vengeance |   3564  | 3565   
T26_Shaman_Restoration |   3508   | 3508   
T26_Priest_Discipline |   3052  | 3052   


