### PR TITLE
[Monk] Move hit combo and fae exposure damage multiplier from abilities to composite_multiplier.

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -485,9 +485,6 @@ struct monk_spell_t : public monk_action_t<spell_t>
     if ( td( t )->debuff.weapons_of_order->up() )
       m *= 1 + td( t )->debuff.weapons_of_order->stack_value();
 
-    if ( td( t )->debuff.fae_exposure->up() )
-      m *= 1 + p()->passives.fae_exposure_dmg->effectN( 1 ).percent();
-
     return m;
   }
 
@@ -538,12 +535,6 @@ struct monk_spell_t : public monk_action_t<spell_t>
 
         am *= 1 + serenity_multiplier;
       }
-    }
-
-    if ( p()->buff.hit_combo->up() )
-    {
-      if ( base_t::data().affected_by( p()->passives.hit_combo->effectN( 1 ) ) )
-        am *= 1 + p()->buff.hit_combo->stack_value();
     }
 
     return am;
@@ -621,12 +612,6 @@ struct monk_heal_t : public monk_action_t<heal_t>
 
         am *= 1 + serenity_multiplier;
       }
-    }
-
-    if ( p()->buff.hit_combo->up() )
-    {
-      if ( base_t::data().affected_by( p()->passives.hit_combo->effectN( 1 ) ) )
-        am *= 1 + p()->buff.hit_combo->stack_value();
     }
 
     return am;
@@ -895,12 +880,6 @@ struct monk_melee_attack_t : public monk_action_t<melee_attack_t>
 
         am *= 1 + serenity_multiplier;
       }
-    }
-
-    if ( p()->buff.hit_combo->up() )
-    {
-      if ( base_t::data().affected_by( p()->passives.hit_combo->effectN( 1 ) ) )
-        am *= 1 + p()->buff.hit_combo->stack_value();
     }
 
     // Increases just physical damage
@@ -2236,7 +2215,7 @@ struct melee_t : public monk_melee_attack_t
       am *= 1 + p()->talent.serenity->effectN( 7 ).percent();
 
     if ( p()->buff.hit_combo->up() )
-      am *= 1 + p()->buff.hit_combo->stack_value();
+      am *= 1 + p()->buff.hit_combo->stack() * p()->passives.hit_combo->effectN( 3 ).percent();
 
     return am;
   }
@@ -7054,6 +7033,56 @@ double monk_t::temporary_movement_modifier() const
     active = std::max( buff.flying_serpent_kick_movement->check_value(), active );
 
   return active;
+}
+
+// monk_t::composite_player_dd_multiplier ================================
+double monk_t::composite_player_dd_multiplier( school_e school, const action_t* action ) const
+{
+  double multiplier = player_t::composite_player_dd_multiplier(school, action);
+
+  if ( buff.hit_combo->up() && action->data().affected_by( passives.hit_combo->effectN( 1 ) ) )
+  {
+    multiplier *= 1 + buff.hit_combo->stack() * passives.hit_combo->effectN( 1 ).percent();
+  }
+
+  return multiplier;
+}
+
+// monk_t::composite_player_td_multiplier ================================
+double monk_t::composite_player_td_multiplier( school_e school, const action_t* action ) const
+{
+  double multiplier = player_t::composite_player_td_multiplier(school, action);
+
+  if ( buff.hit_combo->up() && action->data().affected_by( passives.hit_combo->effectN( 2 ) ) )
+  {
+    multiplier *= 1 + buff.hit_combo->stack() * passives.hit_combo->effectN( 2 ).percent();
+  }
+
+  return multiplier;
+}
+
+// monk_t::composite_player_target_multiplier ============================
+double monk_t::composite_player_target_multiplier( player_t* target, school_e school ) const
+{
+  double multiplier = player_t::composite_player_target_multiplier(target, school);
+
+  if ( get_target_data( target )->debuff.fae_exposure->up() )
+    multiplier *= 1 + passives.fae_exposure_dmg->effectN( 1 ).percent();
+
+  return multiplier;
+}
+
+// monk_t::composite_player_pet_damage_multiplier ========================
+double monk_t::composite_player_pet_damage_multiplier( const action_state_t* state ) const
+{
+  double multiplier = player_t::composite_player_pet_damage_multiplier( state );
+
+  if ( buff.hit_combo->up() )
+  {
+    multiplier *= 1 + buff.hit_combo->stack() * passives.hit_combo->effectN( 4 ).percent();
+  }
+
+  return multiplier;
 }
 
 // monk_t::invalidate_cache ==============================================

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -779,6 +779,10 @@ public:
   double composite_mastery_rating() const override;
   double composite_crit_avoidance() const override;
   double temporary_movement_modifier() const override;
+  double composite_player_dd_multiplier( school_e, const action_t* action ) const override;
+  double composite_player_td_multiplier( school_e, const action_t* action ) const override;
+  double composite_player_target_multiplier( player_t* target, school_e school ) const override;
+  double composite_player_pet_damage_multiplier( const action_state_t* ) const override;
   void create_pets() override;
   void init_spells() override;
   void init_base_stats() override;

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -945,7 +945,6 @@ public:
   struct
   {
     buff_t* bok_proc_sef          = nullptr;
-    buff_t* hit_combo_sef         = nullptr;
     buff_t* pressure_point_sef    = nullptr;
     buff_t* rushing_jade_wind_sef = nullptr;
   } buff;
@@ -1035,9 +1034,6 @@ public:
     if ( o()->buff.bok_proc->up() )
       buff.bok_proc_sef->trigger( 1, buff_t::DEFAULT_VALUE(), 1, o()->buff.bok_proc->remains() );
 
-    if ( o()->buff.hit_combo->up() )
-      buff.hit_combo_sef->trigger( o()->buff.hit_combo->check() );
-
     if ( o()->buff.rushing_jade_wind->up() )
       buff.rushing_jade_wind_sef->trigger( 1, buff_t::DEFAULT_VALUE(), 1, o()->buff.rushing_jade_wind->remains() );
 
@@ -1073,17 +1069,10 @@ public:
                                        else
                                          d->expire( timespan_t::from_millis( 1 ) );
                                      } );
-
-    buff.hit_combo_sef = make_buff( this, "hit_combo_sef", o()->passives.hit_combo )
-                             ->set_default_value_from_effect( 1 )
-                             ->add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
   }
 
   void trigger_attack( sef_ability_e ability, const action_t* source_action )
   {
-    if ( o()->buff.combo_strikes->up() && o()->talent.hit_combo->ok() )
-      buff.hit_combo_sef->trigger();
-
     if ( ability >= SEF_SPELL_MIN )
     {
       auto spell_index = sef_spell_index( ability );
@@ -1189,9 +1178,6 @@ public:
   double composite_player_multiplier( school_e school ) const override
   {
     double cpm = owner->cache.player_multiplier( school );
-
-    if ( o()->buff.hit_combo->up() )
-      cpm *= 1 + o()->buff.hit_combo->stack_value();
 
     if ( o()->conduit.xuens_bond->ok() )
       cpm *= 1 + o()->conduit.xuens_bond.percent();
@@ -1325,9 +1311,6 @@ public:
   {
     double cpm = pet_t::composite_player_multiplier( school );
 
-    if ( o()->buff.hit_combo->up() )
-      cpm *= 1 + o()->buff.hit_combo->stack_value();
-
     cpm *= 1 + o()->spec.brewmaster_monk->effectN( 3 ).percent();
 
     return cpm;
@@ -1387,16 +1370,6 @@ public:
     main_hand_weapon.damage     = ( main_hand_weapon.min_dmg + main_hand_weapon.max_dmg ) / 2;
     main_hand_weapon.swing_time = timespan_t::from_seconds( 1.5 );
     owner_coeff.ap_from_ap      = o()->spec.mistweaver_monk->effectN( 4 ).percent();
-  }
-
-  double composite_player_multiplier( school_e school ) const override
-  {
-    double cpm = monk_pet_t::composite_player_multiplier( school );
-
-    if ( o()->buff.hit_combo->up() )
-      cpm *= 1 + o()->buff.hit_combo->stack_value();
-
-    return cpm;
   }
 
   void init_action_list() override
@@ -1467,13 +1440,8 @@ private:
   };
 
 public:
-  struct
-  {
-    buff_t* hit_combo_fm_ww = nullptr;
-  } buff;
-
   fallen_monk_ww_pet_t( monk_t* owner )
-    : monk_pet_t( owner, "fallen_monk_windwalker", PET_FALLEN_MONK, true, true ), buff()
+    : monk_pet_t( owner, "fallen_monk_windwalker", PET_FALLEN_MONK, true, true )
   {
     npc_id                      = 168033;
     main_hand_weapon.type       = WEAPON_1H;
@@ -1510,31 +1478,10 @@ public:
   {
     double cpm = o()->cache.player_multiplier( school );
 
-    if ( o()->buff.hit_combo->up() )
-      cpm *= 1 + o()->buff.hit_combo->stack_value();
-
     if ( o()->conduit.imbued_reflections->ok() )
       cpm *= 1 + o()->conduit.imbued_reflections.percent();
 
     return cpm;
-  }
-
-  void summon( timespan_t duration = timespan_t::zero() ) override
-  {
-    monk_pet_t::summon( duration );
-
-    if ( o()->buff.hit_combo->up() )
-      buff.hit_combo_fm_ww->trigger( o()->buff.hit_combo->check() );
-  }
-
-  void create_buffs() override
-  {
-    monk_pet_t::create_buffs();
-
-    buff.hit_combo_fm_ww = make_buff( this, "hit_combo_fo_ww", o()->passives.hit_combo )
-                               ->set_default_value_from_effect( 1 )
-                               ->set_quiet( true )
-                               ->add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
   }
 
   struct fallen_monk_fists_of_fury_tick_t : public pet_melee_attack_t
@@ -1689,13 +1636,8 @@ private:
   };
 
 public:
-  struct
-  {
-    buff_t* hit_combo_fm_brm = nullptr;
-  } buff;
-
   fallen_monk_brm_pet_t( monk_t* owner )
-    : monk_pet_t( owner, "fallen_monk_brewmaster", PET_FALLEN_MONK, true, true ), buff()
+    : monk_pet_t( owner, "fallen_monk_brewmaster", PET_FALLEN_MONK, true, true )
   {
     npc_id                      = 168073;
     main_hand_weapon.type       = WEAPON_2H;
@@ -1725,9 +1667,6 @@ public:
   double composite_player_multiplier( school_e school ) const override
   {
     double cpm = o()->cache.player_multiplier( school );
-
-    if ( o()->buff.hit_combo->up() )
-      cpm *= 1 + o()->buff.hit_combo->stack_value();
 
     if ( o()->conduit.imbued_reflections->ok() )
       cpm *= 1 + o()->conduit.imbued_reflections.percent();
@@ -1874,24 +1813,6 @@ public:
     monk_pet_t::init_action_list();
   }
 
-  void summon( timespan_t duration = timespan_t::zero() ) override
-  {
-    monk_pet_t::summon( duration );
-
-    if ( o()->buff.hit_combo->up() )
-      buff.hit_combo_fm_brm->trigger( o()->buff.hit_combo->check() );
-  }
-
-  void create_buffs() override
-  {
-    monk_pet_t::create_buffs();
-
-    buff.hit_combo_fm_brm = make_buff( this, "hit_combo_fo_brm", o()->passives.hit_combo )
-                                ->set_default_value_from_effect( 1 )
-                                ->set_quiet( true )
-                                ->add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
-  }
-
   action_t* create_action( util::string_view name, const std::string& options_str ) override
   {
     if ( name == "auto_attack" )
@@ -1932,9 +1853,6 @@ public:
   double composite_player_multiplier( school_e school ) const override
   {
     double cpm = o()->cache.player_multiplier( school );
-
-    if ( o()->buff.hit_combo->up() )
-      cpm *= 1 + o()->buff.hit_combo->stack_value();
 
     if ( o()->conduit.imbued_reflections->ok() )
       cpm *= 1 + o()->conduit.imbued_reflections.percent();


### PR DESCRIPTION
This should help for trinkets that count as pets (shadowgrasp/infinitely divisible ooze) for when they get implemented as pets