### PR TITLE
[Warlock] time to die

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1279,7 +1279,7 @@ void warlock_t::create_apl_demonology()
   def->add_action( "variable,name=buff_sync_cd,op=set,value=cooldown.decimating_bolt.remains_expected,if=variable.use_bolt_timings" );
   def->add_action( "call_action_list,name=trinkets" );
   def->add_action( "call_action_list,name=ogcd,if=(!variable.use_bolt_timings&pet.demonic_tyrant.active)|(variable.use_bolt_timings&buff.shard_of_annihilation.up&(!talent.power_siphon.enabled|buff.power_siphon.up))" );
-  def->add_action( "implosion,if=target.time_to_die<2*gcd" );
+  def->add_action( "implosion,if=time_to_die<2*gcd" );
   def->add_action( "call_action_list,name=opener,if=time<variable.first_tyrant_time" );
   def->add_action( "interrupt,if=target.debuff.casting.react" );
   def->add_action( "doom,if=refreshable" );

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -1312,8 +1312,8 @@ void warlock_t::create_apl_destruction()
   def->add_action( "chaos_bolt,if=talent.eradication&!variable.pool_soul_shards&debuff.eradication.remains<cast_time" );
   def->add_action( "shadowburn,if=!variable.pool_soul_shards|soul_shard>=4.5" );
   def->add_action( "chaos_bolt,if=soul_shard>3.5" );
-  def->add_action( "chaos_bolt,if=target.time_to_die<5&target.time_to_die>cast_time+travel_time" );
-  def->add_action( "conflagrate,if=charges>1|target.time_to_die<gcd" );
+  def->add_action( "chaos_bolt,if=time_to_die<5&time_to_die>cast_time+travel_time" );
+  def->add_action( "conflagrate,if=charges>1|time_to_die<gcd" );
   def->add_action( "incinerate" );
 
   aoe->add_action( "rain_of_fire,if=pet.infernal.active&(!cooldown.havoc.ready|active_enemies>3)" );
@@ -1333,14 +1333,14 @@ void warlock_t::create_apl_destruction()
   aoe->add_action( "impending_catastrophe,if=!(talent.fire_and_brimstone.enabled|talent.inferno.enabled)" );
   aoe->add_action( "incinerate" );
 
-  cds->add_action( "use_item,name=shadowed_orb_of_torment,if=cooldown.summon_infernal.remains<3|target.time_to_die<42" );
+  cds->add_action( "use_item,name=shadowed_orb_of_torment,if=cooldown.summon_infernal.remains<3|time_to_die<42" );
   cds->add_action( "summon_infernal" );
-  cds->add_action( "dark_soul_instability,if=pet.infernal.active|cooldown.summon_infernal.remains_expected>target.time_to_die" );
+  cds->add_action( "dark_soul_instability,if=pet.infernal.active|cooldown.summon_infernal.remains_expected>time_to_die" );
   cds->add_action( "potion,if=pet.infernal.active" );
   cds->add_action( "berserking,if=pet.infernal.active" );
   cds->add_action( "blood_fury,if=pet.infernal.active" );
   cds->add_action( "fireblood,if=pet.infernal.active" );
-  cds->add_action( "use_items,if=pet.infernal.active|target.time_to_die<21" );
+  cds->add_action( "use_items,if=pet.infernal.active|time_to_die<21" );
 
   havoc->add_action( "conflagrate,if=buff.backdraft.down&soul_shard>=1&soul_shard<=4" );
   havoc->add_action( "soul_fire,if=cast_time<havoc_remains" );


### PR DESCRIPTION
target.time_to_die works different than time_to_die. target.time_to_die breaks in sims that have the target die at higher health percentages.