### PR TITLE
Update T27_Generate_Warlock.simc

### DIFF
--- a/profiles/generators/Tier27/T27_Generate_Warlock.simc
+++ b/profiles/generators/Tier27/T27_Generate_Warlock.simc
@@ -55,7 +55,7 @@ trinket1=soulletting_ruby,id=178809,bonus_id=1566/6536/6646
 trinket2=infinitely_divisible_ooze,id=178769,bonus_id=1566/6536/6646
 main_hand=maledict_opus,id=186406,bonus_id=1498/7187,enchant=celestial_guidance
 
-save=T27_Warlock_Demonology.simc
+save=T27_Warlock_Demonology_Necrolord.simc
 
 warlock="T27_Warlock_Demonology"
 level=60

--- a/profiles/generators/Tier27/T27_Generate_Warlock.simc
+++ b/profiles/generators/Tier27/T27_Generate_Warlock.simc
@@ -9,14 +9,14 @@ covenant=night_fae
 soulbind=dreamweaver,field_of_blossoms/dream_delver/focused_malignancy:11/withering_bolt:11/soul_eater:11
 renown=80
 
-head=hood_of_vengeful_possession,id=186287,bonus_id=1498/7187/6935,gem_id=187312
+head=hood_of_vengeful_possession,id=186287,bonus_id=1498/7187,gem_id=187312
 neck=interplanar_keystone,id=186379,bonus_id=1498/7187/6935,gem_id=173130
 shoulders=frame_of_the_false_margrave,id=186324,bonus_id=1498/7187,gem_id=187315
 back=cloak_of_scarred_honor,id=186289,bonus_id=1498/7187
 chest=sacrificers_sacramental_cassock,id=186282,bonus_id=1498/7187,gem_id=187318,enchant=eternal_stats
-wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187/6935,gem_id=187319,enchant=eternal_intellect
+wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187,gem_id=187319,enchant=eternal_intellect
 hands=grimveiled_mittens,id=173244,bonus_id=7031/6649/6648/1559
-waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187/6935,gem_id=187320
+waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187,gem_id=187320
 legs=purge_protocol_legwraps,id=180107,bonus_id=1566/6536/6646
 feet=sandals_of_sacred_symmetry,id=186354,bonus_id=1498/7187
 finger1=tarnished_insignia_of_quelthalas,id=186377,bonus_id=1498/7187/6935,gem_id=173130,enchant=tenet_of_mastery
@@ -28,7 +28,7 @@ main_hand=maledict_opus,id=186406,bonus_id=1498/7187,enchant=celestial_guidance
 save=T27_Warlock_Affliction.simc
 
 
-warlock="T27_Warlock_Demonology"
+warlock="T27_Warlock_Demonology_Necrolord"
 level=60
 race=orc
 spec=demonology
@@ -39,15 +39,44 @@ covenant=necrolord
 soulbind=plague_deviser_marileth,volatile_solvent/borne_of_blood:11:0/tyrants_soul:11:0/carnivorous_stalkers:11:0/kevins_oozeling
 renown=80
 
-head=veil_of_the_banshee_queen,id=186325,bonus_id=1498/7187/6935,gem_id=187312
+head=veil_of_the_banshee_queen,id=186325,bonus_id=1498/7187,gem_id=187312
+neck=interplanar_keystone,id=186379,bonus_id=1498/7187/6935,gem_id=173128
+shoulders=frame_of_the_false_margrave,id=186324,bonus_id=1498/7187,gem_id=187315
+back=selfreplicating_tissue,id=186374,bonus_id=1498/7187,enchant=soul_vitality
+chest=sacrificers_sacramental_cassock,id=186282,bonus_id=1498/7187,gem_id=187318,enchant=eternal_stats
+wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187,gem_id=187319,enchant=eternal_intellect
+hands=gloves_of_forsaken_purpose,id=186326,bonus_id=1498/7187
+waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187,gem_id=187320
+legs=muehzalas_hexthread_sarong,id=179351,bonus_id=1566/6536/6646
+feet=sandals_of_sacred_symmetry,id=186354,bonus_id=1498/7187
+finger1=tarnished_insignia_of_quelthalas,id=186377,bonus_id=1498/7187/6935,gem_id=173128,enchant=tenet_of_haste
+finger2=shadowghast_ring,id=178926,bonus_id=7025/6649/6648/1559,gem_id=173128,enchant=tenet_of_haste
+trinket1=soulletting_ruby,id=178809,bonus_id=1566/6536/6646
+trinket2=infinitely_divisible_ooze,id=178769,bonus_id=1566/6536/6646
+main_hand=maledict_opus,id=186406,bonus_id=1498/7187,enchant=celestial_guidance
+
+save=T27_Warlock_Demonology.simc
+
+warlock="T27_Warlock_Demonology"
+level=60
+race=orc
+spec=demonology
+role=spell
+position=ranged_back
+talents=3103032
+covenant=night_fae
+soulbind="dreamweaver:2,borne_of_blood:11:0/carnivorous_stalkers:11:0/field_of_blossoms/tyrants_soul:11:0/dream_delver"
+renown=80
+
+head=veil_of_the_banshee_queen,id=186325,bonus_id=1498/7187,gem_id=187312
 neck=interplanar_keystone,id=186379,bonus_id=1498/7187/6935,gem_id=173128
 shoulders=frame_of_the_false_margrave,id=186324,bonus_id=1498/7187,gem_id=187315
 back=dealer_xyexas_cape,id=179349,bonus_id=1566/6536/6646,enchant=soul_vitality
 chest=sacrificers_sacramental_cassock,id=186282,bonus_id=1498/7187,gem_id=187318,enchant=eternal_stats
-wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187/6935,gem_id=187319,enchant=eternal_intellect
-hands=grasps_of_the_clairvoyant_sage,id=186288,bonus_id=1498/7187
-waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187/6935,gem_id=187320
-legs=purge_protocol_legwraps,id=180107,bonus_id=1566/6536/6646
+wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187,gem_id=187319,enchant=eternal_intellect
+hands=gloves_of_forsaken_purpose,id=186326,bonus_id=1498/7187
+waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187,gem_id=187320
+legs=muehzalas_hexthread_sarong,id=179351,bonus_id=1566/6536/6646
 feet=sandals_of_sacred_symmetry,id=186354,bonus_id=1498/7187
 finger1=tarnished_insignia_of_quelthalas,id=186377,bonus_id=1498/7187/6935,gem_id=173128,enchant=tenet_of_haste
 finger2=shadowghast_ring,id=178926,bonus_id=7025/6649/6648/1559,gem_id=173128,enchant=tenet_of_haste
@@ -69,14 +98,14 @@ covenant=necrolord
 soulbind=marileth,volatile_solvent/kevins_oozeling/ashen_remains:11/combusting_engine:11/fatal_decimation:11
 renown=80
 
-head=veil_of_the_banshee_queen,id=186325,bonus_id=1498/7187/6935,gem_id=187312
+head=veil_of_the_banshee_queen,id=186325,bonus_id=1498/7187,gem_id=187312
 neck=interplanar_keystone,id=186379,bonus_id=1498/7187/6935,gem_id=173128
 shoulders=frame_of_the_false_margrave,id=186324,bonus_id=1498/7187,gem_id=187315
 back=cloak_of_scarred_honor,id=186289,bonus_id=1498/7187
 chest=sacrificers_sacramental_cassock,id=186282,bonus_id=1498/7187,gem_id=187318,enchant=eternal_stats
-wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187/6935,gem_id=187319,enchant=eternal_intellect
+wrists=desecrators_keening_wristwraps,id=186321,bonus_id=1498/7187,gem_id=187319,enchant=eternal_intellect
 hands=grasps_of_the_clairvoyant_sage,id=186288,bonus_id=1498/7187
-waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187/6935,gem_id=187320
+waist=sash_of_duplicitous_magics,id=186322,bonus_id=1498/7187,gem_id=187320
 legs=grimveiled_pants,id=173246,bonus_id=7038/6649/6648/1559
 feet=sandals_of_sacred_symmetry,id=186354,bonus_id=1498/7187
 finger1=tarnished_insignia_of_quelthalas,id=186377,bonus_id=1498/7187/6935,gem_id=173128,enchant=tenet_of_haste


### PR DESCRIPTION
added dreamweaver as default demo profile, but kept marileth as necro profile
difference shown here: https://www.raidbots.com/simbot/report/fpW5D8D8SiWWCuX3rJ83Hv
removed redundant sockets from head, waist and wrist
