### PR TITLE
Parse coefficients from trigger data

### DIFF
--- a/engine/player/unique_gear_helper.hpp
+++ b/engine/player/unique_gear_helper.hpp
@@ -347,8 +347,9 @@ struct proc_action_t : public T_ACTION
       bool is_dot = effect->duration() > 0_ms && effect->tick_time() > 0_ms;
       auto type   = effect->action_type();
 
-      if ( ( type == SPECIAL_EFFECT_ACTION_SPELL || type == SPECIAL_EFFECT_ACTION_ATTACK ) &&
-           ( ( is_dot && this->base_td == 0 ) || ( this->base_dd_min == 0 && this->base_dd_max == 0 ) ) )
+      if ( ( type == SPECIAL_EFFECT_ACTION_SPELL || type == SPECIAL_EFFECT_ACTION_ATTACK ||
+             type == SPECIAL_EFFECT_ACTION_CUSTOM ) &&
+           ( ( is_dot && this->base_td == 0 ) || ( !is_dot && this->base_dd_min == 0 && this->base_dd_max == 0 ) ) )
       {
         for ( const auto& eff : this->data().effects() )  // go thru the driver's effects
         {


### PR DESCRIPTION
A common motif found in recent spells, particularly damage procs from items & effects
is to have the damage coefficient determined by the drivers, rather than the damage
spell itself, with a dummy trigger on the damage spell referring back to the driver.

If ALL of the following are true:
  1) the special_effect_t is an offensive spell action or an attack action
  2) the proc action has 0 damage after parsing the spell data
  3) the proc action has a trigger effect referencing the driver
  4) the driver has a trigger effect referencing the proc action
then the coefficient of the effect in 4) will be used for the damage of action 2).