### PR TITLE
[Gear] add options for Grim Eclipse tweaking

### DIFF
--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3565,20 +3565,23 @@ void grim_eclipse( special_effect_t& effect )
         buff( make_buff<stat_buff_t>( e.player, "grim_eclipse", e.player->find_spell( 368645 ), e.item ) ),
         base_duration( 10_s )
     {
-      // TODO: CHECK EVERYTHING SINCE NOTHING IS TESTABLE AND EVERYTHING IS A GUESS
       dot_duration   = data().duration();
+      // Not in spelldata
       base_tick_time = 1_s;
 
-      if ( e.player->sim->shadowlands_opts.grim_eclipse_dot_uptime > 0_ms )
+      if ( e.player->sim->shadowlands_opts.grim_eclipse_dot_duration_multiplier > 0.0 )
       {
-        dot_duration = e.player->sim->shadowlands_opts.grim_eclipse_dot_uptime;
-        e.player->sim->print_debug( "Altering grim_eclipse DoT Uptime: grim_eclipse_dot_uptime={}",
-                                    e.player->sim->shadowlands_opts.grim_eclipse_dot_uptime );
+        e.player->sim->print_debug(
+            "Altering grim_eclipse DoT Uptime by {}. Old Duration: {}. New duration: {}",
+            e.player->sim->shadowlands_opts.grim_eclipse_dot_duration_multiplier, data().duration(),
+            data().duration() * e.player->sim->shadowlands_opts.grim_eclipse_dot_duration_multiplier );
+        dot_duration = data().duration() * e.player->sim->shadowlands_opts.grim_eclipse_dot_duration_multiplier;
       }
 
       tick_action = create_proc_action<generic_proc_t>( "grim_eclipse_damage", e, "grim_eclipse_damage", 369318 );
+      // Use data().duration() here so that if you alter dot_duration the tick value is not changed
       tick_action->base_dd_min = tick_action->base_dd_max =
-          e.driver()->effectN( 1 ).average( e.item ) / dot_duration.total_seconds();
+          e.driver()->effectN( 1 ).average( e.item ) / data().duration().total_seconds();
 
       buff->add_stat( STAT_HASTE_RATING, e.driver()->effectN( 2 ).average( e.item ) );
       base_duration = buff->buff_duration();

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3558,28 +3558,59 @@ void grim_eclipse( special_effect_t& effect )
   struct grim_eclipse_t : public proc_spell_t
   {
     stat_buff_t* buff;
+    timespan_t base_duration;
 
     grim_eclipse_t( const special_effect_t& e )
       : proc_spell_t( "grim_eclipse", e.player, e.trigger() ),
-        buff( make_buff<stat_buff_t>( e.player, "grim_eclipse", e.player->find_spell( 368645 ), e.item ) )
+        buff( make_buff<stat_buff_t>( e.player, "grim_eclipse", e.player->find_spell( 368645 ), e.item ) ),
+        base_duration( 10_s )
     {
       // TODO: CHECK EVERYTHING SINCE NOTHING IS TESTABLE AND EVERYTHING IS A GUESS
-      dot_duration = data().duration();
+      dot_duration   = data().duration();
       base_tick_time = 1_s;
+
+      if ( e.player->sim->shadowlands_opts.grim_eclipse_dot_uptime > 0_ms )
+      {
+        dot_duration = e.player->sim->shadowlands_opts.grim_eclipse_dot_uptime;
+        e.player->sim->print_debug( "Altering grim_eclipse DoT Uptime: grim_eclipse_dot_uptime={}",
+                                    e.player->sim->shadowlands_opts.grim_eclipse_dot_uptime );
+      }
 
       tick_action = create_proc_action<generic_proc_t>( "grim_eclipse_damage", e, "grim_eclipse_damage", 369318 );
       tick_action->base_dd_min = tick_action->base_dd_max =
           e.driver()->effectN( 1 ).average( e.item ) / dot_duration.total_seconds();
 
       buff->add_stat( STAT_HASTE_RATING, e.driver()->effectN( 2 ).average( e.item ) );
+      base_duration = buff->buff_duration();
+
+      if ( player->sim->shadowlands_opts.grim_eclipse_buff_duration_multiplier > 0.0 )
+      {
+        buff->set_duration_multiplier( player->sim->shadowlands_opts.grim_eclipse_buff_duration_multiplier );
+        e.player->sim->print_debug( "Altering grim_eclipse Haste buff duration by {}",
+                                    player->sim->shadowlands_opts.grim_eclipse_buff_duration_multiplier );
+      }
     }
 
-    void last_tick( dot_t* d ) override
+    void execute() override
     {
-      proc_spell_t::last_tick( d );
+      proc_spell_t::execute();
 
-      // TODO: implement modeling of leaving/entering the buff zone
-      buff->trigger();
+      // Always give the haste buff after the Quasar expires, regardless of DoT duration overrides
+      make_event( *sim, data().duration(), [ this ] {
+        // TODO: implement modeling of leaving/entering the buff zone
+        if ( player->sim->shadowlands_opts.grim_eclipse_buff_duration_multiplier > 0.0 )
+        {
+          // Delay the buff proportional to the multiplier change
+          timespan_t buff_delay = base_duration - buff->buff_duration();
+          make_event( *sim, buff_delay, [ this ] { buff->trigger(); } );
+
+          if ( buff_delay > 0_s )
+          {
+            player->sim->print_debug( "Scheduling grim_eclipse haste buff with a {}s delay.",
+                                      buff_delay.total_seconds() );
+          }
+        }
+      } );
     }
   };
 

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -3851,7 +3851,7 @@ void sim_t::create_options()
   add_option( opt_float( "shadowlands.cruciform_veinripper_proc_rate", shadowlands_opts.cruciform_veinripper_proc_rate, 0.0, 1.0) );
   add_option( opt_timespan( "shadowlands.the_first_sigil_fleshcraft_cancel_time", shadowlands_opts.the_first_sigil_fleshcraft_cancel_time, 50_ms, timespan_t::from_seconds( 3 ) ) );
   add_option( opt_uint( "shadowlands.earthbreakers_impact_weak_points", shadowlands_opts.earthbreakers_impact_weak_points, 0, 3 ) );
-  add_option( opt_timespan( "shadowlands.grim_eclipse_dot_uptime", shadowlands_opts.grim_eclipse_dot_uptime, 0_ms, 7_s ) );
+  add_option( opt_float( "shadowlands.grim_eclipse_dot_duration_multiplier", shadowlands_opts.grim_eclipse_dot_duration_multiplier, 0.0, 1.0 ) );
   add_option( opt_float( "shadowlands.grim_eclipse_buff_duration_multiplier", shadowlands_opts.grim_eclipse_buff_duration_multiplier, 0.0, 1.0 ) );
 }
 

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -3851,6 +3851,8 @@ void sim_t::create_options()
   add_option( opt_float( "shadowlands.cruciform_veinripper_proc_rate", shadowlands_opts.cruciform_veinripper_proc_rate, 0.0, 1.0) );
   add_option( opt_timespan( "shadowlands.the_first_sigil_fleshcraft_cancel_time", shadowlands_opts.the_first_sigil_fleshcraft_cancel_time, 50_ms, timespan_t::from_seconds( 3 ) ) );
   add_option( opt_uint( "shadowlands.earthbreakers_impact_weak_points", shadowlands_opts.earthbreakers_impact_weak_points, 0, 3 ) );
+  add_option( opt_timespan( "shadowlands.grim_eclipse_dot_uptime", shadowlands_opts.grim_eclipse_dot_uptime, 0_ms, 7_s ) );
+  add_option( opt_float( "shadowlands.grim_eclipse_buff_duration_multiplier", shadowlands_opts.grim_eclipse_buff_duration_multiplier, 0.0, 1.0 ) );
 }
 
 // sim_t::parse_option ======================================================

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -447,7 +447,7 @@ struct sim_t : private sc_thread_t
     // Earthbreaker's Impact weak points triggered
     unsigned int earthbreakers_impact_weak_points = 3;
     // Grim Eclipse Dot Duration override
-    timespan_t grim_eclipse_dot_uptime = 7_s;
+    double grim_eclipse_dot_duration_multiplier = 1.0;
     // Percentage of default duration for Grim Eclipse haste buff. Set to 90% by default assuming about 1s of movement to get to the Event Horizon
     double grim_eclipse_buff_duration_multiplier = 0.9;
   } shadowlands_opts;

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -442,10 +442,14 @@ struct sim_t : private sc_thread_t
     bool better_together_ally = true;
     bool enable_rune_words = false;
     bool enable_domination_gems = false;
-    // fleshcraft cancel dely from the_first_sigil
+    // fleshcraft cancel delay from the_first_sigil
     timespan_t the_first_sigil_fleshcraft_cancel_time = 50_ms;
     // Earthbreaker's Impact weak points triggered
     unsigned int earthbreakers_impact_weak_points = 3;
+    // Grim Eclipse Dot Duration override
+    timespan_t grim_eclipse_dot_uptime = 7_s;
+    // Percentage of default duration for Grim Eclipse haste buff. Set to 90% by default assuming about 1s of movement to get to the Event Horizon
+    double grim_eclipse_buff_duration_multiplier = 0.9;
   } shadowlands_opts;
 
   // Auras and De-Buffs


### PR DESCRIPTION
This adds support for two new options to adjust the Grim Eclipse trinket:
- `shadowlands.grim_eclipse_dot_uptime`
- `shadowlands.grim_eclipse_dot_duration_multiplier`

## `shadowlands.grim_eclipse_dot_duration_multiplier`
This adjusts the DoT duration manually by overriding the duration of the DoT to the modifier . So instead of having a default 7_s duration DoT you can set this:

```
shadowlands.grim_eclipse_dot_duration_multiplier=0.9
```
Which will only give you 6.3s of the DoT and assume that the target is moving/etc and loses the last .7s of ticks. This does NOT change when the actor gets the Haste buff as it always will wait the max duration for the Quasar to stabalize.

```
0.000 Altering grim_eclipse DoT Uptime by 0.9. Old Duration: 7.000. New duration: 6.300
0.000 Altering grim_eclipse Haste buff duration by 0.9

4.397 Player 'T28_Priest_Shadow' performs Action grim_eclipse (9999)
4.397 New DoT End Event: Player 'T28_Priest_Shadow' Dot grim_eclipse time_to_end=6.300

11.397 Scheduling grim_eclipse haste buff with a 1s delay.
12.397 Player 'T28_Priest_Shadow' gains Buff grim_eclipse (stacks=1) (value=-2.2250738585072014e-308)
21.397 Player 'T28_Priest_Shadow' loses Buff grim_eclipse
```

## `shadowlands.grim_eclipse_buff_duration_multiplier`
The buff duration multiplier allows you to select a percentage of the buff you would like the actor to get. I've defaulted this to 90% to effectively assume it takes you 1s to get inside the Grim Eclipse Haste buff ground effect from when it spawns (it never spawns under you). 

```
11.401 Scheduling grim_eclipse haste buff with a 1s delay. buff_duration: 9s
12.401 Player 'T28_Priest_Shadow' gains Buff grim_eclipse (stacks=1) (value=-2.2250738585072014e-308)
21.401 Player 'T28_Priest_Shadow' loses Buff grim_eclipse
```