### PR TITLE
rename 'pvp_crit' option to 'pvp_mode', make sim use pvp ilvl when enabled.

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -1190,7 +1190,7 @@ double action_t::total_crit_bonus( const action_state_t* state ) const
   double crit_multiplier_buffed = crit_multiplier * composite_player_critical_multiplier( state );
 
   double base_crit_bonus = crit_bonus;
-  if ( sim->pvp_crit )
+  if ( sim->pvp_mode )
     base_crit_bonus += sim->pvp_rules->effectN( 3 ).percent();
 
   double damage_bonus = composite_crit_damage_bonus_multiplier() * composite_target_crit_damage_bonus_multiplier( state->target );

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -4969,7 +4969,7 @@ struct revival_t : public monk_heal_t
     may_miss = false;
     aoe      = -1;
 
-    if ( sim->pvp_crit )
+    if ( sim->pvp_mode )
       base_multiplier *= 2;  // 2016-08-03
   }
 };

--- a/engine/dbc/data_enums.hh
+++ b/engine/dbc/data_enums.hh
@@ -61,6 +61,7 @@ enum item_bonus_type
   ITEM_BONUS_ADD_RANK  = 17, // Add artifact power rank to a specific trait
   ITEM_BONUS_ADD_ITEM_EFFECT = 23,
   ITEM_BONUS_MOD_ITEM_STAT = 25, // Modify item stat to type
+  ITEM_BONUS_ILEVEL_IN_PVP = 36,  // Item has a higher level in PvP context
 };
 
 enum proc_types

--- a/engine/dbc/sc_item_data.cpp
+++ b/engine/dbc/sc_item_data.cpp
@@ -365,6 +365,13 @@ bool item_database::apply_item_bonus( item_t& item, const item_bonus_entry_t& en
       }
       break;
     }
+    // Adjust ilevel if we're using PvP mode
+    case ITEM_BONUS_ILEVEL_IN_PVP:
+      if ( item.sim->pvp_mode )
+      {
+        item.parsed.data.level += entry.value_1;
+      }
+      break;
     default:
       break;
   }

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -1890,7 +1890,7 @@ void retaliatory_fury( special_effect_t& effect )
   effect.spell_id = driver -> id();
 
   // 07-08-2018: this seems to have 2 rppm in pve
-  if ( ! effect.player -> sim -> pvp_crit )
+  if ( ! effect.player -> sim -> pvp_mode )
     effect.ppm_ = -2.0;
 
   new retaliatory_fury_proc_cb_t( effect, { { mastery, absorb } } );
@@ -1955,7 +1955,7 @@ void glory_in_battle( special_effect_t& effect )
   effect.spell_id = driver -> id();
 
   // 07-08-2018: this seems to have 2 rppm in pve
-  if ( ! effect.player -> sim -> pvp_crit )
+  if ( ! effect.player -> sim -> pvp_mode )
     effect.ppm_ = -2.0;
 
   new dbc_proc_callback_t( effect.player, effect );

--- a/engine/report/json/report_json.cpp
+++ b/engine/report/json/report_json.cpp
@@ -1162,7 +1162,7 @@ void to_json( const ::report::json::report_configuration_t& report_configuration
   options_root[ "enemy_death_pct" ] = sim.enemy_death_pct;
   options_root[ "challenge_mode" ] = sim.challenge_mode;
   options_root[ "timewalk" ] = sim.timewalk;
-  options_root[ "pvp_crit" ] = sim.pvp_crit;
+  options_root[ "pvp_mode" ] = sim.pvp_mode;
   options_root[ "rng" ] = sim.rng();
   options_root[ "deterministic" ] = sim.deterministic;
   options_root[ "average_range" ] = sim.average_range;

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -1495,7 +1495,7 @@ sim_t::sim_t() :
   enable_taunts( false ),
   use_item_verification( true ), disable_2_set( 1 ), disable_4_set( 1 ), enable_2_set( 1 ), enable_4_set( 1 ),
   pvp_rules(),
-  pvp_crit( false ),
+  pvp_mode( false ),
   auto_attacks_always_land( false ),
   log_spell_id(),
   active_enemies( 0 ), active_allies( 0 ),
@@ -2635,7 +2635,7 @@ void sim_t::init()
     scale_itemlevel_down_only = true;
   }
 
-  if ( pvp_crit )
+  if ( pvp_mode )
     pvp_rules = dbc::find_spell( this, 134735 );
 
   // set scaling metric
@@ -3563,7 +3563,7 @@ void sim_t::create_options()
   add_option( opt_uint( "disable_4_set", disable_4_set ) );
   add_option( opt_uint( "enable_2_set", enable_2_set ) );
   add_option( opt_uint( "enable_4_set", enable_4_set ) );
-  add_option( opt_bool( "pvp", pvp_crit ) );
+  add_option( opt_bool( "pvp", pvp_mode ) );
   add_option( opt_bool( "auto_attacks_always_land", auto_attacks_always_land ) );
   add_option( opt_bool( "log_spell_id", log_spell_id ) );
   add_option( opt_int( "desired_targets", desired_targets ) );

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -179,7 +179,7 @@ struct sim_t : private sc_thread_t
   unsigned int enable_2_set;// Enables all 2 set bonuses for the tier/integer that this is set as
   unsigned int enable_4_set; // Enables all 4 set bonuses for the tier/integer that this is set as
   const spell_data_t* pvp_rules; // Hidden aura that contains the PvP crit damage reduction
-  bool pvp_crit; // Enables crit damage reduction in PvP
+  bool pvp_mode; // Enables PvP mode - reduces crit damage, adjusts PvP gear iLvl
   bool feast_as_dps = true;
   bool auto_attacks_always_land; /// Allow Auto Attacks (white attacks) to always hit the enemy
   bool log_spell_id; // Add spell data ids to log/debug output where available. (actions, buffs)

--- a/qt/sc_OptionsTab.cpp
+++ b/qt/sc_OptionsTab.cpp
@@ -257,7 +257,7 @@ SC_OptionsTab::SC_OptionsTab( SC_MainWindow* parent ) : QTabWidget( parent ), ma
   connect( choice.plots_step, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
   connect( choice.plots_target_error, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
   connect( choice.plots_iterations, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
-  connect( choice.pvp_crit, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
+  connect( choice.pvp_mode, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
   connect( choice.reforgeplot_amount, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
   connect( choice.reforgeplot_step, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
   connect( choice.report_pets, SIGNAL( currentIndexChanged( int ) ), this, SLOT( _optionsChanged() ) );
@@ -360,8 +360,8 @@ void SC_OptionsTab::createGlobalsTab()
   globalsLayout_middle->addRow(
       tr( "Target Level" ),
       choice.target_level = createChoice( 4, "Raid Boss", "5-Man Heroic", "5-Man Normal", "Max Player Level" ) );
-  globalsLayout_middle->addRow( tr( "PVP Crit Damage Reduction" ),
-                                choice.pvp_crit = createChoice( 2, "Disable", "Enable" ) );
+  globalsLayout_middle->addRow( tr( "PVP Mode" ),
+                                choice.pvp_mode = createChoice( 2, "Disable", "Enable" ) );
   globalsLayout_middle->addRow(
       tr( "Target Race" ), choice.target_race = createChoice( 7, "Humanoid", "Beast", "Demon", "Dragonkin", "Elemental",
                                                               "Giant", "Undead" ) );
@@ -821,7 +821,7 @@ void SC_OptionsTab::decodeOptions()
   load_setting( settings, "update_check", choice.update_check );
   load_setting( settings, "default_role", choice.default_role );
   load_setting( settings, "boss_type", choice.boss_type, "Custom" );
-  load_setting( settings, "pvp_crit", choice.pvp_crit, "Disable" );
+  load_setting( settings, "pvp_mode", choice.pvp_mode, "Disable" );
   load_setting( settings, "tank_dummy", choice.tank_dummy, "None" );
   load_setting( settings, "tmi_window_global", choice.tmi_window, "6" );
   load_setting( settings, "show_etmi", choice.show_etmi );
@@ -923,7 +923,7 @@ void SC_OptionsTab::encodeOptions()
   settings.setValue( "api_client_secret", api_client_secret->text() );
   settings.setValue( "debug", choice.debug->currentText() );
   settings.setValue( "target_level", choice.target_level->currentText() );
-  settings.setValue( "pvp_crit", choice.pvp_crit->currentText() );
+  settings.setValue( "pvp_mode", choice.pvp_mode->currentText() );
   settings.setValue( "report_pets", choice.report_pets->currentText() );
   settings.setValue( "statistics_level", choice.statistics_level->currentText() );
   settings.setValue( "deterministic_rng", choice.deterministic_rng->currentText() );
@@ -1027,9 +1027,7 @@ void SC_OptionsTab::createToolTips()
 
   choice.target_level->setToolTip( tr( "Level of the target and any adds." ) );
 
-  choice.pvp_crit->setToolTip(
-      tr( "In PVP, critical strikes deal 150% damage instead of 200%.\n"
-          "Enabling this option will set target level to max player level." ) );
+  choice.pvp_mode->setToolTip( tr( "Will use PvP crit modifier and PvP iLvl." ) );
 
   choice.threads->setToolTip(
       tr( "Match the number of CPUs for optimal performance.\n"
@@ -1200,7 +1198,7 @@ QString SC_OptionsTab::get_globalSettings()
   else
   {
     static const char* const targetlevel[] = { "3", "2", "1", "0" };
-    if ( choice.pvp_crit->currentIndex() == 1 )
+    if ( choice.pvp_mode->currentIndex() == 1 )
     {
       options += "target_level+=0\n";
       options += "pvp=1\n";

--- a/qt/sc_OptionsTab.hpp
+++ b/qt/sc_OptionsTab.hpp
@@ -69,7 +69,7 @@ public:
     QComboBox* threads;
     QComboBox* process_priority;
     QComboBox* auto_save;
-    QComboBox* pvp_crit;
+    QComboBox* pvp_mode;
     QComboBox* armory_region;
     QComboBox* armory_spec;
     QComboBox* default_role;


### PR DESCRIPTION
This extends the existing pvp flag to also use the pvp ilvl of any pvp gear when the flag is enabled. GUI tooltip/description also updated to match new functionality. 

Bonus ilvl for pvp items appears to be held in the used bonus_type value_1 ... I couldn't find any documentation to back this up though! 

Tested as working on current (SL S3) Honor and Conquest gear.