### PR TITLE
[Monk] Update necrolord windwalker apl

### DIFF
--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -543,11 +543,14 @@ void windwalker( player_t* p )
       "weapons_of_order,if=(raid_event.adds.in>45|raid_event.adds.up)&cooldown.rising_sun_kick.remains<execute_time&cooldown.invoke_xuen_the_white_tiger.remains>(20+20*runeforge.invokers_delight)|fight_remains<35" );
   cd_sef->add_action( "faeline_stomp,if=combo_strike&(raid_event.adds.in>10|raid_event.adds.up)" );
   cd_sef->add_action( "fallen_order,if=raid_event.adds.in>30|raid_event.adds.up" );
-  cd_sef->add_action( "bonedust_brew,if=fight_remains<15|"
-      "(chi>=2&(fight_remains>60&((cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>10)&"
-      "(pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>10|variable.hold_xuen)))|"
-      "(fight_remains<=60&(pet.xuen_the_White_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)&"
-      "(cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>fight_remains|buff.storm_earth_and_fire.up)))" );
+  cd_sef->add_action(
+      "bonedust_brew,if=chi>=2&fight_remains>60&(cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>10)&"
+      "(pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>10|variable.hold_xuen)|"
+      "(chi>=2&fight_remains<=60&(pet.xuen_the_White_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)&"
+      "(cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>fight_remains|buff.storm_earth_"
+      "and_fire.up))|fight_remains<15" );
+
+
 
   cd_sef->add_action( "storm_earth_and_fire_fixate,if=conduit.coordinated_offensive.enabled" );
   cd_sef->add_action(

--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -366,8 +366,13 @@ void windwalker( player_t* p )
   def->add_action( "auto_attack" );
   def->add_action( p, "Spear Hand Strike", "if=target.debuff.casting.react" );
   def->add_action(
-      "variable,name=hold_xuen,op=set,value=cooldown.invoke_xuen_the_white_tiger.remains>fight_remains|fight_remains<"
-      "120&fight_remains>cooldown.serenity.remains&cooldown.serenity.remains>10" );
+      "variable,name=hold_xuen,op=set,value=cooldown.invoke_xuen_the_white_tiger.remains>fight_remains|fight_remains-"
+      "cooldown.invoke_xuen_the_white_tiger.remains<"
+      "120&((talent.serenity&fight_remains>cooldown.serenity.remains&cooldown.serenity.remains>10)|"
+      "(cooldown.storm_earth_and_fire.full_recharge_time<fight_remains&cooldown.storm_earth_and_fire.full_recharge_"
+      "time>15)|"
+      "(cooldown.storm_earth_and_fire.charges=0&cooldown.storm_earth_and_fire.remains<fight_remains))" );
+
   if ( p->sim->allow_potions )
   {
     if ( monk->spec.invoke_xuen->ok() )
@@ -386,14 +391,14 @@ void windwalker( player_t* p )
     def->add_action( "call_action_list,name=opener,if=time<4&chi<5" );
   def->add_talent( p, "Fist of the White Tiger",
                    "target_if=min:debuff.mark_of_the_crane.remains,if=chi.max-chi>=3&(energy.time_to_max<1|energy.time_"
-                   "to_max<4&cooldown.fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)" );
+                   "to_max<4&cooldown.fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)&!debuff.bonedust_brew_debuff.up" );
   def->add_action( p, "Expel Harm",
                    "if=chi.max-chi>=1&(energy.time_to_max<1|cooldown.serenity.remains<2|energy.time_to_max<4&cooldown."
-                   "fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)" );
+                   "fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)&!buff.bonedust_brew.up" );
   def->add_action( p, "Tiger Palm",
                    "target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&chi.max-chi>=2&(energy.time_to_max<"
                    "1|cooldown.serenity.remains<2|energy.time_to_max<4&cooldown.fists_of_fury.remains<1.5|cooldown."
-                   "weapons_of_order.remains<2)" );
+                   "weapons_of_order.remains<2)&!debuff.bonedust_brew_debuff.up" );
   def->add_action( "call_action_list,name=cd_sef,if=!talent.serenity" );
   def->add_action( "call_action_list,name=cd_serenity,if=talent.serenity" );
   def->add_action( "call_action_list,name=st,if=active_enemies<3" );
@@ -511,13 +516,18 @@ void windwalker( player_t* p )
 
   cd_serenity->add_action( "faeline_stomp" );
   cd_serenity->add_action( "fallen_order" );
-  cd_serenity->add_action( "bonedust_brew" );
+  cd_serenity->add_action(
+      "bonedust_brew,if=fight_remains<15|"
+      "(chi>=2&(fight_remains>60&((cooldown.serenity.remains>10|buff.serenity.up|cooldown.serenity.up)&"
+      "(pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>10|variable.hold_xuen)))|"
+      "(fight_remains<=60&(pet.xuen_the_White_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>fight_remains))"
+      ")" );
 
   cd_serenity->add_talent( p, "Serenity", "if=cooldown.rising_sun_kick.remains<2|fight_remains<15" );
   cd_serenity->add_action( "bag_of_tricks" );
 
   // Storm, Earth and Fire Cooldowns
-  cd_sef->add_action( p, "Invoke Xuen, the White Tiger", "if=!variable.hold_xuen&(cooldown.rising_sun_kick.remains<2|!covenant.kyrian)|fight_remains<25" );
+  cd_sef->add_action( p, "Invoke Xuen, the White Tiger", "if=!variable.hold_xuen&(cooldown.rising_sun_kick.remains<2|!covenant.kyrian)&(!covenant.necrolord|cooldown.bonedust_brew.remains<2)|fight_remains<25" );
 
   if ( monk->spec.invoke_xuen->ok() )
     cd_sef->add_action( p, "Touch of Death",
@@ -533,12 +543,16 @@ void windwalker( player_t* p )
       "weapons_of_order,if=(raid_event.adds.in>45|raid_event.adds.up)&cooldown.rising_sun_kick.remains<execute_time&cooldown.invoke_xuen_the_white_tiger.remains>(20+20*runeforge.invokers_delight)|fight_remains<35" );
   cd_sef->add_action( "faeline_stomp,if=combo_strike&(raid_event.adds.in>10|raid_event.adds.up)" );
   cd_sef->add_action( "fallen_order,if=raid_event.adds.in>30|raid_event.adds.up" );
-  cd_sef->add_action( "bonedust_brew,if=raid_event.adds.in>50|raid_event.adds.up,line_cd=60" );
+  cd_sef->add_action( "bonedust_brew,if=fight_remains<15|"
+      "(chi>=2&(fight_remains>60&((cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>10)&"
+      "(pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>10|variable.hold_xuen)))|"
+      "(fight_remains<=60&(pet.xuen_the_White_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)&"
+      "(cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>fight_remains|buff.storm_earth_and_fire.up)))" );
 
   cd_sef->add_action( "storm_earth_and_fire_fixate,if=conduit.coordinated_offensive.enabled" );
   cd_sef->add_action(
       p, "Storm, Earth, and Fire",
-      "if=cooldown.storm_earth_and_fire.charges=2|fight_remains<20|(raid_event.adds.remains>15|!covenant.kyrian&"
+      "if=cooldown.storm_earth_and_fire.charges=2|fight_remains<20|(raid_event.adds.remains>15|(!covenant.kyrian&!covenant.necrolord)&"
       "((raid_event.adds.in>cooldown.storm_earth_and_fire.full_recharge_time|!raid_event.adds.exists)&"
       "(cooldown.invoke_xuen_the_white_tiger.remains>cooldown.storm_earth_and_fire.full_recharge_time|variable.hold_"
       "xuen))&"
@@ -547,6 +561,11 @@ void windwalker( player_t* p )
                       "if=covenant.kyrian&(buff.weapons_of_order.up|(fight_remains<cooldown.weapons_of_order.remains|"
                       "cooldown.weapons_of_order.remains>cooldown.storm_earth_and_fire.full_recharge_time)&cooldown."
                       "fists_of_fury.remains<=9&chi>=2&cooldown.whirling_dragon_punch.remains<=12)" );
+
+  cd_sef->add_action( p, "Storm, Earth, and Fire",
+      "if=covenant.necrolord&debuff.bonedust_brew_debuff.up&(pet.xuen_the_white_tiger.active|variable."
+      "hold_xuen|cooldown.invoke_xuen_the_white_tiger.remains>cooldown.storm_earth_and_fire.full_"
+      "recharge_time|cooldown.invoke_xuen_the_white_tiger.remains>30)" );
 
   // Storm, Earth, and Fire on-use trinkets
   for ( size_t i = 0; i < p->items.size(); i++ )
@@ -670,7 +689,7 @@ void windwalker( player_t* p )
   st->add_action(
       p, "Fists of Fury",
       "if=(raid_event.adds.in>cooldown.fists_of_fury.duration*0.8|raid_event.adds.up)&(energy.time_to_max>execute_time-"
-      "1|chi.max-chi<=1|buff.storm_earth_and_fire.remains<execute_time+1)|fight_remains<execute_time+1" );
+      "1|chi.max-chi<=1|buff.storm_earth_and_fire.remains<execute_time+1)|fight_remains<execute_time+1|debuff.bonedust_brew_debuff.up" );
   st->add_action( p, "Crackling Jade Lightning",
                   "if=buff.the_emperors_capacitor.stack>19&energy.time_to_max>execute_time-1&cooldown.rising_sun_kick."
                   "remains>execute_time|buff.the_emperors_capacitor.stack>14&(cooldown.serenity.remains<5&talent."


### PR DESCRIPTION
Updates Windwalker Necrolord APL cooldown usage. Casts BDB on cooldown for the most part, with some small wiggleroom to try to lineup w/ SEF and xuen. Holds xuen/SEF for BDB accordingly, and holds last BDB cast for xuen/SEF.

Note - there is no specific BDB rotation, at least here - wasn't able to figure out stuff that would beat the existing default ST apl, even when trying to hold rsk, pool more, etc. There might be more room for improvement in terms of rotation within BDB and/or what to hold for BDB.

Raidbots w/ new apl and 9.1 soulbinds:

ST: https://www.raidbots.com/simbot/report/5ss77wSrBa576mqV1SgQYo
DSlice: https://www.raidbots.com/simbot/report/8iau5c2AeCwzzRTAXNhCFx