### PR TITLE
[Demonology] offensive action last in precombat

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1300,10 +1300,10 @@ void warlock_t::apl_precombat()
 
   if ( specialization() == WARLOCK_DEMONOLOGY )
   {
-    precombat->add_action( "demonbolt" );
     //tested different values, even with gfg/vf its better to summon tyrant sooner in the opener
     precombat->add_action( "variable,name=first_tyrant_time,op=set,value=10" );
     precombat->add_action( "use_item,name=shadowed_orb_of_torment" );
+    precombat->add_action( "demonbolt" );
   }
   if ( specialization() == WARLOCK_DESTRUCTION )
   {


### PR DESCRIPTION
currently setting first_tyrant_time is the first action in combat, and using shadowed orb of torment is skipped