### PR TITLE
[Player] cache find_spell lookups

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -10250,9 +10250,15 @@ const spell_data_t* player_t::find_spell( unsigned int id ) const
 {
   if ( id )
   {
+    auto spell_cache_entry = spell_cache.find( id );
+    if ( spell_cache_entry != spell_cache.end() ) {
+      return spell_cache_entry->second;
+    }
+
     auto spell = dbc::find_spell( this, id );
     if ( spell->id() && as<int>( spell->level() ) <= true_level )
     {
+      spell_cache[id] = spell;
       return spell;
     }
   }

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -718,6 +718,7 @@ private:
     resource_callback_function_t callback;
   };
   std::vector<resource_callback_entry_t> resource_callbacks;
+  mutable std::unordered_map<unsigned int, const spell_data_t*> spell_cache;
 
   /// Per-player custom dbc data
   std::unique_ptr<dbc_override_t> dbc_override_;


### PR DESCRIPTION
This is roughly a 33% increase in speed when testing locally for shadow priest. I added a debug line when the cache is hit and it seems like almost all of these are for items or special effects. There were over 300,000 cache hits in a single iteration when testing locally.