### PR TITLE
[Paladin] Aegis of Light

### DIFF
--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -972,21 +972,6 @@ void judgment_t::do_ctor_common( paladin_t* p )
   weapon_multiplier = 0.0;
   may_block = may_parry = may_dodge = false;
 
-  // Handle indomitable justice option
-  if ( p->azerite.indomitable_justice.enabled() )
-  {
-    // If using the default setting, set to 80% hp for protection, 100% hp for other specs
-    if ( p->options.indomitable_justice_pct == 0 )
-    {
-      indomitable_justice_pct = p->specialization() == PALADIN_PROTECTION ? 80 : 100;
-    }
-    // Else, clamp the value between -1 ("real" usage) and 100
-    else
-    {
-      indomitable_justice_pct = clamp<int>( p->options.indomitable_justice_pct, -1, 100 );
-    }
-  }
-
   // rank 2 multiplier
   if ( p->spells.judgment_2->ok() )
   {
@@ -1005,29 +990,6 @@ judgment_t::judgment_t( paladin_t* p )
   : paladin_melee_attack_t( "divine_toll_judgment", p, p->find_class_spell( "Judgment" ) )
 {
   do_ctor_common( p );
-}
-
-double judgment_t::bonus_da( const action_state_t* s ) const
-{
-  double da = paladin_melee_attack_t::bonus_da( s );
-  if ( p()->azerite.indomitable_justice.ok() )
-  {
-    double player_percent = indomitable_justice_pct < 0 ? p()->health_percentage() : indomitable_justice_pct;
-    double target_percent = s->target->health_percentage();
-
-    if ( player_percent > target_percent )
-    {
-      double ij_bonus = p()->azerite.indomitable_justice.value();
-
-      ij_bonus *= ( player_percent - target_percent ) / 100.0;
-
-      // Protection has a 50% damage reduction to IJ
-      ij_bonus *= 1.0 + p()->spec.protection_paladin->effectN( 15 ).percent();
-
-      da += ij_bonus;
-    }
-  }
-  return da;
 }
 
 proc_types judgment_t::proc_type() const
@@ -2382,7 +2344,6 @@ void paladin_t::init_spells()
   // Shared Azerite traits
   azerite.avengers_might        = find_azerite_spell( "Avenger's Might" );
   azerite.grace_of_the_justicar = find_azerite_spell( "Grace of the Justicar" );
-  azerite.indomitable_justice   = find_azerite_spell( "Indomitable Justice" );
 
   // Essences
   azerite_essence.memory_of_lucid_dreams = find_azerite_essence( "Memory of Lucid Dreams" );
@@ -2546,7 +2507,15 @@ double paladin_t::composite_attribute_multiplier( attribute_e attr ) const
   // Protection gets increased stamina
   if ( attr == ATTR_STAMINA )
   {
-    m *= 1.0 + spec.protection_paladin->effectN( 3 ).percent();
+    if ( dbc -> ptr )
+    {
+      if ( passives.aegis_of_light -> ok() )
+        m *= 1.0 + passives.aegis_of_light -> effectN( 1 ).percent();
+    }
+    else
+    {
+      m *= 1.0 + spec.protection_paladin->effectN( 3 ).percent();
+    }    
     if ( buffs.redoubt->up() )
       m *= 1.0 + buffs.redoubt->stack_value();
   }
@@ -2626,7 +2595,15 @@ double paladin_t::composite_base_armor_multiplier() const
   double a = player_t::composite_base_armor_multiplier();
   if ( specialization() != PALADIN_PROTECTION )
     return a;
-  a *= 1.0 + spec.protection_paladin->effectN( 4 ).percent();
+  if ( dbc -> ptr )
+  {
+    if ( passives.aegis_of_light -> ok() )
+      a *= 1.0 + passives.aegis_of_light -> effectN( 2 ).percent();
+  }
+  else
+  {
+    a *= 1.0 + spec.protection_paladin->effectN( 4 ).percent();
+  }
   return a;
 }
 
@@ -2709,8 +2686,11 @@ double paladin_t::composite_spell_power( school_e school ) const
   switch ( specialization() )
   {
     case PALADIN_PROTECTION:
-      sp = spec.protection_paladin->effectN( 9 ).percent() *
-           composite_melee_attack_power_by_type( attack_power_type::WEAPON_MAINHAND ) *
+      if ( dbc -> ptr )
+        sp = spec.protection_paladin->effectN( 7 ).percent();
+      else
+        sp = spec.protection_paladin->effectN( 9 ).percent();
+      sp *= composite_melee_attack_power_by_type( attack_power_type::WEAPON_MAINHAND ) *
            composite_attack_power_multiplier();
       break;
     case PALADIN_RETRIBUTION:
@@ -2807,8 +2787,10 @@ double paladin_t::composite_block_reduction( action_state_t* s ) const
 double paladin_t::composite_crit_avoidance() const
 {
   double c = player_t::composite_crit_avoidance();
-
-  c += spec.protection_paladin->effectN( 10 ).percent();
+  if ( dbc -> ptr )
+    c += spec.protection_paladin->effectN( 8 ).percent();
+  else
+    c += spec.protection_paladin->effectN( 10 ).percent();
 
   return c;
 }
@@ -3050,7 +3032,6 @@ void paladin_t::create_options()
 {
   // TODO: figure out a better solution for this.
   add_option( opt_bool( "paladin_fake_sov", options.fake_sov ) );
-  add_option( opt_int( "indomitable_justice_pct", options.indomitable_justice_pct ) );
   add_option(
       opt_float( "proc_chance_ret_memory_of_lucid_dreams", options.proc_chance_ret_memory_of_lucid_dreams, 0.0, 1.0 ) );
   add_option( opt_float( "proc_chance_prot_memory_of_lucid_dreams", options.proc_chance_prot_memory_of_lucid_dreams,

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -224,6 +224,9 @@ public:
     const spell_data_t* riposte;
     const spell_data_t* sanctuary;
 
+    const spell_data_t* aegis_of_light;
+    const spell_data_t* aegis_of_light_2;
+
     const spell_data_t* boundless_conviction;
 
     const spell_data_t* art_of_war;
@@ -366,7 +369,6 @@ public:
     // Shared
     azerite_power_t avengers_might;
     azerite_power_t grace_of_the_justicar; // Healing, NYI
-    azerite_power_t indomitable_justice;
 
     // Holy
 
@@ -438,7 +440,6 @@ public:
     double proc_chance_ret_memory_of_lucid_dreams = 0.15;
     double proc_chance_prot_memory_of_lucid_dreams = 0.15;
     bool fake_sov = true;
-    int indomitable_justice_pct = 0;
   } options;
   player_t* beacon_target;
 
@@ -1271,11 +1272,9 @@ struct holy_power_consumer_t : public Base
 
 struct judgment_t : public paladin_melee_attack_t
 {
-  int indomitable_justice_pct;
   judgment_t( paladin_t* p, util::string_view options_str );
   judgment_t( paladin_t* p );
 
-  virtual double bonus_da( const action_state_t* s ) const override;
   proc_types proc_type() const override;
   void impact( action_state_t* s ) override;
   void execute() override;

--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -571,6 +571,17 @@ void paladin_t::target_mitigation( school_e school,
   // Passive sources (Sanctuary)
   s -> result_amount *= 1.0 + passives.sanctuary -> effectN( 1 ).percent();
 
+  if ( dbc -> ptr )
+  {
+    if ( passives.aegis_of_light_2 -> ok() )
+      s -> result_amount *= 1.0 + passives.aegis_of_light_2 -> effectN( 1 ).percent();
+  }
+  else
+  {
+    if ( passives.aegis_of_light -> ok() )
+      s -> result_amount *= 1.0 + passives.aegis_of_light -> effectN( 1 ).percent();
+  }
+
   if ( sim -> debug && s -> action && ! s -> target -> is_enemy() && ! s -> target -> is_add() )
     sim -> print_debug( "Damage to {} after passive mitigation is {}", s -> target -> name(), s -> result_amount );
 
@@ -878,6 +889,10 @@ void paladin_t::init_spells_protection()
   passives.grand_crusader      = find_specialization_spell( "Grand Crusader" );
   passives.riposte             = find_specialization_spell( "Riposte" );
   passives.sanctuary           = find_specialization_spell( "Sanctuary" );
+  
+  passives.aegis_of_light      = find_specialization_spell( "Aegis of Light" );
+  if ( dbc -> ptr )
+    passives.aegis_of_light_2    = find_rank_spell( "Aegis of Light", "Rank 2" );
 
   // Azerite traits
   azerite.inspiring_vanguard = find_azerite_spell( "Inspiring Vanguard" );


### PR DESCRIPTION
Some effects moved from spec aura to a new passive.
Indomitable Justice got caught in the crossfire due to it relying on the spec aura and I'd rather just drop support for it rather than update it's effect number