### PR TITLE
Cthuulu destro apl optimizations

### DIFF
--- a/profiles/Tier28/T28_Warlock_Demonology.simc
+++ b/profiles/Tier28/T28_Warlock_Demonology.simc
@@ -45,6 +45,7 @@ actions+=/variable,name=buff_sync_cd,op=set,value=variable.next_tyrant_cd,if=!va
 actions+=/variable,name=buff_sync_cd,op=set,value=cooldown.decimating_bolt.remains_expected,if=variable.use_bolt_timings
 actions+=/call_action_list,name=trinkets
 actions+=/call_action_list,name=ogcd,if=(!variable.use_bolt_timings&pet.demonic_tyrant.active)|(variable.use_bolt_timings&buff.shard_of_annihilation.up&(!talent.power_siphon.enabled|buff.power_siphon.up))
+actions+=/implosion,if=target.time_to_die<2*gcd
 actions+=/call_action_list,name=opener,if=time<variable.first_tyrant_time
 actions+=/interrupt,if=target.debuff.casting.react
 actions+=/doom,if=refreshable

--- a/profiles/Tier28/T28_Warlock_Destruction.simc
+++ b/profiles/Tier28/T28_Warlock_Destruction.simc
@@ -41,6 +41,7 @@ actions.precombat+=/incinerate
 actions=call_action_list,name=havoc,if=havoc_active&active_enemies>1&active_enemies<5-talent.inferno.enabled+(talent.inferno.enabled&talent.internal_combustion.enabled)
 actions+=/fleshcraft,if=soulbind.volatile_solvent,cancel_if=buff.volatile_solvent_humanoid.up
 actions+=/conflagrate,if=talent.roaring_blaze.enabled&debuff.roaring_blaze.remains<1.5
+actions+=/chaos_bolt,if=active_enemies<3&(pet.infernal.active|pet.blasphemy.active)&soul_shard>=4.6
 actions+=/cataclysm
 actions+=/call_action_list,name=aoe,if=active_enemies>2
 actions+=/soul_fire,cycle_targets=1,if=refreshable&soul_shard<=4&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>remains)
@@ -57,12 +58,13 @@ actions+=/soul_rot
 actions+=/havoc,if=runeforge.odr_shawl_of_the_ymirjar.equipped
 actions+=/variable,name=pool_soul_shards,value=active_enemies>1&cooldown.havoc.remains<=10|buff.ritual_of_ruin.up&talent.rain_of_chaos
 actions+=/conflagrate,if=buff.backdraft.down&soul_shard>=1.5-0.3*talent.flashover.enabled&!variable.pool_soul_shards
-actions+=/chaos_bolt,if=pet.infernal.active|buff.rain_of_chaos.up
+actions+=/chaos_bolt,if=(pet.infernal.active|buff.rain_of_chaos.remains>cast_time)&!(buff.ritual_of_ruin.up&buff.madness_of_the_azjaqir.remains>3.7&soul_shard<1.5)
 actions+=/chaos_bolt,if=buff.backdraft.up&!variable.pool_soul_shards
 actions+=/chaos_bolt,if=talent.eradication&!variable.pool_soul_shards&debuff.eradication.remains<cast_time
 actions+=/shadowburn,if=!variable.pool_soul_shards|soul_shard>=4.5
 actions+=/chaos_bolt,if=soul_shard>3.5
-actions+=/conflagrate,if=charges>1
+actions+=/chaos_bolt,if=target.time_to_die<5&target.time_to_die>cast_time+travel_time
+actions+=/conflagrate,if=charges>1|target.time_to_die<gcd
 actions+=/incinerate
 
 actions.aoe=rain_of_fire,if=pet.infernal.active&(!cooldown.havoc.ready|active_enemies>3)
@@ -89,7 +91,7 @@ actions.cds+=/potion,if=pet.infernal.active
 actions.cds+=/berserking,if=pet.infernal.active
 actions.cds+=/blood_fury,if=pet.infernal.active
 actions.cds+=/fireblood,if=pet.infernal.active
-actions.cds+=/use_items,if=pet.infernal.active|target.time_to_die<20
+actions.cds+=/use_items,if=pet.infernal.active|target.time_to_die<21
 
 actions.havoc=conflagrate,if=buff.backdraft.down&soul_shard>=1&soul_shard<=4
 actions.havoc+=/soul_fire,if=cast_time<havoc_remains


### PR DESCRIPTION
Avoid shard capping
Avoid using ritual proc instantly if using madness and low on soul shards
End of fight optimization, prefer spending shards and last conflag charge
Time to die change to avoid wasting uptime of trinkets