### PR TITLE
[Paladin] Remove ardent protector's sanctum support.

### DIFF
--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -612,8 +612,7 @@ void paladin_t::target_mitigation( school_e school,
 
   if ( buffs.ardent_defender -> up() )
   {
-    s -> result_amount *= 1.0 + buffs.ardent_defender -> data().effectN( 1 ).percent()
-      + legendary.the_ardent_protectors_sanctum -> effectN( 1 ).percent();
+    s -> result_amount *= 1.0 + buffs.ardent_defender -> data().effectN( 1 ).percent();
   }
 
   if ( buffs.blessing_of_dusk -> up() )


### PR DESCRIPTION
This was changed early in 9.0 and wasn't updated in simc.
I was procrastinating this a little cause I kind of wanted to support the new version, but it was too much effort for an effect no-one's going to sim.