### PR TITLE
[Warlock] gain buff on Scouring Tithe refresh

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -355,6 +355,17 @@ struct scouring_tithe_t : public warlock_spell_t
 
     LSD_alt_value = p->find_spell( 360953 )->effectN( 2 ).percent();
   }
+  
+  void impact( action_state_t* s ) override
+  {
+    warlock_spell_t::impact( s );
+
+    if ( td( s->target )->dots_scouring_tithe->remains() > p()->find_spell( 312321 )->duration() &&
+         p()->legendary.languishing_soul_detritus.ok() )
+    {
+      p()->buffs.languishing_soul_detritus->trigger( 1, LSD_alt_value );
+    }
+  }
 
   void last_tick( dot_t* d ) override
   {


### PR DESCRIPTION
Implementation of Kyrian legendary interaction with languishing soul detritus when Scouring Tithe is refreshed (dot ticking on target while it gets reapplied).

When Scouring Tithe is on the target and get refreshed, the player gain the buff from Unity Kyrian legendary. It can be reproduced in M+ under effect of Urh and during Rygelon encounter.

This fix should not affect at all any sims if the duration of the cooldown of Scouring Tithe is not changed ( override.spell_data="spell.312321.cooldown=0" ), but allows to sim whether it is better to let the buff drop or not during a fight or keep the infinite cooldown of ST.
