### PR TITLE
[Warlock] Add demonic embrace passive for warlocks

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -760,6 +760,15 @@ double warlock_t::resource_regen_per_second( resource_e r ) const
   return reg;
 }
 
+double warlock_t::composite_attribute_multiplier( attribute_e attr ) const
+{
+  double m = player_t::composite_attribute_multiplier( attr );
+  if ( attr == ATTR_STAMINA )
+    m *= 1.0 + spec.demonic_embrace->effectN( 1 ).percent();
+    
+  return m;
+}
+
 //Note: Level is checked to be >=27 by the function calling this. This is technically wrong for warlocks due to
 //a missing level requirement in data, but correct generally.
 double warlock_t::matching_gear_multiplier( attribute_e attr ) const
@@ -897,6 +906,7 @@ void warlock_t::init_spells()
 
   // General
   spec.nethermancy = find_spell( 86091 );
+  spec.demonic_embrace = find_spell( 288843 );
 
   // Specialization Spells
   spec.immolate         = find_specialization_spell( "Immolate" );

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -316,6 +316,7 @@ public:
   {
     // All Specs
     const spell_data_t* nethermancy; //The probably actual spell controlling armor type bonus. NOTE: Level req is missing, this matches in game behavior.
+    const spell_data_t* demonic_embrace; //Warlock stamina passive
     //TODO: Corruption is now class-wide
     //TODO: Ritual of Doom?
 
@@ -508,6 +509,7 @@ public:
   double composite_melee_crit_chance() const override;
   double composite_mastery() const override;
   double resource_regen_per_second( resource_e ) const override;
+  double composite_attribute_multiplier( attribute_e attr ) const override;
   void combat_begin() override;
   void init_assessors() override;
   std::unique_ptr<expr_t> create_expression( util::string_view name_str ) override;


### PR DESCRIPTION
Warlocks ingame have a passive which increases their stamina by 10% called [Demonic Embrace](https://www.wowhead.com/spell=288843/demonic-embrace). Usually stamina does not play a big part, however for demonology warlocks using [Demonic Consumption](https://www.wowhead.com/spell=267215/demonic-consumption) this was causing the tyrant to drain less health and thus deal less damage than intended. The following [APL](https://pastebin.com/x2BBGVt7) was used to compare player health and tyrant damage with ingame, both turned out less than expected. Following the changes, the health and damage matched ingame values.