### PR TITLE
[Shaman] Elemental APL - Adjust Fae Transfusion to play with fae legendary

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8802,8 +8802,13 @@ void shaman_t::init_action_list_elemental()
     def->add_action( "bag_of_tricks,if=!talent.ascendance.enabled|!buff.ascendance.up" );
     def->add_action( "vesper_totem,if=covenant.kyrian" );
     def->add_action(
-        "fae_transfusion,if=covenant.night_fae&(!talent.master_of_the_elements.enabled|buff.master_of_the_elements.up)&"
+        "fae_transfusion,if=covenant.night_fae&!runeforge.seeds_of_rampant_growth.equipped&"
+        "(!talent.master_of_the_elements.enabled|buff.master_of_the_elements.up)&"
         "spell_targets.chain_lightning<3" );
+    def->add_action(
+        "fae_transfusion,if=covenant.night_fae&runeforge.seeds_of_rampant_growth.equipped&"
+        "(!talent.master_of_the_elements.enabled|buff.master_of_the_elements.up|spell_targets.chain_lightning>=3)&"
+        "(cooldown.fire_elemental.remains>20|cooldown.storm_elemental.remains>20)" );
     def->add_action(
         "run_action_list,name=aoe,if=active_enemies>2&(spell_targets.chain_lightning>2|spell_targets.lava_beam>2)" );
     def->add_action( "run_action_list,name=single_target,if=!talent.storm_elemental.enabled&active_enemies<=2" );


### PR DESCRIPTION
'Seeds of Rampant Growth' (SoRG) legendary reduces the cd for a fire/storm elemental by 42 seconds when 'Fae Transfusion' is fully used.
A separate action has been added for 'Fae Transfusion' to avoid complicating APL with difficult long conditions for various legendaries and for better maintainability.
The 'cooldown > 20' condition was used to avoid holding on 'Fae Transfusion' for too long and still profit from SoRG. This allows SoRG to be used with an efficiency of at least 50%.