### PR TITLE
Tweak CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/cache@v2
-        env: { ccache-prefix: 'ubuntu-${{ matrix.cc }}-ccache-${{ env.ccache-generation }}' }
+        env: { ccache-prefix: 'ubuntu-${{ matrix.cc }}-cpp-${{ matrix.cppVersion }}-ccache-${{ env.ccache-generation }}' }
         with:
           path: ${{ runner.workspace }}/.ccache
           key: ${{ env.ccache-prefix }}-${{ github.sha }}
@@ -138,6 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
+        type: [spell_query, log_debug, patchwerk, dungeon_slice]
         include:
           - type: spell_query
             simc_flags: spell_query=spell > /dev/null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
 
 
   ubuntu-clang-run:
-    name: ubuntu-clang-${{ matrix.type }}
+    name: ubuntu-clang-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ubuntu-20.04
     needs: [ ubuntu-clang-build ]
 


### PR DESCRIPTION
* include cpp version in gcc jobs' ccache cache key - currently cpp-20 job essentially does not use ccache

* explicitly add run types to clang run job - currently only dungeon slice is being run