### PR TITLE
Fix some incorrect hotfix outputs

### DIFF
--- a/dbc_extract3/dbc_extract.py
+++ b/dbc_extract3/dbc_extract.py
@@ -208,11 +208,12 @@ elif options.type == 'view':
             else:
                 print('{}'.format(str(record)))
 
-        for id, entry in entries.items():
-            if id in replaced_ids:
+        for id, item in entries.items():
+            entry, hotfix = item
+            if id in replaced_ids or hotfix['state'] == HotfixType.REMOVED:
                 continue
 
-            print('{} [hotfix/add]'.format(entry[0]))
+            print('{} [hotfix/add]'.format(entry))
     else:
         if id in entries:
             record = entries[id]
@@ -259,7 +260,7 @@ elif options.type == 'json':
 
         for id, item in entries.items():
             entry, hotfix = item
-            if id in replaced_ids:
+            if id in replaced_ids or hotfix['state'] == HotfixType.REMOVED:
                 continue
 
             data_ = entry.obj()
@@ -323,10 +324,10 @@ elif options.type == 'csv':
             first = False
 
         for id, item in entries.items():
-            if id in replaced_ids:
+            entry, hotfix = item
+            if id in replaced_ids or hotfix['state'] == HotfixType.REMOVED:
                 continue
 
-            entry, hotfix = item
             print('{}'.format(entry.csv(options.delim, first)))
 
     else:


### PR DESCRIPTION
For some reason, Blizzard sometimes seems to push hotfix entries with HotfixType.REMOVED that reference records that do not exist. When this happens, the id will not end up in replaced_ids, which would result in the addition of an empty record.

In the current live build (9.1.5.40966), this occurs with a HotfixType.Removed entry for SpellCategory record 1999.

I'm not sure if there are other cases where this issue comes up elsewhere in dbc_extract.

