### PR TITLE
Avoid full rebuilds with cmake by fixing git_info

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -55,6 +55,10 @@ execute_process(
     OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-target_compile_definitions(engine PUBLIC "SC_GIT_REV=\"${GIT_COMMIT_HASH}\"" "SC_GIT_BRANCH=\"${GIT_BRANCH}\"")
-add_custom_target(update_git_info DEPENDS util/git_info.cpp) 
-add_dependencies(engine update_git_info)
+
+target_compile_definitions(engine PRIVATE "SC_GIT_REV=\"${GIT_COMMIT_HASH}\"" "SC_GIT_BRANCH=\"${GIT_BRANCH}\"")
+
+add_custom_target(file_toucher 
+        COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${CMAKE_CURRENT_SOURCE_DIR}/util/git_info.cpp)
+
+add_dependencies(engine file_toucher)


### PR DESCRIPTION
Previously, every build lead to a full rebuild. This adjusts that by setting the compile definitions as PRIVATE. To compensate for this leading to no automatic recompile of the git_info.cpp file, add a custom file_toucher target.