### PR TITLE
[Demonology Warlock] Niya soul rot in opener with dss

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1270,7 +1270,7 @@ void warlock_t::create_apl_demonology()
   action_priority_list_t* dmg    		= get_action_priority_list( "pure_damage_trinks" );
 
   def->add_action( "variable,name=next_tyrant_cd,op=set,value=cooldown.summon_demonic_tyrant.remains_expected,if=!soulbind.field_of_blossoms|cooldown.summon_demonic_tyrant.remains_expected>cooldown.soul_rot.remains_expected" );
-  def->add_action( "variable,name=next_tyrant_cd,op=set,value=cooldown.soul_rot.remains_expected,if=soulbind.field_of_blossoms&cooldown.summon_demonic_tyrant.remains_expected<cooldown.soul_rot.remains_expected" );
+  def->add_action( "variable,name=next_tyrant_cd,op=set,value=cooldown.soul_rot.remains_expected,if=(soulbind.field_of_blossoms|runeforge.decaying_soul_satchel)&cooldown.summon_demonic_tyrant.remains_expected<cooldown.soul_rot.remains_expected" );
   def->add_action( "variable,name=in_opener,op=set,value=0,if=pet.demonic_tyrant.active" );
   def->add_action( "variable,name=buff_sync_cd,op=set,value=variable.next_tyrant_cd,if=!variable.use_bolt_timings&!variable.in_opener" );
   def->add_action( "variable,name=buff_sync_cd,op=set,value=12,if=!variable.use_bolt_timings&variable.in_opener&!pet.dreadstalker.active" );

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -1318,7 +1318,7 @@ void warlock_t::create_apl_demonology()
   def->add_action( "doom,cycle_targets=1,if=refreshable&time>variable.first_tyrant_time" );
   def->add_action( "shadow_bolt" );
 
-  open->add_action( "soul_rot,if=soulbind.grove_invigoration" );
+  open->add_action( "soul_rot,if=soulbind.grove_invigoration,if=!runeforge.decaying_soul_satchel" );
   open->add_action( "nether_portal" );
   open->add_action( "grimoire_felguard" );
   open->add_action( "summon_vilefiend" );


### PR DESCRIPTION
change to use soul rot after tyrant at all times for DSS. also includes holding tyrant for DSS when playing.
old: https://www.raidbots.com/simbot/report/4Aa8vNo6KWX7ovG8kHQnnn
new: https://www.raidbots.com/simbot/report/aynirEUJwGmYoKsQRFvdga

just the opener change, without holding tyrant for dss: https://www.raidbots.com/simbot/report/ur1UXgQDYXTxnMwHM4n4Bf