### PR TITLE
[DK] Adjust Anduin Ring proc rate

### DIFF
--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -4807,7 +4807,7 @@ void soulwarped_seal_of_menethil( special_effect_t& effect )
       assert( s->target );
 
       // Below 70% HP, proc rate appears to be 2rppm
-      double mod = 0.100;
+      double mod = 0.150;
 	  
       // Above 70% HP, proc rate appears to be the full 20rppm.
       if ( s -> target -> health_percentage() >= 70 )


### PR DESCRIPTION
further data shows this being closer to 3rppm, rather than 2rppm. 

most common ranges were 3.5-4rppm, with outliers closer to 2rppm. 3rppm as a middle ground should be more realistic. 