### PR TITLE
[Gear] initial implementation of Architect's Ingenuity Core

### DIFF
--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -547,9 +547,6 @@ struct player_t : public actor_t
 
     // 9.1 Trinkets
     buff_t* reactive_defense_matrix;
-
-    // 9.2 Trinkets
-    buff_t* architects_ingenuity;
   } buffs;
 
   struct debuffs_t

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -547,6 +547,9 @@ struct player_t : public actor_t
 
     // 9.1 Trinkets
     buff_t* reactive_defense_matrix;
+
+    // 9.2 Trinkets
+    buff_t* architects_ingenuity;
   } buffs;
 
   struct debuffs_t

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3002,42 +3002,49 @@ void scars_of_fraternal_strife( special_effect_t& effect )
 // TODO: what happens if another Automa dies near you?
 void architects_ingenuity_core( special_effect_t& effect )
 {
-  if ( unique_gear::create_fallback_buffs( effect, { "chaos_bane" } ) )
+  if ( unique_gear::create_fallback_buffs( effect, { "architects_ingenuity" } ) )
     return;
-
-  // CDR buff you get when an Automa dies
-  auto buff = buff_t::find( effect.player, "architects_ingenuity" );
-  if ( !buff )
-  {
-    auto player              = effect.player;
-    auto recharge_multiplier = 1.0 / ( 1 + effect.driver()->effectN( 2 ).trigger()->effectN( 2 ).percent() );
-
-    buff = make_buff( effect.player, "architects_ingenuity", effect.player->find_spell( 368937 ) )
-               ->set_stack_change_callback( [ player, recharge_multiplier ]( buff_t*, int, int new_ ) {
-                 for ( auto a : player->action_list )
-                 {
-                   // TODO: On the PTR this only affected class spells and did not affect the cooldown of charged
-                   // spells. Is this still the case?
-                   if ( a->data().class_mask() != 0 && a->data().charges() == 0 )
-                   {
-                     if ( new_ == 1 )
-                       a->base_recharge_multiplier *= recharge_multiplier;
-                     else
-                       a->base_recharge_multiplier /= recharge_multiplier;
-                     a->cooldown->adjust_recharge_multiplier();
-                   }
-                 }
-               } );
-  }
 
   struct architects_ingenuity_t : public proc_spell_t
   {
     buff_t* buff;
+    double mult;
 
-    architects_ingenuity_t( const special_effect_t& e, buff_t* b )
-      : proc_spell_t( "architects_ingenuity", e.player, e.player->find_spell( 368203 ) ), buff( b )
+    architects_ingenuity_t( const special_effect_t& e )
+      : proc_spell_t( "architects_ingenuity", e.player, e.player->find_spell( 368203 ) ),
+        buff( buff_t::find( e.player, "architects_ingenuity" ) ),
+        mult( 1.0 / ( 1 + e.driver()->effectN( 2 ).trigger()->effectN( 2 ).percent() ) )
     {
       base_td = data().effectN( 2 ).trigger()->effectN( 1 ).average( e.item );
+
+      if ( !buff )
+      {
+        buff = make_buff( e.player, "architects_ingenuity", e.player->find_spell( 368937 ) );
+      }
+    }
+
+    void init() override
+    {
+      proc_spell_t::init();
+
+      auto p                     = player;
+      double recharge_multiplier = mult;
+
+      buff->set_stack_change_callback( [ p, recharge_multiplier ]( buff_t*, int, int new_ ) {
+        for ( auto a : p->action_list )
+        {
+          // TODO: On the PTR this only affected class spells and did not affect the cooldown of charged
+          // spells. Is this still the case?
+          if ( a->data().class_mask() != 0 && a->data().charges() == 0 )
+          {
+            if ( new_ == 1 )
+              a->base_recharge_multiplier *= recharge_multiplier;
+            else
+              a->base_recharge_multiplier /= recharge_multiplier;
+            a->cooldown->adjust_recharge_multiplier();
+          }
+        }
+      } );
     }
 
     void last_tick( dot_t* d ) override
@@ -3048,7 +3055,7 @@ void architects_ingenuity_core( special_effect_t& effect )
     }
   };
 
-  effect.execute_action = create_proc_action<architects_ingenuity_t>( "architects_ingenuity", effect, buff );
+  effect.execute_action = create_proc_action<architects_ingenuity_t>( "architects_ingenuity", effect );
 }
 
 // Weapons

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3074,6 +3074,7 @@ void architects_ingenuity_core( special_effect_t& effect )
 
     void execute() override
     {
+      // Disabling this parent execute since it creates its own spell
       // proc_spell_t::execute();
       spawner.spawn();
     }
@@ -3087,7 +3088,6 @@ void architects_ingenuity_core( special_effect_t& effect )
   }
 
   effect.player->buffs.architects_ingenuity = buff;
-  // effect.disable_action();
   effect.execute_action = create_proc_action<architects_ingenuity_t>( "architects_ingenuity", effect );
 }
 

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3002,14 +3002,13 @@ void scars_of_fraternal_strife( special_effect_t& effect )
 // TODO: what happens if another Automa dies near you?
 void architects_ingenuity_core( special_effect_t& effect )
 {
-  struct architects_ingenuity_spell_t : public spell_t
+  struct architects_ingenuity_t : public proc_spell_t
   {
-    architects_ingenuity_spell_t( pet_t* p, const special_effect_t& e )
-      : spell_t( "architects_ingenuity", p, p->find_spell( 368203 ) )
+    architects_ingenuity_t( const special_effect_t& e )
+      : proc_spell_t( "architects_ingenuity", e.player, e.player->find_spell( 368203 ) )
     {
       channeled       = true;
       base_td         = data().effectN( 2 ).trigger()->effectN( 1 ).average( e.item );
-      base_multiplier = 1.0;
       hasted_ticks    = false;
     }
 
@@ -3024,59 +3023,12 @@ void architects_ingenuity_core( special_effect_t& effect )
       // Not hasted
       return base_tick_time;
     }
-  };
 
-  struct attendant_automa_pet_t : public pet_t
-  {
-    const special_effect_t& effect;
-
-    attendant_automa_pet_t( const special_effect_t& e )
-      : pet_t( e.player->sim, e.player, "attendant_automa", true, true ), effect( e )
+    void last_tick( dot_t* d ) override
     {
-    }
+      proc_spell_t::last_tick( d );
 
-    action_t* create_action( util::string_view name, util::string_view options ) override
-    {
-      if ( name == "architects_ingenuity" )
-      {
-        return new architects_ingenuity_spell_t( this, effect );
-      }
-
-      return pet_t::create_action( name, options );
-    }
-
-    void init_action_list() override
-    {
-      pet_t::init_action_list();
-
-      if ( action_list_str.empty() )
-        get_action_priority_list( "default" )->add_action( "architects_ingenuity" );
-    }
-
-    virtual void demise() override
-    {
-      pet_t::demise();
-
-      owner->buffs.architects_ingenuity->trigger();
-    }
-  };
-
-  struct architects_ingenuity_t : public proc_spell_t
-  {
-    spawner::pet_spawner_t<attendant_automa_pet_t> spawner;
-
-    architects_ingenuity_t( const special_effect_t& e )
-      : proc_spell_t( "architects_ingenuity", e.player, e.player->find_spell( 368203 ) ),
-        spawner( "architects_ingenuity", e.player, [ &e ]( player_t* ) { return new attendant_automa_pet_t( e ); } )
-    {
-      spawner.set_default_duration( data().duration() );
-    }
-
-    void execute() override
-    {
-      // Disabling this parent execute since it creates its own spell
-      // proc_spell_t::execute();
-      spawner.spawn();
+      player->buffs.architects_ingenuity->trigger();
     }
   };
 

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -4415,7 +4415,7 @@ void register_special_effects()
 
     // 9.2 Trinkets
     unique_gear::register_special_effect( 367930, items::scars_of_fraternal_strife );
-    unique_gear::register_special_effect( 368203 , items::architects_ingenuity_core );
+    unique_gear::register_special_effect( 368203 , items::architects_ingenuity_core, true );
 
     // Weapons
     unique_gear::register_special_effect( 331011, items::poxstorm );


### PR DESCRIPTION
Basic implementation of this trinket: https://ptr.wowhead.com/item=188268/architects-ingenuity-core?bonus=6805

Things missing:
- need a way to add more uptime of the buff. you can gain the buff from other automa's dying, still need to clarify if this is just other people with similar trinkets or if enemies count
- test and verify which spells get the CDR, initial code copied from ineffable truth code