### PR TITLE
[Warlock] Refactor Grimoire Felguard and fix Fel Commando bug

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1585,6 +1585,7 @@ warlock::warlock_t::pets_t::pets_t( warlock_t* w )
     dreadstalkers( "dreadstalker", w ),
     vilefiends( "vilefiend", w ),
     demonic_tyrants( "demonic_tyrant", w ),
+    grimoire_felguards( "grimoire_felguard", w ),
     wild_imps( "wild_imp", w ),
     shivarra( "shivarra", w ),
     darkhounds( "darkhound", w ),

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -84,8 +84,7 @@ public:
 
   unsigned active_pets;
 
-  //TODO: Are the pet definitions here only for temporary pets? If so, should Grimoire: Felguard be included?
-  // Active Pet
+  // Main pet held in active/last, guardians should be handled by pet spawners. TODO: Use spawner for Infernal/Darkglare?
   struct pets_t
   {
     warlock_pet_t* active;
@@ -103,6 +102,7 @@ public:
     spawner::pet_spawner_t<pets::demonology::dreadstalker_t, warlock_t> dreadstalkers;
     spawner::pet_spawner_t<pets::demonology::vilefiend_t, warlock_t> vilefiends;
     spawner::pet_spawner_t<pets::demonology::demonic_tyrant_t, warlock_t> demonic_tyrants;
+    spawner::pet_spawner_t<pets::demonology::grimoire_felguard_pet_t, warlock_t> grimoire_felguards;
 
     spawner::pet_spawner_t<pets::demonology::wild_imp_pet_t, warlock_t> wild_imps;
 

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -797,31 +797,21 @@ struct summon_vilefiend_t : public demonology_spell_t
   }
 };
 
-struct grimoire_felguard_t : public summon_pet_t
+struct grimoire_felguard_t : public demonology_spell_t
 {
   grimoire_felguard_t( warlock_t* p, util::string_view options_str )
-    : summon_pet_t( "grimoire_felguard", p, p->talents.grimoire_felguard )
+    : demonology_spell_t( "grimoire_felguard", p, p->talents.grimoire_felguard )
   {
     parse_options( options_str );
-    cooldown->duration = data().cooldown();
-    summoning_duration = data().duration() + timespan_t::from_millis( 1 );  // TODO: why?
+    harmful = may_crit = false;
   }
 
   void execute() override
   {
-    summon_pet_t::execute();
-    pet->buffs.grimoire_of_service->trigger();
+    demonology_spell_t::execute();
+    
+    p()->warlock_pet_list.grimoire_felguards.spawn( data().duration() );
     p()->buffs.grimoire_felguard->trigger();
-  }
-
-  void init_finished() override
-  {
-    if ( pet )
-    {
-      pet->summon_stats = stats;
-    }
-
-    summon_pet_t::init_finished();
   }
 };
 
@@ -983,8 +973,6 @@ pet_t* warlock_t::create_demo_pet( util::string_view pet_name, util::string_view
   using namespace pets;
 
   if ( pet_name == "felguard" )
-    return new pets::demonology::felguard_pet_t( this, pet_name );
-  if ( pet_name == "grimoire_felguard" )
     return new pets::demonology::felguard_pet_t( this, pet_name );
 
   return nullptr;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -632,6 +632,111 @@ void felguard_pet_t::queue_ds_felstorm()
   }
 }
 
+grimoire_felguard_pet_t::grimoire_felguard_pet_t( warlock_t* owner, const std::string& name )
+  : warlock_pet_t( owner, name, PET_SERVICE_FELGUARD, true ),
+    felstorm_spell( find_spell( 89751 ) ),
+    min_energy_threshold( felstorm_spell->cost( POWER_ENERGY ) ),
+    max_energy_threshold( 100 )
+{
+  action_list_str = "travel";
+  action_list_str += "/felstorm";
+  action_list_str += "/legion_strike,if=energy>=" + util::to_string( max_energy_threshold );
+
+  felstorm_cd = get_cooldown( "felstorm" );
+
+  owner_coeff.health = 0.75;
+
+  is_main_pet = true;
+}
+
+ void grimoire_felguard_pet_t::arise()
+ {
+   warlock_pet_t::arise();
+
+   buffs.grimoire_of_service->trigger();
+ }
+
+timespan_t grimoire_felguard_pet_t::available() const
+{
+  double energy_threshold = max_energy_threshold;
+  double time_to_felstorm = ( felstorm_cd->ready - sim->current_time() ).total_seconds();
+  if ( time_to_felstorm <= 0 )
+  {
+    energy_threshold = min_energy_threshold;
+  }
+
+  double deficit           = resources.current[ RESOURCE_ENERGY ] - energy_threshold;
+  double rps               = resource_regen_per_second( RESOURCE_ENERGY );
+  double time_to_threshold = 0;
+  // Not enough energy, figure out how many milliseconds it'll take to get
+  if ( deficit < 0 )
+  {
+    time_to_threshold = util::ceil( std::fabs( deficit ) / rps, 3 );
+  }
+
+  // Fuzz regen by making the pet wait a bit extra if it's just below the resource threshold
+  if ( time_to_threshold < 0.001 )
+  {
+    return warlock_pet_t::available();
+  }
+
+  // Next event is either going to be the time to felstorm, or the time to gain enough energy for a
+  // threshold value
+  double time_to_next_event = 0;
+  if ( time_to_felstorm <= 0 )
+  {
+    time_to_next_event = time_to_threshold;
+  }
+  else
+  {
+    time_to_next_event = std::min( time_to_felstorm, time_to_threshold );
+  }
+
+  if ( sim->debug )
+  {
+    sim->out_debug.print( "{} waiting, deficit={}, threshold={}, t_threshold={}, t_felstorm={} t_wait={}", name(),
+                          deficit, energy_threshold, time_to_threshold, time_to_felstorm, time_to_next_event );
+  }
+
+  if ( time_to_next_event < 0.001 )
+  {
+    return warlock_pet_t::available();
+  }
+  else
+  {
+    return timespan_t::from_seconds( time_to_next_event );
+  }
+}
+
+void grimoire_felguard_pet_t::init_base_stats()
+{
+  warlock_pet_t::init_base_stats();
+
+  // Felguard is the only warlock pet to use an actual weapon.
+  main_hand_weapon.type = WEAPON_AXE_2H;
+  melee_attack          = new warlock_pet_melee_t( this );
+
+  // TOCHECK Increased by 15% in 8.1.
+  owner_coeff.ap_from_sp *= 1.15;
+  owner_coeff.sp_from_sp *= 1.15;
+
+  // TOCHECK Felguard has a hardcoded 10% multiplier for its auto attack damage. Live as of 10-17-2018
+  melee_attack->base_dd_multiplier *= 1.1;
+  special_action = new axe_toss_t( this, "" );
+}
+
+action_t* grimoire_felguard_pet_t::create_action( util::string_view name, const std::string& options_str )
+{
+  if ( name == "legion_strike" )
+    return new legion_strike_t( this, options_str );
+  if ( name == "felstorm" )
+    return new felstorm_t( this, options_str );
+  if ( name == "axe_toss" )
+    return new axe_toss_t( this, options_str );
+
+  return warlock_pet_t::create_action( name, options_str );
+}
+
 struct fel_firebolt_t : public warlock_pet_spell_t
 {
   bool demonic_power_on_cast_start;

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -397,6 +397,23 @@ struct felguard_pet_t : public warlock_pet_t
   void queue_ds_felstorm();
 };
 
+struct grimoire_felguard_pet_t : public warlock_pet_t
+{
+  const spell_data_t* felstorm_spell;
+  cooldown_t* felstorm_cd;
+
+  // Energy thresholds to wake felguard up for something to do, minimum is the felstorm energy cost,
+  // and maximum is a predetermined empirical value from in game
+  double min_energy_threshold;
+  double max_energy_threshold;
+
+  grimoire_felguard_pet_t( warlock_t* owner, const std::string& name = "grimoire_felguard" );
+  void init_base_stats() override;
+  action_t* create_action( util::string_view name, const std::string& options_str ) override;
+  timespan_t available() const override;
+  void arise() override;
+};
+
 struct wild_imp_pet_t : public warlock_pet_t
 {
   action_t* firebolt;


### PR DESCRIPTION
Fel Commando was inadvertently affecting GFG as well as regular Felguard. Refactor adds separate GFG pet type (type = PET_SERVICE_FELGUARD) and uses pet spawner.