### PR TITLE
Make Shiv proc combat potency

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -4125,7 +4125,7 @@ struct shiv_t : public rogue_attack_t
     }
   }
 
-  // 06/24/2021 - Now procs combat potency according to 9.1 Patch Notes
+  // 2021-06-24 - Now procs combat potency according to 9.1 Patch Notes
   bool procs_combat_potency() const override
   { return true; }
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -4125,9 +4125,9 @@ struct shiv_t : public rogue_attack_t
     }
   }
 
-  // 1/23/2021 - Does not appear to proc Combat Potency despite being an OH attack
+  // 06/24/2021 - Now procs combat potency according to 9.1 Patch Notes
   bool procs_combat_potency() const override
-  { return false; }
+  { return true; }
 
   bool procs_blade_flurry() const override
   { return true; }


### PR DESCRIPTION
According to the official 9.1 Patch Notes, Blizzard has fixed the bug that made shiv not proc combat potency.