### PR TITLE
[Stats] allow actions to use custom stat objects

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -4308,6 +4308,11 @@ dot_t* action_t::find_dot( player_t* t ) const
   return target_specific_dot[ t ];
 }
 
+stats_t* action_t::new_stats( util::string_view name, player_t* player )
+{
+  return new stats_t( name, player );
+}
+
 void action_t::add_child( action_t* child )
 {
   child->parent_dot = target->get_dot( name_str, player );

--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -559,6 +559,8 @@ public:
 
   virtual ~action_t();
 
+  virtual stats_t* new_stats( util::string_view name, player_t* player );
+
   void add_child( action_t* child );
 
   void add_option( std::unique_ptr<option_t> new_option );

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -7299,7 +7299,10 @@ stats_t* player_t::get_stats( util::string_view n, action_t* a )
 
   if ( !stats )
   {
-    stats = new stats_t( n, this );
+    if ( a )
+      stats = a->new_stats( n, this );
+    else
+      stats = new stats_t( n, this );
 
     stats_list.push_back( stats );
   }

--- a/engine/player/stats.hpp
+++ b/engine/player/stats.hpp
@@ -101,11 +101,11 @@ public:
   void add_execute( timespan_t time, player_t* target );
   void add_tick   ( timespan_t time, player_t* target );
   void add_refresh( player_t* target );
-  void datacollection_begin();
-  void datacollection_end();
-  void reset();
-  void analyze();
-  void merge( const stats_t& other );
+  virtual void datacollection_begin();
+  virtual void datacollection_end();
+  virtual void reset();
+  virtual void analyze();
+  virtual void merge( const stats_t& other );
   const std::string& name() const { return name_str; }
   unsigned mask() const { return 1 << type; }
 

--- a/engine/report/decorators.cpp
+++ b/engine/report/decorators.cpp
@@ -301,8 +301,6 @@ public:
 
   std::string token() const override
   {
-    std::string token = spell_decorator_t<action_t>::token();
-
     if ( stat && stat->prefer_name )
       return util::encode_html( stat->name() );
 


### PR DESCRIPTION
`player_t::get_stats()` called with a valid action will use virtual method
`action_t::new_stats()`, which can be overriden to create a custom stat object
derived from `stats_t`.

`player_t::get_stats()` called with a null action will default to creating
a base `stats_t` object.