### PR TITLE
[Destruction] Bugfix for Infernals

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1769,11 +1769,14 @@ void infernal_t::arise()
 {
   warlock_pet_t::arise();
 
-  buffs.embers->trigger();
-  immolation->trigger();
+  // TODO: Work out a more precise timing on this, this seems to be about correct from logs.
+  make_event( *sim, timespan_t::from_seconds( 1.2 ), [ this ] {
+    buffs.embers->trigger();
+    immolation->trigger();
 
-  melee_attack->set_target( target );
-  melee_attack->schedule_execute();
+    melee_attack->set_target( target );
+    melee_attack->schedule_execute();
+  } );
 }
 
 void infernal_t::demise()


### PR DESCRIPTION
Infernals do not take any actions for ~1.2s after being summoned, this is visible in logs. This implements that delay.

e.g.

https://www.warcraftlogs.com/reports/rY6AWmk8fR4LKHTt#fight=1&type=casts&source=16&translate=true&view=events

summon infernal at 0.02.217
infernal awakening 0.03.203
infernal melee at 0.04.491