### PR TITLE
Add cmake install target and try to cleanup paths.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DCMAKE_C_COMPILER=${{ matrix.cc }}
               -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DCMAKE_C_COMPILER_WORKS=TRUE
 
       - name: Build
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,6 @@ jobs:
               -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DCMAKE_C_COMPILER=${{ matrix.cc }}
               -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-              -DCMAKE_C_COMPILER_WORKS=TRUE
 
       - name: Build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ vs/int_gui/
 x64/
 x86/
 simc-*/
+out/
 
 /build
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Projects Settings   
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.10...3.21)
 
 # allow enabling lto from the command line
 if(POLICY CMP0069)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW)
 endif()
 
-project(simc)
+project(simc LANGUAGES CXX)
 
 # switch on/off different build targets
 option(BUILD_GUI "Build the Qt gui along with cli binary" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Projects Settings   
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.1)
 
 # allow enabling lto from the command line
 if(POLICY CMP0069)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Projects Settings   
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.12)
 
 # allow enabling lto from the command line
 if(POLICY CMP0069)
@@ -10,7 +10,6 @@ project(simc)
 
 # switch on/off different build targets
 option(BUILD_GUI "Build the Qt gui along with cli binary" ON)
-option(SC_TO_INSTALL "Enable Linux install mode" OFF)
 
 # disable various features that may be anvailable or unneeded
 option(SC_NO_THREADING "Disable all dependencies on pthreads" OFF)
@@ -32,6 +31,15 @@ endif()
 # output a compile_commands.json used for editor tooling
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Install paths
+if (UNIX)
+    set(SIMC_INSTALL_BIN "bin")
+    set(SIMC_INSTALL_SHARED "share/SimulationCraft/SimulationCraft")
+else() # Otherwise, install everything into a flat directory
+    set(SIMC_INSTALL_BIN ".")
+    set(SIMC_INSTALL_SHARED ".")
+endif()
+
 # link in all activated targets
 add_subdirectory(engine)
 if (BUILD_GUI)
@@ -43,14 +51,24 @@ if (NOT MSVC)
     target_compile_options(engine PUBLIC -Wall -Wextra)
 endif()
 
-# enable SC_TO_INSTALL mode
-if (SC_TO_INSTALL)
-    target_compile_definitions(engine PUBLIC SC_TO_INSTALL)
-endif()
 
 # 'simc' command line interface target
 include(source_files/cmake_engine_main.txt)
 string(REGEX REPLACE "([^;]+)" "engine/\\1" source_files "${source_files}")
 add_executable(simc ${source_files})
 target_link_libraries(simc engine)
-
+install(TARGETS simc DESTINATION ${SIMC_INSTALL_BIN})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/profiles/ DESTINATION ${SIMC_INSTALL_SHARED}/profiles
+    FILES_MATCHING PATTERN "*.simc" )
+install(FILES 
+${CMAKE_CURRENT_SOURCE_DIR}/README.md
+${CMAKE_CURRENT_SOURCE_DIR}/CONTRIBUTING.md
+${CMAKE_CURRENT_SOURCE_DIR}/COPYING
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.BOOST
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.BSD
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.BSD2
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.LGPL
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.MIT
+${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.UNLICENSE
+DESTINATION ${SIMC_INSTALL_SHARED})

--- a/engine/sim/sc_option.cpp
+++ b/engine/sim/sc_option.cpp
@@ -4,6 +4,7 @@
 // ==========================================================================
 
 #include "sc_option.hpp"
+#include "config.hpp"
 
 #include <iostream>
 
@@ -823,6 +824,13 @@ void option_db_t::parse_args( util::span<const std::string> args )
 option_db_t::option_db_t()
 {
   std::vector<std::string> paths = { "..", "./profiles", "../profiles", SC_SHARED_DATA };
+
+#if defined(SC_LINUX)
+  paths.emplace_back("~/.local/share/SimulationCraft/SimulationCraft/profiles");
+  paths.emplace_back("/usr/local/share/SimulationCraft/SimulationCraft/profiles");
+  paths.emplace_back("/usr/share/SimulationCraft/SimulationCraft/profiles");
+  paths.emplace_back("./share/SimulationCraft/SimulationCraft/profiles");
+#endif
 
   // This makes baby pandas cry a bit less, but still makes them weep.
 

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -31,10 +31,6 @@ win32|macx {
 CONFIG(release, debug|release): LIBS += -L../lib/release -lsimcengine
 CONFIG(debug, debug|release): LIBS += -L../lib/debug -lsimcengine
 
-CONFIG(to_install) {
-  DEFINES += SC_TO_INSTALL
-}
-
 Resources.files = ../qt/Welcome.html ../qt/Welcome.png ../qt/Error.html
 Localization.files = $$files(../locale/*.qm)
 Profiles.files = $$files(../profiles/*, recursive=true)

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -26,3 +26,16 @@ include(../source_files/cmake_gui.txt)
 add_executable(SimulationCraft ${source_files})
 target_include_directories(SimulationCraft PUBLIC ../engine/)
 target_link_libraries(SimulationCraft engine Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::WebEngineCore Qt${QT_VERSION_MAJOR}::WebEngineWidgets)
+
+install(TARGETS SimulationCraft DESTINATION ${SIMC_INSTALL_BIN})
+install(FILES 
+${CMAKE_CURRENT_SOURCE_DIR}/Error.html
+${CMAKE_CURRENT_SOURCE_DIR}/Welcome.html
+${CMAKE_CURRENT_SOURCE_DIR}/Welcome.png
+DESTINATION ${SIMC_INSTALL_SHARED})
+install(FILES 
+${CMAKE_CURRENT_SOURCE_DIR}/../locale/sc_de.qm
+${CMAKE_CURRENT_SOURCE_DIR}/../locale/sc_cn.qm
+${CMAKE_CURRENT_SOURCE_DIR}/../locale/sc_it.qm
+${CMAKE_CURRENT_SOURCE_DIR}/../locale/sc_ko.qm
+DESTINATION ${SIMC_INSTALL_SHARED}/locale)

--- a/qt/sc_window.cpp
+++ b/qt/sc_window.cpp
@@ -57,26 +57,20 @@ struct HtmlOutputFunctor
 
 QStringList SC_PATHS::getDataPaths()
 {
-#if defined( Q_OS_WIN )
-  return QStringList( QCoreApplication::applicationDirPath() );
-#elif defined( Q_OS_MAC )
+#if defined( Q_OS_MAC )
   return QStringList( QCoreApplication::applicationDirPath() + "/../Resources" );
 #else
-#if !defined( SC_TO_INSTALL )
-  return QStringList( QCoreApplication::applicationDirPath() );
-#else
   QStringList shared_paths;
-  QStringList appdatalocation = QStandardPaths::standardLocations( QStandardPaths::DataLocation );
-  for ( int i = 0; i < appdatalocation.size(); ++i )
+  shared_paths.append( QCoreApplication::applicationDirPath() );
+  for( const auto& location : QStandardPaths::standardLocations( QStandardPaths::AppDataLocation ))
   {
-    QDir dir( appdatalocation[ i ] );
+    QDir dir( location );
     if ( dir.exists() )
     {
       shared_paths.append( dir.path() );
     }
   }
   return shared_paths;
-#endif
 #endif
 }
 


### PR DESCRIPTION
- Normal install on UNIX to bin and share.
- Flat install on Windows, can be used for creating package for nightly.

Try to use the paths by default in Simc, with less additional build variable setup. Setting SC_SHARED_PATH should still work though.

Cmake install path setup can of course be improved, and maybe it can also be used as a starting point for the macos bundle, not sure.