### PR TITLE
[Player] implement on-kill callbacks

### DIFF
--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -5677,7 +5677,7 @@ void player_t::demise()
    * need to be associated with eg. resolve Diminishing Return list.
    */
 
-  if (arise_time >= timespan_t::zero())
+  if ( arise_time >= 0_ms )
   {
     iteration_fight_length += sim->current_time() - arise_time;
   }
@@ -5688,6 +5688,19 @@ void player_t::demise()
   event_t::cancel( readying );
   event_t::cancel( off_gcd );
   event_t::cancel( cast_while_casting_poll_event );
+
+  // If an enemy mob dies, trigger on-kill callback on all active players
+  if ( is_enemy() )
+  {
+    for ( auto p : sim->player_non_sleeping_list )
+    {
+      // Use index-based lookup since on-kill callbacks may insert new on-kill callbacks to the vector
+      for ( size_t i = 0; i < p->callbacks_on_kill.size(); ++i )  // NOLINT(modernize-loop-convert)
+      {
+        p->callbacks_on_kill[ i ]( this );
+      }
+    }
+  }
 
   // Requires index-based lookup since on-demise callbacks may
   // insert new on-demise callbacks to the vector.
@@ -13115,6 +13128,11 @@ void player_t::register_on_demise_callback( player_t* source, std::function<void
 void player_t::register_on_arise_callback( player_t* source, std::function<void( void )> fn )
 {
   callbacks_on_arise.emplace_back( source, std::move( fn ) );
+}
+
+void player_t::register_on_kill_callback( std::function<void( player_t* )> fn )
+{
+  callbacks_on_kill.emplace_back( std::move( fn ) );
 }
 
 spawner::base_actor_spawner_t* player_t::find_spawner( util::string_view id ) const

--- a/engine/player/sc_player.hpp
+++ b/engine/player/sc_player.hpp
@@ -286,6 +286,7 @@ struct player_t : public actor_t
   auto_dispose< std::vector<special_effect_t*> > special_effects;
   std::vector<std::pair<player_t*, std::function<void( player_t* )>>> callbacks_on_demise;
   std::vector<std::pair<player_t*, std::function<void( void )>>> callbacks_on_arise;
+  std::vector<std::function<void( player_t* )>> callbacks_on_kill;
 
   // Action Priority List
   auto_dispose< std::vector<action_t*> > action_list;
@@ -1220,6 +1221,7 @@ public:
 
   void register_on_demise_callback( player_t* source, std::function<void( player_t* )> fn );
   void register_on_arise_callback( player_t* source, std::function<void( void )> fn );
+  void register_on_kill_callback( std::function<void( player_t* )> fn );
 
   void update_off_gcd_ready();
   void update_cast_while_casting_ready();


### PR DESCRIPTION
Callback triggered on all non-sleeping players on an enemy mob demise()

use `player_t::register_on_kill_callback( void(player_t*) )` to register a new callback