### PR TITLE
Add /bigobj to cmake for MSVC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ shadowlands ]
+    branches: [ shadowlands, dragonflight ]
   push:
     branches: [ shadowlands, dragonflight ]
     paths-ignore:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ function(sc_common_compiler_options target)
   target_compile_options(${target} PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/permissive->
     $<$<CXX_COMPILER_ID:MSVC>:/W3>
+    $<$<CXX_COMPILER_ID:MSVC>:/bigobj> # required for dbc item data object files
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
   )
 endfunction()


### PR DESCRIPTION
Apparently, compiling dbc item_import.obj failed with VS2022 because of the increased item data size compared ot shadowlands.

The flag is already set for the manual VS solutions, but was not set in cmake.