### PR TITLE
[Warlock] fix crash with Urh and Havoc

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -670,7 +670,11 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                           p.havoc_target = nullptr;
                         }
                         else
+                        {
+                          if ( p.havoc_target && p.havoc_target != b->player )
+                            p.get_target_data( p.havoc_target )->debuffs_havoc->expire();
                           p.havoc_target = b->player;
+                        }
 
                         range::for_each( p.havoc_spells, []( action_t* a ) { a->target_cache.is_valid = false; } );
                       } );


### PR DESCRIPTION
Currently, simc will crash if Havoc is cast on a new target while it already active. This occurs sometimes in DungeonRoute sims due to Decrypted Urh Cypher.

I have not tested what happens in game when this occurs, but Havoc has the Limit N (165) attribute, so it is most likely limited to one target.