### PR TITLE
[Buff] fix assert with `single_actor_batch` & `buff_uptime_timeline`

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -2558,7 +2558,7 @@ void buff_t::analyze()
     }
     else
     {
-      uptime_array.adjust( source->collected_data.fight_length );
+      uptime_array.adjust( source->get_owner_or_self()->collected_data.fight_length );
     }
   }
 }


### PR DESCRIPTION
Pets don't collect fight_length data, so we need to get this off of the owner if the source of the buff is a pet