### PR TITLE
Implement target threshold sqrt aoe reduction

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1282,7 +1282,7 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
     amount /= state->n_targets;
 
   // New Shadowlands AoE damage reduction based on total target count
-  if ( ( state->chain_target + 1 ) > full_damage_targets && state->action->reduced_aoe_damage > 0 )
+  if ( state->chain_target >= full_damage_targets && state->action->reduced_aoe_damage > 0 )
     amount *= std::sqrt( state->action->reduced_aoe_damage / state->n_targets );
 
   amount *= composite_aoe_multiplier( state );

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1282,7 +1282,7 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
     amount /= state->n_targets;
 
   // New Shadowlands AoE damage reduction based on total target count
-  if ( state->chain_target > ( full_damage_targets - 1 ) && state->action->reduced_aoe_damage > 0 )
+  if ( ( state->chain_target + 1 ) > full_damage_targets && state->action->reduced_aoe_damage > 0 )
     amount *= std::sqrt( state->action->reduced_aoe_damage / state->n_targets );
 
   amount *= composite_aoe_multiplier( state );

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -336,8 +336,8 @@ action_t::action_t( action_e ty, util::string_view token, player_t* p, const spe
     hasted_ticks(),
     consume_per_tick_(),
     split_aoe_damage(),
-    reduced_aoe_damage(),
-    full_damage_targets( 1 ),
+    reduced_aoe_damage( 0.0 ),
+    full_damage_targets( 0 ),
     normalize_weapon_speed(),
     ground_aoe(),
     round_base_dmg( true ),
@@ -1282,14 +1282,14 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
     amount /= state->n_targets;
 
   // New Shadowlands AoE damage reduction based on total target count
-  if ( state->chain_target >= full_damage_targets && state->action->reduced_aoe_damage > 0 )
-    amount *= std::sqrt( state->action->reduced_aoe_damage / static_cast<double>( state->n_targets ) );
+  if ( state->chain_target >= full_damage_targets && state->action->reduced_aoe_damage > 0.0 )
+    amount *= std::sqrt( state->action->reduced_aoe_damage / state->n_targets );
 
   amount *= composite_aoe_multiplier( state );
 
   // Spell goes over the maximum number of AOE targets - ignore for enemies
   // TODO: determine interaction with new sqrt reduction. currently bugged on ptr as of build 9.1.5.40078 
-  if ( !state->action->split_aoe_damage && !state->action->reduced_aoe_damage &&
+  if ( !state->action->split_aoe_damage && state->action->reduced_aoe_damage != 0.0 &&
        state->n_targets > static_cast<size_t>( sim->max_aoe_enemies ) && !state->action->player->is_enemy() )
     amount *= sim->max_aoe_enemies / static_cast<double>( state->n_targets );
 

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -1283,7 +1283,7 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
 
   // New Shadowlands AoE damage reduction based on total target count
   if ( state->chain_target >= full_damage_targets && state->action->reduced_aoe_damage > 0 )
-    amount *= std::sqrt( state->action->reduced_aoe_damage / state->n_targets );
+    amount *= std::sqrt( state->action->reduced_aoe_damage / static_cast<double>( state->n_targets ) );
 
   amount *= composite_aoe_multiplier( state );
 

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -336,8 +336,8 @@ action_t::action_t( action_e ty, util::string_view token, player_t* p, const spe
     hasted_ticks(),
     consume_per_tick_(),
     split_aoe_damage(),
-    reduced_aoe_damage( 0.0 ),
-    full_damage_targets( 0 ),
+    reduced_aoe_targets( 0.0 ),
+    full_amount_targets( 0 ),
     normalize_weapon_speed(),
     ground_aoe(),
     round_base_dmg( true ),
@@ -1282,14 +1282,14 @@ double action_t::calculate_direct_amount( action_state_t* state ) const
     amount /= state->n_targets;
 
   // New Shadowlands AoE damage reduction based on total target count
-  if ( state->chain_target >= full_damage_targets && state->action->reduced_aoe_damage > 0.0 )
-    amount *= std::sqrt( state->action->reduced_aoe_damage / state->n_targets );
+  if ( state->chain_target >= full_amount_targets && state->action->reduced_aoe_targets > 0.0 )
+    amount *= std::sqrt( state->action->reduced_aoe_targets / state->n_targets );
 
   amount *= composite_aoe_multiplier( state );
 
   // Spell goes over the maximum number of AOE targets - ignore for enemies
   // TODO: determine interaction with new sqrt reduction. currently bugged on ptr as of build 9.1.5.40078 
-  if ( !state->action->split_aoe_damage && state->action->reduced_aoe_damage != 0.0 &&
+  if ( !state->action->split_aoe_damage && state->action->reduced_aoe_targets != 0.0 &&
        state->n_targets > static_cast<size_t>( sim->max_aoe_enemies ) && !state->action->player->is_enemy() )
     amount *= sim->max_aoe_enemies / static_cast<double>( state->n_targets );
 

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -204,8 +204,13 @@ public:
   /// Split damage evenly between targets
   bool split_aoe_damage;
 
-  /// Reduce damage to secondary targets based on total target count
-  bool reduced_aoe_damage;
+  /// Reduce damage to targets when total targets is greater than value
+  /// Formula used is <damage per target> = sqrt( reduced_aoe_damage / <number of targets> )
+  unsigned reduced_aoe_damage;
+
+  /// If reduced_aoe_damage > 0, the number of target(s) that will take full unreduced damage
+  /// Default value is 1
+  unsigned full_damage_targets;
 
   /**
    * @brief Normalize weapon speed for weapon damage calculations

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -210,7 +210,7 @@ public:
 
   /// If reduced_aoe_damage > 0, the number of target(s) that will take full unreduced damage
   /// Default value is 1
-  unsigned full_damage_targets;
+  int full_damage_targets;
 
   /**
    * @brief Normalize weapon speed for weapon damage calculations

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -205,11 +205,11 @@ public:
   bool split_aoe_damage;
 
   /// Reduce damage to targets when total targets is greater than value
-  /// Formula used is <damage per target> = sqrt( reduced_aoe_damage / <number of targets> )
-  double reduced_aoe_damage;
+  /// Formula used is <damage per target> = sqrt( reduced_aoe_targets / <number of targets> )
+  double reduced_aoe_targets;
 
-  /// If reduced_aoe_damage > 0, the number of target(s) that will take full unreduced damage
-  int full_damage_targets;
+  /// If reduced_aoe_targets > 0, the number of target(s) that will take full unreduced amount
+  int full_amount_targets;
 
   /**
    * @brief Normalize weapon speed for weapon damage calculations

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -206,10 +206,9 @@ public:
 
   /// Reduce damage to targets when total targets is greater than value
   /// Formula used is <damage per target> = sqrt( reduced_aoe_damage / <number of targets> )
-  unsigned reduced_aoe_damage;
+  double reduced_aoe_damage;
 
   /// If reduced_aoe_damage > 0, the number of target(s) that will take full unreduced damage
-  /// Default value is 1
   int full_damage_targets;
 
   /**

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1610,8 +1610,7 @@ struct rjw_tick_action_t : public monk_melee_attack_t
       aoe               = (int)p->talent.rushing_jade_wind->effectN( 1 ).base_value();
     else
     {
-      reduced_aoe_damage = as<unsigned>( p->talent.rushing_jade_wind->effectN( 1 ).base_value() );
-      full_damage_targets = 0;
+      reduced_aoe_damage = p->talent.rushing_jade_wind->effectN( 1 ).base_value();
     }
     radius            = data->effectN( 1 ).radius();
 
@@ -1922,7 +1921,10 @@ struct fists_of_fury_tick_t : public monk_melee_attack_t
     if ( !p->dbc->ptr )
       aoe        = 1 + (int)p->spec.fists_of_fury->effectN( 1 ).base_value();
     else
-      reduced_aoe_damage = as<unsigned>( p->spec.fists_of_fury->effectN( 1 ).base_value() );
+    {
+      reduced_aoe_damage = p->spec.fists_of_fury->effectN( 1 ).base_value();
+      full_damage_targets = 1;
+    }
 
     ww_mastery = true;
 
@@ -2343,7 +2345,8 @@ struct keg_smash_t : public monk_melee_attack_t
     parse_options( options_str );
 
     aoe = -1;
-    reduced_aoe_damage = as<unsigned>( p.spec.keg_smash->effectN( 7 ).base_value() );
+    reduced_aoe_damage = p.spec.keg_smash->effectN( 7 ).base_value();
+    full_damage_targets = 1;
     trigger_faeline_stomp = true;
     trigger_bountiful_brew = true;
 
@@ -3018,7 +3021,8 @@ struct breath_of_fire_t : public monk_spell_t
     gcd_type = gcd_haste_type::NONE;
 
     aoe                   = -1;
-    reduced_aoe_damage    = 1;
+    reduced_aoe_damage    = 1.0;
+    full_damage_targets   = 1;
     trigger_faeline_stomp = true;
     trigger_bountiful_brew = true;
 

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1919,7 +1919,7 @@ struct fists_of_fury_tick_t : public monk_melee_attack_t
     : monk_melee_attack_t( name, p, p->passives.fists_of_fury_tick )
   {
     background = true;
-    if ( p->dbc->ptr )
+    if ( !p->dbc->ptr )
       aoe = 1 + (int)p->spec.fists_of_fury->effectN( 1 ).base_value();
     else
     {

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1921,6 +1921,9 @@ struct fists_of_fury_tick_t : public monk_melee_attack_t
     background = true;
     if ( !p->dbc->ptr )
       aoe        = 1 + (int)p->spec.fists_of_fury->effectN( 1 ).base_value();
+    else
+      reduced_aoe_damage = as<unsigned>( p->spec.fists_of_fury->effectN( 1 ).base_value() );
+
     ww_mastery = true;
 
     attack_power_mod.direct    = p->spec.fists_of_fury->effectN( 5 ).ap_coeff();
@@ -1935,14 +1938,7 @@ struct fists_of_fury_tick_t : public monk_melee_attack_t
     double cam = melee_attack_t::composite_aoe_multiplier( state );
 
     if ( state->target != target )
-    {
       cam *= p()->spec.fists_of_fury->effectN( 6 ).percent();
-
-      auto target_cap = p()->spec.fists_of_fury->effectN( 1 ).base_value();
-
-      if ( p()->dbc->ptr && state->n_targets > target_cap )
-        cam *= std::sqrt( target_cap / state->n_targets );
-    }
 
     return cam;
   }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1611,7 +1611,7 @@ struct rjw_tick_action_t : public monk_melee_attack_t
     else
     {
       aoe                = -1;
-      reduced_aoe_damage = p->talent.rushing_jade_wind->effectN( 1 ).base_value();
+      reduced_aoe_targets = p->talent.rushing_jade_wind->effectN( 1 ).base_value();
     }
     radius            = data->effectN( 1 ).radius();
 
@@ -1924,8 +1924,8 @@ struct fists_of_fury_tick_t : public monk_melee_attack_t
     else
     {
       aoe                 = -1;
-      reduced_aoe_damage = p->spec.fists_of_fury->effectN( 1 ).base_value();
-      full_damage_targets = 1;
+      reduced_aoe_targets = p->spec.fists_of_fury->effectN( 1 ).base_value();
+      full_amount_targets = 1;
     }
 
     ww_mastery = true;
@@ -2347,8 +2347,8 @@ struct keg_smash_t : public monk_melee_attack_t
     parse_options( options_str );
 
     aoe = -1;
-    reduced_aoe_damage  = p.spec.keg_smash->effectN( 7 ).base_value();
-    full_damage_targets = 1;
+    reduced_aoe_targets  = p.spec.keg_smash->effectN( 7 ).base_value();
+    full_amount_targets = 1;
     trigger_faeline_stomp = true;
     trigger_bountiful_brew = true;
 
@@ -3011,8 +3011,8 @@ struct breath_of_fire_dot_t : public monk_spell_t
     background    = true;
     tick_may_crit = may_crit = true;
     hasted_ticks             = false;
-    reduced_aoe_damage       = 1.0;
-    full_damage_targets      = 1;
+    reduced_aoe_targets       = 1.0;
+    full_amount_targets      = 1;
   }
 };
 
@@ -3025,8 +3025,8 @@ struct breath_of_fire_t : public monk_spell_t
     gcd_type = gcd_haste_type::NONE;
 
     aoe                   = -1;
-    reduced_aoe_damage  = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets  = 1.0;
+    full_amount_targets = 1;
     trigger_faeline_stomp = true;
     trigger_bountiful_brew = true;
 

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1607,9 +1607,10 @@ struct rjw_tick_action_t : public monk_melee_attack_t
 
     dual = background = true;
     if ( !p->dbc->ptr )
-      aoe               = (int)p->talent.rushing_jade_wind->effectN( 1 ).base_value();
+      aoe = (int)p->talent.rushing_jade_wind->effectN( 1 ).base_value();
     else
     {
+      aoe                = -1;
       reduced_aoe_damage = p->talent.rushing_jade_wind->effectN( 1 ).base_value();
     }
     radius            = data->effectN( 1 ).radius();
@@ -1918,10 +1919,11 @@ struct fists_of_fury_tick_t : public monk_melee_attack_t
     : monk_melee_attack_t( name, p, p->passives.fists_of_fury_tick )
   {
     background = true;
-    if ( !p->dbc->ptr )
-      aoe        = 1 + (int)p->spec.fists_of_fury->effectN( 1 ).base_value();
+    if ( p->dbc->ptr )
+      aoe = 1 + (int)p->spec.fists_of_fury->effectN( 1 ).base_value();
     else
     {
+      aoe                 = -1;
       reduced_aoe_damage = p->spec.fists_of_fury->effectN( 1 ).base_value();
       full_damage_targets = 1;
     }
@@ -2345,7 +2347,7 @@ struct keg_smash_t : public monk_melee_attack_t
     parse_options( options_str );
 
     aoe = -1;
-    reduced_aoe_damage = p.spec.keg_smash->effectN( 7 ).base_value();
+    reduced_aoe_damage  = p.spec.keg_smash->effectN( 7 ).base_value();
     full_damage_targets = 1;
     trigger_faeline_stomp = true;
     trigger_bountiful_brew = true;
@@ -3009,6 +3011,8 @@ struct breath_of_fire_dot_t : public monk_spell_t
     background    = true;
     tick_may_crit = may_crit = true;
     hasted_ticks             = false;
+    reduced_aoe_damage       = 1.0;
+    full_damage_targets      = 1;
   }
 };
 
@@ -3021,8 +3025,8 @@ struct breath_of_fire_t : public monk_spell_t
     gcd_type = gcd_haste_type::NONE;
 
     aoe                   = -1;
-    reduced_aoe_damage    = 1.0;
-    full_damage_targets   = 1;
+    reduced_aoe_damage  = 1.0;
+    full_damage_targets = 1;
     trigger_faeline_stomp = true;
     trigger_bountiful_brew = true;
 

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -665,7 +665,14 @@ struct storm_earth_and_fire_pet_t : public monk_pet_t
     sef_fists_of_fury_tick_t( storm_earth_and_fire_pet_t* p )
       : sef_tick_action_t( "fists_of_fury_tick", p, p->o()->passives.fists_of_fury_tick )
     {
-      aoe = 1 + as<int>( p->o()->spec.fists_of_fury->effectN( 1 ).base_value() );
+      if ( p->dbc->ptr )
+        aoe = 1 + as<int>( p->o()->spec.fists_of_fury->effectN( 1 ).base_value() );
+      else
+      {
+        aoe                 = -1;
+        reduced_aoe_damage  = p->o()->spec.fists_of_fury->effectN( 1 ).base_value();
+        full_damage_targets = 1;
+      }
     }
   };
 
@@ -758,7 +765,13 @@ struct storm_earth_and_fire_pet_t : public monk_pet_t
     sef_rushing_jade_wind_tick_t( storm_earth_and_fire_pet_t* p )
       : sef_tick_action_t( "rushing_jade_wind_tick", p, p->o()->talent.rushing_jade_wind->effectN( 1 ).trigger() )
     {
-      aoe = -1;
+      if ( !p->dbc->ptr )
+        aoe = (int)p->o()->talent.rushing_jade_wind->effectN( 1 ).base_value();
+      else
+      {
+        aoe                = -1;
+        reduced_aoe_damage = p->o()->talent.rushing_jade_wind->effectN( 1 ).base_value();
+      }
     }
   };
 

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -1762,7 +1762,8 @@ public:
       parse_options( options_str );
 
       aoe                     = -1;
-      reduced_aoe_damage      = as<unsigned>( o()->spec.keg_smash->effectN( 7 ).base_value() );
+      reduced_aoe_damage      = o()->spec.keg_smash->effectN( 7 ).base_value();
+      full_damage_targets     = 1;
       attack_power_mod.direct = p->o()->passives.fallen_monk_keg_smash->effectN( 2 ).ap_coeff();
       radius                  = p->o()->passives.fallen_monk_keg_smash->effectN( 2 ).radius();
 
@@ -1806,7 +1807,8 @@ public:
         merge_report  = false;
         tick_may_crit = may_crit = true;
         hasted_ticks             = false;
-        reduced_aoe_damage = 1;
+        reduced_aoe_damage = 1.0;
+        full_damage_targets = 1;
       }
     };
 
@@ -1820,7 +1822,8 @@ public:
       cooldown->hasted   = false;
       trigger_gcd        = timespan_t::from_seconds( 2 );
       aoe                = -1;
-      reduced_aoe_damage = 1;
+      reduced_aoe_damage = 1.0;
+      full_damage_targets = 1;
 
       add_child( dot_action );
     }

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -665,7 +665,7 @@ struct storm_earth_and_fire_pet_t : public monk_pet_t
     sef_fists_of_fury_tick_t( storm_earth_and_fire_pet_t* p )
       : sef_tick_action_t( "fists_of_fury_tick", p, p->o()->passives.fists_of_fury_tick )
     {
-      if ( p->dbc->ptr )
+      if ( !p->dbc->ptr )
         aoe = 1 + as<int>( p->o()->spec.fists_of_fury->effectN( 1 ).base_value() );
       else
       {

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -1762,27 +1762,13 @@ public:
       parse_options( options_str );
 
       aoe                     = -1;
+      reduced_aoe_damage      = as<unsigned>( o()->spec.keg_smash->effectN( 7 ).base_value() );
       attack_power_mod.direct = p->o()->passives.fallen_monk_keg_smash->effectN( 2 ).ap_coeff();
       radius                  = p->o()->passives.fallen_monk_keg_smash->effectN( 2 ).radius();
 
       cooldown->hasted        = false;
 
       trigger_gcd = timespan_t::from_seconds( 1.5 );
-    }
-
-    // For more than 5 targets damage is based on a Sqrt(5/x)
-    double composite_aoe_multiplier( const action_state_t* state ) const override
-    {
-      double cam = pet_melee_attack_t::composite_aoe_multiplier( state );
-
-      if ( state->n_targets > o()->spec.keg_smash->effectN( 7 ).base_value() )
-        // this is the closest we can come up without Blizzard flat out giving us the function
-        // Primary takes the 100% damage
-        // Secondary targets get reduced damage
-        if ( state->target != target )
-          cam *= std::sqrt( 5 / state->n_targets );
-
-      return cam;
     }
 
     double action_multiplier() const override
@@ -1820,17 +1806,7 @@ public:
         merge_report  = false;
         tick_may_crit = may_crit = true;
         hasted_ticks             = false;
-      }
-
-      // Initial damage does Square Root damage
-      double composite_aoe_multiplier( const action_state_t* state ) const override
-      {
-        double cam = pet_spell_t::composite_aoe_multiplier( state );
-
-        if ( state->target != target )
-          return cam / std::sqrt( state->n_targets );
-
-        return cam;
+        reduced_aoe_damage = 1;
       }
     };
 
@@ -1844,18 +1820,9 @@ public:
       cooldown->hasted   = false;
       trigger_gcd        = timespan_t::from_seconds( 2 );
       aoe                = -1;
+      reduced_aoe_damage = 1;
 
       add_child( dot_action );
-    }
-
-    double composite_aoe_multiplier( const action_state_t* state ) const override
-    {
-      double cam = pet_spell_t::composite_aoe_multiplier( state );
-
-      if ( state->target != target )
-        return cam / std::sqrt( state->n_targets );
-
-      return cam;
     }
 
     void impact( action_state_t* s ) override

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -670,8 +670,8 @@ struct storm_earth_and_fire_pet_t : public monk_pet_t
       else
       {
         aoe                 = -1;
-        reduced_aoe_damage  = p->o()->spec.fists_of_fury->effectN( 1 ).base_value();
-        full_damage_targets = 1;
+        reduced_aoe_targets  = p->o()->spec.fists_of_fury->effectN( 1 ).base_value();
+        full_amount_targets = 1;
       }
     }
   };
@@ -770,7 +770,7 @@ struct storm_earth_and_fire_pet_t : public monk_pet_t
       else
       {
         aoe                = -1;
-        reduced_aoe_damage = p->o()->talent.rushing_jade_wind->effectN( 1 ).base_value();
+        reduced_aoe_targets = p->o()->talent.rushing_jade_wind->effectN( 1 ).base_value();
       }
     }
   };
@@ -1775,8 +1775,8 @@ public:
       parse_options( options_str );
 
       aoe                     = -1;
-      reduced_aoe_damage      = o()->spec.keg_smash->effectN( 7 ).base_value();
-      full_damage_targets     = 1;
+      reduced_aoe_targets      = o()->spec.keg_smash->effectN( 7 ).base_value();
+      full_amount_targets     = 1;
       attack_power_mod.direct = p->o()->passives.fallen_monk_keg_smash->effectN( 2 ).ap_coeff();
       radius                  = p->o()->passives.fallen_monk_keg_smash->effectN( 2 ).radius();
 
@@ -1820,8 +1820,8 @@ public:
         merge_report  = false;
         tick_may_crit = may_crit = true;
         hasted_ticks             = false;
-        reduced_aoe_damage = 1.0;
-        full_damage_targets = 1;
+        reduced_aoe_targets = 1.0;
+        full_amount_targets = 1;
       }
     };
 
@@ -1835,8 +1835,8 @@ public:
       cooldown->hasted   = false;
       trigger_gcd        = timespan_t::from_seconds( 2 );
       aoe                = -1;
-      reduced_aoe_damage = 1.0;
-      full_damage_targets = 1;
+      reduced_aoe_targets = 1.0;
+      full_amount_targets = 1;
 
       add_child( dot_action );
     }

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -1208,23 +1208,13 @@ struct ashen_hallow_tick_t : public paladin_spell_t
     : paladin_spell_t( "ashen_hallow_tick", p, p->find_spell( 317221 ) ), hd_damage_tick( hallowed_discernment )
   {
     aoe         = -1;
+    reduced_aoe_damage = 5;
+    full_damage_targets = 0;
     dual        = true;
     direct_tick = true;
     background  = true;
     may_crit    = true;
     ground_aoe  = true;
-  }
-
-  double composite_aoe_multiplier( const action_state_t* state ) const override
-  {
-    double cam = paladin_spell_t::composite_aoe_multiplier( state );
-
-    // Formula courtesy of Mythie. This expression fits experimental data but has not been confirmed.
-    if ( state->n_targets <= 5 )
-      return cam;
-    else
-      return cam * std::sqrt( 5.0 / state->n_targets );
-    // Post 20 is managed by action_t::calculate_direct_amount
   }
 
   void execute() override

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -1208,8 +1208,7 @@ struct ashen_hallow_tick_t : public paladin_spell_t
     : paladin_spell_t( "ashen_hallow_tick", p, p->find_spell( 317221 ) ), hd_damage_tick( hallowed_discernment )
   {
     aoe         = -1;
-    reduced_aoe_damage = 5;
-    full_damage_targets = 0;
+    reduced_aoe_damage = p->covenant.venthyr->effectN( 1 ).base_value();
     dual        = true;
     direct_tick = true;
     background  = true;

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -1208,7 +1208,7 @@ struct ashen_hallow_tick_t : public paladin_spell_t
     : paladin_spell_t( "ashen_hallow_tick", p, p->find_spell( 317221 ) ), hd_damage_tick( hallowed_discernment )
   {
     aoe         = -1;
-    reduced_aoe_damage = p->covenant.venthyr->effectN( 1 ).base_value();
+    reduced_aoe_targets = p->covenant.venthyr->effectN( 1 ).base_value();
     dual        = true;
     direct_tick = true;
     background  = true;

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -755,7 +755,7 @@ struct ascended_nova_t final : public priest_spell_t
   {
     parse_options( options_str );
     aoe                        = -1;
-    reduced_aoe_damage         = 1.0;
+    reduced_aoe_targets         = 1.0;
     radius                     = data().effectN( 1 ).radius_max();
     affected_by_shadow_weaving = true;
 
@@ -866,7 +866,7 @@ struct ascended_eruption_heal_t final : public priest_heal_t
                         p.conduits.courageous_ascension->effectN( 2 ).percent() )
   {
     aoe                = -1;
-    reduced_aoe_damage = 1.0;
+    reduced_aoe_targets = 1.0;
     background         = true;
   }
 
@@ -899,7 +899,7 @@ struct ascended_eruption_t final : public priest_spell_t
                         p.conduits.courageous_ascension->effectN( 2 ).percent() )
   {
     aoe                = -1;
-    reduced_aoe_damage = 1.0;
+    reduced_aoe_targets = 1.0;
     background         = true;
     radius             = data().effectN( 1 ).radius_max();
     // By default the spell tries to use the healing SP Coeff

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -755,6 +755,8 @@ struct ascended_nova_t final : public priest_spell_t
   {
     parse_options( options_str );
     aoe                        = -1;
+    reduced_aoe_damage         = 1;
+    full_damage_targets        = 0;
     radius                     = data().effectN( 1 ).radius_max();
     affected_by_shadow_weaving = true;
 
@@ -781,13 +783,6 @@ struct ascended_nova_t final : public priest_spell_t
     }
 
     return priest_spell_t::ready();
-  }
-
-  double composite_aoe_multiplier( const action_state_t* state ) const override
-  {
-    double cam = priest_spell_t::composite_aoe_multiplier( state );
-
-    return cam / std::sqrt( state->n_targets );
   }
 
   void execute() override

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -865,8 +865,9 @@ struct ascended_eruption_heal_t final : public priest_heal_t
       base_da_increase( p.covenant.boon_of_the_ascended->effectN( 5 ).percent() +
                         p.conduits.courageous_ascension->effectN( 2 ).percent() )
   {
-    aoe        = -1;
-    background = true;
+    aoe                = -1;
+    reduced_aoe_damage = 1.0;
+    background         = true;
   }
 
   void trigger_eruption( int stacks )
@@ -885,16 +886,6 @@ struct ascended_eruption_heal_t final : public priest_heal_t
 
     return m;
   }
-
-  double composite_aoe_multiplier( const action_state_t* state ) const override
-  {
-    double cam  = priest_heal_t::composite_aoe_multiplier( state );
-    int targets = state->n_targets;
-    sim->print_debug( "{} {} sets damage multiplier as if it hit an additional {} targets.", *player, *this,
-                      priest().options.ascended_eruption_additional_targets );
-    targets += priest().options.ascended_eruption_additional_targets;
-    return cam / std::sqrt( targets );
-  }
 };
 
 struct ascended_eruption_t final : public priest_spell_t
@@ -907,9 +898,10 @@ struct ascended_eruption_t final : public priest_spell_t
       base_da_increase( p.covenant.boon_of_the_ascended->effectN( 5 ).percent() +
                         p.conduits.courageous_ascension->effectN( 2 ).percent() )
   {
-    aoe        = -1;
-    background = true;
-    radius     = data().effectN( 1 ).radius_max();
+    aoe                = -1;
+    reduced_aoe_damage = 1.0;
+    background         = true;
+    radius             = data().effectN( 1 ).radius_max();
     // By default the spell tries to use the healing SP Coeff
     spell_power_mod.direct     = data().effectN( 1 ).sp_coeff();
     affected_by_shadow_weaving = true;
@@ -930,16 +922,6 @@ struct ascended_eruption_t final : public priest_spell_t
     m *= 1 + base_da_increase * trigger_stacks;
 
     return m;
-  }
-
-  double composite_aoe_multiplier( const action_state_t* state ) const override
-  {
-    double cam  = priest_spell_t::composite_aoe_multiplier( state );
-    int targets = state->n_targets;
-    sim->print_debug( "{} {} sets damage multiplier as if it hit an additional {} targets.", *player, *this,
-                      priest().options.ascended_eruption_additional_targets );
-    targets += priest().options.ascended_eruption_additional_targets;
-    return cam / std::sqrt( targets );
   }
 };
 
@@ -2102,8 +2084,6 @@ void priest_t::create_options()
   add_option( opt_deprecated( "priest_mindgames_damage_reversal", "priest.mindgames_damage_reversal" ) );
   add_option( opt_deprecated( "priest_self_power_infusion", "priest.self_power_infusion" ) );
   add_option( opt_deprecated( "priest_self_benevolent_faerie", "priest.self_benevolent_faerie" ) );
-  add_option(
-      opt_deprecated( "priest_ascended_eruption_additional_targets", "priest.ascended_eruption_additional_targets" ) );
   add_option( opt_deprecated( "priest_cauterizing_shadows_allies", "priest.cauterizing_shadows_allies" ) );
 
   add_option( opt_bool( "priest.autounshift", options.autoUnshift ) );
@@ -2114,7 +2094,6 @@ void priest_t::create_options()
   add_option( opt_bool( "priest.mindgames_damage_reversal", options.mindgames_damage_reversal ) );
   add_option( opt_bool( "priest.self_power_infusion", options.self_power_infusion ) );
   add_option( opt_bool( "priest.self_benevolent_faerie", options.self_benevolent_faerie ) );
-  add_option( opt_int( "priest.ascended_eruption_additional_targets", options.ascended_eruption_additional_targets ) );
   add_option( opt_int( "priest.cauterizing_shadows_allies", options.cauterizing_shadows_allies ) );
   add_option( opt_string( "priest.bwonsamdis_pact_mask_type", options.bwonsamdis_pact_mask_type ) );
   add_option( opt_int( "priest.shadow_word_manipulation_seconds_remaining",

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -755,8 +755,7 @@ struct ascended_nova_t final : public priest_spell_t
   {
     parse_options( options_str );
     aoe                        = -1;
-    reduced_aoe_damage         = 1;
-    full_damage_targets        = 0;
+    reduced_aoe_damage         = 1.0;
     radius                     = data().effectN( 1 ).radius_max();
     affected_by_shadow_weaving = true;
 

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -370,10 +370,6 @@ public:
     // Fae Blessings CDR can be given to another player, but you can still get the insanity gen
     bool self_benevolent_faerie = true;
 
-    // Add "bugged" targets to Ascended Eruption for the SQRT calculation
-    // Setting to 0 turns off the bug
-    int ascended_eruption_additional_targets = 0;
-
     // The amount of allies to assume for Cauterizing Shadows healing
     int cauterizing_shadows_allies = 3;
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -3852,7 +3852,7 @@ struct breath_of_sindragosa_tick_t: public death_knight_spell_t
   {
     aoe = -1;
     background = true;
-    reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
 
     ap_type = attack_power_type::WEAPON_BOTH;
 
@@ -5516,7 +5516,7 @@ struct howling_blast_t : public death_knight_spell_t
     triggers_shackle_the_unworthy = true;
 
     aoe = -1;
-    reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
 
     impact_action = get_action<frost_fever_t>( "frost_fever", p );
 
@@ -6416,6 +6416,8 @@ struct swarming_mist_damage_t : public death_knight_spell_t
   {
     background = true;
     aoe = -1;
+    reduced_aoe_damage = 5;
+    full_damage_targets = 0;
     base_multiplier *= 1.0 + p -> conduits.impenetrable_gloom.percent();
     swarming_mist_energize_amount = as<int>( p -> covenant.swarming_mist->ok() ? p -> find_spell( 312546 ) -> effectN( 1 ).resource( RESOURCE_RUNIC_POWER ) : 0 );
   }
@@ -6424,17 +6426,6 @@ struct swarming_mist_damage_t : public death_knight_spell_t
   {
     swarming_mist_energize_tick = 0;
     death_knight_spell_t::execute();
-  }
-
-  double composite_aoe_multiplier( const action_state_t* state ) const override
-  {
-    double cam = death_knight_spell_t::composite_aoe_multiplier( state );
-
-    if ( state->n_targets > p() -> covenant.swarming_mist ->effectN( 5 ).base_value() )
-        // When we cross over 5 targets, sqrt on all targets kicks in
-        cam *= std::sqrt( 5.0 / state->n_targets );
-
-    return cam;
   }
 
   void impact( action_state_t* s ) override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -3852,7 +3852,8 @@ struct breath_of_sindragosa_tick_t: public death_knight_spell_t
   {
     aoe = -1;
     background = true;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
 
     ap_type = attack_power_type::WEAPON_BOTH;
 
@@ -5516,7 +5517,8 @@ struct howling_blast_t : public death_knight_spell_t
     triggers_shackle_the_unworthy = true;
 
     aoe = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
 
     impact_action = get_action<frost_fever_t>( "frost_fever", p );
 
@@ -6416,8 +6418,7 @@ struct swarming_mist_damage_t : public death_knight_spell_t
   {
     background = true;
     aoe = -1;
-    reduced_aoe_damage = 5;
-    full_damage_targets = 0;
+    reduced_aoe_damage = p -> covenant.swarming_mist -> effectN( 5 ).base_value();
     base_multiplier *= 1.0 + p -> conduits.impenetrable_gloom.percent();
     swarming_mist_energize_amount = as<int>( p -> covenant.swarming_mist->ok() ? p -> find_spell( 312546 ) -> effectN( 1 ).resource( RESOURCE_RUNIC_POWER ) : 0 );
   }

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -3852,8 +3852,8 @@ struct breath_of_sindragosa_tick_t: public death_knight_spell_t
   {
     aoe = -1;
     background = true;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
 
     ap_type = attack_power_type::WEAPON_BOTH;
 
@@ -5517,8 +5517,8 @@ struct howling_blast_t : public death_knight_spell_t
     triggers_shackle_the_unworthy = true;
 
     aoe = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
 
     impact_action = get_action<frost_fever_t>( "frost_fever", p );
 
@@ -6418,7 +6418,7 @@ struct swarming_mist_damage_t : public death_knight_spell_t
   {
     background = true;
     aoe = -1;
-    reduced_aoe_damage = p -> covenant.swarming_mist -> effectN( 5 ).base_value();
+    reduced_aoe_targets = p -> covenant.swarming_mist -> effectN( 5 ).base_value();
     base_multiplier *= 1.0 + p -> conduits.impenetrable_gloom.percent();
     swarming_mist_energize_amount = as<int>( p -> covenant.swarming_mist->ok() ? p -> find_spell( 312546 ) -> effectN( 1 ).resource( RESOURCE_RUNIC_POWER ) : 0 );
   }

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1942,8 +1942,8 @@ struct eye_beam_t : public demon_hunter_spell_t
     {
       background = dual = true;
       aoe = -1;
-      reduced_aoe_damage = 1.0;
-      full_damage_targets = 1;
+      reduced_aoe_targets = 1.0;
+      full_amount_targets = 1;
     }
 
     double composite_target_multiplier( player_t* target ) const override
@@ -3093,7 +3093,7 @@ struct fodder_to_the_flame_cb_t : public dbc_proc_callback_t
     {
       background = true;
       aoe = -1;
-      reduced_aoe_damage = p->find_spell( 350570 )->effectN( 1 ).base_value();
+      reduced_aoe_targets = p->find_spell( 350570 )->effectN( 1 ).base_value();
 
       if ( p->legendary.demonic_oath->ok() )
       {

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1942,7 +1942,8 @@ struct eye_beam_t : public demon_hunter_spell_t
     {
       background = dual = true;
       aoe = -1;
-      reduced_aoe_damage = 1;
+      reduced_aoe_damage = 1.0;
+      full_damage_targets = 1;
     }
 
     double composite_target_multiplier( player_t* target ) const override
@@ -3092,8 +3093,7 @@ struct fodder_to_the_flame_cb_t : public dbc_proc_callback_t
     {
       background = true;
       aoe = -1;
-      reduced_aoe_damage = as<unsigned>( p->find_spell( 350570 )->effectN( 1 ).base_value() );
-      full_damage_targets = 0;
+      reduced_aoe_damage = p->find_spell( 350570 )->effectN( 1 ).base_value();
 
       if ( p->legendary.demonic_oath->ok() )
       {

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1940,8 +1940,9 @@ struct eye_beam_t : public demon_hunter_spell_t
     eye_beam_tick_t( util::string_view name, demon_hunter_t* p )
       : demon_hunter_spell_t( name, p, p->find_spell( 198030 ) )
     {
-      background = dual = reduced_aoe_damage = true;
+      background = dual = true;
       aoe = -1;
+      reduced_aoe_damage = 1;
     }
 
     double composite_target_multiplier( player_t* target ) const override
@@ -3083,34 +3084,22 @@ struct fodder_to_the_flame_cb_t : public dbc_proc_callback_t
 {
   struct fodder_to_the_flame_damage_t : public demon_hunter_spell_t
   {
-    double target_soft_cap;
     fiery_brand_t* demonic_oath_brand;
 
     fodder_to_the_flame_damage_t( util::string_view name, demon_hunter_t* p )
       : demon_hunter_spell_t( name, p, p->find_spell( 350631 ) ),
-      target_soft_cap( p->find_spell( 350570 )->effectN( 1 ).base_value() ),
       demonic_oath_brand( nullptr )
     {
       background = true;
       aoe = -1;
+      reduced_aoe_damage = as<unsigned>( p->find_spell( 350570 )->effectN( 1 ).base_value() );
+      full_damage_targets = 0;
 
       if ( p->legendary.demonic_oath->ok() )
       {
         demonic_oath_brand = p->get_background_action<fiery_brand_t>( "fiery_brand_demonic_oath", "", true );
         add_child( demonic_oath_brand );
       }
-    }
-
-    double composite_aoe_multiplier( const action_state_t* state ) const override
-    {
-      double cam = demon_hunter_spell_t::composite_aoe_multiplier( state );
-
-      if ( state->n_targets > target_soft_cap )
-      {
-        cam *= std::sqrt( target_soft_cap / state->n_targets );
-      }
-
-      return cam;
     }
 
     void execute() override

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -5231,8 +5231,8 @@ struct fury_of_elune_t : public druid_spell_t
     {
       background = dual = ground_aoe = true;
       aoe = -1;
-      reduced_aoe_damage = 1.0;
-      full_damage_targets = 1;
+      reduced_aoe_targets = 1.0;
+      full_amount_targets = 1;
     }
   };
 
@@ -5404,8 +5404,8 @@ struct full_moon_t : public moon_base_t
   full_moon_t( druid_t* p, const spell_data_t* s, util::string_view opt ) : moon_base_t( "full_moon", p, s, opt )
   {
     aoe = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     stage = moon_stage_e::FULL_MOON;
 
     update_eclipse = true;

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -5229,8 +5229,9 @@ struct fury_of_elune_t : public druid_spell_t
   {
     fury_of_elune_tick_t( druid_t* p ) : druid_spell_t( "fury_of_elune_tick", p, p->spec.fury_of_elune )
     {
-      background = dual = ground_aoe = reduced_aoe_damage = true;
+      background = dual = ground_aoe = true;
       aoe = -1;
+      reduced_aoe_damage = 1;
     }
   };
 
@@ -5402,7 +5403,7 @@ struct full_moon_t : public moon_base_t
   full_moon_t( druid_t* p, const spell_data_t* s, util::string_view opt ) : moon_base_t( "full_moon", p, s, opt )
   {
     aoe                = -1;
-    reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
     stage              = moon_stage_e::FULL_MOON;
 
     update_eclipse = true;

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -5231,7 +5231,8 @@ struct fury_of_elune_t : public druid_spell_t
     {
       background = dual = ground_aoe = true;
       aoe = -1;
-      reduced_aoe_damage = 1;
+      reduced_aoe_damage = 1.0;
+      full_damage_targets = 1;
     }
   };
 
@@ -5402,9 +5403,10 @@ struct full_moon_t : public moon_base_t
 
   full_moon_t( druid_t* p, const spell_data_t* s, util::string_view opt ) : moon_base_t( "full_moon", p, s, opt )
   {
-    aoe                = -1;
-    reduced_aoe_damage = 1;
-    stage              = moon_stage_e::FULL_MOON;
+    aoe = -1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
+    stage = moon_stage_e::FULL_MOON;
 
     update_eclipse = true;
 

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2486,8 +2486,8 @@ struct arcane_blast_t final : public arcane_mage_spell_t
     cost_reductions = { p->buffs.rule_of_threes };
     triggers.radiant_spark = true;
     affected_by.deathborne_cleave = true;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
   }
 
   double cost() const override
@@ -4175,8 +4175,8 @@ struct ice_nova_t final : public frost_mage_spell_t
   {
     parse_options( options_str );
     aoe = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     consumes_winters_chill = triggers.radiant_spark = true;
   }
 
@@ -4314,8 +4314,8 @@ struct living_bomb_explosion_t final : public fire_mage_spell_t
     fire_mage_spell_t( n, p, p->find_spell( 44461 ) )
   {
     aoe = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     background = true;
     affected_by.radiant_spark = false;
   }
@@ -4553,8 +4553,8 @@ struct phoenix_flames_splash_t final : public fire_mage_spell_t
     fire_mage_spell_t( n, p, p->find_spell( 257542 ) )
   {
     aoe = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     background = true;
     callbacks = false;
     triggers.hot_streak = triggers.kindling = TT_MAIN_TARGET;
@@ -5000,8 +5000,8 @@ struct touch_of_the_magi_explosion_t final : public arcane_mage_spell_t
     may_miss = may_crit = callbacks = false;
     affected_by.radiant_spark = false;
     aoe = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     base_dd_min = base_dd_max = 1.0;
   }
 

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2486,7 +2486,8 @@ struct arcane_blast_t final : public arcane_mage_spell_t
     cost_reductions = { p->buffs.rule_of_threes };
     triggers.radiant_spark = true;
     affected_by.deathborne_cleave = true;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
   }
 
   double cost() const override
@@ -4174,7 +4175,8 @@ struct ice_nova_t final : public frost_mage_spell_t
   {
     parse_options( options_str );
     aoe = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
     consumes_winters_chill = triggers.radiant_spark = true;
   }
 
@@ -4312,7 +4314,8 @@ struct living_bomb_explosion_t final : public fire_mage_spell_t
     fire_mage_spell_t( n, p, p->find_spell( 44461 ) )
   {
     aoe = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
     background = true;
     affected_by.radiant_spark = false;
   }
@@ -4550,7 +4553,8 @@ struct phoenix_flames_splash_t final : public fire_mage_spell_t
     fire_mage_spell_t( n, p, p->find_spell( 257542 ) )
   {
     aoe = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
     background = true;
     callbacks = false;
     triggers.hot_streak = triggers.kindling = TT_MAIN_TARGET;
@@ -4996,7 +5000,8 @@ struct touch_of_the_magi_explosion_t final : public arcane_mage_spell_t
     may_miss = may_crit = callbacks = false;
     affected_by.radiant_spark = false;
     aoe = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
     base_dd_min = base_dd_max = 1.0;
   }
 

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2484,8 +2484,9 @@ struct arcane_blast_t final : public arcane_mage_spell_t
   {
     parse_options( options_str );
     cost_reductions = { p->buffs.rule_of_threes };
-    reduced_aoe_damage = triggers.radiant_spark = true;
+    triggers.radiant_spark = true;
     affected_by.deathborne_cleave = true;
+    reduced_aoe_damage = 1;
   }
 
   double cost() const override
@@ -4173,7 +4174,8 @@ struct ice_nova_t final : public frost_mage_spell_t
   {
     parse_options( options_str );
     aoe = -1;
-    consumes_winters_chill = triggers.radiant_spark = reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
+    consumes_winters_chill = triggers.radiant_spark = true;
   }
 
   void impact( action_state_t* s ) override
@@ -4310,7 +4312,8 @@ struct living_bomb_explosion_t final : public fire_mage_spell_t
     fire_mage_spell_t( n, p, p->find_spell( 44461 ) )
   {
     aoe = -1;
-    background = reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
+    background = true;
     affected_by.radiant_spark = false;
   }
 };
@@ -4547,7 +4550,8 @@ struct phoenix_flames_splash_t final : public fire_mage_spell_t
     fire_mage_spell_t( n, p, p->find_spell( 257542 ) )
   {
     aoe = -1;
-    background = reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
+    background = true;
     callbacks = false;
     triggers.hot_streak = triggers.kindling = TT_MAIN_TARGET;
     triggers.ignite = triggers.radiant_spark = true;
@@ -4988,10 +4992,11 @@ struct touch_of_the_magi_explosion_t final : public arcane_mage_spell_t
   touch_of_the_magi_explosion_t( util::string_view n, mage_t* p ) :
     arcane_mage_spell_t( n, p, p->find_spell( 210833 ) )
   {
-    background = reduced_aoe_damage = true;
+    background = true;
     may_miss = may_crit = callbacks = false;
     affected_by.radiant_spark = false;
     aoe = -1;
+    reduced_aoe_damage = 1;
     base_dd_min = base_dd_max = 1.0;
   }
 

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -3714,7 +3714,7 @@ struct crash_lightning_t : public shaman_attack_t
     parse_options( options_str );
 
     aoe     = -1;
-    reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
     weapon  = &( p()->main_hand_weapon );
     ap_type = attack_power_type::WEAPON_BOTH;
   }

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -3714,8 +3714,8 @@ struct crash_lightning_t : public shaman_attack_t
     parse_options( options_str );
 
     aoe     = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     weapon  = &( p()->main_hand_weapon );
     ap_type = attack_power_type::WEAPON_BOTH;
   }

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -3714,7 +3714,8 @@ struct crash_lightning_t : public shaman_attack_t
     parse_options( options_str );
 
     aoe     = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
     weapon  = &( p()->main_hand_weapon );
     ap_type = attack_power_type::WEAPON_BOTH;
   }

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -2663,7 +2663,8 @@ struct dragon_roar_t : public warrior_attack_t
     crit_bonus_multiplier *= 1.0 + p->spell.warrior_aura->effectN( 6 ).percent();
     parse_options( options_str );
     aoe       = -1;
-    reduced_aoe_damage = 1;
+    reduced_aoe_damage = 1.0;
+    full_damage_targets = 1;
     may_dodge = may_parry = may_block = false;
   }
 };

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -2663,7 +2663,7 @@ struct dragon_roar_t : public warrior_attack_t
     crit_bonus_multiplier *= 1.0 + p->spell.warrior_aura->effectN( 6 ).percent();
     parse_options( options_str );
     aoe       = -1;
-    reduced_aoe_damage = true;
+    reduced_aoe_damage = 1;
     may_dodge = may_parry = may_block = false;
   }
 };

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -2663,8 +2663,8 @@ struct dragon_roar_t : public warrior_attack_t
     crit_bonus_multiplier *= 1.0 + p->spell.warrior_aura->effectN( 6 ).percent();
     parse_options( options_str );
     aoe       = -1;
-    reduced_aoe_damage = 1.0;
-    full_damage_targets = 1;
+    reduced_aoe_targets = 1.0;
+    full_amount_targets = 1;
     may_dodge = may_parry = may_block = false;
   }
 };

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -435,7 +435,8 @@ struct implosion_t : public demonology_spell_t
       dual               = true;
       background         = true;
       callbacks          = false;
-      reduced_aoe_damage = 1;
+      reduced_aoe_damage = 1.0;
+      full_damage_targets = 1;
     }
 
     double composite_target_multiplier( player_t* t ) const override

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -435,8 +435,8 @@ struct implosion_t : public demonology_spell_t
       dual               = true;
       background         = true;
       callbacks          = false;
-      reduced_aoe_damage = 1.0;
-      full_damage_targets = 1;
+      reduced_aoe_targets = 1.0;
+      full_amount_targets = 1;
     }
 
     double composite_target_multiplier( player_t* t ) const override

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -435,7 +435,7 @@ struct implosion_t : public demonology_spell_t
       dual               = true;
       background         = true;
       callbacks          = false;
-      reduced_aoe_damage = false;
+      reduced_aoe_damage = 1;
     }
 
     double composite_target_multiplier( player_t* t ) const override

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -241,8 +241,7 @@ void potion_of_empowered_exorcisms( special_effect_t& effect )
         radius *= 1.0 + e.driver()->effectN( 2 ).percent();
       }
 
-      reduced_aoe_damage = 1;
-      full_damage_targets = 0;
+      reduced_aoe_damage = 1.0;
     }
   };
 

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -241,7 +241,7 @@ void potion_of_empowered_exorcisms( special_effect_t& effect )
         radius *= 1.0 + e.driver()->effectN( 2 ).percent();
       }
 
-      reduced_aoe_damage = 1.0;
+      reduced_aoe_targets = 1.0;
     }
   };
 

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -240,13 +240,9 @@ void potion_of_empowered_exorcisms( special_effect_t& effect )
         base_multiplier *= 1.0 + e.driver()->effectN( 2 ).percent();
         radius *= 1.0 + e.driver()->effectN( 2 ).percent();
       }
-    }
 
-    // manually adjust for aoe reduction here instead of via action_t::reduced_aoe_damage as all targets receive reduced
-    // damage, including the primary
-    double composite_aoe_multiplier( const action_state_t* s ) const override
-    {
-      return proc_spell_t::composite_aoe_multiplier( s ) / std::sqrt( s->n_targets );
+      reduced_aoe_damage = 1;
+      full_damage_targets = 0;
     }
   };
 


### PR DESCRIPTION
Adjust action_t::reduced_aoe_damage to account for target threshold before sqrt reduction is applied.

Took a pass at currently existing instances in the various class modules.
No adjustments made to spells newly changed in the 9.1.5 PTR.