### PR TITLE
Dockerfile: Add PGO, drop NoNetworking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,19 +197,6 @@ jobs:
           SIMC_ITERATIONS: 2
         run: tests/run.py ${{ matrix.spec }} -tests talent trinket covenant legendary soulbind --max-profiles-to-use 1
 
-  build-docker:
-    name: docker
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build
-        run: docker build --no-cache --build-arg THREADS=2 --build-arg NONETWORKING=1 -t simulationcraft .
-
-      - name: Test
-        run: docker run simulationcraft ./simc spell_query=spell.name=frost_shock
-
-
   build-osx:
     name: macos-latest
     runs-on: macos-latest


### PR DESCRIPTION
- Switch to clang
- Switch from LTO to LTO_THIN. The performance difference is only about 1%, and the build time is significantly improved.
- Add Profile guided optimization. Collect data from a simple T26_Raid.simc run, and rebuild. Offers about 28% performance improvement compared to current simulationcraftorg/simc image
- Drop NONETWORKING option. It is just not worth the hassle in the docker file, and since the normal version with curl works fine, there is no strong reason to keep the maintenance burden in the docker file.