### PR TITLE
[brm] fix shuffle extension

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -260,8 +260,9 @@ public:
       if ( p()->buff.shuffle->up() )
       {
         timespan_t max_time   = p()->buff.shuffle->buff_duration();
-        timespan_t new_length = std::min( max_time, base_time + p()->buff.shuffle->remains() );
-        p()->buff.shuffle->refresh_duration( new_length );
+        timespan_t old_duration = p()->buff.shuffle->remains();
+        timespan_t new_length = std::min( max_time, base_time + old_duration);
+        p()->buff.shuffle->refresh( 1, buff_t::DEFAULT_VALUE(), new_length );
       }
       else
       {


### PR DESCRIPTION
the `refresh_duration` method on a buff returns the duration that it will be refreshed to.
the `refresh` method actually refreshes the buff.

(this is a confusing naming scheme)

this fixes Brewmaster's Shuffle handling to correctly extend the Shuffle buff when a Shuffle-triggering ability is used (previously, it would be applied if missing but would not extend the buff).