### PR TITLE
[Player] Add Generic Options for Precombat Buff and Cooldown States

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -624,7 +624,8 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     start_intervals(),
     trigger_intervals(),
     duration_lengths(),
-    change_regen_rate( false )
+    change_regen_rate( false ),
+    allow_precombat( true )
 {
   if ( source )  // Player Buffs
   {
@@ -1238,6 +1239,12 @@ buff_t* buff_t::set_reverse_stack_count( int count )
 buff_t* buff_t::set_stack_behavior( buff_stack_behavior b )
 {
   stack_behavior = b;
+  return this;
+}
+
+buff_t* buff_t::set_allow_precombat( bool b )
+{
+  allow_precombat = b;
   return this;
 }
 

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -109,6 +109,7 @@ public:
   buff_refresh_duration_callback_t refresh_duration_callback;
   buff_stack_behavior stack_behavior;
   buff_stack_change_callback_t stack_change_callback;
+  bool allow_precombat;
 
   // Ticking buff values
   unsigned current_tick;
@@ -361,6 +362,7 @@ public:
   buff_t* set_stack_change_callback( const buff_stack_change_callback_t& cb );
   buff_t* set_reverse_stack_count( int count );
   buff_t* set_stack_behavior( buff_stack_behavior b );
+  buff_t* set_allow_precombat( bool b );
 
   virtual buff_t* apply_affecting_aura( const spell_data_t* spell );
   virtual buff_t* apply_affecting_effect( const spelleffect_data_t& effect );

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -3076,12 +3076,12 @@ void player_t::init_finished()
           std::get<0>( precombat_buff_state[ buff ] ) = util::to_int( v.second );
           continue;
         }
-        else if (splits [ 2 ] == "value" )
+        else if ( splits [ 2 ] == "value" )
         {
           std::get<1>( precombat_buff_state[ buff ] ) = util::to_double( v.second );
           continue;
         }
-        else if (splits [ 2 ] == "remains" )
+        else if ( splits [ 2 ] == "remains" )
         {
           std::get<2>( precombat_buff_state[ buff ] ) = timespan_t::from_seconds( util::to_double( v.second ) );
           continue;

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -311,6 +311,9 @@ struct player_t : public actor_t
   bool no_action_list_provided;
   std::unordered_map<std::string, std::string> apl_variable_map;
 
+  // Precombat State
+  std::unordered_map<std::string, std::string> precombat_state_map;
+
   bool quiet;
   // Reporting
   std::unique_ptr<player_report_extension_t> report_extension;
@@ -885,6 +888,8 @@ public:
   virtual void create_actions();
   virtual void init_actions();
   virtual void init_finished();
+  virtual void add_precombat_buff_state( buff_t* buff, int stacks, double value, timespan_t duration );
+  virtual void add_precombat_cooldown_state( cooldown_t* cd, timespan_t duration );
   virtual void apply_affecting_auras(action_t&);
   virtual void action_init_finished(action_t&);
   virtual bool verify_use_items() const;

--- a/engine/sim/cooldown.cpp
+++ b/engine/sim/cooldown.cpp
@@ -107,7 +107,8 @@ cooldown_t::cooldown_t( util::string_view n, player_t& p ) :
   execute_types_mask( 0U ),
   current_charge( 1 ),
   recharge_multiplier( 1.0 ),
-  base_duration( 0_ms )
+  base_duration( 0_ms ),
+  allow_precombat( true )
 { }
 
 cooldown_t::cooldown_t( util::string_view n, sim_t& s ) :
@@ -127,7 +128,8 @@ cooldown_t::cooldown_t( util::string_view n, sim_t& s ) :
   execute_types_mask( 0U ),
   current_charge( 1 ),
   recharge_multiplier( 1.0 ),
-  base_duration( 0_ms )
+  base_duration( 0_ms ),
+  allow_precombat( true )
 { }
 
 /**

--- a/engine/sim/cooldown.hpp
+++ b/engine/sim/cooldown.hpp
@@ -37,6 +37,7 @@ struct cooldown_t
   timespan_t last_start, last_charged;
   bool hasted; // Hasted cooldowns will reschedule based on haste state changing (through buffs). TODO: Separate hastes?
   action_t* action; // Dynamic cooldowns will need to know what action triggered the cd
+  bool allow_precombat;
 
   // Associated execution types amongst all the actions shared by this cooldown. Bitmasks based on
   // the execute_type enum class


### PR DESCRIPTION
This adds a generic system to let users specify the precombat state of buffs and cooldowns for an actor.
Valid options include:
`override.precombat_state=cooldown.<name>=<remaining_cooldown_duration>`
`override.precombat_state=buff.<name>.stack=<buff_stacks>`
`override.precombat_state=buff.<name>.value=<buff_value>`
`override.precombat_state=buff.<name>.remains=<remaining_buff_duration>`

By default, this will simply `start` the cooldown with that name or `execute` the buff with that name.

Individual buffs and cooldowns can have this system disabled by setting their `allow_precombat` member to false. Buffs also have `buff_t* buff_t::set_allow_precombat( bool )` to set this.

Class modules may implement specialized behavior through overriding `player_t::add_precombat_buff_state` and `player_t::add_precombat_cooldown_state` to add support for buffs and cooldowns that will not work with the default system.

Any simulation run with this option will output the following warning due to how easy it is to misuse this system.
> Warning: The 'override.precombat_state' option may not be fully supported for all buffs and cooldowns and and may produce incorrect or misleading results.