### PR TITLE
[Warlock] 9.1 Legendaries, Part 2

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -314,6 +314,18 @@ struct soul_rot_t : public warlock_spell_t
     p()->buffs.soul_rot->trigger();
   }
 
+  void impact( action_state_t* s ) override
+  {
+    warlock_spell_t::impact( s );
+
+    if ( p()->legendary.decaying_soul_satchel.ok() )
+    {
+      //TOCHECK: What happens if one of the Soul Rot targets dies before 8 seconds is up?
+      p()->buffs.decaying_soul_satchel_haste->trigger();
+      p()->buffs.decaying_soul_satchel_crit->trigger();
+    }
+  }
+
   double composite_ta_multiplier( const action_state_t* s ) const override
   {
     double pm = warlock_spell_t::composite_ta_multiplier( s );
@@ -1005,6 +1017,14 @@ void warlock_t::create_buffs()
                                         ->set_default_value( find_spell( 356255 )->effectN( 2 ).percent() );
 
   buffs.shard_of_annihilation = make_buff( this, "shard_of_annihilation", find_spell( 356342 ) );
+
+  buffs.decaying_soul_satchel_haste = make_buff( this, "decaying_soul_satchel_haste", find_spell( 356369 ) )
+                                          ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
+                                          ->set_default_value( find_spell( 356369 )->effectN( 1 ).percent() );
+
+  buffs.decaying_soul_satchel_crit = make_buff( this, "decaying_soul_satchel_crit", find_spell( 356369 ) )
+                                         ->set_pct_buff_type( STAT_PCT_BUFF_CRIT )
+                                         ->set_default_value( find_spell( 356369 )->effectN( 2 ).percent() );
 }
 
 void warlock_t::init_spells()

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -320,7 +320,6 @@ struct soul_rot_t : public warlock_spell_t
 
     if ( p()->legendary.decaying_soul_satchel.ok() )
     {
-      //TOCHECK: What happens if one of the Soul Rot targets dies before 8 seconds is up?
       p()->buffs.decaying_soul_satchel_haste->trigger();
       p()->buffs.decaying_soul_satchel_crit->trigger();
     }

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -422,6 +422,8 @@ public:
     propagate_const<buff_t*> demonic_synergy;
     propagate_const<buff_t*> languishing_soul_detritus;
     propagate_const<buff_t*> shard_of_annihilation; //TODO: 2021-05-28 PTR has a bug where it is not benefiting the last cast of spells (Drain Soul ticks work normally)
+    propagate_const<buff_t*> decaying_soul_satchel_haste; //These are one unified buff in-game but splitting them in simc to make it easier to apply stat pcts
+    propagate_const<buff_t*> decaying_soul_satchel_crit;
   } buffs;
 
   //TODO: Determine if any gains are not currently being tracked


### PR DESCRIPTION
Decaying Soul Satchel is implemented here. There is a major bug with Contained Perpetual Explosion, so implementation will be delayed on that one (https://github.com/SimCMinMax/WoW-BugTracker/issues/858)