### PR TITLE
Expressions: Simplify is_constant interface

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -3264,6 +3264,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
         }
         return t.total_seconds();
       }
+      bool is_constant() override
+      {
+        return action_list.empty();
+      }
     };
     return std::make_unique<last_used_expr_t>( std::move(last_used_list) );
   }
@@ -3319,6 +3323,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
             return action.player->last_foreground_action->internal_id == prev->internal_id;
           return false;
         }
+        bool is_constant() override
+        {
+          return !prev;
+        }
       };
       return std::make_unique<prev_expr_t>( *this, splits[ 1 ] );
     }
@@ -3342,6 +3350,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
             }
           }
           return false;
+        }
+        bool is_constant() override
+        {
+          return !previously_off_gcd;
         }
       };
       return std::make_unique<prev_gcd_expr_t>( *this, splits[ 1 ] );
@@ -3503,14 +3515,9 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
         }
       }
 
-      bool is_constant( double* result ) override
+      bool is_constant() override
       {
-        if ( !previously_used )
-        {
-          *result = 0;
-          return true;
-        }
-        return false;
+        return !previously_used;
       }
 
       double evaluate() override
@@ -3578,6 +3585,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
             ret = expr_result;
         }
         return ret;
+      }
+      bool is_constant() override
+      {
+        return expr_list.empty();
       }
     };
 
@@ -3712,6 +3723,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
           {
             return range::any_of( action_list, []( const action_t* a ) { return a->has_travel_events(); } );
           }
+          bool is_constant() override
+          {
+            return action_list.empty();
+          }
         };
         return std::make_unique<in_flight_multi_expr_t>( std::move(in_flight_list) );
       }
@@ -3735,6 +3750,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
                 return true;
             }
             return false;
+          }
+          bool is_constant() override
+          {
+            return action_list.empty();
           }
         };
         return std::make_unique<in_flight_to_target_multi_expr_t>( std::move(in_flight_list), *this );
@@ -3764,6 +3783,10 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
             }
 
             return event_found ? t.total_seconds() : 0.0;
+          }
+          bool is_constant() override
+          {
+            return action_list.empty();
           }
         };
         return std::make_unique<in_flight_remains_multi_expr_t>( std::move(in_flight_list) );

--- a/engine/action/variable.hpp
+++ b/engine/action/variable.hpp
@@ -37,7 +37,7 @@ struct variable_t : public action_t
   //    are both constant
   // 3) The operation is reset/floor/ceil and all of the other actions manipulating the variable are
   //    constant
-  bool is_constant(double* const_value) const;
+  bool is_constant() const;
 
   // Variable action expressions have to do an optimization pass before other actions, so that
   // actions with variable expressions can know if the associated variable is constant

--- a/engine/buff/sc_buff.cpp
+++ b/engine/buff/sc_buff.cpp
@@ -86,13 +86,9 @@ struct buff_expr_t : public expr_t
     return buff;
   }
 
-  bool is_constant( double* v ) override
+  bool is_constant() override
   {
-    bool constant = buff()->s_data != spell_data_t::nil() && !buff()->s_data->ok();
-
-    *v = evaluate();
-
-    return constant;
+    return buff()->s_data != spell_data_t::nil() && !buff()->s_data->ok();
   }
 };
 
@@ -128,16 +124,9 @@ struct fn_const_buff_expr_t final : public buff_expr_t
     return coerce( fn( buff() ) );
   }
   
-  bool is_constant( double* v ) override
+  bool is_constant() override
   {
-    bool constant = is_const_fn( buff() );
-
-    if ( constant )
-    {
-      *v = evaluate();
-    }
-
-    return constant;
+    return is_const_fn( buff() );
   }
 };
 
@@ -468,16 +457,9 @@ std::unique_ptr<expr_t> create_buff_expression( util::string_view buff_name, uti
       double evaluate() override
       { return buff()->stack_react(); }
       
-      bool is_constant( double* v ) override
+      bool is_constant() override
       {
-        bool constant = buff()->default_chance == 0;
-
-        if ( constant )
-        {
-          *v = evaluate();
-        }
-
-        return constant;
+        return buff()->default_chance == 0;
       }
     };
 
@@ -504,16 +486,9 @@ std::unique_ptr<expr_t> create_buff_expression( util::string_view buff_name, uti
       double evaluate() override
       { return 100.0 * buff()->stack_react() / buff()->max_stack(); }
       
-      bool is_constant( double* v ) override
+      bool is_constant() override
       {
-        bool constant = buff()->default_chance == 0;
-
-        if ( constant )
-        {
-          *v = evaluate();
-        }
-
-        return constant;
+        return buff()->default_chance == 0;
       }
     };
 

--- a/engine/player/action_variable.cpp
+++ b/engine/player/action_variable.cpp
@@ -21,9 +21,8 @@ action_variable_t::action_variable_t( std::string name, double default_value )
 {
 }
 
-bool action_variable_t::is_constant( double* constant_value ) const
+bool action_variable_t::is_constant() const
 {
-  *constant_value = constant_value_;
   return constant_value_ != std::numeric_limits<double>::lowest();
 }
 
@@ -54,12 +53,11 @@ void action_variable_t::optimize()
   }
 
   bool is_constant = true;
-  double const_value;
   for ( auto action : variable_actions )
   {
     variable_t* var_action = debug_cast<variable_t*>( action );
 
-    is_constant = var_action->is_constant(&const_value);
+    is_constant = var_action->is_constant();
     if ( !is_constant )
     {
       break;

--- a/engine/player/action_variable.hpp
+++ b/engine/player/action_variable.hpp
@@ -28,7 +28,7 @@ struct action_variable_t
     current_value_ = default_value_;
   }
 
-  bool is_constant( double* constant_value ) const;
+  bool is_constant() const;
 
   void optimize();
 };

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -8390,7 +8390,7 @@ struct use_item_t : public action_t
       {
       }
 
-      bool is_constant( double* ) override
+      bool is_constant() override
       {
         return true;
       }
@@ -10197,8 +10197,8 @@ std::unique_ptr<expr_t> player_t::create_expression( util::string_view expressio
           }
         }
 
-        bool is_constant( double* value ) override
-        { return var_->is_constant( value ); }
+        bool is_constant() override
+        { return var_->is_constant(); }
 
         double evaluate() override
         { return var_->current_value_; }

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -3954,14 +3954,9 @@ struct item_effect_expr_t : public item_effect_base_expr_t
     return result;
   }
   
-  bool is_constant( double* value ) override
+  bool is_constant() override
   {
-    if (exprs.empty())
-    {
-      *value = 0;
-      return true;
-    }
-    return false;
+    return exprs.empty();
   }
 };
 
@@ -4002,9 +3997,8 @@ struct item_buff_exists_expr_t : public item_effect_expr_t
     }
   }
 
-  bool is_constant( double* value) override
+  bool is_constant() override
   {
-    *value = v;
     return true;
   }
 
@@ -4059,14 +4053,9 @@ struct item_ready_expr_t : public item_effect_base_expr_t
     return 1;
   }
     
-  bool is_constant( double* value ) override
+  bool is_constant() override
   {
-    if (effects.empty())
-    {
-      *value = 1;
-      return true;
-    }
-    return false;
+    return effects.empty();
   }
 };
 
@@ -4084,9 +4073,8 @@ struct item_is_expr_t : public expr_t
     }
   }
 
-  bool is_constant( double* value) override
+  bool is_constant() override
   {
-    *value = is;
     return true;
   }
 
@@ -4113,9 +4101,8 @@ struct item_cooldown_exists_expr_t : public item_effect_expr_t
     }
   }
 
-  bool is_constant( double* value) override
+  bool is_constant() override
   {
-    *value = v;
     return true;
   }
 
@@ -4198,9 +4185,8 @@ struct item_has_use_buff_expr_t : public item_effect_expr_t
       v = 1;
   }
 
-  bool is_constant( double* value) override
+  bool is_constant() override
   {
-    *value = v;
     return true;
   }
 

--- a/engine/sim/sc_expressions.cpp
+++ b/engine/sim/sc_expressions.cpp
@@ -392,10 +392,9 @@ public:
 
     expr_t::optimize_expression(input, analyze_further, spacing + 2);
 
-    double input_value;
-    if ( input->is_constant( &input_value ) )
+    if ( input->is_constant() )
     {
-      double result = F()( input_value );
+      double result = F()( input->evaluate() );
       if (EXPRESSION_DEBUG)
       {
         printf("Reduced %*d %s (%s) unary expression to %f\n", spacing, id(),
@@ -507,11 +506,10 @@ struct left_reduced_t : public expr_t
   std::unique_ptr<expr_t> build_optimized_expression( bool analyze_further, int spacing ) override
   {
     expr_t::optimize_expression( right, analyze_further, spacing + 2 );
-    double right_value;
-    bool right_constant = right->is_constant( &right_value );
+    bool right_constant = right->is_constant();
     if ( right_constant )
     {
-      auto result = static_cast<double>( F<T>()( static_cast<T>( left ), static_cast<T>( right_value ) ) );
+      auto result = static_cast<double>( F<T>()( static_cast<T>( left ), static_cast<T>( right->evaluate() ) ) );
       if ( EXPRESSION_DEBUG )
       {
         printf( "Reduced %*d %s binary expression to %f\n", spacing, id(), name(), result );
@@ -540,11 +538,10 @@ struct right_reduced_t : public expr_t
   std::unique_ptr<expr_t> build_optimized_expression( bool analyze_further, int spacing ) override
   {
     expr_t::optimize_expression( left, analyze_further, spacing + 2 );
-    double left_value;
-    bool left_constant = left->is_constant( &left_value );
+    bool left_constant = left->is_constant();
     if ( left_constant )
     {
-      auto result = static_cast<double>( F<T>()( static_cast<T>( left_value ), static_cast<T>( right ) ) );
+      auto result = static_cast<double>( F<T>()( static_cast<T>( left->evaluate() ), static_cast<T>( right ) ) );
       if ( EXPRESSION_DEBUG )
       {
         printf( "Reduced %*d %s binary expression to %f\n", spacing, id(), name(), result );
@@ -886,13 +883,11 @@ public:
     }
     expr_t::optimize_expression(left, analyze_further, spacing + 2);
     expr_t::optimize_expression(right, analyze_further, spacing + 2);
-    double left_value;
-    double right_value;
-    bool left_constant  = left->is_constant( &left_value );
-    bool right_constant = right->is_constant( &right_value );
+    bool left_constant  = left->is_constant();
+    bool right_constant = right->is_constant();
     if ( left_constant && right_constant )
     {
-      result = static_cast<double>( F<T>()( static_cast<T>( left_value ), static_cast<T>( right_value ) ) );
+      result = static_cast<double>( F<T>()( static_cast<T>( left->evaluate() ), static_cast<T>( right->evaluate() ) ) );
       if (EXPRESSION_DEBUG)
       {
         printf("Reduced %*d %s (%s, %s) binary expression to %f\n", spacing,
@@ -910,7 +905,7 @@ public:
       
       return std::make_unique<left_reduced_t<F, T>>(
           fmt::format( "{}_left_reduced('{}')", name(), left->name() ),
-          op_, left_value, std::move(right) );
+          op_, left->evaluate(), std::move(right) );
     }
     if ( right_constant )
     {
@@ -920,7 +915,7 @@ public:
       
       return std::make_unique<right_reduced_t<F, T>>(
           fmt::format( "{}_right_reduced('{}')", name(), left->name() ),
-          op_, std::move(left), right_value );
+          op_, std::move(left), right->evaluate() );
     }
     return select_binary( analyze_further, name(), op_, std::move(left), std::move(right) );
   }

--- a/engine/sim/sc_expressions.hpp
+++ b/engine/sim/sc_expressions.hpp
@@ -120,15 +120,12 @@ public:
   }
   bool always_true()
   {
-    double v;
-    return is_constant( &v ) && v != 0.0;
+    return is_constant() && evaluate() != 0.0;
   }
   bool always_false()
   {
-    double v;
-    return is_constant( &v ) && v == 0.0;
+    return is_constant() && evaluate() == 0.0;
   }
-
   static double coerce( timespan_t t )
   {
     return t.total_seconds();
@@ -150,7 +147,7 @@ public:
 
   virtual double evaluate() = 0;
 
-  virtual bool is_constant( double* /*return_value*/ )
+  virtual bool is_constant()
   {
     return false;
   }
@@ -193,9 +190,8 @@ public:
     return value;
   }
 
-  bool is_constant( double* v ) override  // override
+  bool is_constant() override  // override
   {
-    *v = value;
     return true;
   }
 };


### PR DESCRIPTION
No longer require that is_constant returns the constant value as an out parameter. Instead, assume that for a expression that is promised to be constant, we can just call evaluate() and get the constant value.
The constant checks are only performed in specific core code when optimizing expressions and don't mind that extra step, while the implementation of a potentially const expression now has a much simpler job for providing info whether the expression is constant or not.

Also removes any potential bugs where the out parameter of constant could potentially not be equal to the result of a evaluate() call on that expression.

Add some more is_constant overrides to action expressions.