### PR TITLE
[Warlock] Fix issue with vilefiend bile spit cast

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -844,12 +844,7 @@ struct summon_vilefiend_t : public demonology_spell_t
   {
     demonology_spell_t::execute();
     p()->buffs.vilefiend->trigger();
-
-    // Spawn a single vilefiend, and grab it's pointer so we can execute an instant bile split
-    // TODO: The bile split execution should move to the pet itself, instead of here
-    auto vilefiend = p()->warlock_pet_list.vilefiends.spawn( data().duration() ).front();
-    vilefiend->bile_spit->set_target( execute_state->target );
-    vilefiend->bile_spit->execute();
+    p()->warlock_pet_list.vilefiends.spawn( data().duration() );
   }
 };
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1071,6 +1071,8 @@ struct bile_spit_t : public warlock_pet_spell_t
   {
     tick_may_crit = false;
     hasted_ticks  = false;
+    // Single cast per sim
+    cooldown->duration = sim->max_time * ( 1 + sim->vary_combat_length );
   }
 };
 
@@ -1085,7 +1087,9 @@ struct headbutt_t : public warlock_pet_melee_attack_t
 vilefiend_t::vilefiend_t( warlock_t* owner )
   : warlock_simple_pet_t( owner, "vilefiend", PET_VILEFIEND ), bile_spit( nullptr )
 {
-  action_list_str += "travel/headbutt";
+  action_list_str = "bile_spit";
+  action_list_str += "/travel";
+  action_list_str += "/headbutt";
   owner_coeff.ap_from_sp = 0.23;
   owner_coeff.health     = 0.75;
 }
@@ -1098,8 +1102,18 @@ void vilefiend_t::init_base_stats()
   bile_spit    = new bile_spit_t( this );
 }
 
+void vilefiend_t::arise()
+{
+  warlock_pet_t::arise();
+  //Reset cooldown to allow cast for new vilefiend
+  bile_spit->reset();
+}
+
 action_t* vilefiend_t::create_action( util::string_view name, const std::string& options_str )
 {
+  if ( name == "bile_spit" )
+    return bile_spit;
+
   if ( name == "headbutt" )
   {
     special_ability = new headbutt_t( this );

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -449,6 +449,7 @@ struct vilefiend_t : public warlock_simple_pet_t
 
   vilefiend_t( warlock_t* owner );
   void init_base_stats() override;
+  void arise() override;
   action_t* create_action( util::string_view name, const std::string& options_str ) override;
 };
 


### PR DESCRIPTION
Fixes an issue where the vilefiend can continue to perform actions which casting bilespit, unlike in game.

Ingame logs:
https://www.warcraftlogs.com/reports/XtCBHbgx8aGVk7Fw#fight=9&type=casts&source=4.1&view=timeline
https://www.warcraftlogs.com/reports/XtCBHbgx8aGVk7Fw#fight=9&type=summary&source=4.1&view=events

APL used to generate simc logs:
https://pastebin.com/CGrb82Fs

Log before change
```
2.000 Player 'Necrovanish' summons vilefiend for 15.000.
2.000 Player 'Necrovanish_vilefiend' tries to arise.
2.000 Player 'Necrovanish_vilefiend' arises. Spawn Index=2
2.000 Player 'Necrovanish_vilefiend' schedules execute for Action melee
2.000 Player 'Necrovanish_vilefiend' performs Action bile_spit (200)
2.000 Player 'Necrovanish_vilefiend' schedules travel (0.615) for Action bile_spit
2.000 Player 'Necrovanish_vilefiend' performs Action melee (200)
2.000 Player 'Necrovanish_vilefiend' melee hits Player 'Fluffy_Pillow' for 86.7158087398488 physical damage (hit)
2.000 Player 'Necrovanish_vilefiend' schedules execute for Action melee
2.000 Player 'Necrovanish_vilefiend' schedules execute for Action travel
2.615 Player 'Necrovanish_vilefiend' bile_spit hits Player 'Fluffy_Pillow' for 549.313732296 nature damage (hit)
3.212 Player 'Necrovanish_vilefiend' schedules execute for Action headbutt
3.212 Player 'Necrovanish_vilefiend' performs Action headbutt (200)
3.212 Player 'Necrovanish_vilefiend' headbutt hits Player 'Fluffy_Pillow' for 176.90024982929154 physical damage (hit)
4.000 Player 'Necrovanish_vilefiend' performs Action melee (200)
4.000 Player 'Necrovanish_vilefiend' melee hits Player 'Fluffy_Pillow' for 173.4316174796976 physical damage (crit)
```

Log after change
```
2.000 Player 'Necrovanish' summons vilefiend for 15.000.
2.000 Player 'Necrovanish_vilefiend' tries to arise.
2.000 Player 'Necrovanish_vilefiend' arises. Spawn Index=2
2.000 Player 'Necrovanish_vilefiend' schedules execute for Action melee
2.000 Player 'Necrovanish_vilefiend' performs Action melee (200)
2.000 Player 'Necrovanish_vilefiend' melee hits Player 'Fluffy_Pillow' for 86.7158087398488 physical damage (hit)
2.000 Player 'Necrovanish_vilefiend' schedules execute for Action melee
2.000 Player 'Necrovanish_vilefiend' schedules execute for Action bile_spit
2.000 Player 'Necrovanish_vilefiend' gains Buff casting (stacks=1) (value=-2.2250738585072014e-308)
4.000 Player 'Necrovanish_vilefiend' schedules execute for Action melee
4.000 Player 'Necrovanish_vilefiend' performs Action bile_spit (200)
4.000 Player 'Necrovanish_vilefiend' schedules travel (0.615) for Action bile_spit
4.000 Player 'Necrovanish_vilefiend' loses Buff casting
4.000 Player 'Necrovanish_vilefiend' schedules execute for Action travel
4.615 Player 'Necrovanish_vilefiend' bile_spit hits Player 'Fluffy_Pillow' for 549.313732296 nature damage (hit)
5.212 Player 'Necrovanish_vilefiend' schedules execute for Action headbutt
5.212 Player 'Necrovanish_vilefiend' performs Action headbutt (200)
5.212 Player 'Necrovanish_vilefiend' headbutt hits Player 'Fluffy_Pillow' for 176.90024982929154 physical damage (hit)
6.000 Player 'Necrovanish_vilefiend' performs Action melee (200)
6.000 Player 'Necrovanish_vilefiend' melee hits Player 'Fluffy_Pillow' for 86.7158087398488 physical damage (hit)
```

Note the time delay of 2s of the headbut and next melee, due to vilefiend spending 2s casting bilespit.