### PR TITLE
feat(Docker): Add conditional arg to PTR data build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM alpine:latest AS build
 
 ARG THREADS=1
 ARG APIKEY=''
+ARG PTR_DATA=1
 
 COPY . /app/SimulationCraft/
 
@@ -56,7 +57,8 @@ RUN make -C /app/SimulationCraft/engine clean && make -C /app/SimulationCraft/en
 RUN apk del build_dependencies
 
 # disable ptr to reduce build size
-# sed -i '' -e 's/#define SC_USE_PTR 1/#define SC_USE_PTR 0/g' engine/dbc.hpp
+# if PTR_DATA is equal to 1, it leaves the files in the build.
+RUN sh -c "if [ $PTR_DATA -ne 1 ]; then sed -i '' -e 's/#define SC_USE_PTR 1/#define SC_USE_PTR 0/g' engine/dbc.hpp; fi;"
 
 # fresh image to reduce size
 FROM alpine:latest


### PR DESCRIPTION
the option to build a smaller version of the Docker image without PTR-related data should now be controlled by the Docker build ARG PTR_DATA.