### PR TITLE
Use smart pointer for player creation.

### DIFF
--- a/engine/action/absorb.cpp
+++ b/engine/action/absorb.cpp
@@ -88,7 +88,7 @@ result_amount_type absorb_t::amount_type(const action_state_t*, bool) const
 int absorb_t::num_targets() const
 {
   return as<int>(range::count_if(sim->actor_list,
-    [](player_t* t) {
+    [](const auto& t) {
       if (t->is_sleeping()) return false;
       if (t->is_enemy()) return false;
       return true;

--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -1497,10 +1497,8 @@ timespan_t action_t::cooldown_base_duration( const cooldown_t& cd ) const
 int action_t::num_targets() const
 {
   int count = 0;
-  for ( size_t i = 0, actors = sim->actor_list.size(); i < actors; i++ )
+  for ( const auto& t : sim->actor_list )
   {
-    player_t* t = sim->actor_list[ i ];
-
     if ( !t->is_sleeping() && t->is_enemy() )
       count++;
   }

--- a/engine/action/heal.cpp
+++ b/engine/action/heal.cpp
@@ -371,10 +371,10 @@ player_t* heal_t::smart_target() const
 int heal_t::num_targets() const
 {
   return as<int>(range::count_if(sim->actor_list,
-    [this](player_t* t) {
+    [this](const auto& t) {
       if (t->is_sleeping()) return false;
       if (t->is_enemy()) return false;
-      if (t == target) return false;
+      if (t.get() == target) return false;
       if (group_only && (t->party != target->party)) return false;
       return true;
     }));

--- a/engine/class_modules/class_module.hpp
+++ b/engine/class_modules/class_module.hpp
@@ -11,6 +11,7 @@
 #include "util/generic.hpp"
 #include "util/string_view.hpp"
 
+#include <memory>
 #include <vector>
 
 struct player_t;
@@ -25,10 +26,10 @@ struct module_t
   {
   }
 
-  virtual ~module_t()                                                                               = default;
-  virtual player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const = 0;
-  virtual bool valid() const                                                                        = 0;
-  virtual void init( player_t* ) const                                                              = 0;
+  virtual ~module_t() = default;
+  virtual std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const = 0;
+  virtual bool valid() const                                                                                        = 0;
+  virtual void init( player_t* ) const                                                                              = 0;
   virtual void static_init() const
   {
   }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -8761,9 +8761,9 @@ struct monk_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r ) const override
   {
-    auto p              = new monk_t( sim, name, r );
+    auto p              = std::make_unique<monk_t>( sim, name, r );
     p->report_extension = std::make_unique<monk_report_t>( *p );
     return p;
   }

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -3443,10 +3443,10 @@ struct paladin_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto p              = new paladin_t( sim, name, r );
-    p->report_extension = std::unique_ptr<player_report_extension_t>( new paladin_report_t( *p ) );
+    auto p              = std::make_unique<paladin_t>( sim, name, r );
+    p->report_extension = std::make_unique<paladin_report_t>( *p );
     return p;
   }
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -2363,9 +2363,9 @@ struct priest_module_t final : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r ) const override
   {
-    return new priest_t( sim, name, r );
+    return std::make_unique<priest_t>( sim, name, r );
   }
   bool valid() const override
   {

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9102,7 +9102,7 @@ void death_knight_t::activate()
 {
   player_t::activate();
 
-  range::for_each( sim->actor_list, [ this ]( player_t* target ) {
+  range::for_each( sim->actor_list, [ this ]( const auto& target ) {
     if ( !target->is_enemy() )
     {
       return;
@@ -9739,10 +9739,10 @@ private:
 struct death_knight_module_t : public module_t {
   death_knight_module_t() : module_t( DEATH_KNIGHT ) {}
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto  p = new death_knight_t( sim, name, r );
-    p -> report_extension = std::unique_ptr<player_report_extension_t>( new death_knight_report_t( *p ) );
+    auto  p = std::make_unique<death_knight_t>( sim, name, r );
+    p -> report_extension = std::make_unique<death_knight_report_t>( *p );
     return p;
   }
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6942,10 +6942,10 @@ public:
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto p = new demon_hunter_t( sim, name, r );
-    p->report_extension = std::unique_ptr<player_report_extension_t>( new demon_hunter_report_t( *p ) );
+    auto p = std::make_unique<demon_hunter_t>( sim, name, r );
+    p->report_extension = std::make_unique<demon_hunter_report_t>( *p );
     return p;
   }
 

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -4856,9 +4856,9 @@ struct lifebloom_t : public druid_heal_t
   void impact( action_state_t* state ) override
   {
     // Cancel Dot/td-buff on all targets other than the one we impact on
-    for ( size_t i = 0; i < sim->actor_list.size(); ++i )
+    for ( auto& actor : sim->actor_list )
     {
-      player_t* t = sim->actor_list[ i ];
+      player_t* t = actor.get();
 
       if ( state->target == t )
         continue;
@@ -6370,7 +6370,7 @@ struct stampeding_roar_t : public druid_spell_t
     if ( !p()->conduit.front_of_the_pack->ok() )
       return;
 
-    for ( auto actor : sim->actor_list )
+    for ( const auto& actor : sim->actor_list )
     {
       if ( actor->type == PLAYER_GUARDIAN )
         continue;
@@ -10991,10 +10991,10 @@ struct druid_module_t : public module_t
 {
   druid_module_t() : module_t( DRUID ) {}
 
-  player_t* create_player( sim_t* sim, std::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, std::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto p              = new druid_t( sim, name, r );
-    p->report_extension = std::unique_ptr<player_report_extension_t>( new druid_report_t( *p ) );
+    auto p              = std::make_unique<druid_t>( sim, name, r );
+    p->report_extension = std::make_unique<druid_report_t>( *p );
     return p;
   }
   bool valid() const override { return true; }

--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -234,7 +234,7 @@ struct enemy_action_t : public ACTION_TYPE
     {
       for ( size_t i = 0, actors = this->sim->actor_list.size(); i < actors; i++ )
       {
-        player_t* actor = this->sim->actor_list[ i ];
+        player_t* actor = this->sim->actor_list[ i ].get();
         // only add non heal_target tanks to this list for now
         if ( !actor->is_sleeping() && !actor->is_enemy() && actor->primary_role() == ROLE_TANK &&
              actor != this->target && actor != this->sim->heal_target )
@@ -820,11 +820,11 @@ struct spell_aoe_t : public enemy_action_t<spell_t>
     }
     else
     {
-      for ( size_t i = 0, actors = sim->actor_list.size(); i < actors; ++i )
+      for (auto & actor : sim->actor_list)
       {
-        if ( !sim->actor_list[ i ]->is_sleeping() && !sim->actor_list[ i ]->is_enemy() &&
-             sim->actor_list[ i ] != target )
-          tl.push_back( sim->actor_list[ i ] );
+        player_t* t = actor.get();
+        if ( !t->is_sleeping() && !t->is_enemy() && t != target )
+          tl.push_back( t );
       }
     }
 
@@ -1876,9 +1876,9 @@ struct enemy_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e /* r = RACE_NONE */ ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e /* r = RACE_NONE */ ) const override
   {
-    return new enemy_t( sim, name );
+    return std::make_unique<enemy_t>( sim, name );
   }
   bool valid() const override
   {
@@ -1903,10 +1903,9 @@ struct heal_enemy_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e /* r = RACE_NONE */ ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e /* r = RACE_NONE */ ) const override
   {
-    auto p = new heal_enemy_t( sim, name );
-    return p;
+    return std::make_unique<heal_enemy_t>( sim, name );
   }
   bool valid() const override
   {
@@ -1931,10 +1930,9 @@ struct tank_dummy_enemy_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e /* r = RACE_NONE */ ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e /* r = RACE_NONE */ ) const override
   {
-    auto p = new tank_dummy_enemy_t( sim, name );
-    return p;
+    return std::make_unique<tank_dummy_enemy_t>( sim, name );
   }
   bool valid() const override
   {

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -6925,10 +6925,10 @@ struct hunter_module_t: public module_t
 {
   hunter_module_t(): module_t( HUNTER ) {}
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto  p = new hunter_t( sim, name, r );
-    p -> report_extension = std::unique_ptr<player_report_extension_t>( new hunter_report_t( *p ) );
+    auto  p = std::make_unique<hunter_t>( sim, name, r );
+    p -> report_extension = std::make_unique<hunter_report_t>( *p );
     return p;
   }
 

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -7513,9 +7513,9 @@ public:
     module_t( MAGE )
   { }
 
-  player_t* create_player( sim_t* sim, std::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, std::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto p = new mage_t( sim, name, r );
+    auto p = std::make_unique<mage_t>( sim, name, r );
     p->report_extension = std::make_unique<mage_report_t>( *p );
     return p;
   }

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -9269,9 +9269,9 @@ class rogue_module_t : public module_t
 public:
   rogue_module_t() : module_t( ROGUE ) {}
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    return new rogue_t( sim, name, r );
+    return std::make_unique<rogue_t>( sim, name, r );
   }
 
   bool valid() const override

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -10630,10 +10630,10 @@ struct shaman_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto p              = new shaman_t( sim, name, r );
-    p->report_extension = std::unique_ptr<player_report_extension_t>( new shaman_report_t( *p ) );
+    auto p              = std::make_unique<shaman_t>( sim, name, r );
+    p->report_extension = std::make_unique<shaman_report_t>( *p );
     return p;
   }
 

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -8879,10 +8879,10 @@ struct warrior_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    auto p              = new warrior_t( sim, name, r );
-    p->report_extension = std::unique_ptr<player_report_extension_t>( new warrior_report_t( *p ) );
+    auto p              = std::make_unique<warrior_t>( sim, name, r );
+    p->report_extension = std::make_unique<warrior_report_t>( *p );
     return p;
   }
 

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1925,9 +1925,9 @@ struct warlock_module_t : public module_t
   {
   }
 
-  player_t* create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
+  std::unique_ptr<player_t> create_player( sim_t* sim, util::string_view name, race_e r = RACE_NONE ) const override
   {
-    return new warlock_t( sim, name, r );
+    return std::make_unique<warlock_t>( sim, name, r );
   }
 
   //TODO: Hotfix may not be needed any longer, if so leave this function empty instead

--- a/engine/interfaces/bcp_api.cpp
+++ b/engine/interfaces/bcp_api.cpp
@@ -795,12 +795,8 @@ player_t* parse_player( sim_t*            sim,
   {
     throw std::runtime_error(fmt::format("No class module could be found for '{}'.", class_name ));
   }
-  const module_t* module = module_t::get( player_type );
 
-  if ( ! module || ! module -> valid() )
-  {
-    throw std::runtime_error(fmt::format("Module for class '{}' is currently not available.", class_name ));
-  }
+
 
   std::string name = player.name;
 
@@ -813,7 +809,7 @@ player_t* parse_player( sim_t*            sim,
   if ( ! name.empty() )
     sim -> current_name = name;
 
-  player_t* p = sim -> active_player = module -> create_player( sim, name, race );
+  player_t* p = sim -> active_player = sim->create_player( player_type, name, race );
 
   if ( ! p )
   {

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -1917,7 +1917,7 @@ void blood_rite( special_effect_t& effect )
   auto buff = effect.custom_buff;
 
   //Kills refresh buff
-  range::for_each( effect.player -> sim -> actor_list, [buff]( player_t* target ) {
+  range::for_each( effect.player -> sim -> actor_list, [buff]( const auto& target ) {
     if ( !target -> is_enemy() )
     {
       return;
@@ -5475,7 +5475,7 @@ void aegis_of_the_deep( special_effect_t& effect )
 
   //Spelldata shows a buff trigger every 1s, but in-game observation show an immediate change
   //Add a callback on arise and demise to each enemy in the simulation
-  range::for_each( effect.player -> sim -> actor_list, [ p = effect.player, aegis_buff ]( player_t* target )
+  range::for_each( effect.player -> sim -> actor_list, [ p = effect.player, aegis_buff ]( const auto& target )
   {
     // Don't do anything on players
     if ( !target -> is_enemy() )
@@ -5672,7 +5672,7 @@ struct reaping_flames_t : public azerite_essence_major_t
       damage_buff = make_buff( player, "reaping_flames", player->find_spell( 311202 ) )
         ->set_default_value( essence.spell_ref( 3U, essence_spell::UPGRADE, essence_type::MAJOR ).effectN( 1 ).percent() );
 
-      range::for_each( sim->actor_list, [ this ] ( player_t* target )
+      range::for_each( sim->actor_list, [ this ] ( const auto& target )
       {
         if ( !target->is_enemy() )
           return;

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -1220,7 +1220,6 @@ player_t::player_t( sim_t* s, player_e t, util::string_view n, race_e r )
     resource_threshold_trigger()
 {
   actor_index = sim->actor_list.size();
-  sim->actor_list.push_back( this );
 
   if ( ! is_enemy() && ! is_pet() )
   {

--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -1869,11 +1869,11 @@ void kevins_oozeling( special_effect_t& effect )
       pet_t::demise();
 
       // When the pet expires any debuffs it put out are expired as well
-      range::for_each( owner->sim->actor_list, [ this ]( player_t* t ) {
+      range::for_each( owner->sim->actor_list, [ this ]( const auto& t ) {
         if ( !t->is_enemy() )
           return;
 
-        auto td = owner->get_target_data( t );
+        auto td = owner->get_target_data( t.get() );
         if ( td->debuff.kevins_wrath->check() )
           td->debuff.kevins_wrath->expire();
       } );

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -1612,7 +1612,7 @@ void items::briny_barnacle( special_effect_t& effect )
 
   auto p = effect.player;
   // Add a callback on demise to each enemy in the simulation
-  range::for_each( p->sim->actor_list, [p, explosion]( player_t* target ) {
+  range::for_each( p->sim->actor_list, [p, explosion]( const auto& target ) {
     // Don't do anything on players
     if ( !target->is_enemy() )
     {

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -2965,7 +2965,7 @@ struct ceaseless_toxin_t : public proc_spell_t
   {
     proc_spell_t::activate();
 
-    range::for_each( sim -> actor_list, [ this ]( player_t* target ) {
+    range::for_each( sim -> actor_list, [ this ]( const auto& target ) {
       if ( ! target -> is_enemy() )
       {
         return;

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -1723,7 +1723,7 @@ void shadowgrasp_totem( special_effect_t& effect )
       cd_adjust = timespan_t::from_seconds(
         -source->find_spell( 329878 )->effectN( 3 ).base_value() );
 
-      range::for_each( effect.player->sim->actor_list, [ this ]( player_t* t ) {
+      range::for_each( effect.player->sim->actor_list, [ this ]( const auto& t ) {
         t->register_on_demise_callback( source, [ this ]( player_t* actor ) {
           trigger_target_death( actor );
         } );

--- a/engine/report/reports.cpp
+++ b/engine/report/reports.cpp
@@ -24,9 +24,8 @@ namespace report
 void print_profiles(sim_t* sim)
 {
   int k = 0;
-  for (unsigned int i = 0; i < sim->actor_list.size(); i++)
+  for ( const auto& p : sim->actor_list )
   {
-    player_t* p = sim->actor_list[i];
     if (p->is_pet())
       continue;
 
@@ -132,9 +131,8 @@ void print_profiles(sim_t* sim)
         "# Contains %d Players.\n\n",
         k);
 
-      for (unsigned int i = 0; i < sim->actor_list.size(); ++i)
+      for ( const auto& p : sim->actor_list )
       {
-        player_t* p = sim->actor_list[i];
         if (p->is_pet())
           continue;
 

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -30,6 +30,7 @@ namespace highchart {
     struct chart_t;
 }
 struct iteration_data_entry_t;
+struct module_t;
 struct option_t;
 struct plot_t;
 struct raid_event_t;
@@ -136,7 +137,7 @@ struct sim_t : private sc_thread_t
   std::string current_name, default_region_str, default_server_str, save_prefix_str, save_suffix_str;
   bool         save_talent_str;
   talent_format talent_input_format;
-  auto_dispose< std::vector<player_t*> > actor_list;
+  std::vector<std::unique_ptr<player_t>> actor_list;
   std::string main_target_str;
   int         stat_cache;
   int         max_aoe_enemies;
@@ -623,6 +624,7 @@ struct sim_t : private sc_thread_t
   cooldown_t* get_cooldown( util::string_view name );
   void      use_optimal_buffs_and_debuffs( int value );
   std::unique_ptr<expr_t>   create_expression( util::string_view name );
+  player_t* create_player(player_e player_type, util::string_view name, race_e race); 
   /**
    * Create error with printf formatting.
    */
@@ -713,6 +715,7 @@ struct sim_t : private sc_thread_t
   }
 
 private:
+  player_t* create_player(const module_t& class_module, util::string_view name, race_e race); 
   void set_error(std::string error);
   void do_pause();
   void print_spell_query();


### PR DESCRIPTION
Change module_t::create_player to return std::unique_ptr<player_t> and store it to sim->actor_list.

This avoid direct new usage and in theory avoids memory leaks if anything throws in player construction, or something even stranger if the derived player class throws.

- Add some convenience functions in sim_t
- Adjust loops using actor_list with hardcoded type
- Use make_unique for some player report extensions.