### PR TITLE
[Demonology Warlock] Double use trinket fix

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -380,8 +380,8 @@ void demonology( player_t* p )
   pure_damage_trinks->add_action( "use_item,name=darkmoon_deck_putrescence" );
   pure_damage_trinks->add_action( "use_item,name=ebonsoul_vise" );
   pure_damage_trinks->add_action( "use_item,name=unchained_gladiators_shackles" );
-  pure_damage_trinks->add_action( "use_item,slot=trinket1" );
-  pure_damage_trinks->add_action( "use_item,slot=trinket2" );
+  pure_damage_trinks->add_action( "use_item,slot=trinket1,if=!trinket.1.has_use_buff" );
+  pure_damage_trinks->add_action( "use_item,slot=trinket2,if=!trinket.2.has_use_buff" );
 
   trinkets->add_action( "variable,name=use_buff_trinkets,value=(!variable.use_bolt_timings&pet.demonic_tyrant.active)|(variable.use_bolt_timings&buff.shard_of_annihilation.up)" );
   trinkets->add_action( "use_item,name=scars_of_fraternal_strife,if=!buff.scars_of_fraternal_strife_4.up" );


### PR DESCRIPTION
before: https://www.raidbots.com/simbot/report/6wVrbBLsnF5RuyBzK68ou4
after: https://www.raidbots.com/simbot/report/9DgkTYLNjhqiAsMDXskacL
the change @Azevara made, made the sim use buff trinkets outside of tyrant