### PR TITLE
[Warlock] Add modelling of extra tyrant casts

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -570,7 +570,7 @@ struct summon_demonic_tyrant_t : public demonology_spell_t
   {
     demonology_spell_t::execute();
 
-    // Last tested 13/07/21
+    // Last tested 2021-07-13
     // Ingame there is a chance for tyrant to get an extra cast off before reaching the required haste breakpoint. In-game testing
     // found the tyrant sometimes stayed longer than the specified duration and can be modelled fairly closely using a normal distribution.
     timespan_t extraTyrantTime = timespan_t::from_millis(rng().gauss( 380.0, 220.0, true ));

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -570,7 +570,11 @@ struct summon_demonic_tyrant_t : public demonology_spell_t
   {
     demonology_spell_t::execute();
 
-    p()->warlock_pet_list.demonic_tyrants.spawn( data().duration() );
+    // Last tested 13/07/21
+    // Ingame there is a chance for tyrant to get an extra cast off before reaching the required haste breakpoint. In-game testing
+    // found the tyrant sometimes stayed longer than the specified duration and can be modelled fairly closely using a normal distribution.
+    timespan_t extraTyrantTime = timespan_t::from_millis(rng().gauss( 380.0, 220.0, true ));
+    p()->warlock_pet_list.demonic_tyrants.spawn( data().duration() + extraTyrantTime );
 
     p()->buffs.demonic_power->trigger();
 


### PR DESCRIPTION
It has been known for a while that you can sometimes get extra tyrant casts before the required haste value. Simc doesnt model this, and it causes haste breakpoints to appear which dont actually exist ingame.

I performed some fairly extensive testing (over 250 casts of tyrant) to determine how this behaves ingame with various haste values so that it could be modelled within Simc. All of the results of the tests can be found in the sheet below:
https://docs.google.com/spreadsheets/d/1WN-YmIPcaQOyO7moDaCe62cb7HWXA90XtTW-Cwr7o2U/edit?usp=sharing
And warcraft logs for the testing:
https://www.warcraftlogs.com/reports/pdFHXvGMA6jLhwck
https://www.warcraftlogs.com/reports/MFgA81nmPpHqZGrD
https://www.warcraftlogs.com/reports/2RAbBawPWK1rxtym
https://www.warcraftlogs.com/reports/hwQ9Yt3KdDr1JLvb

I found that the ingame behaviour could be modelled pretty closely by extending the tyrant duration using a random normal distribution. I tried a few other distributions too (linear, exponential) but I found normal produced the best results. The graphs for this can be found in the attached sheet.

Sim comparisons between current simc and updates can be found on last page of linked sheet.