### PR TITLE
[Warlock] Shadowed orb of torment timing

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1303,6 +1303,7 @@ void warlock_t::apl_precombat()
     precombat->add_action( "demonbolt" );
     //tested different values, even with gfg/vf its better to summon tyrant sooner in the opener
     precombat->add_action( "variable,name=first_tyrant_time,op=set,value=12" );
+    precombat->add_action( "use_item,name=shadowed_orb_of_torment" );
   }
   if ( specialization() == WARLOCK_DESTRUCTION )
   {

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1265,7 +1265,7 @@ void warlock_t::create_apl_demonology()
   ogcd->add_action( "fireblood" );
   ogcd->add_action( "use_items" );
 
-  trinks->add_action( "use_item,name=shadowed_orb_of_torment,if=cooldown.summon_demonic_tyrant.remains_expected<15" );
+  trinks->add_action( "use_item,name=shadowed_orb_of_torment,if=cooldown.summon_demonic_tyrant.remains_expected<22" );
   trinks->add_action( "call_action_list,name=hp_trinks,if=talent.demonic_consumption.enabled&cooldown.summon_demonic_tyrant.remains_expected<20" );
   trinks->add_action( "call_action_list,name=5y_per_sec_trinkets", "Effects that travel slowly to target require additional, separate handling" );
   trinks->add_action( "use_item,name=overflowing_anima_cage,if=pet.demonic_tyrant.active" );


### PR DESCRIPTION
old: https://www.raidbots.com/simbot/report/vDpuamyhpwJ4skrMoCGEXS
new: https://www.raidbots.com/simbot/report/weCHDZp9SWdZUBwTnoRHgH
its now before any setup for tyrant. makes more sense and less of a magic number.
compared to current using it later in the setup is a dps loss: https://www.raidbots.com/simbot/report/bj7B9w6j9dxvHtT4mhm4eb
https://www.raidbots.com/simbot/report/3qSLiSYzpupthhPgRcgBte
using it once tyrant is up as well: https://www.raidbots.com/simbot/report/cBTncF5i4ir1mxoJemMear
https://www.raidbots.com/simbot/report/rThi3huUqWX3LXXA4MzzN