### PR TITLE
[Warlock] 9.1 Legendary Implementation, Part 1

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -552,6 +552,11 @@ void warlock_td_t::target_demise()
     {
       warlock.buffs.soul_tithe->trigger();
     }
+
+    if ( warlock.legendary.languishing_soul_detritus.ok() )
+    {
+      warlock.buffs.languishing_soul_detritus->trigger();
+    }
   }
 
   if ( debuffs_haunt->check() )
@@ -988,6 +993,10 @@ void warlock_t::create_buffs()
 
   buffs.demonic_synergy = make_buff( this, "demonic_synergy", find_spell( 337060 ) )
                               ->set_default_value( legendary.relic_of_demonic_synergy->effectN( 1 ).percent() * ( this->specialization() == WARLOCK_DEMONOLOGY ? 1.5 : 1.0 ) );
+
+  buffs.languishing_soul_detritus = make_buff( this, "languishing_soul_detritus", find_spell( 356255 ) )
+                                        ->set_pct_buff_type( STAT_PCT_BUFF_CRIT )
+                                        ->set_default_value( find_spell( 356255 )->effectN( 2 ).percent() );
 }
 
 void warlock_t::init_spells()

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1027,6 +1027,11 @@ void warlock_t::init_spells()
   //Wrath is implemented here to catch any potential cross-spec periodic effects
   legendary.wrath_of_consumption = find_runeforge_legendary("Wrath of Consumption");
 
+  legendary.languishing_soul_detritus = find_runeforge_legendary( "Languishing Soul Detritus" );
+  legendary.shard_of_annihilation = find_runeforge_legendary( "Shard of Annihilation" );
+  legendary.decaying_soul_satchel = find_runeforge_legendary( "Decaying Soul Satchel" );
+  legendary.contained_perpetual_explosion = find_runeforge_legendary( "Contained Perpetual Explosion" );
+
   // Conduits
   conduit.catastrophic_origin  = find_conduit_spell( "Catastrophic Origin" );   // Venthyr
   conduit.soul_eater           = find_conduit_spell( "Soul Eater" );            // Night Fae

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -396,6 +396,12 @@ struct decimating_bolt_t : public warlock_spell_t
       value *= 0.4;
     p()->buffs.decimating_bolt->trigger( 3, value );
     
+    if ( p()->legendary.shard_of_annihilation.ok() )
+    {
+      //Note: For Drain Soul, 3 stacks appear to be triggered but all are removed when the Decimating Bolt buff is
+      p()->buffs.shard_of_annihilation->trigger( 3 );
+    }
+
     warlock_spell_t::impact( s );
     
     auto e = make_event<ground_aoe_event_t>( *sim, p(), ground_aoe_params_t()
@@ -997,6 +1003,8 @@ void warlock_t::create_buffs()
   buffs.languishing_soul_detritus = make_buff( this, "languishing_soul_detritus", find_spell( 356255 ) )
                                         ->set_pct_buff_type( STAT_PCT_BUFF_CRIT )
                                         ->set_default_value( find_spell( 356255 )->effectN( 2 ).percent() );
+
+  buffs.shard_of_annihilation = make_buff( this, "shard_of_annihilation", find_spell( 356342 ) );
 }
 
 void warlock_t::init_spells()

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -420,6 +420,7 @@ public:
     propagate_const<buff_t*> implosive_potential_small;
     propagate_const<buff_t*> dread_calling;
     propagate_const<buff_t*> demonic_synergy;
+    propagate_const<buff_t*> languishing_soul_detritus;
   } buffs;
 
   //TODO: Determine if any gains are not currently being tracked

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -266,6 +266,11 @@ public:
     item_runeforge_t embers_of_the_diabolic_raiment;
     item_runeforge_t madness_of_the_azjaqir;
     item_runeforge_t odr_shawl_of_the_ymirjar;
+    // Covenant
+    item_runeforge_t languishing_soul_detritus;
+    item_runeforge_t shard_of_annihilation;
+    item_runeforge_t decaying_soul_satchel;
+    item_runeforge_t contained_perpetual_explosion;
   } legendary;
 
   struct conduit_t

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -421,6 +421,7 @@ public:
     propagate_const<buff_t*> dread_calling;
     propagate_const<buff_t*> demonic_synergy;
     propagate_const<buff_t*> languishing_soul_detritus;
+    propagate_const<buff_t*> shard_of_annihilation; //TODO: 2021-05-28 PTR has a bug where it is not benefiting the last cast of spells (Drain Soul ticks work normally)
   } buffs;
 
   //TODO: Determine if any gains are not currently being tracked

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -137,6 +137,29 @@ struct shadow_bolt_t : public affliction_spell_t
     return m;
   }
 
+  double composite_target_crit_chance( player_t* t ) const override
+  {
+    double m = affliction_spell_t::composite_target_crit_chance( t );
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+    {
+      //PTR 2020-05-28: "Critical Strike chance increased by 100%" was not producing guaranteed crits, assuming multiplicative
+      m *= 1.0 + p()->buffs.shard_of_annihilation->data().effectN( 1 ).percent();
+    }
+
+    return m;
+  }
+
+  double composite_crit_damage_bonus_multiplier() const override
+  {
+    double m = affliction_spell_t::composite_crit_damage_bonus_multiplier();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      m += p()->buffs.shard_of_annihilation->data().effectN( 2 ).percent();
+
+    return m;
+  }
+
   void schedule_execute( action_state_t* s ) override
   {
     affliction_spell_t::schedule_execute( s );
@@ -149,6 +172,9 @@ struct shadow_bolt_t : public affliction_spell_t
       p()->buffs.nightfall->decrement();
 
     p()->buffs.decimating_bolt->decrement();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      p()->buffs.shard_of_annihilation->decrement();
   }
 };
 
@@ -591,8 +617,12 @@ struct drain_soul_t : public affliction_spell_t
   {
     dot_t* dot = get_dot( target );
     if ( dot->is_ticking() )
+    {
       p()->buffs.decimating_bolt->decrement();
 
+      if ( p()->legendary.shard_of_annihilation.ok() )
+        p()->buffs.shard_of_annihilation->decrement( 3 );
+    }
     affliction_spell_t::execute();
   }
 
@@ -623,10 +653,37 @@ struct drain_soul_t : public affliction_spell_t
     return m;
   }
 
+  double composite_target_crit_chance( player_t* t ) const override
+  {
+    double m = affliction_spell_t::composite_target_crit_chance( t );
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+    {
+      //PTR 2020-05-28: "Critical Strike chance increased by 100%" was not producing guaranteed crits, assuming multiplicative
+      m *= 1.0 + p()->buffs.shard_of_annihilation->data().effectN( 3 ).percent();
+    }
+
+    return m;
+  }
+
+  double composite_crit_damage_bonus_multiplier() const override
+  {
+    double m = affliction_spell_t::composite_crit_damage_bonus_multiplier();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      m += p()->buffs.shard_of_annihilation->data().effectN( 4 ).percent();
+
+    return m;
+  }
+
   void last_tick( dot_t* d ) override
   {
     affliction_spell_t::last_tick( d );
+
     p()->buffs.decimating_bolt->decrement();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      p()->buffs.shard_of_annihilation->decrement( 3 );
   }
 
 };

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -137,9 +137,9 @@ struct shadow_bolt_t : public affliction_spell_t
     return m;
   }
 
-  double composite_target_crit_chance( player_t* t ) const override
+  double composite_crit_chance_multiplier() const override
   {
-    double m = affliction_spell_t::composite_target_crit_chance( t );
+    double m = affliction_spell_t::composite_crit_chance_multiplier();
 
     if ( p()->legendary.shard_of_annihilation.ok() )
     {
@@ -653,9 +653,9 @@ struct drain_soul_t : public affliction_spell_t
     return m;
   }
 
-  double composite_target_crit_chance( player_t* t ) const override
+  double composite_crit_chance_multiplier() const override
   {
-    double m = affliction_spell_t::composite_target_crit_chance( t );
+    double m = affliction_spell_t::composite_crit_chance_multiplier();
 
     if ( p()->legendary.shard_of_annihilation.ok() )
     {

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -291,6 +291,9 @@ struct demonbolt_t : public demonology_spell_t
       p()->buffs.demonic_calling->trigger();
 
     p()->buffs.decimating_bolt->decrement();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      p()->buffs.shard_of_annihilation->decrement();
   }
 
   double action_multiplier() const override
@@ -310,6 +313,29 @@ struct demonbolt_t : public demonology_spell_t
     m *= 1.0 + p()->buffs.balespiders_burning_core->check_stack_value();
 
     m *= 1 + p()->buffs.decimating_bolt->check_value();
+
+    return m;
+  }
+
+  double composite_target_crit_chance( player_t* t ) const override
+  {
+    double m = demonology_spell_t::composite_target_crit_chance( t );
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+    {
+      //PTR 2020-05-28: "Critical Strike chance increased by 100%" was not producing guaranteed crits, assuming multiplicative
+      m *= 1.0 + p()->buffs.shard_of_annihilation->data().effectN( 5 ).percent();
+    }
+
+    return m;
+  }
+
+  double composite_crit_damage_bonus_multiplier() const override
+  {
+    double m = demonology_spell_t::composite_crit_damage_bonus_multiplier();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      m += p()->buffs.shard_of_annihilation->data().effectN( 6 ).percent();
 
     return m;
   }

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -317,9 +317,9 @@ struct demonbolt_t : public demonology_spell_t
     return m;
   }
 
-  double composite_target_crit_chance( player_t* t ) const override
+  double composite_crit_chance_multiplier() const override
   {
-    double m = demonology_spell_t::composite_target_crit_chance( t );
+    double m = demonology_spell_t::composite_crit_chance_multiplier();
 
     if ( p()->legendary.shard_of_annihilation.ok() )
     {

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -402,9 +402,9 @@ struct incinerate_fnb_t : public destruction_spell_t
       p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_fnb_crits );
   }
 
-  double composite_target_crit_chance( player_t* t ) const override
+  double composite_crit_chance_multiplier() const override
   {
-    double m = destruction_spell_t::composite_target_crit_chance( t );
+    double m = destruction_spell_t::composite_crit_chance_multiplier();
 
     if ( p()->legendary.shard_of_annihilation.ok() )
     {
@@ -528,9 +528,9 @@ struct incinerate_t : public destruction_spell_t
       p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_crits );
   }
 
-  double composite_target_crit_chance( player_t* t ) const override
+  double composite_crit_chance_multiplier() const override
   {
-    double m = destruction_spell_t::composite_target_crit_chance( t );
+    double m = destruction_spell_t::composite_crit_chance_multiplier();
 
     if ( p()->legendary.shard_of_annihilation.ok() )
     {

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -402,9 +402,26 @@ struct incinerate_fnb_t : public destruction_spell_t
       p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_fnb_crits );
   }
 
-  double composite_target_crit_chance( player_t* target ) const override
+  double composite_target_crit_chance( player_t* t ) const override
   {
-    double m = destruction_spell_t::composite_target_crit_chance( target );
+    double m = destruction_spell_t::composite_target_crit_chance( t );
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+    {
+      //PTR 2020-05-28: "Critical Strike chance increased by 100%" was not producing guaranteed crits, assuming multiplicative
+      m *= 1.0 + p()->buffs.shard_of_annihilation->data().effectN( 1 ).percent();
+    }
+
+    return m;
+  }
+
+  double composite_crit_damage_bonus_multiplier() const override
+  {
+    double m = destruction_spell_t::composite_crit_damage_bonus_multiplier();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      m += p()->buffs.shard_of_annihilation->data().effectN( 2 ).percent();
+
     return m;
   }
 
@@ -497,6 +514,9 @@ struct incinerate_t : public destruction_spell_t
       fnb_action->execute();
     }
     p()->buffs.decimating_bolt->decrement();
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+      p()->buffs.shard_of_annihilation->decrement();
   }
 
   void impact( action_state_t* s ) override
@@ -508,9 +528,16 @@ struct incinerate_t : public destruction_spell_t
       p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_crits );
   }
 
-  double composite_target_crit_chance( player_t* target ) const override
+  double composite_target_crit_chance( player_t* t ) const override
   {
-    double m = destruction_spell_t::composite_target_crit_chance( target );
+    double m = destruction_spell_t::composite_target_crit_chance( t );
+
+    if ( p()->legendary.shard_of_annihilation.ok() )
+    {
+      //PTR 2020-05-28: "Critical Strike chance increased by 100%" was not producing guaranteed crits, assuming multiplicative
+      m *= 1.0 + p()->buffs.shard_of_annihilation->data().effectN( 1 ).percent();
+    }
+
     return m;
   }
 


### PR DESCRIPTION
Finished Languishing Soul Detritus (Kyrian) and Shard of Annihilation (Necrolord). Placeholders created for Venthyr and Night Fae legendaries.