### PR TITLE
[Priest] rework shadow T28 set bonuses

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1518,6 +1518,8 @@ void priest_t::create_procs()
   procs.void_lasher                     = get_proc( "Void Lasher proc from Eternal Call to the Void" );
   procs.dark_thoughts_flay              = get_proc( "Dark Thoughts proc from Mind Flay" );
   procs.dark_thoughts_sear              = get_proc( "Dark Thoughts proc from Mind Sear" );
+  procs.dark_thoughts_devouring_plague  = get_proc( "Dark Thoughts proc from T28 2-set Devouring Plague" );
+  procs.dark_thoughts_searing_nightmare = get_proc( "Dark Thoughts proc from T28 2-set Searing Nightmare" );
   procs.dark_thoughts_missed            = get_proc( "Dark Thoughts proc not consumed" );
   procs.living_shadow                   = get_proc( "Living Shadow T28 4-set procs" );
 }
@@ -2377,9 +2379,9 @@ struct priest_module_t final : public module_t
   void init( player_t* p ) const override
   {
     p->buffs.guardian_spirit   = make_buff( p, "guardian_spirit",
-                                            p->find_spell( 47788 ) );  // Let the ability handle the CD
+                                          p->find_spell( 47788 ) );  // Let the ability handle the CD
     p->buffs.pain_suppression  = make_buff( p, "pain_suppression",
-                                            p->find_spell( 33206 ) );  // Let the ability handle the CD
+                                           p->find_spell( 33206 ) );  // Let the ability handle the CD
     p->buffs.benevolent_faerie = make_buff<buffs::benevolent_faerie_t>( p );
   }
   void static_init() const override

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -317,6 +317,8 @@ public:
     propagate_const<proc_t*> void_lasher;
     propagate_const<proc_t*> dark_thoughts_flay;
     propagate_const<proc_t*> dark_thoughts_sear;
+    propagate_const<proc_t*> dark_thoughts_devouring_plague;
+    propagate_const<proc_t*> dark_thoughts_searing_nightmare;
     propagate_const<proc_t*> dark_thoughts_missed;
     propagate_const<proc_t*> living_shadow;
   } procs;
@@ -946,11 +948,6 @@ struct priest_spell_t : public priest_action_t<spell_t>
 
     int dots                          = swp->is_ticking() + vt->is_ticking() + dp->is_ticking();
     double dark_thoughts_proc_percent = priest().specs.dark_thoughts->effectN( 1 ).percent();
-
-    if ( priest().sets->has_set_bonus( PRIEST_SHADOW, T28, B2 ) )
-    {
-      dark_thoughts_proc_percent += priest().sets->set( PRIEST_SHADOW, T28, B2 )->effectN( 1 ).percent();
-    }
 
     // Currently Mind-Sear has 1/3 the proc rate of Mind Flay 3% -> 1%
     // https://github.com/SimCMinMax/WoW-BugTracker/issues/699

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -675,17 +675,30 @@ struct your_shadow_t final : public priest_pet_t
   action_t* create_action( util::string_view name, util::string_view options_str ) override;
 };
 
-// TODO: if it has duration is hasted, does it recast when the channel finishes?
-// TODO: verify hasted ticks/duration
+struct your_shadow_torment_mind_tick_t final : public priest_pet_spell_t
+{
+  your_shadow_torment_mind_tick_t( your_shadow_t& p, const spell_data_t* s )
+    : priest_pet_spell_t( "torment_mind_tick", p, s )
+  {
+    background                 = true;
+    dual                       = true;
+    affected_by_shadow_weaving = true;
+    tick_zero                  = true;
+    aoe                        = -1;
+    radius                     = data().effectN( 2 ).radius();
+    spell_power_mod.tick       = data().effectN( 2 ).sp_coeff();
+  }
+};
+
 struct your_shadow_torment_mind_t final : public priest_pet_spell_t
 {
   your_shadow_torment_mind_t( your_shadow_t& p, util::string_view options )
     : priest_pet_spell_t( "torment_mind", p, p.o().find_spell( 363656 ) )
   {
     parse_options( options );
-    channeled                  = true;
-    affected_by_shadow_weaving = false;
-    tick_zero                  = true;
+    channeled   = true;
+    tick_zero   = true;
+    tick_action = new your_shadow_torment_mind_tick_t( p, data().effectN( 1 ).trigger() );
   }
 
   void init() override

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1059,6 +1059,18 @@ struct devouring_plague_t final : public priest_spell_t
     }
   }
 
+  void execute() override
+  {
+    priest_spell_t::execute();
+
+    if ( priest().sets->has_set_bonus( PRIEST_SHADOW, T28, B2 ) &&
+         rng().roll( priest().sets->set( PRIEST_SHADOW, T28, B2 )->effectN( 1 ).percent() ) )
+    {
+      priest().buffs.dark_thought->trigger();
+      priest().procs.dark_thoughts_devouring_plague->occur();
+    }
+  }
+
   timespan_t calculate_dot_refresh_duration( const dot_t* d, timespan_t duration ) const override
   {
     // if you only have the partial tick, roll that damage over
@@ -1584,6 +1596,18 @@ struct searing_nightmare_t final : public priest_spell_t
 
     child_swp->target = s->target;
     child_swp->execute();
+  }
+
+  void execute() override
+  {
+    priest_spell_t::execute();
+
+    if ( priest().sets->has_set_bonus( PRIEST_SHADOW, T28, B2 ) &&
+         rng().roll( priest().sets->set( PRIEST_SHADOW, T28, B2 )->effectN( 2 ).percent() ) )
+    {
+      priest().buffs.dark_thought->trigger();
+      priest().procs.dark_thoughts_searing_nightmare->occur();
+    }
   }
 };
 


### PR DESCRIPTION
- t28 2 set now works off of Devouring Plague and Searing Nightmare
- t28 4 set is now AoE
- added two new proc actions to track the new Dark Thought proc mechanisms

https://www.wowhead.com/news/patch-9-2-ptr-tier-set-tuning-build-41462-shadow-priest-rework-arms-warrior-nerf-325331