### PR TITLE
[Soulbinds] add support for Wild Hunt Strategem

### DIFF
--- a/engine/player/actor_target_data.hpp
+++ b/engine/player/actor_target_data.hpp
@@ -58,6 +58,7 @@ struct actor_target_data_t : public actor_pair_t, private noncopyable
     buff_t* kevins_wrath;                // Marileth Kevin's Oozeling Kevin's Wrath debuff
     buff_t* frozen_heart;                // Relic of the Frozen Wastes debuff
     buff_t* volatile_satchel;            // Ticking Sack of Terror debuff
+    buff_t* wild_hunt_strategem;         // night_fae/korayn/ wild hunt strategem debuff
   } debuff;
 
   struct atd_dot_t

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -132,6 +132,7 @@ double pet_t::composite_player_target_multiplier( player_t* target, school_e sch
     m *= 1.0 + td->debuff.scouring_touch->check_stack_value();
     m *= 1.0 + td->debuff.exsanguinated->check_value();
     m *= 1.0 + td->debuff.kevins_wrath->check_value();
+    m *= 1.0 + td->debuff.wild_hunt_strategem->check_value();
   }
 
   return m;

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -4046,6 +4046,8 @@ double player_t::composite_player_target_multiplier( player_t* target, school_e 
     double health_threshold = 100.0 - ( 100.0 - buffs.wild_hunt_tactics->data().effectN( 5 ).base_value() ) * sim->shadowlands_opts.wild_hunt_tactics_duration_multiplier;
     // This buff is never triggered so use default_value.
     if ( target->health_percentage() > health_threshold )
+      if ( find_soulbind_spell( "Wild Hunt Strategem" )->ok() )
+        buffs.wild_hunt_strategem_tracking->trigger();
       m *= 1.0 + buffs.wild_hunt_tactics->default_value;
   }
 
@@ -4061,6 +4063,7 @@ double player_t::composite_player_target_multiplier( player_t* target, school_e 
     m *= 1.0 + td->debuff.scouring_touch->check_stack_value();
     m *= 1.0 + td->debuff.exsanguinated->check_value();
     m *= 1.0 + td->debuff.kevins_wrath->check_value();
+    m *= 1.0 + td->debuff.wild_hunt_strategem->check_value();
   }
 
   return m;

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -4046,7 +4046,7 @@ double player_t::composite_player_target_multiplier( player_t* target, school_e 
     double health_threshold = 100.0 - ( 100.0 - buffs.wild_hunt_tactics->data().effectN( 5 ).base_value() ) * sim->shadowlands_opts.wild_hunt_tactics_duration_multiplier;
     // This buff is never triggered so use default_value.
     if ( target->health_percentage() > health_threshold )
-      if ( find_soulbind_spell( "Wild Hunt Strategem" )->ok() )
+      if ( buffs.wild_hunt_strategem_tracking )
         buffs.wild_hunt_strategem_tracking->trigger();
       m *= 1.0 + buffs.wild_hunt_tactics->default_value;
   }

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -526,6 +526,9 @@ struct player_t : public actor_t
     buff_t* hold_your_ground; //venthyr/draven - stamina % buff when standing still
     buff_t* waking_bone_breastplate; //necrolord/heirmir - max health % buff when near 3 or more enemies
 
+    // 9.1 Soulbinds
+    buff_t* wild_hunt_strategem_tracking; //night_fae/korayn - tracking buff to allow procs of wild_hunt_strategem on enemy targets
+
     // 9.0 Runecarves
     buff_t* norgannons_sagacity_stacks;  // stacks on every cast
     buff_t* norgannons_sagacity;         // consume stacks to allow casting while moving


### PR DESCRIPTION
DungeonSlice quick example:
![ds_example](https://user-images.githubusercontent.com/10604059/125223458-6d7d5e00-e291-11eb-906c-1d31d157fd5f.png)

Debug logs:
```
0.000 Player 'Base' performs Action vampiric_touch (9999)
0.000 Player 'Base' gains Buff wild_hunt_strategem_tracking (stacks=1) (value=-2.2250738585072014e-308)
...
33.674 Player 'Base' refreshes wild_hunt_strategem_tracking_1 (value=-2.2250738585072014e-308, duration=60.000)
...
88.827 Player 'Base' void_bolt hits Player 'Fluffy_Pillow_Boss1' for 6548.409154760222 shadow damage (hit)
88.827 WHS: target hp: 34.10019956822043, hp_pct_dmg: 35
88.827 Player 'Fluffy_Pillow_Boss1' gains Buff wild_hunt_strategem (stacks=1) (value=0.05)
88.827 Add Event: core_event_t(#3299) time=98.827 reschedule=0.000
88.827 Player 'Base' loses Buff wild_hunt_strategem_tracking
...
98.827 Player 'Fluffy_Pillow_Boss1' loses Buff wild_hunt_strategem
```