### PR TITLE
[Warlock] Update T26_Warlock_Affliction.simc

### DIFF
--- a/profiles/Tier26/T26_Warlock_Affliction.simc
+++ b/profiles/Tier26/T26_Warlock_Affliction.simc
@@ -2,12 +2,12 @@ warlock="T26_Warlock_Affliction"
 source=default
 spec=affliction
 level=60
-race=mechagnome
+race=orc
 role=spell
 position=ranged_back
 talents=3302023
 covenant=night_fae
-soulbind=niya,grove_invigoration/focused_malignancy:7/niyas_tools_burrs
+soulbind=niya,grove_invigoration/focused_malignancy:7/withering_bolt:7
 renown=40
 
 # Default consumables
@@ -202,20 +202,20 @@ actions.trinket_split_check+=/variable,name=trinket_two,value=(trinket.2.has_pro
 actions.trinket_split_check+=/variable,name=damage_trinket,value=(!(trinket.1.has_proc.any&trinket.1.has_cooldown))|(!(trinket.2.has_proc.any&trinket.2.has_cooldown))|equipped.glyph_of_assimilation
 actions.trinket_split_check+=/variable,name=trinket_split,value=(variable.trinket_one&variable.damage_trinket)|(variable.trinket_two&variable.damage_trinket)|(variable.trinket_one^variable.special_equipped)|(variable.trinket_two^variable.special_equipped)
 
-head=grimveiled_hood,id=173245,bonus_id=6648/6649/6758/7027/1532/6935,gem_id=173130
+head=confidants_favored_cap,id=183021,bonus_id=7187/1498,gem_id=173130
 neck=nobles_birthstone_pendant,id=183039,bonus_id=7187/1498/6935,gem_id=173130
 shoulders=shawl_of_the_penitent,id=183020,bonus_id=7187/1498
 back=crest_of_the_legionnaire_general,id=183032,bonus_id=7187/1498
 chest=robes_of_the_cursed_commando,id=182998,bonus_id=7187/1498,enchant=eternal_stats
 wrists=grim_pursuants_maille,id=182996,bonus_id=7187/1498/6935,gem_id=173130,enchant=eternal_intellect
-hands=impossibly_oversized_mitts,id=183022,bonus_id=7187/1498
+hands=grimveiled_mittens,id=173244,bonus_id=6648/6649/6758/7031/1532
 waist=shadewarped_sash,id=183004,bonus_id=7187/1498/6935,gem_id=173130
 legs=courtiers_costume_trousers,id=183011,bonus_id=7187/1498
 feet=slippers_of_the_forgotten_heretic,id=182979,bonus_id=7187/1498
 finger1=hyperlight_band,id=183038,bonus_id=7187/1498/6935,gem_id=173130,enchant=tenet_of_mastery
 finger2=most_regal_signet_of_sire_denathrius,id=183036,bonus_id=7187/1498,gem_id=173130,enchant=tenet_of_mastery
-trinket1=soul_igniter,id=184019,bonus_id=7187/1498
-trinket2=dreadfire_vessel,id=184030,bonus_id=7187/1498
+trinket1=soulletting_ruby,id=178809,bonus_id=6536/1540/6646
+trinket2=cabalists_hymnal,id=184028,bonus_id=7187/1498
 main_hand=sinbearers_absolution_staff,id=182392,bonus_id=7187/1531,enchant=sinful_revelation
 
 # Gear Summary


### PR DESCRIPTION
Update T26 profiles as a baseline for T27. 

Current T26 sim (6070 dps): https://www.raidbots.com/simbot/report/vT1bXTSCJYivhXTWVsBhzV
Updated T26 sim (6355 dps): https://www.raidbots.com/simbot/report/rttFuiDcGBQTvJmYUMseBm