### PR TITLE
[DBC] switch to floats for random prop data

### DIFF
--- a/engine/dbc/rand_prop_points.hpp
+++ b/engine/dbc/rand_prop_points.hpp
@@ -12,8 +12,8 @@
 struct random_prop_data_t
 {
   unsigned ilevel;
-  double   damage_replace_stat;
-  double   damage_secondary;
+  float    damage_replace_stat;
+  float    damage_secondary;
   float    p_epic[5];
   float    p_rare[5];
   float    p_uncommon[5];


### PR DESCRIPTION
The fields are doubles because in
  https://github.com/simulationcraft/simc/pull/5799
we had to support both ptr and live spell data and the latter had them
as integers with some values resulting in narrowing conversion errors.

Now that we don't have to care about integers and all of the source
values in client data a 32b floats we can safely use floats like every
other item-related data.