### PR TITLE
Do not set `-march=native` on darwin/arm64

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -12,6 +12,7 @@
 
 
 FLAVOR     =
+ARCH       =
 DESTDIR    =
 PREFIX    ?= ..
 
@@ -49,6 +50,7 @@ ifeq (${OS},)
   else
     OS         = UNIX
     FLAVOR     = $(shell uname)
+    ARCH       = $(shell uname -m)
   endif
 endif
 
@@ -223,11 +225,31 @@ release: $(MODULE)
 
 optimized:CPP_FLAGS += -DNDEBUG
 optimized:OPTS_INTERNAL += -ffast-math -fomit-frame-pointer
-ifneq (${FLAVOR},Darwin)
-  ifneq ($(uname -m),arm64)
+
+# MacOS's default compiler, `clang`, does not support `-march=native` on Apple
+# Silicon chips, and as of 2021-11-22 will return an error like the following
+# at compile time:
+#
+#     clang: error: the clang compiler does not support '-march=native'
+#
+# This conditional preserves the existing default `-march=native` flag on all
+# non-Apple systems, and also on Apple Intel systems, while instead setting
+# `-mcpu=apple-m1` on Apple Silicon systems to enable any M1-specific
+# optimizations that clang supports.
+#
+# In a future release, presumably when there are M2 chips, M3 chips, and so on,
+# hopefully clang will support `-march=native` on these platforms and we can
+# eliminate this block.
+ifeq (${FLAVOR},Darwin)
+  ifeq (${ARCH},arm64)
+    optimized:OPTS_INTERNAL += -mcpu=apple-m1
+  else
     optimized:OPTS_INTERNAL += -march=native
   endif
+else
+  optimized:OPTS_INTERNAL += -march=native
 endif
+
 optimized: $(MODULE)
 
 install: all

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -222,7 +222,12 @@ release:CPP_FLAGS += -DNDEBUG
 release: $(MODULE)
 
 optimized:CPP_FLAGS += -DNDEBUG
-optimized:OPTS_INTERNAL += -march=native -ffast-math -fomit-frame-pointer
+optimized:OPTS_INTERNAL += -ffast-math -fomit-frame-pointer
+ifneq (${FLAVOR},Darwin)
+  ifneq ($(uname -m),arm64)
+    optimized:OPTS_INTERNAL += -march=native
+  endif
+endif
 optimized: $(MODULE)
 
 install: all


### PR DESCRIPTION
The version of `clang` in XCode 13 does not support `-march=native` for
this chipset, so we exclude it from the `optimized` target by default on
that particular architecture.

This means darwin/arm64 builds may be slightly less optimized than non-darwin/arm64
builds, but that these do work out of the box without requiring extra
flags on my 2021 MacBook Pro M1 Max.

I've only tested this out locally so far and I'm far from an expert on this particular part of the build process so I mostly just banged on stuff until `make -j 8 optimized` passed.