### PR TITLE
[Priest] Change Shadow Weaving for Pets to a Spell

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -31,6 +31,7 @@ struct ascended_eruption_heal_t;
 struct wrathful_faerie_t;
 struct wrathful_faerie_fermata_t;
 struct psychic_link_t;
+struct shadow_weaving_t;
 struct eternal_call_to_the_void_t;
 struct unholy_transfusion_healing_t;
 }  // namespace actions::spells
@@ -334,6 +335,7 @@ public:
     propagate_const<actions::spells::ascended_eruption_heal_t*> ascended_eruption_heal;
     propagate_const<actions::spells::eternal_call_to_the_void_t*> eternal_call_to_the_void;
     propagate_const<actions::spells::psychic_link_t*> psychic_link;
+    propagate_const<actions::spells::shadow_weaving_t*> shadow_weaving;
     propagate_const<actions::spells::shadowy_apparition_spell_t*> shadowy_apparitions;
     propagate_const<actions::spells::unholy_transfusion_healing_t*> unholy_transfusion_healing;
     propagate_const<actions::spells::wrathful_faerie_t*> wrathful_faerie;
@@ -550,6 +552,7 @@ public:
   void trigger_eternal_call_to_the_void( action_state_t* );
   void trigger_shadowy_apparitions( action_state_t* );
   void trigger_psychic_link( action_state_t* );
+  void trigger_shadow_weaving( action_state_t* );
   bool hungering_void_active( player_t* target ) const;
   void remove_hungering_void( player_t* target );
   void refresh_talbadars_buff( action_state_t* s );

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -141,14 +141,14 @@ struct priest_pet_melee_t : public melee_attack_t
     first_swing = true;
   }
 
-  double composite_target_multiplier( player_t* target ) const override
+  /*double composite_target_multiplier( player_t* target ) const override
   {
     double mul = attack_t::composite_target_multiplier( target );
 
     mul *= p().o().shadow_weaving_multiplier( target, 0 );
 
     return mul;
-  }
+  }*/
 
   timespan_t execute_time() const override
   {
@@ -431,6 +431,8 @@ struct fiend_melee_t : public priest_pet_melee_t
                                  p().o().gains.insanity_surrender_to_madness );
         }
         p().o().resource_gain( RESOURCE_INSANITY, amount, p().gains.fiend, nullptr );
+
+        p().o().trigger_shadow_weaving( s );
       }
       else
       {

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -141,15 +141,6 @@ struct priest_pet_melee_t : public melee_attack_t
     first_swing = true;
   }
 
-  /*double composite_target_multiplier( player_t* target ) const override
-  {
-    double mul = attack_t::composite_target_multiplier( target );
-
-    mul *= p().o().shadow_weaving_multiplier( target, 0 );
-
-    return mul;
-  }*/
-
   timespan_t execute_time() const override
   {
     // First swing comes instantly after summoning the pet

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -714,7 +714,7 @@ struct your_shadow_torment_mind_t final : public priest_pet_spell_t
   {
     parse_options( options );
     channeled   = true;
-    tick_zero = true;
+    tick_zero   = true;
     tick_action = new your_shadow_torment_mind_tick_t( p, torment_mind_tick_spell );
   }
 

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1536,13 +1536,13 @@ struct shadow_weaving_t final : public priest_spell_t
   {
     background                 = true;
     affected_by_shadow_weaving = false;
-    may_crit   = false;
-    may_miss   = false;
+    may_crit                   = false;
+    may_miss                   = false;
   }
 
   void trigger( player_t* target, double original_amount )
   {
-    base_dd_min = base_dd_max = ( original_amount * (priest().shadow_weaving_multiplier( target, 0 )-1) );
+    base_dd_min = base_dd_max = ( original_amount * ( priest().shadow_weaving_multiplier( target, 0 ) - 1 ) );
     player->sim->print_debug( "{} triggered shadow weaving on target {}.", priest(), *target );
 
     set_target( target );
@@ -2190,7 +2190,6 @@ void priest_t::trigger_shadow_weaving( action_state_t* s )
 {
   background_actions.shadow_weaving->trigger( s->target, s->result_amount );
 }
-
 
 // ==========================================================================
 // Check for the Hungering Void talent and find the debuff on that target

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1528,6 +1528,29 @@ struct psychic_link_t final : public priest_spell_t
 };
 
 // ==========================================================================
+// Shadow Weaving
+// ==========================================================================
+struct shadow_weaving_t final : public priest_spell_t
+{
+  shadow_weaving_t( priest_t& p ) : priest_spell_t( "shadow_weaving", p, p.find_spell( 346111 ) )
+  {
+    background                 = true;
+    affected_by_shadow_weaving = false;
+    may_crit   = false;
+    may_miss   = false;
+  }
+
+  void trigger( player_t* target, double original_amount )
+  {
+    base_dd_min = base_dd_max = ( original_amount * (priest().shadow_weaving_multiplier( target, 0 )-1) );
+    player->sim->print_debug( "{} triggered shadow weaving on target {}.", priest(), *target );
+
+    set_target( target );
+    execute();
+  }
+};
+
+// ==========================================================================
 // Shadow Crash
 // ==========================================================================
 struct shadow_crash_damage_t final : public priest_spell_t
@@ -2113,6 +2136,8 @@ void priest_t::init_background_actions_shadow()
   {
     background_actions.eternal_call_to_the_void = new actions::spells::eternal_call_to_the_void_t( *this );
   }
+
+  background_actions.shadow_weaving = new actions::spells::shadow_weaving_t( *this );
 }
 
 // ==========================================================================
@@ -2157,6 +2182,15 @@ void priest_t::trigger_psychic_link( action_state_t* s )
     }
   }
 }
+
+// ==========================================================================
+// Trigger Shadow Weaving on the Target
+// ==========================================================================
+void priest_t::trigger_shadow_weaving( action_state_t* s )
+{
+  background_actions.shadow_weaving->trigger( s->target, s->result_amount );
+}
+
 
 // ==========================================================================
 // Check for the Hungering Void talent and find the debuff on that target


### PR DESCRIPTION
Change Shadow Weaving for pets to a spell. Shadow Weaving can proc
background effects/proc such as moonlit prism. This greatly increases
the power of moonlit prism for shadow priests.