### PR TITLE
[HTML] adjust reporting of queued actions that become invalid 

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -141,7 +141,7 @@ struct queued_action_execute_event_t : public event_t
           auto& seq = actor->collected_data.action_sequence;
           auto it = std::find_if( seq.rbegin(), seq.rend(),
                                   [ this ]( const player_collected_data_t::action_sequence_data_t& s ) {
-                                    return s.action == action;
+                                    return s.action == action && !s.queue_failed;
                                   } );
           if ( it != seq.rend() )
             ( *it ).queue_failed = true;

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -128,7 +128,9 @@ struct queued_action_execute_event_t : public event_t
 
         // This is an extremely rare event, only seen in a handful of specs with abilities on cooldown that have
         // conditional activation requirements or dynamic cost adjustments.
-        actor->get_proc( action->name_str + " (queue failed)" )->occur();
+        if ( action->queue_failed_proc )
+          action->queue_failed_proc->occur();
+
         actor->iteration_executed_foreground_actions--;
         action->total_executions--;
 
@@ -451,6 +453,7 @@ action_t::action_t( action_e ty, util::string_view token, player_t* p, const spe
     target_specific_dot( false ),
     action_list(),
     starved_proc(),
+    queue_failed_proc(),
     total_executions(),
     line_cooldown( new cooldown_t("line_cd", *p) ),
     signature(),

--- a/engine/action/sc_action.hpp
+++ b/engine/action/sc_action.hpp
@@ -508,6 +508,10 @@ public:
    * Can be overridden by class modules for tracking purposes.
    */
   proc_t* starved_proc;
+
+  // Tracking proc triggered when action fails to execute after being queued.
+  // Can be overridden by class modules for tracking purposes.
+  proc_t* queue_failed_proc;
   uint_least64_t total_executions;
 
   /**

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -6358,7 +6358,7 @@ struct starfall_t : public druid_spell_t
     : druid_spell_t( "starfall", p, s, opt ), dummy_cd( p->get_cooldown( "starfall_dummy_cd" ) ), orig_cd( cooldown )
   {
     may_miss = may_crit = false;
-    queue_failed_proc = p->get_proc( "stafall queue failed" );
+    queue_failed_proc = p->get_proc( "starfall queue failed" );
 
     damage        = p->get_secondary_action<starfall_damage_t>( "starfall_dmg" );
     damage->stats = stats;

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -6358,6 +6358,7 @@ struct starfall_t : public druid_spell_t
     : druid_spell_t( "starfall", p, s, opt ), dummy_cd( p->get_cooldown( "starfall_dummy_cd" ) ), orig_cd( cooldown )
   {
     may_miss = may_crit = false;
+    queue_failed_proc = p->get_proc( "stafall queue failed" );
 
     damage        = p->get_secondary_action<starfall_damage_t>( "starfall_dmg" );
     damage->stats = stats;

--- a/engine/player/player_collected_data.hpp
+++ b/engine/player/player_collected_data.hpp
@@ -134,6 +134,7 @@ struct player_collected_data_t
     const player_t* target;
     const timespan_t time;
     timespan_t wait_time;
+    bool queue_failed;
     std::vector< record_t<buff_t> > buff_list;
     std::vector< record_t<cooldown_t> > cooldown_list;
     std::vector< std::pair<player_t*, std::vector< record_t<buff_t> > > > target_list;

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -11926,14 +11926,10 @@ void player_t::do_update_movement( double yards )
   }
 }
 
-
 player_collected_data_t::action_sequence_data_t::action_sequence_data_t( const action_t* a, const player_t* t,
                                                                          timespan_t ts, timespan_t wait,
-                                                                         const player_t* p ) :
-  action( a ),
-  target( t ),
-  time( ts ),
-  wait_time( wait )
+                                                                         const player_t* p )
+  : action( a ), target( t ), time( ts ), wait_time( wait ), queue_failed( false )
 {
   for ( buff_t* b : p->buff_list )
   {

--- a/engine/report/json/report_json.cpp
+++ b/engine/report/json/report_json.cpp
@@ -475,6 +475,7 @@ void to_json( JsonOutput root,
       json[ "name" ] = entry.action -> name();
       json[ "target" ] = entry.action->harmful ? entry.target -> name() : "none";
       json[ "spell_name" ] = entry.action->data_reporting().name_cstr();
+      json[ "queue_failed" ] = entry.queue_failed;
       if (entry.action->item) {
         json[ "item_name" ] = entry.action->item->name_str;
       }

--- a/engine/report/sc_report_html_player.cpp
+++ b/engine/report/sc_report_html_player.cpp
@@ -2291,11 +2291,11 @@ void print_html_sample_sequence_table_entry( report::sc_html_stream& os,
   {
     os.printf( "<td class=\"left\">%s</td>\n"
                "<td class=\"left\">%c</td>\n"
-               "<td class=\"left\">%s</td>\n"
+               "<td class=\"left\">%s%s</td>\n"
                "<td class=\"left\">%s</td>\n",
                data.action->action_list ? util::encode_html( data.action->action_list->name_str ).c_str() : "unknown",
                data.action->marker != 0 ? data.action->marker : ' ',
-               util::encode_html( data.action->name() ).c_str(),
+               util::encode_html( data.action->name() ).c_str(), data.queue_failed ? " (queue failed)" : "",
                util::encode_html( data.target->name() ).c_str() );
   }
   else


### PR DESCRIPTION
Because APL action line execution data, as well as sample sequence, is recorded
upon the action being queued, rather than execute, it's very rarely possible
for the queued action to no longer be valid when it becomes time to execute.

This usually happens with abilities that have cooldowns and/or abilities with
dynamic adjustments to their cost.

When this happens, the action counter for HTML reporting purposes is properly
decremented, `action_t::queue_failed_proc` is triggered if it is assigned in the
class modules, and if it was during the first iteration, the sample sequence entry is
editted to read `<action name> (queue failed)`.