### PR TITLE
Priest Initial insanity

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1890,6 +1890,9 @@ void priest_t::init_base_stats()
 void priest_t::init_resources( bool force )
 {
   base_t::init_resources( force );
+
+  if ( options.initial_insanity > 0.0 )
+    resources.current[ RESOURCE_INSANITY ] = options.initial_insanity;
 }
 
 void priest_t::init_scaling()
@@ -2218,6 +2221,8 @@ void priest_t::create_options()
   add_option( opt_int( "priest.shadow_word_manipulation_seconds_remaining",
                        options.shadow_word_manipulation_seconds_remaining, 0, 8 ) );
   add_option( opt_int( "priest.pallid_command_allies", options.pallid_command_allies, 0, 50 ) );
+
+  add_option( opt_float( "priest.initial_insanity", options.initial_insanity, 0.0, 100.0 ) );
 }
 
 std::string priest_t::create_profile( save_e type )

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1891,7 +1891,7 @@ void priest_t::init_resources( bool force )
 {
   base_t::init_resources( force );
 
-  if ( options.initial_insanity > 0.0 )
+  if ( options.initial_insanity > 0.0 && specialization() == PRIEST_SHADOW )
     resources.current[ RESOURCE_INSANITY ] = options.initial_insanity;
 }
 

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -395,6 +395,8 @@ public:
     // to the number of allies
     // 20m raid this stacks in 1-2s
     int pallid_command_allies = 50;
+
+    double initial_insanity = 0.0;
   } options;
 
   // Legendaries


### PR DESCRIPTION
Adds "priest.initial_insanity" to set sim starting insanity.
For testing APLs and some people may find use of this for M+ scenarios or other things.

Couldn't remember if there was a way of specifying initial insanity/resource any other way, so I just went and copied how the druids did it. 