### PR TITLE
Update shaman t28 profiles

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9721,7 +9721,7 @@ void shaman_t::init_action_list_elemental()
     def->add_action( "run_action_list,name=single_target,if=!talent.storm_elemental.enabled&active_enemies<=2" );
     def->add_action( "run_action_list,name=se_single_target,if=talent.storm_elemental.enabled&active_enemies<=2" );
 
-    aoe->add_talent( this, "Storm Elemental" );
+    aoe->add_talent( this, "Storm Elemental", "if=!pet.storm_elemental.active" );
     aoe->add_action( this, "Earthquake", "if=buff.echoing_shock.up" );
     aoe->add_action( "chain_harvest" );
     aoe->add_talent( this, "Stormkeeper", "if=talent.stormkeeper.enabled" );
@@ -9871,7 +9871,7 @@ void shaman_t::init_action_list_elemental()
     single_target->add_action( this, "Flame Shock", "moving=1,if=movement.distance>6" );
     single_target->add_action( this, "Frost Shock", "moving=1" );
 
-    se_single_target->add_talent( this, "Storm Elemental" );
+    se_single_target->add_talent( this, "Storm Elemental", "if=!pet.storm_elemental.active" );
     se_single_target->add_action( this, "Lightning Bolt", "if=buff.surge_of_power.up");
     se_single_target->add_action( "primordial_wave,target_if=min:dot.flame_shock.remains,cycle_targets=1,if=covenant.necrolord&!buff.primordial_wave.up&!buff.splintered_elements.up" );
     se_single_target->add_action( this, "Frost Shock",
@@ -9945,7 +9945,7 @@ void shaman_t::init_action_list_elemental()
     def->add_action( "use_items" );
     def->add_action( this, "Flame Shock", "if=!ticking" );
     def->add_action( this, "Fire Elemental" );
-    def->add_talent( this, "Storm Elemental" );
+    def->add_talent( this, "Storm Elemental", "if=!pet.storm_elemental.active" );
     def->add_action( this, "Earth Elemental", "if=!talent.primal_elementalist.enabled|!pet.fire_elemental.active&!pet.storm_elemental.active" );
 
     // Racials

--- a/profiles/T28_Raid.simc
+++ b/profiles/T28_Raid.simc
@@ -50,9 +50,12 @@ T28_Rogue_Outlaw.simc
 T28_Rogue_Subtlety.simc
 
 T28_Shaman_Elemental.simc
-T28_Shaman_Elemental_Kyrian.simc
-T28_Shaman_Elemental_Necrolord.simc
-T28_Shaman_Elemental_Venthyr.simc
+T28_Shaman_Elemental_SE.simc
+# These profiles exist but are not terribly relevant for most situations,
+# so they remain but are not shown in the stack chart.
+# T28_Shaman_Elemental_Kyrian.simc
+# T28_Shaman_Elemental_Necrolord.simc
+# T28_Shaman_Elemental_Venthyr.simc
 T28_Shaman_Enhancement.simc
 T28_Shaman_Enhancement_Kyrian.simc
 T28_Shaman_Enhancement_Necrolord.simc

--- a/profiles/Tier28/T28_Shaman_Elemental_SE.simc
+++ b/profiles/Tier28/T28_Shaman_Elemental_SE.simc
@@ -1,11 +1,11 @@
-shaman="T28_Shaman_Elemental"
+shaman="T28_Shaman_Elemental_SE"
 source=default
 spec=elemental
 level=60
 race=tauren
 role=spell
 position=ranged_back
-talents=2301022
+talents=1102021
 covenant=night_fae
 soulbind=dreamweaver,pyroclastic_shock:11:1/high_voltage:11:1/field_of_blossoms/essential_extraction:11:1/dream_delver
 renown=80

--- a/profiles/generators/Tier28/T28_Generate_Shaman.simc
+++ b/profiles/generators/Tier28/T28_Generate_Shaman.simc
@@ -4,7 +4,7 @@ race=tauren
 spec=elemental
 role=spell
 position=ranged_back
-talents=1102021
+talents=2301022
 covenant=night_fae
 soulbind=dreamweaver,pyroclastic_shock:11:1/high_voltage:11:1/field_of_blossoms/essential_extraction:11:1/dream_delver
 renown=80
@@ -30,6 +30,39 @@ shadowlands.soleahs_secret_technique_type_override=versatility
 main_hand=pursuit_of_victory,id=189789,ilevel=278,enchant=sinful_revelation
 
 save=T28_Shaman_Elemental.simc
+
+shaman="T28_Shaman_Elemental_SE"
+level=60
+race=tauren
+spec=elemental
+role=spell
+position=ranged_back
+talents=1102021
+covenant=night_fae
+soulbind=dreamweaver,pyroclastic_shock:11:1/high_voltage:11:1/field_of_blossoms/essential_extraction:11:1/dream_delver
+renown=80
+
+# unity
+head=boneshatter_helm,id=172325,ilevel=291,bonus_id=8128/6650/6649/6935,gem_id=173128
+neck=worldkiller_iris,id=189859,ilevel=285
+shoulders=theurgic_starspeakers_adornment,id=188920,ilevel=285
+back=lurking_predators_camouflage,id=189815,ilevel=278
+chest=theurgic_starspeakers_ringmail,id=188922,ilevel=285,enchant=eternal_insight
+wrists=interdimensional_manica,id=189849,ilevel=285,enchant=eternal_intellect
+# recreated from 285 drop, Lord of Dread - Gauntlets of Unseen Guests, 189844
+hands=theurgic_starspeakers_runebindings,id=188925,ilevel=285
+waist=kings_wolfheart_waistband,id=189837,ilevel=278
+# recreated from 285 drop, The Jailer - Epochal Opressor's Greaves, 189857
+legs=theurgic_starspeakers_tassets,id=188924,ilevel=285
+feet=boneshatter_treads,id=172323,ilevel=291,bonus_id=6992/6650/6649
+finger1=taciturn_keepers_lapis,id=189833,ilevel=278,enchant=tenet_of_haste
+finger2=rygelons_heraldric_ring,id=189854,ilevel=285,enchant=tenet_of_haste
+trinket1=unbound_changeling,id=178708,ilevel=278,bonus_id=6917
+trinket2=soleahs_secret_technique,id=190958,ilevel=278
+shadowlands.soleahs_secret_technique_type_override=versatility
+main_hand=pursuit_of_victory,id=189789,ilevel=278,enchant=sinful_revelation
+
+save=T28_Shaman_Elemental_SE.simc
 
 
 shaman="T28_Shaman_Elemental_Necrolord"


### PR DESCRIPTION
The previous PR https://github.com/simulationcraft/simc/pull/6441 was merged before the change was retargeted against the shadowlands branch and thus got orphaned.