### PR TITLE
Storm Elemental update

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8639,6 +8639,7 @@ void shaman_t::init_action_list_elemental()
   precombat->add_talent( this, "Stormkeeper",
                          "if=talent.stormkeeper.enabled&(raid_event.adds.count<3|raid_event.adds.in>50)",
                          "Use Stormkeeper precombat unless some adds will spawn soon." );
+  precombat->add_action( this, "Fire Elemental"
   precombat->add_talent( this, "Elemental Blast", "if=talent.elemental_blast.enabled" );
   precombat->add_action( this, "Lava Burst", "if=!talent.elemental_blast.enabled" );
 
@@ -8655,8 +8656,9 @@ void shaman_t::init_action_list_elemental()
     def->add_action( this, "Wind Shear", "", "Interrupt of casts." );
     def->add_action( "potion" );
     def->add_action( "use_items" );
-    def->add_action( this, "Flame Shock", "if=!ticking" );
+    def->add_action( this, "Flame Shock", "if=!covenant.necrolord&!ticking"  );
     def->add_action( this, "Fire Elemental" );
+    def->add_action( this, "Flame Shock", "if=!(ticking&pet.storm_elemental.active)"  );
     def->add_talent( this, "Storm Elemental" );
     // Racials
     def->add_action( "blood_fury,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50" );
@@ -8727,7 +8729,7 @@ void shaman_t::init_action_list_elemental()
         this, "Stormkeeper",
         "if=talent.stormkeeper.enabled&(maelstrom<44)" );
     se_single_target->add_talent( this, "Echoing Shock", "if=talent.echoing_shock.enabled" );
-    se_single_target->add_action( this, "Lava Burst", "if=buff.wind_gust.stack<18|buff.lava_surge.up" );
+    se_single_target->add_action( this, "Lava Burst", "if=(runeforge.echoes_of_great_sundering.equipped)&!(buff.bloodlust.up&pet.storm_elemental.active)&buff.wind_gust.stack<18|buff.lava_surge.up" );
     se_single_target->add_action( this, "Lightning Bolt", "if=buff.stormkeeper.up" );
     se_single_target->add_action( this, "Earthquake", "if=buff.echoes_of_great_sundering.up" );
     se_single_target->add_action( this, "Earthquake",
@@ -8743,7 +8745,9 @@ void shaman_t::init_action_list_elemental()
         this, "Frost Shock",
                                "if=talent.icefury.enabled&talent.master_of_the_elements.enabled&buff.icefury.up&buff."
                                "master_of_the_elements.up" );
+    se_single_target->add_action( this, "Lava Burst", "if=buff.primordial_wave.up&(buff.lava_surge.up|buff.primordial_wave.remains<=2*gcd"  );
     se_single_target->add_action( this, "Lava Burst", "if=buff.ascendance.up" );
+    se_single_target->add_action( this, "Lightning Bolt", "if=(runeforge.echoes_of_great_sundering.equipped)&buff.bloodlust.up&pet.storm_elemental.active"  );
     se_single_target->add_action( this, "Lava Burst", "if=cooldown_react&!talent.master_of_the_elements.enabled" );
     se_single_target->add_talent( this, "Icefury",
                                "if=talent.icefury.enabled&!(maelstrom>75&cooldown.lava_burst.remains<=0)" );

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8639,7 +8639,7 @@ void shaman_t::init_action_list_elemental()
   precombat->add_talent( this, "Stormkeeper",
                          "if=talent.stormkeeper.enabled&(raid_event.adds.count<3|raid_event.adds.in>50)",
                          "Use Stormkeeper precombat unless some adds will spawn soon." );
-  precombat->add_action( this, "Fire Elemental"
+  precombat->add_action( this, "Fire Elemental"  );
   precombat->add_talent( this, "Elemental Blast", "if=talent.elemental_blast.enabled" );
   precombat->add_action( this, "Lava Burst", "if=!talent.elemental_blast.enabled" );
 

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8745,7 +8745,7 @@ void shaman_t::init_action_list_elemental()
         this, "Frost Shock",
                                "if=talent.icefury.enabled&talent.master_of_the_elements.enabled&buff.icefury.up&buff."
                                "master_of_the_elements.up" );
-    se_single_target->add_action( this, "Lava Burst", "if=buff.primordial_wave.up&(buff.lava_surge.up|buff.primordial_wave.remains<=2*gcd"  );
+    se_single_target->add_action( this, "Lava Burst", "if=buff.primordial_wave.up&(buff.lava_surge.up|buff.primordial_wave.remains<=2*gcd)"  );
     se_single_target->add_action( this, "Lava Burst", "if=buff.ascendance.up" );
     se_single_target->add_action( this, "Lightning Bolt", "if=(runeforge.echoes_of_great_sundering.equipped)&buff.bloodlust.up&pet.storm_elemental.active"  );
     se_single_target->add_action( this, "Lava Burst", "if=cooldown_react&!talent.master_of_the_elements.enabled" );


### PR DESCRIPTION
This is the culmination of work done on 'What should I do during Storm Elemental uptime?' full numbers located here: https://drive.google.com/file/d/1kBePrXOdf83npJrzDxg6NBKGl7IHNyop/view 
The gameplay change to focus Lightning Bolt spam was only a gain in specific circumstances, so all lines added are with that in mind. This does not affect Storm Elemental use when anything but EoGS is equipped. 

8642- added Fire Elemental to the precast sequence for regular opener
8659 - replaced  Flame Shock line with :  if not necrolord and not ticking. necrolords will apply FS via PW. Moved line for Flame Shock above Storm Elemental such that builds without Elemental Blast talented (and therefore pre-casting LvB) will still LvB->Flame Shock before using Storm Elemental. (8661)
8732 - line that enables the sim to only cast LvB when any one of the 'trifecta' is not currently true i.e. it will only cast LvBs when bloodlust+SEactive+EoGS equipped is not true and also when surge procs are active
8748 - added line to ensure PW buff is consumed, will delay to fish for lava surge procs but will hardcast to consume appropriately.
8750 - added line to make hardcasting LB more important than regular LvBs when EoGS equipped+SE active+BL up