### PR TITLE
Reset dynamic pet cooldowns on demise

### DIFF
--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -1645,14 +1645,6 @@ public:
       base_tick_time = dot_duration / 4;
       may_crit = may_miss = may_block = may_dodge = may_parry = callbacks = false;
 
-      // Due to the fact that pet spawners do not reset cooldowns on despawn need to make sure
-      // that the spell is cast 4 times in a 24 second duration
-      // so setting the cooldown to 8 seconds
-      cooldown->duration = p->o()->passives.fallen_monk_spec_duration->duration();
-      // If the legendary is active, we need to make sure this is cast 5 times in 24 seconds
-      // so setting the cooldown to 7 seconds
-      if ( p->o()->legendary.sinister_teachings->ok() )
-        cooldown->duration -= timespan_t::from_seconds( 1 );
       cooldown->hasted   = false;
 
       tick_action = new fallen_monk_fists_of_fury_tick_t( p );

--- a/engine/player/pet.hpp
+++ b/engine/player/pet.hpp
@@ -137,5 +137,7 @@ public:
 
   void acquire_target( retarget_source /* event */, player_t* /* context */ = nullptr ) override;
   
+  void demise() override;
+  
   friend void sc_format_to( const pet_t&, fmt::format_context::iterator );
 };

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -234,6 +234,7 @@ void pet_t::demise()
   // Reset cooldowns of dynamic pets, so that eg. reused pet spawner pets get summoned with all their cooldowns reset.
   if ( dynamic )
   {
+    sim->print_debug( "{} resetting all cooldowns", *this );
     for ( auto* cooldown : cooldown_list )
     {
       cooldown->reset( false );

--- a/engine/player/sc_pet.cpp
+++ b/engine/player/sc_pet.cpp
@@ -8,6 +8,7 @@
 #include "action/sc_action.hpp"
 #include "action/sc_action_state.hpp"
 #include "buff/sc_buff.hpp"
+#include "sim/sc_cooldown.hpp"
 #include "dbc/dbc.hpp"
 #include "player/actor_target_data.hpp"
 #include "player/spawner_base.hpp"
@@ -224,6 +225,20 @@ void pet_t::dismiss( bool expired )
   duration = timespan_t::zero();
 
   demise();
+}
+
+void pet_t::demise()
+{
+  player_t::demise();
+
+  // Reset cooldowns of dynamic pets, so that eg. reused pet spawner pets get summoned with all their cooldowns reset.
+  if ( dynamic )
+  {
+    for ( auto* cooldown : cooldown_list )
+    {
+      cooldown->reset( false );
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
To avoid reused pets (eg pet spawner wih dynamic pets) get their pets without reset cooldown, do so on demise. See issue #6186

Remove monk fallen order pet cd adjustment, since that was the case that initiated this change.