### PR TITLE
[Retribution] New on use trinkets for Ret APL

### DIFF
--- a/engine/class_modules/paladin/sc_paladin_retribution.cpp
+++ b/engine/class_modules/paladin/sc_paladin_retribution.cpp
@@ -995,7 +995,7 @@ void paladin_t::generate_action_prio_list_ret()
   // Items
 
   // special-cased items
-  std::unordered_set<std::string> special_items { "skulkers_wing", "macabre_sheet_music", "memory_of_past_sins", "dreadfire_vessel", "darkmoon_deck_voracity", "overwhelming_power_crystal", "spare_meat_hook", "grim_codex", "inscrutable_quantum_device", "sinful_gladiators_badge_of_ferocity", "sinful_aspirants_badge_of_ferocity" };
+  std::unordered_set<std::string> special_items { "skulkers_wing", "macabre_sheet_music", "memory_of_past_sins", "dreadfire_vessel", "darkmoon_deck_voracity", "overwhelming_power_crystal", "spare_meat_hook", "grim_codex", "inscrutable_quantum_device", "salvaged_fusion_amplifier", "unchained_gladiators_badge_of_ferocity", "unchained_aspirants_badge_of_ferocity", "sinful_gladiators_badge_of_ferocity", "sinful_aspirants_badge_of_ferocity" };
 
   cds -> add_action( "use_item,name=inscrutable_quantum_device,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10|fight_remains<30" );
   cds -> add_action( "use_item,name=overwhelming_power_crystal,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10|fight_remains<15" );
@@ -1006,6 +1006,9 @@ void paladin_t::generate_action_prio_list_ret()
   cds -> add_action( "use_item,name=grim_codex" );
   cds -> add_action( "use_item,name=memory_of_past_sins" );
   cds -> add_action( "use_item,name=spare_meat_hook" );
+  cds -> add_action( "use_item,name=salvaged_fusion_amplifier" );
+  cds -> add_action( "use_item,name=unchained_gladiators_badge_of_ferocity,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack>=10|cooldown.avenging_wrath.remains>45|cooldown.crusade.remains>45" );
+  cds -> add_action( "use_item,name=unchained_aspirants_badge_of_ferocity,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack>=10|cooldown.avenging_wrath.remains>45|cooldown.crusade.remains>45" );
   cds -> add_action( "use_item,name=sinful_gladiators_badge_of_ferocity,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack>=10|cooldown.avenging_wrath.remains>45|cooldown.crusade.remains>45" );
   cds -> add_action( "use_item,name=sinful_aspirants_badge_of_ferocity,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack>=10|cooldown.avenging_wrath.remains>45|cooldown.crusade.remains>45" );
 


### PR DESCRIPTION
New trinkets need conditions to be used properly. Added conditions for new PvP Badges to be used the same as the previous season's ones and for Salvaged Fusion Amplifier to be used on cooldown instead of with Avenging Wrath.