### PR TITLE
[Raid Events] dungeon pull event WIP

### DIFF
--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -700,9 +700,9 @@ bool parse_fight_style( sim_t*             sim,
                         util::string_view /*name*/,
                         util::string_view value )
 {
-  static constexpr std::array<util::string_view, 10> FIGHT_STYLES { {
+  static constexpr std::array<util::string_view, 11> FIGHT_STYLES { {
     "Patchwerk", "Ultraxion", "CleaveAdd", "HelterSkelter", "LightMovement", "HeavyMovement",
-    "HecticAddCleave", "Beastlord", "CastingPatchwerk", "DungeonSlice"
+    "HecticAddCleave", "Beastlord", "CastingPatchwerk", "DungeonSlice", "DungeonRoute"
   } };
 
   auto it = range::find_if( FIGHT_STYLES, [ &value ]( util::string_view n ) {
@@ -2340,6 +2340,14 @@ void sim_t::init_fight_style()
         "/adds,name=Boss,count=1,cooldown=500,duration=135,type=add_boss,duration_stddev=1"
         "/adds,name=SmallAdd,count=5,count_range=1,first=140,cooldown=45,duration=15,duration_stddev=2"
         "/adds,name=BigAdd,count=2,count_range=1,first=160,cooldown=50,duration=30,duration_stddev=2";
+  }
+  else if( util::str_compare_ci( fight_style, "DungeonRoute" ) )
+  { // To be used in conjunction with "pull" raid events for a simulated dungeon run.
+    desired_targets = 1;
+    fixed_time = 0;
+    ignore_invulnerable_targets = true;
+    shadowlands_opts.enable_rune_words = false;
+    overrides.bloodlust = 0; // Bloodlust is handled by an option on each pull raid event
   }
   else
   {

--- a/engine/sim/sc_sim.cpp
+++ b/engine/sim/sc_sim.cpp
@@ -3282,7 +3282,7 @@ std::unique_ptr<expr_t> sim_t::create_expression( util::string_view name_str )
 
   if ( util::str_compare_ci( name_str, "active_enemies" ) )
   {
-    if ( target_list.size() == 1U && !has_raid_event( "adds" ) )
+    if ( target_list.size() == 1U && !has_raid_event( "adds" ) && !has_raid_event( "pull" ) )
     {
       return expr_t::create_constant( name_str, 1.0 );
     }


### PR DESCRIPTION
a raid event enabling health based add waves, used with input such as:
https://github.com/Jayezi/mdt-sim/blob/master/DoS%2020%20Tyrannical.simc

ideal input generation would be done with a MythicDungeonTools based export weakaura:
https://github.com/Nnoggie/MythicDungeonTools
https://wago.io/Yya4XBbl-

manual edits to the default buff overrides and pull bloodlust options based on the group would then be needed
the pull delay option should also be defined for each pull based on rough travel times from logs for the most accurate results

future considerations:
typical add wave expressions are difficult to find adequate results for due to them not being timer based events
current handling is rough but can probably be improved eventually
bloodlust timings are not strictly enforced (the 10 minute exhaustion debuff is not triggered) to enable a bit more flexibility and allow imperfect pull timings in sim to still reflect in game bloodlust usage