### PR TITLE
Fix stat_buff_t value computation

### DIFF
--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -399,8 +399,8 @@ struct stat_buff_t : public buff_t
       // Blizzard likes to use effect coefficients that give (almost) exact values at the
       // intended level. Small floating point conversion errors can add up to give the wrong
       // value. We compensate by increasing the absolute value by a tiny bit before truncating.
-      double epsilon = amount >= 0.0 ? 1e-3 : -1e-3;
-      return std::trunc( stacks * amount + epsilon );
+      double val = std::max( 1.0, std::fabs( amount ) );
+      return std::copysign( std::trunc( stacks * val + 1e-3 ), amount );
     }
   };
   std::vector<buff_stat_t> stats;

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -393,6 +393,14 @@ struct stat_buff_t : public buff_t
       : stat( s ), amount( a ), current_value( 0 ), check_func( std::move( c ) )
     {
     }
+
+    double stack_amount( int stacks ) const
+    {
+      // Blizzard likes to use effect coefficients that give (almost) exact values at the
+      // intended level. Small floating point conversion errors can add up to give the wrong
+      // value. We compensate by increasing the value by a tiny bit before truncating.
+      return std::trunc( stacks * amount + 1e-3 );
+    }
   };
   std::vector<buff_stat_t> stats;
   gain_t* stat_gain;

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -398,8 +398,9 @@ struct stat_buff_t : public buff_t
     {
       // Blizzard likes to use effect coefficients that give (almost) exact values at the
       // intended level. Small floating point conversion errors can add up to give the wrong
-      // value. We compensate by increasing the value by a tiny bit before truncating.
-      return std::trunc( stacks * amount + 1e-3 );
+      // value. We compensate by increasing the absolute value by a tiny bit before truncating.
+      double epsilon = amount >= 0.0 ? 1e-3 : -1e-3;
+      return std::trunc( stacks * amount + epsilon );
     }
   };
   std::vector<buff_stat_t> stats;

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -5201,7 +5201,7 @@ struct worldvein_resonance_buff_t : public buff_t
 
     if ( lifeblood->check() )
     {
-      double delta = stat_entry.amount * lifeblood->current_stack - stat_entry.current_value;
+      double delta = stat_entry.stack_amount( lifeblood->current_stack ) - stat_entry.current_value;
       sim->print_debug( "{} worldvein_resonance {}creases lifeblood stats by {}%,"
                         " stacks={}, old={}, new={} ({}{})",
         player->name(),

--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -353,7 +353,7 @@ void grove_invigoration( special_effect_t& effect )
           {
             s.amount /= mul;
 
-            double delta = s.amount * ra->current_stack - s.current_value;
+            double delta = s.stack_amount( ra->current_stack ) - s.current_value;
 
             if ( delta > 0 )
               b->player->stat_gain( s.stat, delta, ra->stat_gain, nullptr, ra->buff_duration() > 0_ms );


### PR DESCRIPTION
In game, the value of a stat buff is truncated after it is multiplied by the stack number, not before.