### PR TITLE
[DBC] allow override of bit array fields in spell data

### DIFF
--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -102,11 +102,10 @@ bool spell_data_t::override_field( util::string_view field, double value )
 {
   if ( util::str_prefix_ci( field, "class_flags_" ) )
   {
-    auto idx = static_cast<unsigned>( value / 32 );
-
-    if ( idx < 0 || idx >= NUM_CLASS_FAMILY_FLAGS )
+    if ( value < 0 || value >= NUM_CLASS_FAMILY_FLAGS * 32 )
       throw std::invalid_argument( "Invalid class flag value." );
 
+    auto idx = static_cast<unsigned>( value / 32 );
     auto bit = 1u << ( static_cast<unsigned>( value ) % 32 );
 
     if ( util::str_in_str_ci( field, "add" ) )

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -89,6 +89,13 @@ double get_field( const T* data, const Fields& fields, util::string_view name ) 
     }, -std::numeric_limits<double>::max(), detail::size_c<std::tuple_size<Fields>::value>{} );
 }
 
+template <typename T, typename Fields>
+bool is_bit_array_field( const T* data, const Fields& fields, util::string_view name ) {
+  return detail::handle_field( data, fields, name, [] ( const auto& ) {
+    return true;
+  }, false, detail::size_c<std::tuple_size<Fields>::value>{} );
+}
+
 } // anon namespace
 
 // ==========================================================================
@@ -140,6 +147,9 @@ bool spell_data_t::override_field( util::string_view field, double value )
 
 double spell_data_t::get_field( util::string_view field ) const
 {
+  if ( ::is_bit_array_field( this, spell_data_bit_array_fields, field ) )
+    return 0.0;
+
   return ::get_field( this, spell_data_fields, field );
 }
 
@@ -181,6 +191,9 @@ bool spelleffect_data_t::override_field( util::string_view field, double value )
 
 double spelleffect_data_t::get_field( util::string_view field ) const
 {
+  if ( ::is_bit_array_field( this, spelleffect_data_bit_array_fields, field ) )
+    return 0.0;
+
   return ::get_field( this, spelleffect_data_fields, field );
 }
 

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -58,7 +58,6 @@ template <typename T, typename Fields>
 bool override_bit_array_field( T* data, const Fields& fields, util::string_view name, double value )
 {
   return detail::handle_field( data, fields, name, [ value ] ( auto& field ) {
-    auto max = std::size( field );
     bool add = true;
     auto v = static_cast<int>( value );
     if ( v < 0 )
@@ -67,7 +66,7 @@ bool override_bit_array_field( T* data, const Fields& fields, util::string_view 
       v = std::abs( v );
     }
 
-    if ( v > max * 32 )
+    if ( v >= std::size( field ) * 32 )
       throw std::invalid_argument( "Invalid value (too large)." );
 
     int idx = v / 32;
@@ -168,8 +167,15 @@ static constexpr auto spelleffect_data_fields = std::make_tuple(
   data_field( "chain_target",            &spelleffect_data_t::_chain_target )
 );
 
+static constexpr auto spelleffect_data_bit_array_fields = std::make_tuple(
+  data_field( "class_flags", &spelleffect_data_t::_class_flags )
+);
+
 bool spelleffect_data_t::override_field( util::string_view field, double value )
 {
+  if ( ::override_bit_array_field( this, spelleffect_data_bit_array_fields, field, value ) )
+    return true;
+
   return ::override_field( this, spelleffect_data_fields, field, value );
 }
 

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -102,7 +102,7 @@ bool spell_data_t::override_field( util::string_view field, double value )
 {
   if ( util::str_prefix_ci( field, "class_flags_" ) )
   {
-    if ( value < 0 || value >= NUM_CLASS_FAMILY_FLAGS * 32 )
+    if ( value < 0 || value > NUM_CLASS_FAMILY_FLAGS * 32 )
       throw std::invalid_argument( "Invalid class flag value." );
 
     auto idx = static_cast<unsigned>( value / 32 );

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -94,11 +94,33 @@ static constexpr auto spell_data_fields = std::make_tuple(
   data_field( "rppm",              &spell_data_t::_rppm ),
   data_field( "dmg_class",         &spell_data_t::_dmg_class ),
   data_field( "max_targets",       &spell_data_t::_max_targets ),
-  data_field( "category",          &spell_data_t::_category )
+  data_field( "category",          &spell_data_t::_category ),
+  data_field( "class_flags_family",&spell_data_t::_class_flags_family )
 );
 
 bool spell_data_t::override_field( util::string_view field, double value )
 {
+  if ( util::str_prefix_ci( field, "class_flags_" ) )
+  {
+    auto idx = static_cast<unsigned>( value / 32 );
+
+    if ( idx < 0 || idx >= NUM_CLASS_FAMILY_FLAGS )
+      throw std::invalid_argument( "Invalid class flag value." );
+
+    auto bit = 1u << ( static_cast<unsigned>( value ) % 32 );
+
+    if ( util::str_in_str_ci( field, "add" ) )
+    {
+      _class_flags[idx] |= bit;
+      return true;
+    }
+    else if ( util::str_in_str_ci( field, "remove" ) )
+    {
+      _class_flags[idx] &= ~bit;
+      return true;
+    }
+  }
+
   return ::override_field( this, spell_data_fields, field, value );
 }
 


### PR DESCRIPTION
Bit array fields such as class_flags & attributes can have bits added & removed via:

`override.spell_data=spell|effect.<id>.<field>=<value>`

`<field>` can be `class_flags` for spells and effects, and `attributes` for spells only.

`<value>` is an integer representing the family/attribute, e.g. 77 for Guardian Druid abilities family, 173 for hasted dot attribute.
A positive \<value\> will add the family/attribute. A negative \<value\> will remove the family/attribute.

Note that class_flags overrides will not show up in `spell_query` outputs.