### PR TITLE
[Warlock] Update Affliction T28 and regenerate profiles

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -1049,6 +1049,8 @@ void warlock_t::create_apl_affliction()
   action_priority_list_t* necro = get_action_priority_list( "necro_mw" );
 
   def->add_action( "call_action_list,name=aoe,if=active_enemies>3" );
+
+  def->add_action( "malefic_rapture,if=ptr=1&buff.calamitous_crescendo.up");
   
   def->add_action( "run_action_list,name=necro_mw,if=covenant.necrolord&runeforge.malefic_wrath&active_enemies=1&talent.phantom_singularity", "Call separate action list for Necrolord MW in ST. Currently only optimized for use with PS." );
 

--- a/profiles/PreRaids/PR_Warlock_Affliction.simc
+++ b/profiles/PreRaids/PR_Warlock_Affliction.simc
@@ -38,6 +38,7 @@ actions.precombat+=/unstable_affliction
 
 # Executed every time the actor is available.
 actions=call_action_list,name=aoe,if=active_enemies>3
+actions+=/malefic_rapture,if=ptr=1&buff.calamitous_crescendo.up
 # Call separate action list for Necrolord MW in ST. Currently only optimized for use with PS.
 actions+=/run_action_list,name=necro_mw,if=covenant.necrolord&runeforge.malefic_wrath&active_enemies=1&talent.phantom_singularity
 # Action lists for trinket behavior. Stats are saved for before Soul Rot/Impending Catastrophe/Phantom Singularity, otherwise on cooldown

--- a/profiles/T28_Raid.simc
+++ b/profiles/T28_Raid.simc
@@ -56,10 +56,11 @@ T28_Shaman_Enhancement.simc
 # T28_Shaman_Enhancement_Venthyr.simc
 # T28_Shaman_Enhancement_Necrolord.simc
 
-# T28_Warlock_Affliction.simc
-# T28_Warlock_Demonology.simc
-# T28_Warlock_Demonology_Necrolord.simc
-# T28_Warlock_Destruction.simc
+T28_Warlock_Affliction.simc
+T28_Warlock_Affliction_Necrolord.simc
+T28_Warlock_Demonology.simc
+T28_Warlock_Demonology_Necrolord.simc
+T28_Warlock_Destruction.simc
 
 # T28_Warrior_Arms.simc
 # T28_Warrior_Fury.simc

--- a/profiles/Tier26/T26_Warlock_Affliction.simc
+++ b/profiles/Tier26/T26_Warlock_Affliction.simc
@@ -39,6 +39,7 @@ actions.precombat+=/unstable_affliction
 
 # Executed every time the actor is available.
 actions=call_action_list,name=aoe,if=active_enemies>3
+actions+=/malefic_rapture,if=ptr=1&buff.calamitous_crescendo.up
 # Call separate action list for Necrolord MW in ST. Currently only optimized for use with PS.
 actions+=/run_action_list,name=necro_mw,if=covenant.necrolord&runeforge.malefic_wrath&active_enemies=1&talent.phantom_singularity
 # Action lists for trinket behavior. Stats are saved for before Soul Rot/Impending Catastrophe/Phantom Singularity, otherwise on cooldown

--- a/profiles/Tier27/T27_Warlock_Affliction.simc
+++ b/profiles/Tier27/T27_Warlock_Affliction.simc
@@ -39,6 +39,7 @@ actions.precombat+=/unstable_affliction
 
 # Executed every time the actor is available.
 actions=call_action_list,name=aoe,if=active_enemies>3
+actions+=/malefic_rapture,if=ptr=1&buff.calamitous_crescendo.up
 # Call separate action list for Necrolord MW in ST. Currently only optimized for use with PS.
 actions+=/run_action_list,name=necro_mw,if=covenant.necrolord&runeforge.malefic_wrath&active_enemies=1&talent.phantom_singularity
 # Action lists for trinket behavior. Stats are saved for before Soul Rot/Impending Catastrophe/Phantom Singularity, otherwise on cooldown

--- a/profiles/Tier28/T28_Warlock_Affliction.simc
+++ b/profiles/Tier28/T28_Warlock_Affliction.simc
@@ -39,6 +39,7 @@ actions.precombat+=/unstable_affliction
 
 # Executed every time the actor is available.
 actions=call_action_list,name=aoe,if=active_enemies>3
+actions+=/malefic_rapture,if=ptr=1&buff.calamitous_crescendo.up
 # Call separate action list for Necrolord MW in ST. Currently only optimized for use with PS.
 actions+=/run_action_list,name=necro_mw,if=covenant.necrolord&runeforge.malefic_wrath&active_enemies=1&talent.phantom_singularity
 # Action lists for trinket behavior. Stats are saved for before Soul Rot/Impending Catastrophe/Phantom Singularity, otherwise on cooldown
@@ -264,26 +265,26 @@ shoulders=mantle_of_the_demon_star,id=188888,bonus_id=1505/7187
 back=shroud_of_the_sires_chosen,id=189847,bonus_id=1524/7187
 chest=robes_of_the_demon_star,id=188884,bonus_id=1505/7187,enchant=eternal_stats
 wrists=cuffs_of_the_covert_commander,id=189842,bonus_id=1524/7187/6935,gem_id=173128,enchant=eternal_intellect
-hands=grasps_of_the_demon_star,id=188890,bonus_id=1498/7187
+hands=grimveiled_mittens,id=173244,bonus_id=7031/6649/6648/1588
 waist=grimveiled_belt,id=173248,bonus_id=6648/6649/8129/1588,gem_id=173128
 legs=leggings_of_the_demon_star,id=188887,bonus_id=1498/7187
 feet=boots_of_ceaseless_conflict,id=189794,bonus_id=1524/7187
-finger1=shadowghast_ring,id=178926,bonus_id=7031/6649/6648/1588,gem_id=173128,enchant=tenet_of_haste
+finger1=death_gods_signet,id=179355,bonus_id=1592/7187,gem_id=173128,enchant=tenet_of_haste
 finger2=rygelons_heraldric_ring,id=189854,bonus_id=1524/7187/6935,gem_id=173128,enchant=tenet_of_haste
 trinket1=soulletting_ruby,id=178809,bonus_id=1592/7187
 trinket2=unbound_changeling,id=178708,bonus_id=1592/7187
-main_hand=antumbra_shadow_of_the_cosmos,id=189852,bonus_id=1524/7187,enchant=celestial_guidance
+main_hand=antumbra_shadow_of_the_cosmos,id=189852,bonus_id=1524/7187,enchant=sinful_revelation
 off_hand=forbidden_truth,id=189860,bonus_id=1524/7187
 
 # Gear Summary
 # gear_ilvl=283.13
-# gear_stamina=2915
-# gear_intellect=1900
-# gear_crit_rating=349
-# gear_haste_rating=907
-# gear_mastery_rating=944
+# gear_stamina=2924
+# gear_intellect=1913
+# gear_crit_rating=310
+# gear_haste_rating=937
+# gear_mastery_rating=941
 # gear_versatility_rating=262
-# gear_armor=522
+# gear_armor=526
 # set_bonus=tier28_2pc=1
 # set_bonus=tier28_4pc=1
 default_pet=imp

--- a/profiles/Tier28/T28_Warlock_Affliction_Necrolord.simc
+++ b/profiles/Tier28/T28_Warlock_Affliction_Necrolord.simc
@@ -39,6 +39,7 @@ actions.precombat+=/unstable_affliction
 
 # Executed every time the actor is available.
 actions=call_action_list,name=aoe,if=active_enemies>3
+actions+=/malefic_rapture,if=ptr=1&buff.calamitous_crescendo.up
 # Call separate action list for Necrolord MW in ST. Currently only optimized for use with PS.
 actions+=/run_action_list,name=necro_mw,if=covenant.necrolord&runeforge.malefic_wrath&active_enemies=1&talent.phantom_singularity
 # Action lists for trinket behavior. Stats are saved for before Soul Rot/Impending Catastrophe/Phantom Singularity, otherwise on cooldown
@@ -264,11 +265,11 @@ shoulders=mantle_of_the_demon_star,id=188888,bonus_id=1505/7187
 back=shroud_of_the_sires_chosen,id=189847,bonus_id=1524/7187
 chest=robes_of_the_demon_star,id=188884,bonus_id=1505/7187,enchant=eternal_stats
 wrists=cuffs_of_the_covert_commander,id=189842,bonus_id=1524/7187/6935,gem_id=173128,enchant=eternal_intellect
-hands=grasps_of_the_demon_star,id=188890,bonus_id=1498/7187
+hands=grimveiled_mittens,id=173244,bonus_id=7031/6649/6648/1588
 waist=grimveiled_belt,id=173248,bonus_id=6648/6649/8129/1588,gem_id=173128
 legs=leggings_of_the_demon_star,id=188887,bonus_id=1498/7187
 feet=boots_of_ceaseless_conflict,id=189794,bonus_id=1524/7187
-finger1=shadowghast_ring,id=178926,bonus_id=7031/6649/6648/1588,gem_id=173128,enchant=tenet_of_haste
+finger1=death_gods_signet,id=179355,bonus_id=1592/7187,gem_id=173128,enchant=tenet_of_haste
 finger2=rygelons_heraldric_ring,id=189854,bonus_id=1524/7187/6935,gem_id=173128,enchant=tenet_of_haste
 trinket1=soulletting_ruby,id=178809,bonus_id=1592/7187
 trinket2=unbound_changeling,id=178708,bonus_id=1592/7187
@@ -277,13 +278,13 @@ off_hand=forbidden_truth,id=189860,bonus_id=1524/7187
 
 # Gear Summary
 # gear_ilvl=283.13
-# gear_stamina=2915
-# gear_intellect=1900
-# gear_crit_rating=349
-# gear_haste_rating=907
-# gear_mastery_rating=944
+# gear_stamina=2924
+# gear_intellect=1913
+# gear_crit_rating=310
+# gear_haste_rating=937
+# gear_mastery_rating=941
 # gear_versatility_rating=262
-# gear_armor=522
+# gear_armor=526
 # set_bonus=tier28_2pc=1
 # set_bonus=tier28_4pc=1
 default_pet=imp

--- a/profiles/generators/Tier28/T28_Generate_Warlock.simc
+++ b/profiles/generators/Tier28/T28_Generate_Warlock.simc
@@ -15,15 +15,15 @@ shoulders=mantle_of_the_demon_star,id=188888,bonus_id=1505/7187
 back=shroud_of_the_sires_chosen,id=189847,bonus_id=1524/7187
 chest=robes_of_the_demon_star,id=188884,bonus_id=1505/7187,enchant=eternal_stats
 wrists=cuffs_of_the_covert_commander,id=189842,bonus_id=1524/7187/6935,gem_id=173128,enchant=eternal_intellect
-hands=grasps_of_the_demon_star,id=188890,bonus_id=1498/7187
+hands=grimveiled_mittens,id=173244,bonus_id=7031/6649/6648/1588
 waist=grimveiled_belt,id=173248,bonus_id=6648/6649/8129/1588,gem_id=173128
 legs=leggings_of_the_demon_star,id=188887,bonus_id=1498/7187
 feet=boots_of_ceaseless_conflict,id=189794,bonus_id=1524/7187
-finger1=shadowghast_ring,id=178926,bonus_id=7031/6649/6648/1588,gem_id=173128,enchant=tenet_of_haste
+finger1=death_gods_signet,id=179355,bonus_id=1592/7187,gem_id=173128,enchant=tenet_of_haste
 finger2=rygelons_heraldric_ring,id=189854,bonus_id=1524/7187/6935,gem_id=173128,enchant=tenet_of_haste
 trinket1=soulletting_ruby,id=178809,bonus_id=1592/7187
 trinket2=unbound_changeling,id=178708,bonus_id=1592/7187
-main_hand=antumbra_shadow_of_the_cosmos,id=189852,bonus_id=1524/7187,enchant=celestial_guidance
+main_hand=antumbra_shadow_of_the_cosmos,id=189852,bonus_id=1524/7187,enchant=sinful_revelation
 off_hand=forbidden_truth,id=189860,bonus_id=1524/7187
 
 save=T28_Warlock_Affliction.simc
@@ -45,11 +45,11 @@ shoulders=mantle_of_the_demon_star,id=188888,bonus_id=1505/7187
 back=shroud_of_the_sires_chosen,id=189847,bonus_id=1524/7187
 chest=robes_of_the_demon_star,id=188884,bonus_id=1505/7187,enchant=eternal_stats
 wrists=cuffs_of_the_covert_commander,id=189842,bonus_id=1524/7187/6935,gem_id=173128,enchant=eternal_intellect
-hands=grasps_of_the_demon_star,id=188890,bonus_id=1498/7187
+hands=grimveiled_mittens,id=173244,bonus_id=7031/6649/6648/1588
 waist=grimveiled_belt,id=173248,bonus_id=6648/6649/8129/1588,gem_id=173128
 legs=leggings_of_the_demon_star,id=188887,bonus_id=1498/7187
 feet=boots_of_ceaseless_conflict,id=189794,bonus_id=1524/7187
-finger1=shadowghast_ring,id=178926,bonus_id=7031/6649/6648/1588,gem_id=173128,enchant=tenet_of_haste
+finger1=death_gods_signet,id=179355,bonus_id=1592/7187,gem_id=173128,enchant=tenet_of_haste
 finger2=rygelons_heraldric_ring,id=189854,bonus_id=1524/7187/6935,gem_id=173128,enchant=tenet_of_haste
 trinket1=soulletting_ruby,id=178809,bonus_id=1592/7187
 trinket2=unbound_changeling,id=178708,bonus_id=1592/7187


### PR DESCRIPTION
Moved the affliction legendary to an accurate slot and regenerated profiles.