### PR TITLE
[Warlock] Destruction T28 consuming backdraft

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -717,7 +717,7 @@ struct chaos_bolt_t : public destruction_spell_t
     destruction_spell_t::execute();
 
     // PTR 2022-02-16: Backdraft is no longer consumed for T28 free Chaos Bolts
-    if ( p()->buffs.ritual_of_ruin->check() )
+    if ( !p()->buffs.ritual_of_ruin->check() )
       p()->buffs.backdraft->decrement();
 
     // SL - Legendary


### PR DESCRIPTION
Correct an issue where backdraft stacks are only being used when the actor has the tier set proc.