### PR TITLE
[Shaman] Experimental Elemental T28 set

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -4386,7 +4386,7 @@ struct lava_burst_overload_t : public elemental_overload_spell_t
       m *= 1.0 + p()->buff.windspeakers_lava_resurgence->data().effectN( 1 ).percent();
     }
 
-    if ( p()->sets->has_set_bonus( SHAMAN_ELEMENTAL, T28, B2 ) && p()->buff.fireheart->up() )
+    if ( p()->sets->has_set_bonus( SHAMAN_ELEMENTAL, T28, B2 ) && p()->buff.fireheart->check() )
     {
       m *= 1.0 + p()->spell.t28_2pc_ele->effectN(2).percent();
     }
@@ -4762,7 +4762,7 @@ struct lava_burst_t : public shaman_spell_t
       m *= 1.0 + p()->buff.windspeakers_lava_resurgence->data().effectN( 1 ).percent();
     }
 
-    if ( p()->sets->has_set_bonus( SHAMAN_ELEMENTAL, T28, B2 ) && p()->buff.fireheart->up() )
+    if ( p()->sets->has_set_bonus( SHAMAN_ELEMENTAL, T28, B2 ) && p()->buff.fireheart->check() )
     {
       m *= 1.0 + p()->spell.t28_2pc_ele->effectN(2).percent();
     }

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -564,6 +564,8 @@ public:
     proc_t* lava_surge;
     proc_t* wasted_lava_surge;
     proc_t* surge_during_lvb;
+    proc_t* t28_4pc_ele_cd_extension;
+    proc_t* t28_4pc_ele_cd_reduction;
 
     // Enhancement
     proc_t* hot_hand;
@@ -4805,6 +4807,7 @@ struct lava_burst_t : public shaman_spell_t
   {
     shaman_spell_t::execute();
 
+    // TODO: check if this needs a guard against background effects (echoing shock, ascendance)
     if ( p()->sets->has_set_bonus( SHAMAN_ELEMENTAL, T28, B4 ) )
     {
       pet_t* pet = p()->get_active_elemental_pet();
@@ -4816,6 +4819,8 @@ struct lava_burst_t : public shaman_spell_t
         p()->buff.fireheart->extend_duration( p(), extension );
         pet->adjust_duration( extension );
         p()->buff.fire_elemental->extend_duration( p(), extension );
+
+        p()->proc.t28_4pc_ele_cd_extension->occur();
       }
     }
     
@@ -5377,6 +5382,8 @@ struct earthquake_t : public shaman_spell_t
 
       p()->cooldown.storm_elemental->adjust( -1.0 * extension );
       p()->cooldown.fire_elemental->adjust( -1.0 * extension );
+
+      p()->proc.t28_4pc_ele_cd_reduction->occur();
     }
 
     make_event<ground_aoe_event_t>(
@@ -5547,6 +5554,8 @@ struct earth_shock_t : public shaman_spell_t
 
       p()->cooldown.storm_elemental->adjust( -1.0 * extension );
       p()->cooldown.fire_elemental->adjust( -1.0 * extension );
+
+      p()->proc.t28_4pc_ele_cd_reduction->occur();
     }
 
     // Echoed Earth Shock does not generate Surge of Power stacks
@@ -8751,8 +8760,9 @@ void shaman_t::init_procs()
 
   proc.lava_surge        = get_proc( "Lava Surge" );
   proc.wasted_lava_surge = get_proc( "Lava Surge: Wasted" );
-  proc.windfury_uw       = get_proc( "Windfury: Unruly Winds" );
   proc.surge_during_lvb  = get_proc( "Lava Surge: During Lava Burst" );
+
+  proc.windfury_uw       = get_proc( "Windfury: Unruly Winds" );
   proc.maelstrom_weapon  = get_proc( "Maelstrom Weapon" );
   proc.maelstrom_weapon_fs= get_proc( "Maelstrom Weapon: Feral Spirit" );
   proc.maelstrom_weapon_ea= get_proc( "Maelstrom Weapon: Elemental Assault" );
@@ -8761,6 +8771,8 @@ void shaman_t::init_procs()
   proc.stormflurry       = get_proc( "Stormflurry" );
 
   proc.t28_4pc_enh       = get_proc( "Set Bonus: Tier28 4PC Enhancement" );
+  proc.t28_4pc_ele_cd_reduction = get_proc( "Set Bonus: Tier28 4PC Elemental CD Reduction" );
+  proc.t28_4pc_ele_cd_extension = get_proc( "Set Bonus: Tier28 4PC Elemental CD Extension" );
 }
 
 // shaman_t::init_assessors =================================================

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -6007,7 +6007,7 @@ struct ascendance_dre_t : public ascendance_t
       }
       else
       {
-        lvb = new lava_burst_t( p(), lava_burst_type::ASCENDANCE, "dre" );
+        lvb = new lava_burst_t( p(), lava_burst_type::DRE_ASCENDANCE, "dre" );
         add_child( lvb );
       }
     }

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -808,7 +808,7 @@ public:
   void trigger_lightning_shield( const action_state_t* state );
   void trigger_hot_hand( const action_state_t* state );
   void trigger_vesper_totem( const action_state_t* state );
-  void trigger_lava_surge( const player_t* source );
+  void trigger_lava_surge();
 
   // Legendary
   void trigger_legacy_of_the_frost_witch( unsigned consumed_stacks );
@@ -5690,7 +5690,7 @@ struct flame_shock_t : public shaman_spell_t
 
     if ( rng().roll( proc_chance ) )
     {
-      p()->trigger_lava_surge( d->source );
+      p()->trigger_lava_surge();
     }
 
     // Fire Elemental passive effect (MS generation on FS tick)
@@ -8493,14 +8493,14 @@ void shaman_t::trigger_lightning_shield( const action_state_t* state )
   }
 }
 
-void shaman_t::trigger_lava_surge(const player_t* source ) {
+void shaman_t::trigger_lava_surge() {
   if ( buff.lava_surge->check() )
   {
     proc.wasted_lava_surge->occur();
   }
 
   proc.lava_surge->occur();
-  if ( !source->executing || source->executing->id != 51505 )
+  if ( !executing || executing->id != 51505 )
   {
     cooldown.lava_burst->reset( true );
   } else
@@ -8647,7 +8647,7 @@ void shaman_t::create_buffs()
                        // TODO: confirm if duration is affected by conduit and tier set 4pc bonus
                        ->set_duration( buff.fire_elemental->buff_duration() )
                        ->set_tick_callback( [ this ]( buff_t* b, int, timespan_t ) {
-                         trigger_lava_surge( b->source );
+                         trigger_lava_surge();
                        } )
                        // TODO: confirm recasting elemental during uptime behaviour
                        ->set_refresh_behavior( buff_refresh_behavior::EXTEND );


### PR DESCRIPTION
Preliminary implementation of T28 set bonuses 
```
Fireheart (2-Set) While your Storm Elemental or Fire Elemental is active, your Lava Burst deals 20% additional damage and you gain Lava Surge every 8 sec.
Fireheart (4-Set) Casting Lava Burst extends the duration of your Storm Elemental and Fire Elemental by 1.5 sec. If your Storm Elemental or Fire Elemental is not active, spending Maelstrom has a 20% chance to reduce its remaining cooldown by 10 sec instead.
```