### PR TITLE
[Priest] add tracking buff for Your Shadow

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -132,6 +132,9 @@ public:
     // Covenants
     propagate_const<buff_t*> fae_guardians;
     propagate_const<buff_t*> boon_of_the_ascended;
+
+    // Tier Sets
+    propagate_const<buff_t*> living_shadow;
   } buffs;
 
   // Talents

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -672,6 +672,21 @@ struct your_shadow_t final : public priest_pet_t
     def->add_action( "torment_mind" );
   }
 
+  // Tracking buff to easily get pet uptime (especially in AoE this is easier)
+  virtual void arise() override
+  {
+    pet_t::arise();
+
+    o().buffs.living_shadow->trigger();
+  }
+
+  virtual void demise() override
+  {
+    pet_t::demise();
+
+    o().buffs.living_shadow->expire();
+  }
+
   action_t* create_action( util::string_view name, util::string_view options_str ) override;
 };
 

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1908,6 +1908,9 @@ void priest_t::create_buffs_shadow()
   buffs.talbadars_stratagem = make_buff( this, "talbadars_stratagem", find_spell( 342415 ) )
                                   ->set_duration( timespan_t::zero() )
                                   ->set_refresh_behavior( buff_refresh_behavior::DURATION );
+
+  // Tier Sets
+  buffs.living_shadow = make_buff( this, "living_shadow", find_spell( 363574 ) );
 }
 
 void priest_t::init_rng_shadow()


### PR DESCRIPTION
With the way the pet works, you can get uptime of the spell it casts, Torment Mind, but this is not exactly helpful in AoE scenarios. In AoE the actual uptime tracking in SimC on the spell is simply tracking it based on the target currently being channeled on, but becase uptime is then divided by targets (more or less) you get this confusing output:
![old_uptime](https://user-images.githubusercontent.com/10604059/146842632-066617b2-7643-4328-a75a-8f2f252c34e7.png)

From the screenshot you can see it shows an uptime of 18% for Torment Mind, which doesn't correspond to pet uptime as a function of the entire sim, but rather of targets. To work around this I've added a tracking buff to [mimic how this works in-game](https://www.warcraftlogs.com/reports/L6WFMYrDBNCpAtmG#fight=2&type=auras&source=6&ability=363574) so now we get this:
![living_shadow](https://user-images.githubusercontent.com/10604059/146842814-50bf92ee-c4fb-4a0f-9ae7-e6b64b8148f2.png)

Longer term fix would be to have some sort of pet stats section in the SimC output that could include these kinds of stats.