### PR TITLE
[Expr] use action_t::get_dot() instead of player_t::get_dot() in dot_expr_t

### DIFF
--- a/engine/action/dot.cpp
+++ b/engine/action/dot.cpp
@@ -375,7 +375,7 @@ struct dot_expr_t : public expr_t
 
     dot_t*& dot = specific_dot[ dot_target ];
     if ( !dot )
-      dot = dot_target->get_dot( action->name_str, action->player );
+      dot = action->get_dot( dot_target );
 
     return dot;
   }


### PR DESCRIPTION
Currently player_t::get_dot() is used to find the matching dot by name string
match with the action name. For actions where get_dot() is overridden and
returns a dot with a differing name, dot expressions such as `refreshable`
and `ticking` will fail to find the correct dot.

Switch to using action_t::get_dot() to allow overriden methods to return the
correct dot, while the base method resolves to calling player_t::get_dot().