### PR TITLE
Clean string/string_view usage in class modules

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -477,7 +477,7 @@ public:
   void create_options() override;
   std::string create_profile( save_e ) override;
   action_t* create_action( util::string_view name, util::string_view options ) override;
-  pet_t* create_pet( util::string_view name, util::string_view type = "" ) override;
+  pet_t* create_pet( util::string_view name, util::string_view type = {} ) override;
   void create_pets() override;
   void copy_from( player_t* source ) override;
   resource_e primary_resource() const override

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -1629,7 +1629,7 @@ struct death_knight_pet_t : public pet_t
   bool use_auto_attack, precombat_spawn;
   double precombat_spawn_adjust, spawn_travel_duration, spawn_travel_stddev;
 
-  death_knight_pet_t( death_knight_t* player, const std::string& name, bool guardian = true, bool auto_attack = true, bool dynamic = true ) :
+  death_knight_pet_t( death_knight_t* player, util::string_view name, bool guardian = true, bool auto_attack = true, bool dynamic = true ) :
     pet_t( player -> sim, player, name, guardian, dynamic ), use_auto_attack( auto_attack ),
     precombat_spawn( false ), precombat_spawn_adjust( 0 ),
     spawn_travel_duration( 0 ), spawn_travel_stddev( 0 )
@@ -1875,7 +1875,7 @@ struct pet_spell_t : public pet_action_t<T_PET, spell_t>
 template <typename T>
 struct auto_attack_melee_t : public pet_melee_attack_t<T>
 {
-  auto_attack_melee_t( T* p, const std::string& name = "main_hand" ) :
+  auto_attack_melee_t( T* p, util::string_view name = "main_hand" ) :
     pet_melee_attack_t<T>( p, name )
   {
     this -> background = this -> repeating = true;
@@ -1901,7 +1901,7 @@ struct auto_attack_melee_t : public pet_melee_attack_t<T>
 
 struct base_ghoul_pet_t : public death_knight_pet_t
 {
-  base_ghoul_pet_t( death_knight_t* owner, const std::string& name, bool guardian = false, bool dynamic = true ) :
+  base_ghoul_pet_t( death_knight_t* owner, util::string_view name, bool guardian = false, bool dynamic = true ) :
     death_knight_pet_t( owner, name, guardian, true, dynamic )
   {
     main_hand_weapon.swing_time = 2.0_s;
@@ -2140,7 +2140,7 @@ struct army_ghoul_pet_t : public base_ghoul_pet_t
     }
   };
 
-  army_ghoul_pet_t( death_knight_t* owner, const std::string& name = "army_ghoul" ) :
+  army_ghoul_pet_t( death_knight_t* owner, util::string_view name = "army_ghoul" ) :
     base_ghoul_pet_t( owner, name, true )
   { }
 
@@ -3248,7 +3248,7 @@ void death_knight_melee_attack_t::impact( action_state_t* state )
 
 struct razorice_attack_t : public death_knight_melee_attack_t
 {
-  razorice_attack_t( death_knight_t* player, const std::string& name ) :
+  razorice_attack_t( death_knight_t* player, util::string_view name ) :
     death_knight_melee_attack_t( name, player, player -> find_spell( 50401 ) )
   {
     school      = SCHOOL_FROST;
@@ -4540,7 +4540,7 @@ struct death_and_decay_base_t : public death_knight_spell_t
   action_t* damage;
   action_t* relish_in_blood;
 
-  death_and_decay_base_t( death_knight_t* p, const std::string& name, const spell_data_t* spell ) :
+  death_and_decay_base_t( death_knight_t* p, util::string_view name, const spell_data_t* spell ) :
     death_knight_spell_t( name, p, spell ),
     damage( nullptr )
   {
@@ -5418,7 +5418,7 @@ struct frostwyrms_fury_t : public death_knight_spell_t
 
 struct frost_strike_strike_t : public death_knight_melee_attack_t
 {
-  frost_strike_strike_t( death_knight_t* p, const std::string& n, weapon_t* w, const spell_data_t* s ) :
+  frost_strike_strike_t( death_knight_t* p, util::string_view n, weapon_t* w, const spell_data_t* s ) :
     death_knight_melee_attack_t( n, p, s )
   {
     background = special = true;
@@ -5929,7 +5929,7 @@ struct mind_freeze_t : public death_knight_spell_t
 struct obliterate_strike_t : public death_knight_melee_attack_t
 {
   int deaths_due_cleave_targets;
-  obliterate_strike_t( death_knight_t* p, const std::string& name,
+  obliterate_strike_t( death_knight_t* p, util::string_view name,
                        weapon_t* w, const spell_data_t* s ) :
     death_knight_melee_attack_t( name, p, s )
   {
@@ -6044,7 +6044,7 @@ struct obliterate_t : public death_knight_melee_attack_t
   obliterate_strike_t *mh, *oh, *km_mh, *km_oh;
   action_t* inexorable_assault;
 
-  obliterate_t( death_knight_t* p, util::string_view options_str = std::string() ) :
+  obliterate_t( death_knight_t* p, util::string_view options_str = {} ) :
     death_knight_melee_attack_t( "obliterate", p, p -> spec.obliterate ),
     mh( nullptr ), oh( nullptr ), km_mh( nullptr ), km_oh( nullptr )
   {
@@ -6465,7 +6465,7 @@ struct sacrificial_pact_t : public death_knight_heal_t
 
 struct scourge_strike_base_t : public death_knight_melee_attack_t
 {
-  scourge_strike_base_t( const std::string& name, death_knight_t* p, const spell_data_t* spell ) :
+  scourge_strike_base_t( util::string_view name, death_knight_t* p, const spell_data_t* spell ) :
     death_knight_melee_attack_t( name, p, spell )
   {
     weapon = &( player -> main_hand_weapon );

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -154,7 +154,7 @@ struct movement_buff_t : public buff_t
   double distance_moved;
   demon_hunter_t* dh;
 
-  movement_buff_t( demon_hunter_t* p, const std::string& name, const spell_data_t* spell_data = spell_data_t::nil(), const item_t* item = nullptr );
+  movement_buff_t( demon_hunter_t* p, util::string_view name, const spell_data_t* spell_data = spell_data_t::nil(), const item_t* item = nullptr );
 
   bool trigger( int s = 1, double v = DEFAULT_VALUE(), double c = -1.0, timespan_t d = timespan_t::min() ) override;
 };
@@ -703,7 +703,7 @@ public:
 
   // Cooldown Tracking
   template <typename T_CONTAINER, typename T_DATA>
-  T_CONTAINER* get_data_entry( const std::string& name, std::vector<T_DATA*>& entries )
+  T_CONTAINER* get_data_entry( util::string_view name, std::vector<T_DATA*>& entries )
   {
     for ( size_t i = 0; i < entries.size(); i++ )
     {
@@ -1043,7 +1043,7 @@ namespace pets
 struct demon_hunter_pet_t : public pet_t
 {
   demon_hunter_pet_t( sim_t* sim, demon_hunter_t& owner,
-                      const std::string& pet_name, pet_e pt,
+                      util::string_view pet_name, pet_e pt,
                       bool guardian = false )
     : pet_t( sim, &owner, pet_name, pt, guardian )
   {
@@ -1570,7 +1570,7 @@ struct demon_hunter_heal_t : public demon_hunter_action_t<heal_t>
 {
   demon_hunter_heal_t( util::string_view n, demon_hunter_t* p,
                        const spell_data_t* s = spell_data_t::nil(),
-                       const std::string& o = std::string() )
+                       util::string_view o = {} )
     : base_t( n, p, s, o )
   {
     harmful = false;
@@ -1655,7 +1655,7 @@ struct consume_soul_t : public demon_hunter_heal_t
   const spell_data_t* vengeance_heal;
   const timespan_t vengeance_heal_interval;
 
-  consume_soul_t( demon_hunter_t* p, const std::string& n, const spell_data_t* s, soul_fragment t )
+  consume_soul_t( demon_hunter_t* p, util::string_view n, const spell_data_t* s, soul_fragment t )
     : demon_hunter_heal_t( n, p, s ),
     type( t ),
     vengeance_heal( p->find_specialization_spell( 203783 ) ),
@@ -2293,7 +2293,7 @@ struct fiery_brand_t : public demon_hunter_spell_t
   fiery_brand_dot_t* dot_action;
   bool from_demonic_oath;
 
-  fiery_brand_t( util::string_view name, demon_hunter_t* p, util::string_view options_str = "", bool from_demonic_oath = false )
+  fiery_brand_t( util::string_view name, demon_hunter_t* p, util::string_view options_str = {}, bool from_demonic_oath = false )
     : demon_hunter_spell_t( name, p, from_demonic_oath ? p->find_spell( 204021 ) : p->spec.fiery_brand, options_str ),
     dot_action( nullptr ),
     from_demonic_oath( from_demonic_oath )
@@ -2836,7 +2836,7 @@ struct pick_up_fragment_t : public demon_hunter_spell_t
     range = 5.0;  // Disallow use outside of melee.
   }
 
-  void parse_mode( const std::string& value )
+  void parse_mode( util::string_view value )
   {
     if ( value == "close" || value == "near" || value == "closest" || value == "nearest" )
     {
@@ -2859,7 +2859,7 @@ struct pick_up_fragment_t : public demon_hunter_spell_t
     }
   }
 
-  void parse_type( const std::string& value )
+  void parse_type( util::string_view value )
   {
     if ( value == "greater" )
     {
@@ -3318,7 +3318,7 @@ namespace attacks
       status_e main_hand, off_hand;
     } status;
 
-    auto_attack_damage_t( const std::string& name, demon_hunter_t* p, weapon_t* w, const spell_data_t* s = spell_data_t::nil() )
+    auto_attack_damage_t( util::string_view name, demon_hunter_t* p, weapon_t* w, const spell_data_t* s = spell_data_t::nil() )
       : demon_hunter_attack_t( name, p, s )
     {
       school = SCHOOL_PHYSICAL;
@@ -3535,7 +3535,7 @@ struct blade_dance_base_t : public demon_hunter_attack_t
   trail_of_ruin_dot_t* trail_of_ruin_dot;
   timespan_t ability_cooldown;
 
-  blade_dance_base_t( const std::string& n, demon_hunter_t* p,
+  blade_dance_base_t( util::string_view n, demon_hunter_t* p,
                       const spell_data_t* s, util::string_view options_str, buff_t* dodge_buff )
     : demon_hunter_attack_t( n, p, s, options_str ), dodge_buff( dodge_buff ), trail_of_ruin_dot ( nullptr )
   {
@@ -3764,7 +3764,7 @@ struct chaos_strike_base_t : public demon_hunter_attack_t
   std::vector<chaos_strike_damage_t*> attacks;
   bool from_onslaught;
 
-  chaos_strike_base_t( util::string_view n, demon_hunter_t* p, const spell_data_t* s, util::string_view options_str = "", bool from_onslaught = false )
+  chaos_strike_base_t( util::string_view n, demon_hunter_t* p, const spell_data_t* s, util::string_view options_str = {}, bool from_onslaught = false )
     : demon_hunter_attack_t( n, p, s, options_str ),
     from_onslaught( from_onslaught )
   {
@@ -3825,7 +3825,7 @@ struct chaos_strike_base_t : public demon_hunter_attack_t
 
 struct chaos_strike_t : public chaos_strike_base_t
 {
-  chaos_strike_t( util::string_view name, demon_hunter_t* p, util::string_view options_str = "", bool from_onslaught = false )
+  chaos_strike_t( util::string_view name, demon_hunter_t* p, util::string_view options_str = {}, bool from_onslaught = false )
     : chaos_strike_base_t( name, p, p->spec.chaos_strike, options_str, from_onslaught )
   {
     if ( attacks.empty() )
@@ -3855,7 +3855,7 @@ struct chaos_strike_t : public chaos_strike_base_t
 
 struct annihilation_t : public chaos_strike_base_t
 {
-  annihilation_t( util::string_view name, demon_hunter_t* p, util::string_view options_str = "", bool from_onslaught = false )
+  annihilation_t( util::string_view name, demon_hunter_t* p, util::string_view options_str = {}, bool from_onslaught = false )
     : chaos_strike_base_t( name, p, p->spec.annihilation, options_str, from_onslaught )
   {
     if ( attacks.empty() )
@@ -4504,10 +4504,10 @@ struct demon_hunter_buff_t : public BuffBase
 {
   using base_t = demon_hunter_buff_t;
 
-  demon_hunter_buff_t( demon_hunter_t& p, const std::string& name, const spell_data_t* s = spell_data_t::nil(), const item_t* item = nullptr )
+  demon_hunter_buff_t( demon_hunter_t& p, util::string_view name, const spell_data_t* s = spell_data_t::nil(), const item_t* item = nullptr )
     : BuffBase( &p, name, s, item )
   { }
-  demon_hunter_buff_t( demon_hunter_td_t& td, const std::string& name, const spell_data_t* s = spell_data_t::nil(), const item_t* item = nullptr )
+  demon_hunter_buff_t( demon_hunter_td_t& td, util::string_view name, const spell_data_t* s = spell_data_t::nil(), const item_t* item = nullptr )
     : BuffBase( td, name, s, item )
   { }
 
@@ -4724,7 +4724,7 @@ struct spirit_bomb_event_t : public event_t
   }
 };
 
-movement_buff_t::movement_buff_t( demon_hunter_t* p, const std::string& name, const spell_data_t* spell_data, const item_t* item )
+movement_buff_t::movement_buff_t( demon_hunter_t* p, util::string_view name, const spell_data_t* spell_data, const item_t* item )
   : buff_t( p, name, spell_data, item ), yards_from_melee( 0.0 ), distance_moved( 0.0 ), dh( p )
 {
 }
@@ -5030,7 +5030,7 @@ struct metamorphosis_adjusted_cooldown_expr_t : public expr_t
   demon_hunter_t* dh;
   double cooldown_multiplier;
 
-  metamorphosis_adjusted_cooldown_expr_t( demon_hunter_t* p, const std::string& name_str )
+  metamorphosis_adjusted_cooldown_expr_t( demon_hunter_t* p, util::string_view name_str )
     : expr_t( name_str ), dh( p ), cooldown_multiplier( 1.0 )
   {
   }

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -934,7 +934,7 @@ public:
   form_e get_form() const { return form; }
   void shapeshift( form_e );
   void init_beast_weapon( weapon_t&, double );
-  const spell_data_t* find_affinity_spell( const std::string& ) const;
+  const spell_data_t* find_affinity_spell( util::string_view ) const;
   specialization_e get_affinity_spec() const;
   void moving() override;
   void trigger_natures_guardian( const action_state_t* );
@@ -2487,7 +2487,7 @@ public:
   bool update_eclipse;
 
   druid_spell_t( util::string_view n, druid_t* p, const spell_data_t* s = spell_data_t::nil(),
-                 util::string_view opt = std::string() )
+                 util::string_view opt = {} )
     : ab( n, p, s ), update_eclipse( false )
   {
     parse_options( opt );
@@ -2851,7 +2851,7 @@ struct druid_heal_t : public druid_spell_base_t<heal_t>
   bool target_self;
 
   druid_heal_t( util::string_view token, druid_t* p, const spell_data_t* s = spell_data_t::nil(),
-                util::string_view options_str = std::string() )
+                util::string_view options_str = {} )
     : base_t( token, p, s ), target_self( false )
   {
     add_option( opt_bool( "target_self", target_self ) );
@@ -2908,7 +2908,7 @@ namespace caster_attacks
 struct caster_attack_t : public druid_attack_t<melee_attack_t>
 {
   caster_attack_t( util::string_view token, druid_t* p, const spell_data_t* s = spell_data_t::nil(),
-                   const std::string& options = std::string() )
+                   util::string_view options = {} )
     : base_t( token, p, s )
   {
     parse_options( options );
@@ -2967,7 +2967,7 @@ public:
   std::vector<buff_effect_t> persistent_multiplier_buffeffects;
 
   cat_attack_t( util::string_view token, druid_t* p, const spell_data_t* s = spell_data_t::nil(),
-                util::string_view options = std::string() )
+                util::string_view options = {} )
     : base_t( token, p, s ),
       requires_stealth( false ),
       consumes_combo_points( false ),
@@ -4315,7 +4315,7 @@ struct bear_attack_t : public druid_attack_t<melee_attack_t>
   bool proc_gore;
 
   bear_attack_t( util::string_view n, druid_t* p, const spell_data_t* s = spell_data_t::nil(),
-                 util::string_view options_str = std::string() )
+                 util::string_view options_str = {} )
     : base_t( n, p, s ), proc_gore( false )
   {
     parse_options( options_str );
@@ -10233,7 +10233,7 @@ const affinity_spells_t affinity_spells[] =
     { "Primal Fury", 159286, DRUID_FERAL }
 };
 
-const spell_data_t* druid_t::find_affinity_spell( const std::string& name ) const
+const spell_data_t* druid_t::find_affinity_spell( util::string_view name ) const
 {
   const spell_data_t* spec_spell = find_specialization_spell( name );
 

--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -79,7 +79,7 @@ struct enemy_t : public player_t
   void init_stats() override;
   double resource_loss( resource_e, double, gain_t*, action_t* ) override;
   void create_options() override;
-  pet_t* create_pet( util::string_view add_name, util::string_view pet_type = "" ) override;
+  pet_t* create_pet( util::string_view add_name, util::string_view pet_type = {} ) override;
   void create_pets() override;
   double health_percentage() const override;
   timespan_t time_to_percent( double ) const override;

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -164,14 +164,14 @@ struct buff_stack_benefit_t
   const buff_t* buff;
   std::vector<benefit_t*> buff_stack_benefit;
 
-  buff_stack_benefit_t( const buff_t* _buff, const std::string& prefix ) :
+  buff_stack_benefit_t( const buff_t* _buff, std::string_view prefix ) :
     buff( _buff ),
     buff_stack_benefit()
   {
     for ( int i = 0; i <= buff->max_stack(); i++ )
     {
-      buff_stack_benefit.push_back( buff->player->get_benefit(
-        prefix + " " + buff->data().name_cstr() + " " + util::to_string( i ) ) );
+      auto benefit_name = fmt::format("{} {} {}", prefix, buff->data().name_cstr(), i);
+      buff_stack_benefit.push_back( buff->player->get_benefit( benefit_name ) );
     }
   }
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -854,7 +854,7 @@ private:
 
 public:
   template <typename T, typename... Ts>
-  T* find_background_action( util::string_view n = "" )
+  T* find_background_action( util::string_view n = {} )
   {
     T* found_action = nullptr;
     for ( auto action : background_actions )
@@ -892,7 +892,7 @@ private:
 
 public:
   template <typename T, typename... Ts>
-  T* find_secondary_trigger_action( secondary_trigger_e source, util::string_view n = "" )
+  T* find_secondary_trigger_action( secondary_trigger_e source, util::string_view n = {} )
   {
     T* found_action = nullptr;
     for ( auto action : secondary_trigger_actions )
@@ -1823,7 +1823,7 @@ struct rogue_heal_t : public rogue_action_t<heal_t>
 {
   rogue_heal_t( util::string_view n, rogue_t* p,
                        const spell_data_t* s = spell_data_t::nil(),
-                       const std::string& o = std::string() )
+                       util::string_view o = {} )
     : base_t( n, p, s, o )
   {
     harmful = false;
@@ -2326,7 +2326,7 @@ struct adrenaline_rush_t : public rogue_spell_t
 {
   timespan_t precombat_seconds;
 
-  adrenaline_rush_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  adrenaline_rush_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p->spec.adrenaline_rush ),
     precombat_seconds( 0_s )
   {
@@ -2367,7 +2367,7 @@ struct adrenaline_rush_t : public rogue_spell_t
 
 struct ambush_t : public rogue_attack_t
 {
-  ambush_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  ambush_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_class_spell( "Ambush" ), options_str )
   {
   }
@@ -2386,7 +2386,7 @@ struct ambush_t : public rogue_attack_t
 
 struct backstab_t : public rogue_attack_t
 {
-  backstab_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  backstab_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Backstab" ), options_str )
   {
     if ( p->active.weaponmaster.backstab && p->active.weaponmaster.backstab != this )
@@ -2449,7 +2449,7 @@ struct backstab_t : public rogue_attack_t
 
 struct between_the_eyes_t : public rogue_attack_t
 {
-  between_the_eyes_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  between_the_eyes_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->spec.between_the_eyes, options_str )
   {
     ap_type = attack_power_type::WEAPON_BOTH;
@@ -2536,7 +2536,7 @@ struct blade_flurry_t : public rogue_attack_t
 
   blade_flurry_instant_attack_t* instant_attack;
 
-  blade_flurry_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  blade_flurry_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> spec.blade_flurry, options_str ),
     instant_attack( nullptr )
   {
@@ -2596,7 +2596,7 @@ struct blade_rush_t : public rogue_attack_t
     }
   };
 
-  blade_rush_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  blade_rush_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> talent.blade_rush, options_str )
   {
     execute_action = p->get_background_action<blade_rush_attack_t>( "blade_rush_attack" );
@@ -2619,7 +2619,7 @@ struct bloodfang_t : public rogue_attack_t
 
 struct crimson_tempest_t : public rogue_attack_t
 {
-  crimson_tempest_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  crimson_tempest_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> talent.crimson_tempest, options_str )
   {
     aoe = -1;
@@ -2652,7 +2652,7 @@ struct crimson_tempest_t : public rogue_attack_t
 // This ability does nothing but for some odd reasons throughout the history of Rogue spaghetti, we may want to look at using it. So, let's support it.
 struct detection_t : public rogue_spell_t
 {
-  detection_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  detection_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> find_class_spell( "Detection" ), options_str )
   {
     gcd_type = gcd_haste_type::ATTACK_HASTE;
@@ -2664,7 +2664,7 @@ struct detection_t : public rogue_spell_t
 
 struct dispatch_t: public rogue_attack_t
 {
-  dispatch_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  dispatch_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Dispatch" ), options_str )
   {
   }
@@ -2686,7 +2686,7 @@ struct dispatch_t: public rogue_attack_t
 
 struct dreadblades_t : public rogue_attack_t
 {
-  dreadblades_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  dreadblades_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->talent.dreadblades, options_str )
   {}
 
@@ -2704,7 +2704,7 @@ struct dreadblades_t : public rogue_attack_t
 
 struct envenom_t : public rogue_attack_t
 {
-  envenom_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  envenom_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->spec.envenom, options_str )
   {
     dot_duration = timespan_t::zero();
@@ -2781,7 +2781,7 @@ struct eviscerate_t : public rogue_attack_t
 
   eviscerate_bonus_t* bonus_attack;
 
-  eviscerate_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  eviscerate_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_attack_t( name, p, p->spec.eviscerate, options_str ),
     bonus_attack( nullptr )
   {
@@ -2818,7 +2818,7 @@ struct eviscerate_t : public rogue_attack_t
 
 struct exsanguinate_t : public rogue_attack_t
 {
-  exsanguinate_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  exsanguinate_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_attack_t( name, p, p -> talent.exsanguinate, options_str )
   { }
 
@@ -2834,7 +2834,7 @@ struct exsanguinate_t : public rogue_attack_t
 
 struct fan_of_knives_t: public rogue_attack_t
 {
-  fan_of_knives_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  fan_of_knives_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_attack_t( name, p, p -> find_specialization_spell( "Fan of Knives" ), options_str )
   {
     energize_type     = action_energize::ON_HIT;
@@ -2873,7 +2873,7 @@ struct fan_of_knives_t: public rogue_attack_t
 
 struct feint_t : public rogue_attack_t
 {
-  feint_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  feint_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_attack_t( name, p, p -> find_class_spell( "Feint" ), options_str )
   { }
 
@@ -2888,7 +2888,7 @@ struct feint_t : public rogue_attack_t
 
 struct garrote_t : public rogue_attack_t
 {
-  garrote_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  garrote_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> spec.garrote, options_str )
   {
   }
@@ -2938,7 +2938,7 @@ struct garrote_t : public rogue_attack_t
 
 struct gouge_t : public rogue_attack_t
 {
-  gouge_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  gouge_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Gouge" ), options_str )
   {
     if ( p -> talent.dirty_tricks -> ok() )
@@ -2958,7 +2958,7 @@ struct gouge_t : public rogue_attack_t
 
 struct ghostly_strike_t : public rogue_attack_t
 {
-  ghostly_strike_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  ghostly_strike_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> talent.ghostly_strike, options_str )
   {
   }
@@ -2982,7 +2982,7 @@ struct ghostly_strike_t : public rogue_attack_t
 
 struct gloomblade_t : public rogue_attack_t
 {
-  gloomblade_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  gloomblade_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> talent.gloomblade, options_str )
   {
   }
@@ -3017,7 +3017,7 @@ struct gloomblade_t : public rogue_attack_t
 
 struct kick_t : public rogue_attack_t
 {
-  kick_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  kick_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_class_spell( "Kick" ), options_str )
   {
     is_interrupt = true;
@@ -3058,7 +3058,7 @@ struct killing_spree_t : public rogue_attack_t
   melee_attack_t* attack_mh;
   melee_attack_t* attack_oh;
 
-  killing_spree_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  killing_spree_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->talent.killing_spree, options_str ),
     attack_mh( nullptr ), attack_oh( nullptr )
   {
@@ -3106,7 +3106,7 @@ struct killing_spree_t : public rogue_attack_t
 
 struct pistol_shot_t : public rogue_attack_t
 {
-  pistol_shot_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  pistol_shot_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Pistol Shot" ), options_str )
   {
     ap_type = attack_power_type::WEAPON_BOTH;
@@ -3231,7 +3231,7 @@ struct marked_for_death_t : public rogue_spell_t
 {
   double precombat_seconds;
 
-  marked_for_death_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  marked_for_death_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_spell_t( name, p, p -> find_talent_spell( "Marked for Death" ) ),
     precombat_seconds( 0.0 )
   {
@@ -3319,7 +3319,7 @@ struct mutilate_t : public rogue_attack_t
   mutilate_strike_t* mh_strike;
   mutilate_strike_t* oh_strike;
 
-  mutilate_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  mutilate_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Mutilate" ), options_str ),
     mh_strike( nullptr ), oh_strike( nullptr )
   {
@@ -3382,7 +3382,7 @@ struct roll_the_bones_t : public rogue_spell_t
 {
   timespan_t precombat_seconds;
 
-  roll_the_bones_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  roll_the_bones_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> spec.roll_the_bones ),
     precombat_seconds( 0_s )
   {
@@ -3409,7 +3409,7 @@ struct roll_the_bones_t : public rogue_spell_t
 
 struct rupture_t : public rogue_attack_t
 {
-  rupture_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  rupture_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Rupture" ), options_str )
   {
   }
@@ -3519,7 +3519,7 @@ struct secret_technique_t : public rogue_attack_t
   secret_technique_attack_t* player_attack;
   secret_technique_attack_t* clone_attack;
 
-  secret_technique_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  secret_technique_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->talent.secret_technique, options_str )
   {
     may_miss = false;
@@ -3581,7 +3581,7 @@ struct shadow_blades_t : public rogue_spell_t
 {
   timespan_t precombat_seconds;
 
-  shadow_blades_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shadow_blades_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p->spec.shadow_blades ),
     precombat_seconds( 0_s )
   {
@@ -3614,7 +3614,7 @@ struct shadow_dance_t : public rogue_spell_t
 {
   //cooldown_t* icd;
 
-  shadow_dance_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shadow_dance_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p->spec.shadow_dance, options_str )
   {
     harmful = false;
@@ -3646,7 +3646,7 @@ struct shadow_dance_t : public rogue_spell_t
 
 struct shadowstep_t : public rogue_spell_t
 {
-  shadowstep_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shadowstep_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> spec.shadowstep, options_str )
   {
     harmful = false;
@@ -3681,7 +3681,7 @@ struct akaaris_shadowstrike_t : public rogue_attack_t
 
 struct shadowstrike_t : public rogue_attack_t
 {
-  shadowstrike_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shadowstrike_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> spec.shadowstrike, options_str )
   {
   }
@@ -3828,7 +3828,7 @@ struct black_powder_t: public rogue_attack_t
 
   black_powder_bonus_t* bonus_attack;
 
-  black_powder_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  black_powder_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_attack_t( name, p, p->spec.black_powder, options_str ),
     bonus_attack( nullptr )
   {
@@ -3893,7 +3893,7 @@ struct black_powder_t: public rogue_attack_t
 
 struct shuriken_storm_t: public rogue_attack_t
 {
-  shuriken_storm_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  shuriken_storm_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_attack_t( name, p, p -> find_specialization_spell( "Shuriken Storm" ), options_str )
   {
     energize_type = action_energize::PER_HIT;
@@ -3927,7 +3927,7 @@ struct shuriken_storm_t: public rogue_attack_t
 
 struct shuriken_tornado_t : public rogue_spell_t
 {
-  shuriken_tornado_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shuriken_tornado_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> talent.shuriken_tornado, options_str )
   {
     dot_duration = timespan_t::zero();
@@ -3952,7 +3952,7 @@ struct shuriken_tornado_t : public rogue_spell_t
 
 struct shuriken_toss_t : public rogue_attack_t
 {
-  shuriken_toss_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shuriken_toss_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Shuriken Toss" ), options_str )
   {
     ap_type = attack_power_type::WEAPON_BOTH;
@@ -4017,7 +4017,7 @@ struct sinister_strike_t : public rogue_attack_t
 
   sinister_strike_extra_attack_t* extra_attack;
 
-  sinister_strike_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  sinister_strike_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->spec.sinister_strike, options_str )
   {
     extra_attack = p->get_secondary_trigger_action<sinister_strike_extra_attack_t>( TRIGGER_SINISTER_STRIKE, "sinister_strike_extra_attack" );
@@ -4074,7 +4074,7 @@ struct slice_and_dice_t : public rogue_spell_t
 {
   timespan_t precombat_seconds;
 
-  slice_and_dice_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  slice_and_dice_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> spell.slice_and_dice ),
     precombat_seconds( 0_s )
   {
@@ -4133,7 +4133,7 @@ struct slice_and_dice_t : public rogue_spell_t
 
 struct sprint_t : public rogue_spell_t
 {
-  sprint_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ):
+  sprint_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ):
     rogue_spell_t( name, p, p -> spell.sprint, options_str )
   {
     harmful = callbacks = false;
@@ -4151,7 +4151,7 @@ struct sprint_t : public rogue_spell_t
 
 struct symbols_of_death_t : public rogue_spell_t
 {
-  symbols_of_death_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  symbols_of_death_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> spec.symbols_of_death, options_str )
   {
     harmful = callbacks = false;
@@ -4174,7 +4174,7 @@ struct symbols_of_death_t : public rogue_spell_t
 
 struct shiv_t : public rogue_attack_t
 {
-  shiv_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  shiv_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->find_class_spell( "Shiv" ), options_str )
   {
   }
@@ -4205,7 +4205,7 @@ struct shiv_t : public rogue_attack_t
 struct vanish_t : public rogue_spell_t
 {
 
-  vanish_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  vanish_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p -> find_class_spell( "Vanish" ), options_str )
   {
     harmful = false;
@@ -4234,7 +4234,7 @@ struct vendetta_t : public rogue_spell_t
 {
   timespan_t precombat_seconds;
 
-  vendetta_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  vendetta_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p->spec.vendetta, options_str ),
     precombat_seconds( 0_s )
   {
@@ -4271,7 +4271,7 @@ struct vendetta_t : public rogue_spell_t
 
 struct stealth_t : public rogue_spell_t
 {
-  stealth_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  stealth_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p->find_class_spell( "Stealth" ), options_str )
   {
     harmful = false;
@@ -4342,7 +4342,7 @@ struct kidney_shot_t : public rogue_attack_t
 
   internal_bleeding_t* internal_bleeding;
 
-  kidney_shot_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  kidney_shot_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_class_spell( "Kidney Shot" ), options_str ),
     internal_bleeding( nullptr )
   {
@@ -4370,7 +4370,7 @@ struct kidney_shot_t : public rogue_attack_t
 
 struct cheap_shot_t : public rogue_attack_t
 {
-  cheap_shot_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  cheap_shot_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_class_spell( "Cheap Shot" ), options_str )
   {
   }
@@ -4407,7 +4407,7 @@ struct poison_bomb_t : public rogue_attack_t
 
 struct poisoned_knife_t : public rogue_attack_t
 {
-  poisoned_knife_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  poisoned_knife_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p -> find_specialization_spell( "Poisoned Knife" ), options_str )
   {
   }
@@ -4426,7 +4426,7 @@ struct echoing_reprimand_t : public rogue_attack_t
 {
   double random_min, random_max;
 
-  echoing_reprimand_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  echoing_reprimand_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->covenant.echoing_reprimand, options_str ),
     random_min( 0 ), random_max( 3 ) // Randomizes between 2CP and 4CP buffs
   {
@@ -4482,7 +4482,7 @@ struct flagellation_t : public rogue_attack_t
 {
   int initial_lashes;
 
-  flagellation_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  flagellation_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->covenant.flagellation, options_str ),
     initial_lashes()
   {
@@ -4548,7 +4548,7 @@ struct sepsis_t : public rogue_attack_t
 
   sepsis_expire_damage_t* sepsis_expire_damage;
 
-  sepsis_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  sepsis_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->covenant.sepsis, options_str )
   {
     // 04/22/2021 - Not in the whitelist but confirmed as working in-game
@@ -4643,7 +4643,7 @@ struct serrated_bone_spike_t : public rogue_attack_t
   int base_impact_cp;
   serrated_bone_spike_dot_t* serrated_bone_spike_dot;
 
-  serrated_bone_spike_t( util::string_view name, rogue_t* p, util::string_view options_str = "" ) :
+  serrated_bone_spike_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_attack_t( name, p, p->covenant.serrated_bone_spike, options_str )
   {
     // Combo Point generation is in a secondary spell due to scripting logic
@@ -4740,7 +4740,7 @@ struct serrated_bone_spike_t : public rogue_attack_t
 struct cancel_autoattack_t : public action_t
 {
   rogue_t* rogue;
-  cancel_autoattack_t( rogue_t* rogue_, util::string_view options_str = "" ) :
+  cancel_autoattack_t( rogue_t* rogue_, util::string_view options_str = {} ) :
     action_t( ACTION_OTHER, "cancel_autoattack", rogue_ ),
     rogue( rogue_ )
   {

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -860,7 +860,7 @@ public:
   double composite_maelstrom_gain_coefficient( const action_state_t* state = nullptr ) const;
   double matching_gear_multiplier( attribute_e attr ) const override;
   action_t* create_action( util::string_view name, util::string_view options ) override;
-  pet_t* create_pet( util::string_view name, util::string_view type = "" ) override;
+  pet_t* create_pet( util::string_view name, util::string_view type = {} ) override;
   void create_pets() override;
   std::unique_ptr<expr_t> create_expression( util::string_view name ) override;
   resource_e primary_resource() const override
@@ -901,7 +901,7 @@ public:
                                   bool inherit_state = false );
 
   template <typename T_CONTAINER, typename T_DATA>
-  T_CONTAINER* get_data_entry( const std::string& name, std::vector<T_DATA*>& entries )
+  T_CONTAINER* get_data_entry( util::string_view name, std::vector<T_DATA*>& entries )
   {
     for ( size_t i = 0; i < entries.size(); i++ )
     {
@@ -1417,7 +1417,7 @@ public:
 
   proc_t *proc_wf, *proc_ft, *proc_fb, *proc_mw, *proc_sb, *proc_ls, *proc_hh;
 
-  shaman_attack_t( const std::string& token, shaman_t* p, const spell_data_t* s )
+  shaman_attack_t( util::string_view token, shaman_t* p, const spell_data_t* s )
     : base_t( token, p, s ),
       may_proc_windfury( p->spec.windfury->ok() ),
       may_proc_flametongue( true ),
@@ -1612,7 +1612,7 @@ public:
   // General things
   execute_type exec_type;
 
-  shaman_spell_t( const std::string& token, shaman_t* p, const spell_data_t* s = spell_data_t::nil() ) :
+  shaman_spell_t( util::string_view token, shaman_t* p, const spell_data_t* s = spell_data_t::nil() ) :
     base_t( token, p, s ), overload( nullptr ), proc_sb( nullptr ),
     may_proc_echoing_shock( false ),
     echoing_shock_stats( nullptr ), normal_stats( nullptr ),
@@ -2044,7 +2044,7 @@ struct shaman_pet_t : public pet_t
 {
   bool use_auto_attack;
 
-  shaman_pet_t( shaman_t* owner, const std::string& name, bool guardian = true, bool auto_attack = true )
+  shaman_pet_t( shaman_t* owner, util::string_view name, bool guardian = true, bool auto_attack = true )
     : pet_t( owner->sim, owner, name, guardian ), use_auto_attack( auto_attack )
   {
     resource_regeneration = regen_type::DISABLED;
@@ -2100,7 +2100,7 @@ struct pet_action_t : public T_ACTION
 {
   using super = pet_action_t<T_PET, T_ACTION>;
 
-  pet_action_t( T_PET* pet, const std::string& name, const spell_data_t* spell = spell_data_t::nil(),
+  pet_action_t( T_PET* pet, util::string_view name, const spell_data_t* spell = spell_data_t::nil(),
                 util::string_view options = {} )
     : T_ACTION( name, pet, spell )
   {
@@ -2142,8 +2142,8 @@ struct pet_melee_attack_t : public pet_action_t<T_PET, melee_attack_t>
 {
   using super = pet_melee_attack_t<T_PET>;
 
-  pet_melee_attack_t( T_PET* pet, const std::string& name, const spell_data_t* spell = spell_data_t::nil(),
-                      const std::string& options = std::string() )
+  pet_melee_attack_t( T_PET* pet, util::string_view name, const spell_data_t* spell = spell_data_t::nil(),
+                      util::string_view options = {} )
     : pet_action_t<T_PET, melee_attack_t>( pet, name, spell, options )
   {
     if ( this->school == SCHOOL_NONE )
@@ -2210,7 +2210,7 @@ struct pet_spell_t : public pet_action_t<T_PET, spell_t>
 {
   using super = pet_spell_t<T_PET>;
 
-  pet_spell_t( T_PET* pet, const std::string& name, const spell_data_t* spell = spell_data_t::nil(),
+  pet_spell_t( T_PET* pet, util::string_view name, const spell_data_t* spell = spell_data_t::nil(),
                util::string_view options = {} )
     : pet_action_t<T_PET, spell_t>( pet, name, spell, options )
   {
@@ -2240,7 +2240,7 @@ struct base_wolf_t : public shaman_pet_t
   buff_t* alpha_wolf_buff;
   wolf_type_e wolf_type;
 
-  base_wolf_t( shaman_t* owner, const std::string& name )
+  base_wolf_t( shaman_t* owner, util::string_view name )
     : shaman_pet_t( owner, name ), alpha_wolf( nullptr ), alpha_wolf_buff( nullptr ), wolf_type( SPIRIT_WOLF )
   {
     owner_coeff.ap_from_ap = 1.5;
@@ -2254,7 +2254,7 @@ struct wolf_base_auto_attack_t : public pet_melee_attack_t<T>
 {
   using super = wolf_base_auto_attack_t<T>;
 
-  wolf_base_auto_attack_t( T* wolf, const std::string& n, const spell_data_t* spell = spell_data_t::nil(),
+  wolf_base_auto_attack_t( T* wolf, util::string_view n, const spell_data_t* spell = spell_data_t::nil(),
                            util::string_view options_str = {} )
     : pet_melee_attack_t<T>( wolf, n, spell )
   {
@@ -2318,7 +2318,7 @@ struct elemental_wolf_base_t : public base_wolf_t
 
   cooldown_t* special_ability_cd;
 
-  elemental_wolf_base_t( shaman_t* owner, const std::string& name )
+  elemental_wolf_base_t( shaman_t* owner, util::string_view name )
     : base_wolf_t( owner, name ), special_ability_cd( nullptr )
   {
     dynamic = true;
@@ -2385,7 +2385,7 @@ struct primal_elemental_t : public shaman_pet_t
     }
   };
 
-  primal_elemental_t( shaman_t* owner, const std::string& name, bool guardian = false, bool auto_attack = true )
+  primal_elemental_t( shaman_t* owner, util::string_view name, bool guardian = false, bool auto_attack = true )
     : shaman_pet_t( owner, name, guardian, auto_attack )
   {
   }
@@ -2700,7 +2700,7 @@ struct storm_elemental_t : public primal_elemental_t
 
 struct flametongue_weapon_spell_t : public shaman_spell_t  // flametongue_attack
 {
-  flametongue_weapon_spell_t( const std::string& n, shaman_t* player, weapon_t* /* w */ )
+  flametongue_weapon_spell_t( util::string_view n, shaman_t* player, weapon_t* /* w */ )
     : shaman_spell_t( n, player, player->find_spell( 10444 ) )
   {
     may_crit = background      = true;
@@ -2726,7 +2726,7 @@ struct windfury_attack_t : public shaman_attack_t
     std::array<proc_t*, 6> at_fw;
   } stats_;
 
-  windfury_attack_t( const std::string& n, shaman_t* player, const spell_data_t* s, weapon_t* w )
+  windfury_attack_t( util::string_view n, shaman_t* player, const spell_data_t* s, weapon_t* w )
     : shaman_attack_t( n, player, s )
   {
     weapon     = w;
@@ -2816,7 +2816,7 @@ struct crashing_storm_damage_t : public shaman_spell_t
 
 struct icy_edge_attack_t : public shaman_attack_t
 {
-  icy_edge_attack_t( const std::string& n, shaman_t* p, weapon_t* w ) : shaman_attack_t( n, p, p->find_spell( 271920 ) )
+  icy_edge_attack_t( util::string_view n, shaman_t* p, weapon_t* w ) : shaman_attack_t( n, p, p->find_spell( 271920 ) )
   {
     weapon                 = w;
     background             = true;
@@ -2836,7 +2836,7 @@ struct stormstrike_attack_t : public shaman_attack_t
 {
   bool stormflurry, stormbringer;
 
-  stormstrike_attack_t( const std::string& n, shaman_t* player, const spell_data_t* s, weapon_t* w )
+  stormstrike_attack_t( util::string_view n, shaman_t* player, const spell_data_t* s, weapon_t* w )
     : shaman_attack_t( n, player, s ), stormflurry( false ), stormbringer( false )
   {
     background = true;
@@ -2893,7 +2893,7 @@ struct stormstrike_attack_t : public shaman_attack_t
 
 struct windstrike_attack_t : public stormstrike_attack_t
 {
-  windstrike_attack_t( const std::string& n, shaman_t* player, const spell_data_t* s, weapon_t* w )
+  windstrike_attack_t( util::string_view n, shaman_t* player, const spell_data_t* s, weapon_t* w )
     : stormstrike_attack_t( n, player, s, w )
   { }
 
@@ -2907,7 +2907,7 @@ struct windlash_t : public shaman_attack_t
 {
   double swing_timer_variance;
 
-  windlash_t( const std::string& n, const spell_data_t* s, shaman_t* player, weapon_t* w, double stv )
+  windlash_t( util::string_view n, const spell_data_t* s, shaman_t* player, weapon_t* w, double stv )
     : shaman_attack_t( n, player, s ), swing_timer_variance( stv )
   {
     background = repeating = may_miss = may_dodge = may_parry = true;
@@ -2951,7 +2951,7 @@ struct windlash_t : public shaman_attack_t
 // Ground AOE pulse
 struct ground_aoe_spell_t : public spell_t
 {
-  ground_aoe_spell_t( shaman_t* p, const std::string& name, const spell_data_t* spell ) : spell_t( name, p, spell )
+  ground_aoe_spell_t( shaman_t* p, util::string_view name, const spell_data_t* spell ) : spell_t( name, p, spell )
   {
     aoe        = -1;
     callbacks  = false;
@@ -2993,7 +2993,7 @@ struct elemental_overload_spell_t : public shaman_spell_t
 {
   shaman_spell_t* parent;
 
-  elemental_overload_spell_t( shaman_t* p, const std::string& name, const spell_data_t* s, shaman_spell_t* parent_ )
+  elemental_overload_spell_t( shaman_t* p, util::string_view name, const spell_data_t* s, shaman_spell_t* parent_ )
     : shaman_spell_t( name, p, s ), parent( parent_ )
   {
     base_execute_time = timespan_t::zero();
@@ -3100,7 +3100,7 @@ struct melee_t : public shaman_attack_t
   bool first;
   double swing_timer_variance;
 
-  melee_t( const std::string& name, const spell_data_t* s, shaman_t* player, weapon_t* w, int sw, double stv )
+  melee_t( util::string_view name, const spell_data_t* s, shaman_t* player, weapon_t* w, int sw, double stv )
     : shaman_attack_t( name, player, s ), sync_weapons( sw ), first( true ), swing_timer_variance( stv )
   {
     background = repeating = may_glance = true;
@@ -3361,7 +3361,7 @@ struct stormstrike_base_t : public shaman_attack_t
   stormstrike_attack_t *mh, *oh;
   bool stormflurry;
 
-  stormstrike_base_t( shaman_t* player, const std::string& name, const spell_data_t* spell,
+  stormstrike_base_t( shaman_t* player, util::string_view name, const spell_data_t* spell,
                       util::string_view options_str )
     : shaman_attack_t( name, player, spell ), mh( nullptr ), oh( nullptr ),
       stormflurry( false )
@@ -3599,7 +3599,7 @@ struct weapon_imbue_t : public shaman_spell_t
   slot_e slot, default_slot;
   imbue_e imbue;
 
-  weapon_imbue_t( const std::string& name, shaman_t* player, slot_e d_, const spell_data_t* spell, util::string_view options_str ) :
+  weapon_imbue_t( util::string_view name, shaman_t* player, slot_e d_, const spell_data_t* spell, util::string_view options_str ) :
     shaman_spell_t( name, player, spell ), slot( SLOT_INVALID ), default_slot( d_ ), imbue( IMBUE_NONE )
   {
     harmful = false;
@@ -3967,7 +3967,7 @@ struct bloodlust_t : public shaman_spell_t
 
 struct chained_overload_base_t : public elemental_overload_spell_t
 {
-  chained_overload_base_t( shaman_t* p, const std::string& name, const spell_data_t* spell, double mg, shaman_spell_t* parent_ )
+  chained_overload_base_t( shaman_t* p, util::string_view name, const spell_data_t* spell, double mg, shaman_spell_t* parent_ )
     : elemental_overload_spell_t( p, name, spell, parent_ )
   {
     if ( data().effectN( 1 ).chain_multiplier() != 0 )
@@ -4014,7 +4014,7 @@ struct lava_beam_overload_t : public chained_overload_base_t
 
 struct chained_base_t : public shaman_spell_t
 {
-  chained_base_t( shaman_t* player, const std::string& name, const spell_data_t* spell, double mg,
+  chained_base_t( shaman_t* player, util::string_view name, const spell_data_t* spell, double mg,
                   util::string_view options_str )
     : shaman_spell_t( name, player, spell )
   {
@@ -4285,12 +4285,12 @@ struct lava_burst_overload_t : public elemental_overload_spell_t
   lava_burst_type type;
   bool wlr_buffed_impact;
 
-  static std::string action_name( const std::string& suffix )
+  static std::string action_name( util::string_view suffix )
   {
-    return !suffix.empty() ? "lava_burst_overload_" + suffix : "lava_burst_overload";
+    return !suffix.empty() ? util::string_join("lava_burst_overload_", suffix) : "lava_burst_overload";
   }
 
-  lava_burst_overload_t( shaman_t* player, lava_burst_type type, shaman_spell_t* parent_, const std::string& suffix )
+  lava_burst_overload_t( shaman_t* player, lava_burst_type type, shaman_spell_t* parent_, util::string_view suffix )
     : elemental_overload_spell_t( player, action_name( suffix ), player->find_spell( 285466 ), parent_ ),
       impact_flags(), type(type), wlr_buffed_impact( false )
   {
@@ -4560,13 +4560,13 @@ struct lava_burst_t : public shaman_spell_t
   unsigned impact_flags;
   bool wlr_buffed_impact;
 
-  static std::string action_name( const std::string& suffix )
+  static std::string action_name( util::string_view suffix )
   {
-    return !suffix.empty() ? "lava_burst_" + suffix : "lava_burst";
+    return !suffix.empty() ? util::string_join( "lava_burst_", suffix ) : "lava_burst";
   }
 
-  lava_burst_t( shaman_t* player, lava_burst_type type_, const std::string& suffix,
-                util::string_view options_str = std::string() )
+  lava_burst_t( shaman_t* player, lava_burst_type type_, util::string_view suffix,
+                util::string_view options_str = {} )
     : shaman_spell_t( action_name( suffix ), player,
                       player->find_specialization_spell( "Lava Burst" ) ),
       type( type_ ), impact_flags(), wlr_buffed_impact( false )
@@ -4871,7 +4871,7 @@ struct lightning_bolt_t : public shaman_spell_t
     }
   }
 
-  lightning_bolt_t( shaman_t* player, lightning_bolt_type type_, util::string_view options_str = std::string() ) :
+  lightning_bolt_t( shaman_t* player, lightning_bolt_type type_, util::string_view options_str = {} ) :
     shaman_spell_t( action_name( type_ ), player, player->find_class_spell( "Lightning Bolt" ) ),
     type( type_ )
   {
@@ -5543,7 +5543,7 @@ struct flame_shock_t : public shaman_spell_t
   const spell_data_t* elemental_resource;
   const spell_data_t* skybreakers_effect;
 
-  flame_shock_t( shaman_t* player, util::string_view options_str = std::string() ) :
+  flame_shock_t( shaman_t* player, util::string_view options_str = {} ) :
     shaman_spell_t( "flame_shock", player, player->find_class_spell( "Flame Shock" ) ),
     spreader( player->talent.surge_of_power->ok() ? new flame_shock_spreader_t( player ) : nullptr ),
     elemental_resource( player->find_spell( 263819 ) ),
@@ -5803,7 +5803,7 @@ struct wind_shear_t : public shaman_spell_t
 
 struct ascendance_damage_t : public shaman_spell_t
 {
-  ascendance_damage_t( shaman_t* player, const std::string& name_str )
+  ascendance_damage_t( shaman_t* player, util::string_view name_str )
     : shaman_spell_t( name_str, player, player->find_spell( 344548 ) )
   {
     aoe = -1;
@@ -5819,7 +5819,7 @@ struct ascendance_t : public shaman_spell_t
   ascendance_damage_t* ascendance_damage;
   lava_burst_t* lvb;
 
-  ascendance_t( shaman_t* player, const std::string& name_str, util::string_view options_str = std::string() ) :
+  ascendance_t( shaman_t* player, util::string_view name_str, util::string_view options_str = {} ) :
     shaman_spell_t( name_str, player, player->find_talent_spell( "Ascendance", player->specialization(), false, false ) ),
     fs( player->specialization() == SHAMAN_ELEMENTAL ? new flame_shock_t( player, "" ) : nullptr ),
     ascendance_damage( nullptr ), lvb( nullptr )
@@ -6307,7 +6307,7 @@ struct shaman_totem_pet_t : public pet_t
   std::string pet_name;
   pet_t* summon_pet;
 
-  shaman_totem_pet_t( shaman_t* p, const std::string& n )
+  shaman_totem_pet_t( shaman_t* p, util::string_view n )
     : pet_t( p->sim, p, n, true ),
       pulse_action( nullptr ),
       pulse_event( nullptr ),
@@ -6376,7 +6376,7 @@ struct shaman_totem_t : public shaman_spell_t
   shaman_totem_pet_t* totem_pet;
   timespan_t totem_duration;
 
-  shaman_totem_t( const std::string& totem_name, shaman_t* player, util::string_view options_str,
+  shaman_totem_t( util::string_view totem_name, shaman_t* player, util::string_view options_str,
                   const spell_data_t* spell_data ) :
     shaman_spell_t( totem_name, player, spell_data ),
     totem_pet( nullptr ), totem_duration( data().duration() )
@@ -6432,7 +6432,7 @@ struct totem_pulse_action_t : public spell_t
   double pulse_multiplier;
   shaman_totem_pet_t* totem;
 
-  totem_pulse_action_t( const std::string& token, shaman_totem_pet_t* p, const spell_data_t* s )
+  totem_pulse_action_t( util::string_view token, shaman_totem_pet_t* p, const spell_data_t* s )
     : spell_t( token, p, s ), hasted_pulse( false ), pulse_multiplier( 1.0 ), totem( p )
   {
     may_crit = harmful = background = true;
@@ -6684,7 +6684,7 @@ struct fae_transfusion_tick_t : public shaman_spell_t
 {
   const spell_data_t* seeds_effect;
 
-  fae_transfusion_tick_t( const std::string& n, shaman_t* player )
+  fae_transfusion_tick_t( util::string_view n, shaman_t* player )
     : shaman_spell_t( n, player, player->find_spell( 328928 ) ),
       seeds_effect( player->find_spell( 356218 ) )
   {

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -41,7 +41,7 @@ using data_t        = std::pair<std::string, simple_sample_data_with_min_max_t>;
 using simple_data_t = std::pair<std::string, simple_sample_data_t>;
 
 template <typename T_CONTAINER, typename T_DATA>
-T_CONTAINER* get_data_entry( const std::string& name, std::vector<T_DATA*>& entries )
+T_CONTAINER* get_data_entry( util::string_view name, std::vector<T_DATA*>& entries )
 {
   for ( size_t i = 0; i < entries.size(); i++ )
   {
@@ -1234,7 +1234,7 @@ public:
 
 struct warrior_heal_t : public warrior_action_t<heal_t>
 {  // Main Warrior Heal Class
-  warrior_heal_t( const std::string& n, warrior_t* p, const spell_data_t* s = spell_data_t::nil() ) : base_t( n, p, s )
+  warrior_heal_t( util::string_view n, warrior_t* p, const spell_data_t* s = spell_data_t::nil() ) : base_t( n, p, s )
   {
     may_crit = tick_may_crit = hasted_ticks = false;
     target                                  = p;
@@ -1380,7 +1380,7 @@ struct melee_t : public warrior_attack_t
   bool mh_lost_melee_contact, oh_lost_melee_contact;
   double base_rage_generation, arms_rage_multiplier, fury_rage_multiplier, seasoned_soldier_crit_mult;
   devastator_t* devastator;
-  melee_t( const std::string& name, warrior_t* p )
+  melee_t( util::string_view name, warrior_t* p )
     : warrior_attack_t( name, p, spell_data_t::nil() ), reckless_flurry( nullptr ),
       mh_lost_melee_contact( true ),
       oh_lost_melee_contact( true ),
@@ -1624,7 +1624,7 @@ struct mortal_strike_unhinged_t : public warrior_attack_t
   bool from_mortal_combo;
   double enduring_blow_chance;
   double mortal_combo_chance;
-  mortal_strike_unhinged_t( warrior_t* p, const std::string& name, bool mortal_combo = false )
+  mortal_strike_unhinged_t( warrior_t* p, util::string_view name, bool mortal_combo = false )
   : warrior_attack_t( name, p, p->spec.mortal_strike ), mortal_combo_strike( nullptr ),
   from_mortal_combo( mortal_combo ),
   enduring_blow_chance( p->legendary.enduring_blow->proc_chance() ),
@@ -1834,7 +1834,7 @@ struct mortal_strike_t : public warrior_attack_t
 
 struct bladestorm_tick_t : public warrior_attack_t
 {
-  bladestorm_tick_t( warrior_t* p, const std::string& name, const spell_data_t* spell )
+  bladestorm_tick_t( warrior_t* p, util::string_view name, const spell_data_t* spell )
     : warrior_attack_t( name, p, spell )
 
   {
@@ -3757,7 +3757,7 @@ struct rampage_attack_t : public warrior_attack_t
   double rage_from_valarjar_berserking;
   double rage_from_simmering_rage;
   double reckless_defense_chance;
-  rampage_attack_t( warrior_t* p, const spell_data_t* rampage, const std::string& name )
+  rampage_attack_t( warrior_t* p, const spell_data_t* rampage, util::string_view name )
     : warrior_attack_t( name, p, rampage ),
       aoe_targets( as<int>( p->spell.whirlwind_buff->effectN( 1 ).base_value() ) ),
       first_attack( false ),
@@ -3973,7 +3973,7 @@ struct rampage_parent_t : public warrior_attack_t
 struct ravager_tick_t : public warrior_attack_t
 {
   double rage_from_ravager;
-  ravager_tick_t( warrior_t* p, const std::string& name )
+  ravager_tick_t( warrior_t* p, util::string_view name )
     : warrior_attack_t( name, p, p->find_spell( 156287 ) ), rage_from_ravager( 0.0 )
   {
     aoe = -1;
@@ -5597,7 +5597,7 @@ struct in_for_the_kill_t : public buff_t
   double below_pct_increase_amount;
   double below_pct_increase;
 
-  in_for_the_kill_t( warrior_t& p, const std::string& n, const spell_data_t* s )
+  in_for_the_kill_t( warrior_t& p, util::string_view n, const spell_data_t* s )
     : buff_t( &p, n, s ),
       base_value( p.talents.in_for_the_kill->effectN( 1 ).percent() ),
       below_pct_increase_amount( p.talents.in_for_the_kill->effectN( 2 ).percent() ),
@@ -6968,13 +6968,13 @@ public:
   using base_t = warrior_buff_t;
 
 
-  warrior_buff_t( warrior_td_t& td, const std::string& name, const spell_data_t* s = spell_data_t::nil(),
+  warrior_buff_t( warrior_td_t& td, util::string_view name, const spell_data_t* s = spell_data_t::nil(),
                  const item_t* item = nullptr )
     : Base( td, name, s, item )
   {
   }
 
-  warrior_buff_t( warrior_t& p, const std::string& name, const spell_data_t* s = spell_data_t::nil(),
+  warrior_buff_t( warrior_t& p, util::string_view name, const spell_data_t* s = spell_data_t::nil(),
                  const item_t* item = nullptr )
     : Base( &p, name, s, item )
   {
@@ -6995,7 +6995,7 @@ protected:
 
 struct deadly_calm_t : public warrior_buff_t<buff_t>
 {
-  deadly_calm_t( warrior_t& p, const std::string& n, const spell_data_t* s ) :
+  deadly_calm_t( warrior_t& p, util::string_view n, const spell_data_t* s ) :
     base_t( p, n, s )
   {
    //set_initial_stacks( 4 ); trigger initial stacks in spell execution
@@ -7052,7 +7052,7 @@ struct rallying_cry_t : public buff_t
 struct last_stand_buff_t : public warrior_buff_t<buff_t>
 {
   double health_change;
-  last_stand_buff_t( warrior_t& p, const std::string& n, const spell_data_t* s ) :
+  last_stand_buff_t( warrior_t& p, util::string_view n, const spell_data_t* s ) :
     base_t( p, n, s ), health_change( data().effectN( 1 ).percent() )
   {
     add_invalidate( CACHE_BLOCK );
@@ -7129,7 +7129,7 @@ struct debuff_demo_shout_t : public warrior_buff_t<buff_t>
 
 struct test_of_might_t : public warrior_buff_t<buff_t>
 {
-  test_of_might_t( warrior_t& p, const std::string& n, const spell_data_t* s )
+  test_of_might_t( warrior_t& p, util::string_view n, const spell_data_t* s )
     : base_t( p, n, s )
   {
     quiet = true;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -511,7 +511,7 @@ public:
   void malignancy_reduction_helper();
   bool min_version_check( version_check_e version ) const;
   action_t* create_action( util::string_view name, util::string_view options ) override;
-  pet_t* create_pet( util::string_view name, util::string_view type = "" ) override;
+  pet_t* create_pet( util::string_view name, util::string_view type = {} ) override;
   void create_pets() override;
   std::string create_profile( save_e ) override;
   void copy_from( player_t* source ) override;
@@ -648,7 +648,7 @@ struct sc_event_t : public player_event_t
 
 struct warlock_heal_t : public heal_t
 {
-  warlock_heal_t( const std::string& n, warlock_t* p, const uint32_t id ) : heal_t( n, p, p->find_spell( id ) )
+  warlock_heal_t( util::string_view n, warlock_t* p, const uint32_t id ) : heal_t( n, p, p->find_spell( id ) )
   {
     target = p;
   }
@@ -911,8 +911,8 @@ private:
   }
 
 public:
-  summon_pet_t( const std::string& n, warlock_t* p, const std::string& sname = "" )
-    : warlock_spell_t( p, sname.empty() ? "Summon " + n : sname ),
+  summon_pet_t( util::string_view n, warlock_t* p, util::string_view sname = {} )
+    : warlock_spell_t( p, sname.empty() ? fmt::format( "Summon {}", n ) : sname ),
       summoning_duration( timespan_t::zero() ),
       pet_name( sname.empty() ? n : sname ),
       pet( nullptr )
@@ -920,7 +920,7 @@ public:
     _init_summon_pet_t();
   }
 
-  summon_pet_t( const std::string& n, warlock_t* p, int id )
+  summon_pet_t( util::string_view n, warlock_t* p, int id )
     : warlock_spell_t( n, p, p->find_spell( id ) ),
       summoning_duration( timespan_t::zero() ),
       pet_name( n ),
@@ -929,7 +929,7 @@ public:
     _init_summon_pet_t();
   }
 
-  summon_pet_t( const std::string& n, warlock_t* p, const spell_data_t* sd )
+  summon_pet_t( util::string_view n, warlock_t* p, const spell_data_t* sd )
     : warlock_spell_t( n, p, sd ), summoning_duration( timespan_t::zero() ), pet_name( n ), pet( nullptr )
   {
     _init_summon_pet_t();
@@ -963,14 +963,14 @@ struct summon_main_pet_t : public summon_pet_t
 {
   cooldown_t* instant_cooldown;
 
-  summon_main_pet_t( const std::string& n, warlock_t* p )
+  summon_main_pet_t( util::string_view n, warlock_t* p )
     : summon_pet_t( n, p ), instant_cooldown( p->get_cooldown( "instant_summon_pet" ) )
   {
     instant_cooldown->duration = timespan_t::from_seconds( 60 );
     ignore_false_positive      = true;
   }
 
-  virtual void schedule_execute( action_state_t* state = nullptr ) override
+  void schedule_execute( action_state_t* state = nullptr ) override
   {
     warlock_spell_t::schedule_execute( state );
 
@@ -1042,14 +1042,14 @@ template <typename Base>
 struct warlock_buff_t : public Base
 {
 public:
-  typedef warlock_buff_t base_t;
-  warlock_buff_t( warlock_td_t& p, const std::string& name, const spell_data_t* s = spell_data_t::nil(),
+  using base_t = warlock_buff_t;
+  warlock_buff_t( warlock_td_t& p, util::string_view name, const spell_data_t* s = spell_data_t::nil(),
                   const item_t* item = nullptr )
     : Base( p, name, s, item )
   {
   }
 
-  warlock_buff_t( warlock_t& p, const std::string& name, const spell_data_t* s = spell_data_t::nil(),
+  warlock_buff_t( warlock_t& p, util::string_view name, const spell_data_t* s = spell_data_t::nil(),
                   const item_t* item = nullptr )
     : Base( &p, name, s, item )
   {

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -199,7 +199,7 @@ warlock_pet_td_t::warlock_pet_td_t( player_t* target, warlock_pet_t& p ) :
 
 namespace pets
 {
-warlock_simple_pet_t::warlock_simple_pet_t( warlock_t* owner, const std::string& pet_name, pet_e pt )
+warlock_simple_pet_t::warlock_simple_pet_t( warlock_t* owner, util::string_view pet_name, pet_e pt )
   : warlock_pet_t( owner, pet_name, pt, true ), special_ability( nullptr )
 {
   resource_regeneration = regen_type::DISABLED;
@@ -1146,7 +1146,7 @@ struct demonfire_t : public warlock_pet_spell_t
   }
 };
 
-demonic_tyrant_t::demonic_tyrant_t( warlock_t* owner, const std::string& name )
+demonic_tyrant_t::demonic_tyrant_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_DEMONIC_TYRANT, name != "demonic_tyrant" )
 {
   resource_regeneration = regen_type::DISABLED;
@@ -1677,7 +1677,7 @@ struct infernal_melee_t : warlock_pet_melee_t
   }
 };
 
-infernal_t::infernal_t( warlock_t* owner, const std::string& name )
+infernal_t::infernal_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_INFERNAL, name != "infernal" ), immolation( nullptr )
 {
   resource_regeneration = regen_type::DISABLED;
@@ -1768,7 +1768,7 @@ struct dark_glare_t : public warlock_pet_spell_t
   }
 };
 
-darkglare_t::darkglare_t( warlock_t* owner, const std::string& name )
+darkglare_t::darkglare_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_DARKGLARE, name != "darkglare" )
 {
   action_list_str += "dark_glare";

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -146,7 +146,7 @@ namespace pets
  */
 struct warlock_simple_pet_t : public warlock_pet_t
 {
-  warlock_simple_pet_t( warlock_t* owner, const std::string& pet_name, pet_e pt );
+  warlock_simple_pet_t( warlock_t* owner, util::string_view pet_name, pet_e pt );
   timespan_t available() const override;
 
 protected:
@@ -162,7 +162,7 @@ private:
 public:
   typedef warlock_pet_action_t base_t;
 
-  warlock_pet_action_t( const std::string& n, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
+  warlock_pet_action_t( util::string_view n, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
     : ab( n, p, s )
   {
     ab::may_crit = true;
@@ -316,12 +316,12 @@ private:
   }
 
 public:
-  warlock_pet_melee_attack_t( warlock_pet_t* p, const std::string& n ) : base_t( n, p, p->find_pet_spell( n ) )
+  warlock_pet_melee_attack_t( warlock_pet_t* p, util::string_view n ) : base_t( n, p, p->find_pet_spell( n ) )
   {
     _init_warlock_pet_melee_attack_t();
   }
 
-  warlock_pet_melee_attack_t( const std::string& token, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
+  warlock_pet_melee_attack_t( util::string_view token, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
     : base_t( token, p, s )
   {
     _init_warlock_pet_melee_attack_t();
@@ -331,11 +331,11 @@ public:
 struct warlock_pet_spell_t : public warlock_pet_action_t<spell_t>
 {
 public:
-  warlock_pet_spell_t( warlock_pet_t* p, const std::string& n ) : base_t( n, p, p->find_pet_spell( n ) )
+  warlock_pet_spell_t( warlock_pet_t* p, util::string_view n ) : base_t( n, p, p->find_pet_spell( n ) )
   {
   }
 
-  warlock_pet_spell_t( const std::string& token, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
+  warlock_pet_spell_t( util::string_view token, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
     : base_t( token, p, s )
   {
   }
@@ -455,7 +455,7 @@ struct vilefiend_t : public warlock_simple_pet_t
 
 struct demonic_tyrant_t : public warlock_pet_t
 {
-  demonic_tyrant_t( warlock_t* owner, const std::string& name = "demonic_tyrant" );
+  demonic_tyrant_t( warlock_t* owner, util::string_view name = "demonic_tyrant" );
   void init_base_stats() override;
   void demise() override;
   action_t* create_action( util::string_view name, util::string_view options_str ) override;
@@ -550,11 +550,11 @@ struct infernal_t : public warlock_pet_t
 {
   buff_t* immolation;
 
-  infernal_t( warlock_t* owner, const std::string& name = "infernal" );
-  virtual void init_base_stats() override;
-  virtual void create_buffs() override;
-  virtual void arise() override;
-  virtual void demise() override;
+  infernal_t( warlock_t* owner, util::string_view name = "infernal" );
+  void init_base_stats() override;
+  void create_buffs() override;
+  void arise() override;
+  void demise() override;
 };
 }  // namespace destruction
 
@@ -562,9 +562,9 @@ namespace affliction
 {
 struct darkglare_t : public warlock_pet_t
 {
-  darkglare_t( warlock_t* owner, const std::string& name = "darkglare" );
-  virtual double composite_player_multiplier( school_e school ) const override;
-  virtual action_t* create_action( util::string_view name, util::string_view options_str ) override;
+  darkglare_t( warlock_t* owner, util::string_view name = "darkglare" );
+  double composite_player_multiplier( school_e school ) const override;
+  action_t* create_action( util::string_view name, util::string_view options_str ) override;
 };
 }  // namespace affliction
 }  // namespace pets

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -482,7 +482,7 @@ public:
   unsigned class_ability_id( player_e c, specialization_e spec_id, util::string_view spell_name, bool tokenized = false ) const;
   unsigned pet_ability_id( player_e c, util::string_view spell_name, bool tokenized = false ) const;
   unsigned race_ability_id( player_e c, race_e r, util::string_view spell_name ) const;
-  unsigned specialization_ability_id( specialization_e spec_id, util::string_view spell_name, util::string_view spell_desc = "" ) const;
+  unsigned specialization_ability_id( specialization_e spec_id, util::string_view spell_name, util::string_view spell_desc = {} ) const;
   unsigned mastery_ability_id( specialization_e spec ) const;
 
   bool     is_specialization_ability( uint32_t spell_id ) const;

--- a/engine/dbc/specialization_spell.hpp
+++ b/engine/dbc/specialization_spell.hpp
@@ -23,7 +23,7 @@ struct specialization_spell_entry_t
   static const specialization_spell_entry_t& find( util::string_view name,
                                                    bool ptr,
                                                    specialization_e spec = SPEC_NONE,
-                                                   util::string_view desc = "",
+                                                   util::string_view desc = {},
                                                    bool tokenized = false );
 
   static const specialization_spell_entry_t& nil()

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -720,8 +720,8 @@ public:
   void change_position( position_e );
   void register_resource_callback(resource_e resource, double value, resource_callback_function_t callback,
       bool use_pct, bool fire_once = true);
-  bool add_action( util::string_view action, util::string_view options = "", util::string_view alist = "default" );
-  bool add_action( const spell_data_t* s, util::string_view options = "", util::string_view alist = "default" );
+  bool add_action( util::string_view action, util::string_view options = {}, util::string_view alist = "default" );
+  bool add_action( const spell_data_t* s, util::string_view options = {}, util::string_view alist = "default" );
   void add_option( std::unique_ptr<option_t> o );
   void parse_talents_numbers( util::string_view talent_string );
   bool parse_talents_armory( util::string_view talent_string );
@@ -1084,7 +1084,7 @@ public:
 
   virtual action_t* create_action( util::string_view name, util::string_view options );
   virtual void      create_pets() { }
-  virtual pet_t*    create_pet( util::string_view name,  util::string_view type = "" );
+  virtual pet_t*    create_pet( util::string_view name,  util::string_view type = {} );
 
   virtual void armory_extensions( const std::string& /* region */, const std::string& /* server */, const std::string& /* character */,
                                   cache::behavior_e /* behavior */ = cache::players() )

--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -104,8 +104,8 @@ void add_covenant_cast_callback( player_t* p, S&&... args )
   }
 }
 
-double value_from_desc_vars( const special_effect_t& e, util::string_view var, util::string_view prefix = "",
-                             util::string_view postfix = "" )
+double value_from_desc_vars( const special_effect_t& e, util::string_view var, util::string_view prefix = {},
+                             util::string_view postfix = {} )
 {
   double value = 0;
 

--- a/engine/sim/sc_raid_event.cpp
+++ b/engine/sim/sc_raid_event.cpp
@@ -1876,7 +1876,7 @@ void raid_event_t::init( sim_t* sim )
   for ( const auto& split : splits )
   {
     auto name    = split;
-    util::string_view options = "";
+    util::string_view options{};
 
     sim->print_debug( "Creating raid event '{}'.", name );
 


### PR DESCRIPTION
- replace most remaining const std::string& parameters with util::string_view, since they usually call other functions/constructor accepting string_view anyway.
- adjust default parameter arguments for string_view