### PR TITLE
[Warlock] Grimoire Felguard Consistency Update

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -632,8 +632,8 @@ void felguard_pet_t::queue_ds_felstorm()
   }
 }
 
-grimoire_felguard_pet_t::grimoire_felguard_pet_t( warlock_t* owner, const std::string& name )
-  : warlock_pet_t( owner, name, PET_SERVICE_FELGUARD, true ),
+grimoire_felguard_pet_t::grimoire_felguard_pet_t( warlock_t* owner )
+  : warlock_pet_t( owner, "grimoire_felguard", PET_SERVICE_FELGUARD, true ),
     felstorm_spell( find_spell( 89751 ) ),
     min_energy_threshold( felstorm_spell->cost( POWER_ENERGY ) ),
     max_energy_threshold( 100 )

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -407,7 +407,7 @@ struct grimoire_felguard_pet_t : public warlock_pet_t
   double min_energy_threshold;
   double max_energy_threshold;
 
-  grimoire_felguard_pet_t( warlock_t* owner, const std::string& name = "grimoire_felguard" );
+  grimoire_felguard_pet_t( warlock_t* owner );
   void init_base_stats() override;
   action_t* create_action( util::string_view name, const std::string& options_str ) override;
   timespan_t available() const override;


### PR DESCRIPTION
There is an issue where if an apl contains pet.grimoire_felguard and the Grimoire: Felguard talent is not selected, an error will ocurr.

Cannot parse expression from 'pet.grimoire_felguard.active': Cannot find pet or pet spawner 'grimoire_felguard'.

The following APL will trigger this error:
https://pastebin.com/DpfdA72t

This is due to how the name of the pet is defined in the pet definition. Changing this to match how the other warlock pets work (i.e. vilefiend) resolves the issue.