### PR TITLE
[Gear] Implement The First Sigil Trinket

### DIFF
--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -22,6 +22,7 @@
 #include "unique_gear_helper.hpp"
 
 #include "report/decorators.hpp"
+#include <dbc/covenant_data.hpp>
 
 namespace unique_gear::shadowlands
 {
@@ -3174,7 +3175,6 @@ void resonant_reservoir( special_effect_t& effect )
   effect.execute_action = create_proc_action<disintegration_halo_t>( "disintegration_halo", effect );
 }
 
-// TODO: is there a flag we can use to detect covenant signature abilities instead of hardcoding ids?
 void the_first_sigil( special_effect_t& effect )
 {
   auto buff = buff_t::find( effect.player, "the_first_sigil" );
@@ -3190,9 +3190,7 @@ void the_first_sigil( special_effect_t& effect )
     std::vector<unsigned> covenant_actions;
     action_t* covenant_action;
 
-    the_first_sigil_t( const special_effect_t& effect )
-      : generic_proc_t( effect, "the_first_sigil", effect.trigger() ),
-        covenant_actions( { 324631, 310143, 300728, 324739 } )
+    the_first_sigil_t( const special_effect_t& effect ) : generic_proc_t( effect, "the_first_sigil", effect.trigger() )
     {
     }
 
@@ -3201,6 +3199,14 @@ void the_first_sigil( special_effect_t& effect )
       proc_spell_t::init();
 
       // Find any covenant signature abilities in the action list
+      for ( const auto& e : covenant_ability_entry_t::data( player->dbc->ptr ) )
+      {
+        if ( e.class_id == 0 && e.ability_type == 1 )
+        {
+          covenant_actions.push_back( e.spell_id );
+        }
+      }
+
       for ( auto a : player->action_list )
       {
         if ( range::contains( covenant_actions, a->data().id() ) )

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3205,6 +3205,7 @@ void the_first_sigil( special_effect_t& effect )
              e.covenant_id == static_cast<unsigned>( player->covenant->type() ) )
         {
           covenant_signature_id = e.spell_id;
+          break;
         }
       }
 
@@ -3213,6 +3214,7 @@ void the_first_sigil( special_effect_t& effect )
         if ( covenant_signature_id == a->data().id() )
         {
           covenant_action = a;
+          break;
         }
       }
     }

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3187,7 +3187,6 @@ void the_first_sigil( special_effect_t& effect )
 
   struct the_first_sigil_t : generic_proc_t
   {
-    std::vector<unsigned> covenant_actions;
     action_t* covenant_action;
 
     the_first_sigil_t( const special_effect_t& effect ) : generic_proc_t( effect, "the_first_sigil", effect.trigger() )
@@ -3197,19 +3196,21 @@ void the_first_sigil( special_effect_t& effect )
     void init() override
     {
       proc_spell_t::init();
+      unsigned covenant_signature_id;
 
       // Find any covenant signature abilities in the action list
       for ( const auto& e : covenant_ability_entry_t::data( player->dbc->ptr ) )
       {
-        if ( e.class_id == 0 && e.ability_type == 1 )
+        if ( e.class_id == 0 && e.ability_type == 1 &&
+             e.covenant_id == static_cast<unsigned>( player->covenant->type() ) )
         {
-          covenant_actions.push_back( e.spell_id );
+          covenant_signature_id = e.spell_id;
         }
       }
 
       for ( auto a : player->action_list )
       {
-        if ( range::contains( covenant_actions, a->data().id() ) )
+        if ( covenant_signature_id == a->data().id() )
         {
           covenant_action = a;
         }


### PR DESCRIPTION
The buff for this trinket was already working correct but needed to wire up the signature ability reset. Using hard coded IDs for now as I'm not sure there is some way to determine spells otherwise.