### PR TITLE
[Gear] The First Sigil has different effects for Necro and Kyrian

### DIFF
--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3190,6 +3190,11 @@ void resonant_reservoir( special_effect_t& effect )
   effect.execute_action = create_proc_action<disintegration_halo_t>( "disintegration_halo", effect );
 }
 
+// This has a unique on-use depending on your covenant signature ability
+// Necrolord: Starts channeling a free Fleshcraft
+// Kyrian: Consumes a free charge of Phial of Serenity
+// Night Fae: Resets the cooldown of Soulshape
+// Venthyr: Resets the cooldown of Door of Shadows
 void the_first_sigil( special_effect_t& effect )
 {
   auto buff = buff_t::find( effect.player, "the_first_sigil" );
@@ -3239,9 +3244,20 @@ void the_first_sigil( special_effect_t& effect )
     {
       if ( covenant_action )
       {
-        player->sim->print_debug( "{} resets cooldown of {} from the_first_sigil.", player->name(),
-                                  covenant_action->name() );
-        covenant_action->cooldown->reset( false );
+        // Night Fae's Soulshape (NYI) and Venthyr's Door of Shadows (NYI) CDs are Reset
+        if ( player->covenant->type() == covenant_e::NIGHT_FAE || player->covenant->type() == covenant_e::VENTHYR )
+        {
+          player->sim->print_debug( "{} resets cooldown of {} from the_first_sigil.", player->name(),
+                                    covenant_action->name() );
+          covenant_action->cooldown->reset( false );
+        }
+        // Necrolord's Fleshcraft and Kyrian's Phial of Serenity (NYI) cast a free use of the CD
+        if ( player->covenant->type() == covenant_e::NECROLORD || player->covenant->type() == covenant_e::KYRIAN )
+        {
+          player->sim->print_debug( "{} casts a free {} from the_first_sigil.", player->name(),
+                                    covenant_action->name() );
+          covenant_action->execute();
+        }
       }
     }
   };

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3208,9 +3208,14 @@ void the_first_sigil( special_effect_t& effect )
   struct the_first_sigil_t : generic_proc_t
   {
     action_t* covenant_action;
+    cooldown_t* orig_cd;
+    cooldown_t* dummy_cd;
 
     the_first_sigil_t( const special_effect_t& effect )
-      : generic_proc_t( effect, "the_first_sigil", effect.trigger() ), covenant_action( nullptr )
+      : generic_proc_t( effect, "the_first_sigil", effect.trigger() ),
+        covenant_action( nullptr ),
+        orig_cd( cooldown ),
+        dummy_cd( player->get_cooldown( "the_first_sigil" ) )
     {
     }
 
@@ -3256,7 +3261,11 @@ void the_first_sigil( special_effect_t& effect )
         {
           player->sim->print_debug( "{} casts a free {} from the_first_sigil.", player->name(),
                                     covenant_action->name() );
+          // The cooldown of the spell stays intact when we cast the free one
+          covenant_action->cooldown = dummy_cd;
           covenant_action->execute();
+          make_event( *sim, player->sim->shadowlands_opts.the_first_sigil_fleshcraft_cancel_time, [ this ] { covenant_action->cancel(); } );
+          covenant_action->cooldown = orig_cd;
         }
       }
     }

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3195,6 +3195,7 @@ void resonant_reservoir( special_effect_t& effect )
 // Kyrian: Consumes a free charge of Phial of Serenity
 // Night Fae: Resets the cooldown of Soulshape
 // Venthyr: Resets the cooldown of Door of Shadows
+// TODO: use a separate fleshcraft_t action to trigger the effect so that the channel is cancelled correctly
 void the_first_sigil( special_effect_t& effect )
 {
   auto buff = buff_t::find( effect.player, "the_first_sigil" );

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -3848,6 +3848,7 @@ void sim_t::create_options()
   add_option( opt_uint( "shadowlands.precombat_pustules", shadowlands_opts.precombat_pustules, 1, 9 ) );
   add_option( opt_float( "shadowlands.field_of_blossoms_duration_multiplier", shadowlands_opts.field_of_blossoms_duration_multiplier, 0.0, 1.0 ) );
   add_option( opt_float( "shadowlands.cruciform_veinripper_proc_rate", shadowlands_opts.cruciform_veinripper_proc_rate, 0.0, 1.0) );
+  add_option( opt_timespan( "shadowlands.the_first_sigil_fleshcraft_cancel_time", shadowlands_opts.the_first_sigil_fleshcraft_cancel_time, 50_ms, timespan_t::from_seconds( 3 ) ) );
 }
 
 // sim_t::parse_option ======================================================

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -440,6 +440,8 @@ struct sim_t : private sc_thread_t
     bool better_together_ally = true;
     bool enable_rune_words = true;
     bool enable_domination_gems = true;
+    // fleshcraft cancel dely from the_first_sigil
+    timespan_t the_first_sigil_fleshcraft_cancel_time = 50_ms;
   } shadowlands_opts;
 
   // Auras and De-Buffs


### PR DESCRIPTION
Updates the logic of the first sigil to work correctly for Necrolord's. In game it resets the cooldowns of Soulshape and Door of Shadows, and casts a free Fleshcraft of Phial of Serenity.

Right now fleshcraft is the only one implemented in simc but if the other 3 ever get added this should work, although that would depend on how the Kyrian Phial is added.

# Current implementation
## fleshcraft is not on cd:
- casts fleshcraft and refreshes volatile solvent (does not alter cd)
- begins to channel
- cancels based on option Xs later based on the option

## fleshcraft is on cd:
- casts fleshcraft and refreshes volatile solvent (does not alter cd)
- moves onto the next action in the list immediately 