### PR TITLE
[Cooldown] Refactor out target-specific cooldowns into target_specifi…

### DIFF
--- a/engine/action/dbc_proc_callback.hpp
+++ b/engine/action/dbc_proc_callback.hpp
@@ -13,6 +13,7 @@
 struct action_state_t;
 struct buff_t;
 struct cooldown_t;
+struct target_specific_cooldown_t;
 struct item_t;
 struct real_ppm_t;
 namespace rng {
@@ -66,15 +67,7 @@ struct dbc_proc_callback_t : public action_callback_t
   const item_t& item;
   const special_effect_t& effect;
   cooldown_t* cooldown;
-  bool has_target_specific_cooldown;
-
-  struct target_cooldown_t
-  {
-    cooldown_t* cooldown;
-    int spawn_index;
-  };
-
-  std::vector<target_cooldown_t> target_specific_cooldown;
+  target_specific_cooldown_t* target_specific_cooldown;
 
   // Proc trigger types, cached/initialized here from special_effect_t to avoid
   // needless spell data lookups in vast majority of cases

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -5344,6 +5344,8 @@ void player_t::reset()
 
   range::for_each( cooldown_list, []( cooldown_t* cooldown ) { cooldown->reset_init(); } );
 
+  range::for_each( target_specific_cooldown_list, []( target_specific_cooldown_t* tcd ) { tcd->reset(); } );
+
   range::for_each( dot_list, []( dot_t* dot ) { dot->reset(); } );
 
   range::for_each( stats_list, []( stats_t* stat ) { stat->reset(); } );
@@ -7264,6 +7266,11 @@ cooldown_t* player_t::find_cooldown( util::string_view name ) const
   return find_vector_member( cooldown_list, name );
 }
 
+target_specific_cooldown_t* player_t::find_target_specific_cooldown( cooldown_t& base_cd ) const
+{
+  return find_vector_member( target_specific_cooldown_list, base_cd.name() );
+}
+
 action_t* player_t::find_action( util::string_view name ) const
 {
   return find_vector_member( action_list, name );
@@ -7284,6 +7291,19 @@ cooldown_t* player_t::get_cooldown( util::string_view name, action_t* a )
     c->action = a;
 
   return c;
+}
+
+target_specific_cooldown_t* player_t::get_target_specific_cooldown( cooldown_t& base_cd )
+{
+  target_specific_cooldown_t* tcd = find_target_specific_cooldown( base_cd );
+
+  if ( !tcd )
+  {
+    tcd = new target_specific_cooldown_t( *this, base_cd );
+    target_specific_cooldown_list.push_back( tcd );
+  }
+
+  return tcd;
 }
 
 real_ppm_t* player_t::get_rppm( util::string_view name )

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -7266,9 +7266,9 @@ cooldown_t* player_t::find_cooldown( util::string_view name ) const
   return find_vector_member( cooldown_list, name );
 }
 
-target_specific_cooldown_t* player_t::find_target_specific_cooldown( cooldown_t& base_cd ) const
+target_specific_cooldown_t* player_t::find_target_specific_cooldown( util::string_view name ) const
 {
-  return find_vector_member( target_specific_cooldown_list, base_cd.name() );
+  return find_vector_member( target_specific_cooldown_list, name );
 }
 
 action_t* player_t::find_action( util::string_view name ) const
@@ -7293,13 +7293,26 @@ cooldown_t* player_t::get_cooldown( util::string_view name, action_t* a )
   return c;
 }
 
-target_specific_cooldown_t* player_t::get_target_specific_cooldown( cooldown_t& base_cd )
+target_specific_cooldown_t* player_t::get_target_specific_cooldown( util::string_view name, timespan_t duration )
 {
-  target_specific_cooldown_t* tcd = find_target_specific_cooldown( base_cd );
+  target_specific_cooldown_t* tcd = find_target_specific_cooldown( name );
 
   if ( !tcd )
   {
-    tcd = new target_specific_cooldown_t( *this, base_cd );
+    tcd = new target_specific_cooldown_t( name, *this, duration );
+    target_specific_cooldown_list.push_back( tcd );
+  }
+
+  return tcd;
+}
+
+target_specific_cooldown_t* player_t::get_target_specific_cooldown( cooldown_t& base_cooldown )
+{
+  target_specific_cooldown_t* tcd = find_target_specific_cooldown( base_cooldown.name() );
+
+  if ( !tcd )
+  {
+    tcd = new target_specific_cooldown_t( *this, base_cooldown );
     target_specific_cooldown_list.push_back( tcd );
   }
 

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -40,6 +40,7 @@ struct benefit_t;
 struct item_t;
 struct buff_t;
 struct cooldown_t;
+struct target_specific_cooldown_t;
 struct cooldown_waste_data_t;
 struct dot_t;
 struct event_t;
@@ -333,6 +334,7 @@ struct player_t : public actor_t
   auto_dispose< std::vector<benefit_t*> > benefit_list;
   auto_dispose< std::vector<uptime_t*> > uptime_list;
   auto_dispose< std::vector<cooldown_t*> > cooldown_list;
+  auto_dispose< std::vector<target_specific_cooldown_t*> > target_specific_cooldown_list;
   auto_dispose< std::vector<real_ppm_t*> > rppm_list;
   auto_dispose< std::vector<shuffled_rng_t*> > shuffled_rng_list;
   std::vector<cooldown_t*> dynamic_cooldown_list;
@@ -818,6 +820,7 @@ public:
   item_t*     find_item_by_use_effect_name( util::string_view name );
   action_t*   find_action( util::string_view ) const;
   cooldown_t* find_cooldown( util::string_view name ) const;
+  target_specific_cooldown_t* find_target_specific_cooldown( cooldown_t& base_cd ) const;
   dot_t*      find_dot     ( util::string_view name, player_t* source ) const;
   stats_t*    find_stats   ( util::string_view name ) const;
   gain_t*     find_gain    ( util::string_view name ) const;
@@ -829,6 +832,7 @@ public:
   int find_action_id( util::string_view name ) const;
 
   cooldown_t* get_cooldown( util::string_view name, action_t* action = nullptr );
+  target_specific_cooldown_t* get_target_specific_cooldown( cooldown_t& base_cd );
   real_ppm_t* get_rppm    ( util::string_view );
   real_ppm_t* get_rppm    ( util::string_view, const spell_data_t* data, const item_t* item = nullptr );
   real_ppm_t* get_rppm    ( util::string_view, double freq, double mod = 1.0, unsigned s = RPPM_NONE );

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -820,7 +820,7 @@ public:
   item_t*     find_item_by_use_effect_name( util::string_view name );
   action_t*   find_action( util::string_view ) const;
   cooldown_t* find_cooldown( util::string_view name ) const;
-  target_specific_cooldown_t* find_target_specific_cooldown( cooldown_t& base_cd ) const;
+  target_specific_cooldown_t* find_target_specific_cooldown( util::string_view name ) const;
   dot_t*      find_dot     ( util::string_view name, player_t* source ) const;
   stats_t*    find_stats   ( util::string_view name ) const;
   gain_t*     find_gain    ( util::string_view name ) const;
@@ -832,7 +832,8 @@ public:
   int find_action_id( util::string_view name ) const;
 
   cooldown_t* get_cooldown( util::string_view name, action_t* action = nullptr );
-  target_specific_cooldown_t* get_target_specific_cooldown( cooldown_t& base_cd );
+  target_specific_cooldown_t* get_target_specific_cooldown( util::string_view name, timespan_t duration = timespan_t::zero() );
+  target_specific_cooldown_t* get_target_specific_cooldown( cooldown_t& base_cooldown );
   real_ppm_t* get_rppm    ( util::string_view );
   real_ppm_t* get_rppm    ( util::string_view, const spell_data_t* data, const item_t* item = nullptr );
   real_ppm_t* get_rppm    ( util::string_view, double freq, double mod = 1.0, unsigned s = RPPM_NONE );

--- a/engine/sim/cooldown.hpp
+++ b/engine/sim/cooldown.hpp
@@ -126,20 +126,21 @@ private:
 struct target_specific_cooldown_t
 {
   player_t* const player;
-  cooldown_t* const base_cooldown;
   const std::string name_str;
+  timespan_t base_duration;
 
 private:
   struct target_cooldown_t
   {
-    cooldown_t* cooldown;
-    int spawn_index;
+    cooldown_t* cooldown = nullptr;
+    int spawn_index = -1;
   };
 
   std::vector<target_cooldown_t> target_cooldowns;
 
 public:
-  target_specific_cooldown_t( player_t&, cooldown_t& base_cd );
+  target_specific_cooldown_t( player_t& p, cooldown_t& base_cooldown );
+  target_specific_cooldown_t( util::string_view name, player_t& p, timespan_t duration );
 
   cooldown_t* get_cooldown( player_t* target );
 

--- a/engine/sim/cooldown.hpp
+++ b/engine/sim/cooldown.hpp
@@ -12,6 +12,7 @@
 #include "util/format.hpp"
 
 #include <string>
+#include <vector>
 #include <memory>
 
 struct action_t;
@@ -120,4 +121,30 @@ struct cooldown_t
 
 private:
   void adjust_remaining_duration( double delta ); // Modify the remaining duration of an ongoing cooldown.
+};
+
+struct target_specific_cooldown_t
+{
+  player_t* const player;
+  cooldown_t* const base_cooldown;
+  const std::string name_str;
+
+private:
+  struct target_cooldown_t
+  {
+    cooldown_t* cooldown;
+    int spawn_index;
+  };
+
+  std::vector<target_cooldown_t> target_cooldowns;
+
+public:
+  target_specific_cooldown_t( player_t&, cooldown_t& base_cd );
+
+  cooldown_t* get_cooldown( player_t* target );
+
+  void reset();
+
+  const std::string& name() const
+  { return name_str; }
 };


### PR DESCRIPTION
…c_cooldown_t

* Refactor into dedicated wrapper class so that they can be used elsewhere--such as actions, buffs, or as standalone objects within modules
* Tested as having the same results results with Dream Delver in HAC/DungeonSlice simulations