### PR TITLE
[Warlock] Fix low-prio mistake in Destro AOE APL

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -1330,7 +1330,7 @@ void warlock_t::create_apl_destruction()
   aoe->add_action( "soul_fire" );
   aoe->add_action( "conflagrate,if=buff.backdraft.down" );
   aoe->add_action( "shadowburn,if=target.health.pct<20" );
-  aoe->add_action( "immolate");
+  aoe->add_action( "immolate,if=refreshable");
   aoe->add_action( "scouring_tithe" );
   aoe->add_action( "incinerate" );
 


### PR DESCRIPTION
Previous testing from warlock discord showed that uncapped immolate cycling was not worth above 4-5 targets, and a change was made that kept Immolate on main target as a low priority filler. However, as pointed out in #6513 , a condition was missing for only casting when refreshable, causing it to spam the spell if it reached the bottom of the list.