### PR TITLE
[DK] Update Soulwarped Seal proc rate

### DIFF
--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -4912,8 +4912,8 @@ void soulwarped_seal_of_menethil( special_effect_t& effect )
       assert( rppm );
       assert( s->target );
 
-      // Below 70% HP, proc rate appears to be 2rppm
-      double mod = 0.150;
+      // Below 70% HP, proc rate appears to be 4rppm
+      double mod = 0.2;
 	  
       // Above 70% HP, proc rate appears to be the full 20rppm.
       if ( s -> target -> health_percentage() >= 70 )


### PR DESCRIPTION
We have been undervaluing this for a while to be safe due to some inconsistent test data. Seems to be fairly consistent now at around 4rppm.