### PR TITLE
[Warlock] fix dstr condition

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1220,7 +1220,7 @@ void warlock_t::create_apl_demonology()
   def->add_action( "call_action_list,name=tyrant_setup" );
   def->add_action( "potion,if=(cooldown.summon_demonic_tyrant.remains_expected<10&time>variable.first_tyrant_time-10|soulbind.refined_palate&cooldown.summon_demonic_tyrant.remains_expected<38)" );
   def->add_action( "call_action_list,name=ogcd,if=pet.demonic_tyrant.active" );
-  def->add_action( "demonic_strength,if=(!runeforge.wilfreds_sigil_of_superior_summoning&cooldown.summon_demonic_tyrant.remains_expected>9)|pet.demonic_tyrant.remains<6*gcd.max" );
+  def->add_action( "demonic_strength,if=(!runeforge.wilfreds_sigil_of_superior_summoning&cooldown.summon_demonic_tyrant.remains_expected>9)|(pet.demonic_tyrant.active&pet.demonic_tyrant.remains<6*gcd.max)" );
   def->add_action( "call_dreadstalkers,if=cooldown.summon_demonic_tyrant.remains_expected>20-5*!runeforge.wilfreds_sigil_of_superior_summoning" );
   def->add_action( "power_siphon,if=buff.wild_imps.stack>1&buff.demonic_core.stack<3" );
   def->add_action( "bilescourge_bombers,if=buff.tyrant.down&cooldown.summon_demonic_tyrant.remains_expected>5" );


### PR DESCRIPTION
apearently remains is 0 when tyrant is down.
before: https://www.raidbots.com/simbot/report/eDfSn1KEvf7wXRY4nnaQzp
after: https://www.raidbots.com/simbot/report/mvvFQev89mgsC9nvNaCVLy