### PR TITLE
[Priest] add in timing delays for T28 Your Shadow

### DIFF
--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -721,6 +721,21 @@ struct your_shadow_torment_mind_t final : public priest_pet_spell_t
 
     merge_pet_stats( p().o(), p(), *this );
   }
+
+  timespan_t execute_time() const override
+  {
+    // Right now there is a bug/delay between channels and on spawn time
+    // There is a delay between the last tick of channel 1 and the first tick of channel 2
+    // https://github.com/WarcraftPriests/sl-shadow-priest/issues/229
+    if ( p().o().bugs )
+    {
+      return timespan_t::from_millis( 500 );
+    }
+    else
+    {
+      return priest_pet_spell_t::execute_time();
+    }
+  }
 };
 
 action_t* your_shadow_t::create_action( util::string_view name, util::string_view options_str )

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -179,7 +179,12 @@ public:
         }
         else
         {
-          priest().pets.your_shadow.spawn();
+          // There is a ~1s delay between consuming the Dark Thought, and the Shadow Spawning
+          // This is intentional due to the way the pet spawns attached to the player
+          // NOTE: This could cause 2 pets to be scheduled if you consume a Dark Thought proc while waiting for the first pet to spawn
+          // NOTE: While not ideal this is basically not possible unless Dark Thought buffs start stacking.
+          sim->print_debug( "{} consumes Dark Thought, delaying Your Shadow spawn by 1 second.", priest() );
+          make_event( *sim, timespan_t::from_seconds( 1 ), [ this ] { priest().pets.your_shadow.spawn(); } );
         }
       }
     }


### PR DESCRIPTION
This implements the "quirks"/bugs with this issue: https://github.com/WarcraftPriests/sl-shadow-priest/issues/229

Specifically:
- Add delay between consuming Dark Thought and spawning the shadow, equivalent to 1 second
- Add delay between channel 1 last tick and channel 2 cast/first tick

I did this by the following:
- Add in a 1 second delay between consuming the Dark Thought and the spawn of the pet by using a Make Event delay
- Add a cast time of 500ms to the channel cast of Torment Mind

Overall I'm mostly happy with these changes, the one concern I have is the pet spawn delay could impact things if Dark Thought ever gets to stack. Basically there is a bad zone where you schedule a pet to spawn 1s later, but if you get and consume another proc in that 1s you would try and spawn a second pet. I'm not actually sure how simc would handle this, but since Dark Thought currently does not stack this should be more than fine for now. The GCD to consume the Dark Thought is already going to make it nearly impossible to execute this in practice anyways.

Sim log post change:

```
7.333 Player 'Publord' loses Buff dark_thought
7.333 Player 'Publord' consumes Dark Thought, delaying Your Shadow spawn by 1 second.
8.333 Player 'Publord_your_shadow' arises. Spawn Index=2
8.333 New Action Execute Event: Player 'Publord_your_shadow' Action torment_mind time_to_execute=0.500 (target=Fluffy_Pillow, marker=0)
8.833 Player 'Publord_your_shadow' performs Action torment_mind (0)
8.833 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 988.0786211246216 shadow damage (hit)
9.620 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 988.0786211246216 shadow damage (hit)
10.407 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 1086.3437070205293 shadow damage (hit)
11.194 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 1086.3437070205293 shadow damage (hit)
11.981 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 1086.3437070205293 shadow damage (hit)
12.768 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 1086.3437070205293 shadow damage (hit)
13.555 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 1086.3437070205293 shadow damage (hit)
14.055 Player 'Publord_your_shadow' torment_mind_tick hits Player 'Fluffy_Pillow' for 2172.6874140410587 shadow damage (crit)

```