### PR TITLE
[Warlock] Implosion fixes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -455,8 +455,6 @@ struct implosion_t : public demonology_spell_t
 
   void execute() override
   {
-    demonology_spell_t::execute();
-
     p()->buffs.implosive_potential->expire();
     p()->buffs.implosive_potential_small->expire();
 
@@ -496,6 +494,8 @@ struct implosion_t : public demonology_spell_t
       p()->buffs.implosive_potential->trigger( imps_consumed );
     else if ( p()->legendary.implosive_potential.ok() )
       p()->buffs.implosive_potential_small->trigger( imps_consumed );
+
+    demonology_spell_t::execute();
   }
 };
 


### PR DESCRIPTION
A couple of issues have been found with implosion which should be addressed.
1. The target of the implosion aoe does not match the target of the initial cast. Since the target of the cast is dealt less damage than the other targets, this is causing the modelling of changing the implosion target to a different one to be incorrect.
```
4.818 Player 'Necrovanish' implosion hits Player 'enemy2' for 0 none damage (hit)
4.818 Player 'Necrovanish' implosion_aoe hits Player 'Fluffy_Pillow' for 125.52978182976004 shadowflame damage (hit)
4.818 Player 'Necrovanish' implosion_aoe hits Player 'enemy2' for 298.880432928 shadowflame damage (crit)
4.818 Player 'Necrovanish' implosion_aoe hits Player 'enemy3' for 149.440216464 shadowflame damage (hit)
4.818 Player 'Necrovanish' implosion_aoe hits Player 'enemy4' for 149.440216464 shadowflame damage (hit)
```
Note the reduced damage to "Fluffy_Pillow" rather than "enemy2".

2. The implosion cast itself is being delayed using a travel time, when instead the cast should be instant and the imp explosions should be delayed by the travel time.
```
4.203 Player 'Necrovanish' performs Action implosion (49002.5)
4.203 Player 'Necrovanish' schedules travel (0.615) for Action implosion
4.818 Player 'Necrovanish' implosion hits Player 'enemy2' for 0 none damage (hit)
```

The first issue is fixed by moving the `demonology_spell_t::execute()` call to be later, as this is resetting the current target. The second issue can be fixed by removing the `travel_speed` from the implosion cast itself, and delaying the implosion aoe event by an equivalent amount. The end result is the following log:
```
3.819 Player 'Necrovanish' performs Action implosion (50000)
3.819 Player 'Necrovanish' implosion hits Player 'enemy2' for 0 none damage (hit)
4.434 Player 'Necrovanish' implosion_aoe hits Player 'enemy2' for 125.52978182976004 shadowflame damage (hit)
4.434 Player 'Necrovanish' implosion_aoe hits Player 'Fluffy_Pillow' for 149.440216464 shadowflame damage (hit)
4.434 Player 'Necrovanish' implosion_aoe hits Player 'enemy3' for 149.440216464 shadowflame damage (hit)
```
Note the reduced damage to the target of the implosion, "enemy2"

The following [APL](https://pastebin.com/y4tb6AC1) was used for testing.