### PR TITLE
[Gear] Fix Master Duelist's Chit trinket

### DIFF
--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -1310,8 +1310,8 @@ class SpellDataGenerator(DataGenerator):
          356305,
          # Shredded Soul (Ebonsoul Vise)
          357785,
-         # Dueling Form (Master Duelist's Chit)
-         336236,
+         # Duelist's Shot (Master Duelist's Chit)
+         336234,
          # Nerubian Ambush, Frost-Tinged Carapace Spikes (Relic of the Frozen Wastes)
          355912, 357409,
          # Volatile Detonation (Ticking Sack of Terror)

--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -1310,8 +1310,8 @@ class SpellDataGenerator(DataGenerator):
          356305,
          # Shredded Soul (Ebonsoul Vise)
          357785,
-		 # Dueling Form (Master Duelist's Chit)
-		 336236,
+         # Dueling Form (Master Duelist's Chit)
+         336236,
          # Nerubian Ambush, Frost-Tinged Carapace Spikes (Relic of the Frozen Wastes)
          355912, 357409,
          # Volatile Detonation (Ticking Sack of Terror)

--- a/dbc_extract3/dbc/generator.py
+++ b/dbc_extract3/dbc/generator.py
@@ -1310,6 +1310,8 @@ class SpellDataGenerator(DataGenerator):
          356305,
          # Shredded Soul (Ebonsoul Vise)
          357785,
+		 # Dueling Form (Master Duelist's Chit)
+		 336236,
          # Nerubian Ambush, Frost-Tinged Carapace Spikes (Relic of the Frozen Wastes)
          355912, 357409,
          # Volatile Detonation (Ticking Sack of Terror)

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -1984,6 +1984,24 @@ void murmurs_in_the_dark( special_effect_t& effect )
   new dbc_proc_callback_t( effect.player, effect );
 }
 
+// id=336219 driver
+// id=336236 unknown use, triggered by driver
+// id=336234 damage spell
+// id=336222 melee damage spell?
+void dueling_form( special_effect_t& effect )
+{
+  struct dueling_form_t : public generic_proc_t
+  {
+    dueling_form_t( const special_effect_t& e ) : generic_proc_t( e, "dueling_form", 336236 )
+    {
+      base_dd_min = e.driver()->effectN( 1 ).min( e.item );
+      base_dd_max = e.driver()->effectN( 1 ).max( e.item );
+    }
+  };
+
+  effect.execute_action = create_proc_action<dueling_form_t>( "dueling_form", effect );
+  new dbc_proc_callback_t( effect.player, effect );
+}
 
 // 9.1 Trinkets
 
@@ -4131,6 +4149,8 @@ void register_special_effects()
     unique_gear::register_special_effect( 336182, items::tablet_of_despair );
     unique_gear::register_special_effect( 329536, items::rotbriar_sprout );
     unique_gear::register_special_effect( 339343, items::murmurs_in_the_dark );
+    unique_gear::register_special_effect( 336219, items::dueling_form );
+
 
     // 9.1 Trinkets
     unique_gear::register_special_effect( 353492, items::forbidden_necromantic_tome );

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -1990,9 +1990,10 @@ void murmurs_in_the_dark( special_effect_t& effect )
 // id=336222 melee damage spell?
 void dueling_form( special_effect_t& effect )
 {
-  struct dueling_form_t : public generic_proc_t
+  struct dueling_form_t : public proc_spell_t
   {
-    dueling_form_t( const special_effect_t& e ) : generic_proc_t( e, "dueling_form", 336236 )
+    dueling_form_t( const special_effect_t& e )
+      : proc_spell_t( "dueling_form", e.player, e.player->find_spell( 336236 ) )
     {
       base_dd_min = e.driver()->effectN( 1 ).min( e.item );
       base_dd_max = e.driver()->effectN( 1 ).max( e.item );

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -1993,14 +1993,14 @@ void dueling_form( special_effect_t& effect )
   struct dueling_form_t : public proc_spell_t
   {
     dueling_form_t( const special_effect_t& e )
-      : proc_spell_t( "dueling_form", e.player, e.player->find_spell( 336236 ) )
+      : proc_spell_t( "duelists_shot", e.player, e.player->find_spell( 336234 ) )
     {
       base_dd_min = e.driver()->effectN( 1 ).min( e.item );
       base_dd_max = e.driver()->effectN( 1 ).max( e.item );
     }
   };
 
-  effect.execute_action = create_proc_action<dueling_form_t>( "dueling_form", effect );
+  effect.execute_action = create_proc_action<dueling_form_t>( "duelists_shot", effect );
   new dbc_proc_callback_t( effect.player, effect );
 }
 


### PR DESCRIPTION
First SimC commit, fixes the Master Duelist's Chit trinket: https://www.wowhead.com/item=175730/master-duelists-chit / https://www.wowhead.com/item=181358/master-duelists-chit.

The trinket uses spell [Dueling Form #336219](https://www.wowhead.com/spell=336219/dueling-form), which doesn't seem to be doing much? [Dueling Form #336236](https://www.wowhead.com/spell=336236/dueling-form) appears to be calling [the spell that deals damage](https://www.wowhead.com/spell=336234/duelists-shot). In Details, the spell [Duelist's Strike](https://www.wowhead.com/spell=336222/duelists-strike) is displayed (at least for melee classes), not sure why.

I added a special effect to use the correct spell, let me know if there is a better way to do this.

Fixes #5930 