### PR TITLE
Adjust Cruciform Veinripper implementation for position=front

### DIFF
--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -266,7 +266,7 @@ void brewmaster( player_t* p )
   def->add_talent( p, "Chi Burst" );
   def->add_talent( p, "Chi Wave" );
   def->add_action( p, "Spinning Crane Kick",
-      "if=!runeforge.shaohaos_might.equipped&(active_enemies>=3|conduit.walk_with_the_ox.enabled)&cooldown.keg_smash.remains>gcd&(energy+(energy.regen*("
+      "if=!runeforge.shaohaos_might.equipped&active_enemies>=3&cooldown.keg_smash.remains>gcd&(energy+(energy.regen*("
       "cooldown.keg_smash.remains+execute_time)))>=65&(!talent.spitfire.enabled|!runeforge.charred_passions.equipped)",
       "Cast SCK if enough enemies are around, or if WWWTO is enabled. This is a slight defensive loss over using TP "
       "but generally reduces sim variance more than anything else." );

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3017,6 +3017,16 @@ void cruciform_veinripper(special_effect_t& effect)
   effect.spell_id = 357588;
   effect.rppm_modifier_ = 0.5;
 
+
+  /* override proc rate for tanks (40% of regular proc rate unless option is
+     set), and allow override via expansion option */
+  auto proc_option = effect.player->sim->shadowlands_opts.cruciform_veinripper_proc_rate;
+  if (proc_option == 0.0 && effect.player->position() == POSITION_FRONT) {
+    effect.ppm_ = -effect.driver()->_rppm * 0.4;
+  } else if(proc_option > 0.0) {
+    effect.ppm_ = -effect.driver()->_rppm * proc_option;
+  }
+
   new dbc_proc_callback_t(effect.player, effect);
 }
 

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3015,6 +3015,7 @@ void cruciform_veinripper(special_effect_t& effect)
     sadistic_glee->scaled_dmg += effect.driver()->effectN(1).average(effect.item);
 
   effect.spell_id = 357588;
+  /* apparently due to proc rate being lower than reported in spell data (?) - emallson */
   effect.rppm_modifier_ = 0.5;
 
 
@@ -3022,9 +3023,9 @@ void cruciform_veinripper(special_effect_t& effect)
      set), and allow override via expansion option */
   auto proc_option = effect.player->sim->shadowlands_opts.cruciform_veinripper_proc_rate;
   if (proc_option == 0.0 && effect.player->position() == POSITION_FRONT) {
-    effect.ppm_ = -effect.driver()->_rppm * 0.4;
+    effect.rppm_modifier_ *= 0.4;
   } else if(proc_option > 0.0) {
-    effect.ppm_ = -effect.driver()->_rppm * proc_option;
+    effect.rppm_modifier_ *= proc_option;
   }
 
   new dbc_proc_callback_t(effect.player, effect);

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -3849,6 +3849,7 @@ void sim_t::create_options()
   add_option( opt_timespan( "shadowlands.shadowed_orb_of_torment_precombat_channel", shadowlands_opts.shadowed_orb_of_torment_precombat_channel, 0_ms, 42_s ) );
   add_option( opt_uint( "shadowlands.precombat_pustules", shadowlands_opts.precombat_pustules, 1, 9 ) );
   add_option( opt_float( "shadowlands.field_of_blossoms_duration_multiplier", shadowlands_opts.field_of_blossoms_duration_multiplier, 0.0, 1.0 ) );
+  add_option( opt_float( "shadowlands.cruciform_veinripper_proc_rate", shadowlands_opts.cruciform_veinripper_proc_rate, 0.0, 1.0) );
 }
 
 // sim_t::parse_option ======================================================

--- a/engine/sim/sc_sim.hpp
+++ b/engine/sim/sc_sim.hpp
@@ -440,6 +440,8 @@ struct sim_t : private sc_thread_t
     unsigned int precombat_pustules = 9;
     /// Percentage of default duration for Field of Blossoms.
     double field_of_blossoms_duration_multiplier = 1.0;
+    /// Modifier for Cruciform Veinripper to control uptime for tanks. When set to 0, proc rate is not affected unless position=front, in which case 0.4 is used.
+    double cruciform_veinripper_proc_rate = 0.0;
   } shadowlands_opts;
 
   // Auras and De-Buffs


### PR DESCRIPTION
- Adds an expansion option `shadowlands.cruciform_veinripper_proc_rate`, which adjusts the proc rate. Defaults to 1.0 for `position=back`, 0.4 for `position=front`.
- Random APL change for Brewmaster to SCK usage (minor dps bump for most sims)