### PR TITLE
[DBC] update python scripts to use collections.abc

### DIFF
--- a/casc_extract/build_cfg.py
+++ b/casc_extract/build_cfg.py
@@ -6,9 +6,9 @@ import configparser, os, glob, sys, io, collections
 
 import jenkins
 
-class DBFileList(collections.Mapping):
+class DBFileList(collections.abc.Mapping):
 	def __init__(self, options):
-		collections.Mapping.__init__(self)
+		collections.abc.Mapping.__init__(self)
 
 		self.options = options
 

--- a/dbc_extract3/dbc/wdc1.py
+++ b/dbc_extract3/dbc/wdc1.py
@@ -129,7 +129,7 @@ class WDC1HotfixKeyIdParser:
 # Parse a segment of the record data, and return a tuple containing the column data
 class WDC1SegmentParser:
     def __init__(self, record_parser, columns):
-        if isinstance(columns, collections.Iterable):
+        if isinstance(columns, collections.abc.Iterable):
             self.columns = columns
         else:
             self.columns = [ columns ]


### PR DESCRIPTION
With python 3.3 Iterables & Mapping were moved to collections.abc. Backwards compatibility support was removed in python 3.10.