### PR TITLE
[Druid] enable `druid.ptr_bugs=1` option

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -4077,22 +4077,17 @@ struct sickle_of_the_lion_t : public cat_attack_t
     return pm;
   }
 
+  void assess_damage( result_amount_type type, action_state_t* s )
+  {
+    cat_attack_t::assess_damage( p()->options.ptr_bugs ? result_amount_type::DMG_DIRECT : type, s );
+  }
+
   double composite_target_ta_multiplier( player_t* t ) const override
   {
     double ttm = cat_attack_t::composite_target_ta_multiplier( t );
 
-    if ( p()->options.ptr_bugs )
-    {
-      double armor = composite_target_armor( t );
-      double resist = armor / ( armor + t->base.armor_coeff );
-      resist = clamp( resist, 0.0, 0.85 );
-      ttm *= 1.0 - resist;
-    }
-    else
-    {
-      if ( td( t )->dots.adaptive_swarm_damage->is_ticking() )
+    if ( !p()->options.ptr_bugs && td( t )->dots.adaptive_swarm_damage->is_ticking() )
         ttm *= 1.0 + as_mul;
-    }
 
     return ttm;
   }

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -4082,16 +4082,6 @@ struct sickle_of_the_lion_t : public cat_attack_t
     cat_attack_t::assess_damage( p()->options.ptr_bugs ? result_amount_type::DMG_DIRECT : type, s );
   }
 
-  double composite_target_ta_multiplier( player_t* t ) const override
-  {
-    double ttm = cat_attack_t::composite_target_ta_multiplier( t );
-
-    if ( !p()->options.ptr_bugs && td( t )->dots.adaptive_swarm_damage->is_ticking() )
-        ttm *= 1.0 + as_mul;
-
-    return ttm;
-  }
-
   double composite_ta_multiplier( const action_state_t* s ) const override
   {
     double tam = cat_attack_t::composite_ta_multiplier( s );


### PR DESCRIPTION
This will enable the following presumptive bugs from the 9.2 PTR:

Balance:
1. Celestial Infusion (AP generation from Fury of Elune proc'd by 2pc set bonus) does not stack and will overwrite itself
    - Default simc behavior is that AP generation from every proc stacks

Feral:
1. Sickle of the Lion (4pc set bonus) snapshots mastery
    - Default simc behavior is that it is not affected by mastery as it is missing from the mastery effect list
2. Sickle of the Lion snapshots Adaptive Swarm debuff
    - Default is that it is not affected by Adaptive Swarm as it is missing from the effect list
3. Sickle of the Lion is mitigated by armor
    - Default is that it ignores armor
4. Sickle of the Lion is dynamically buffed by Tiger's Fury including the Carnivorous Instinct conduit effect
5. Sickle of the Lion is dynamically buffed again by Tiger's Fury only
    - Default is that these dynamic adjustments with Tiger's Fury does not happen