### PR TITLE
[Monk / SL] Fix SCK cast-thru

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1132,6 +1132,21 @@ struct monk_melee_attack_t : public monk_action_t<melee_attack_t>
     special    = true;
     may_glance = false;
   }
+  
+  bool ready() override
+  {
+    // Spell data nil or not_found
+    if ( data().id() == 0 )
+      return false;
+
+    // These abilities are able to be used during Spinning Crane Kick
+    if ( data().id() == 100780    // Tiger Palm
+      || data().id() == 100784    // Blackout Kick 
+      || data().id() == 107428 )  // Rising Sun Kick
+      usable_while_casting = p()->channeling && p()->channeling->id == 101546;
+
+    return monk_action_t::ready();
+  }
 
   void init_finished() override
   {
@@ -1379,6 +1394,9 @@ struct tiger_palm_t : public monk_melee_attack_t
     trigger_ww_t28_4p_power     = true;
     sef_ability                 = sef_ability_e::SEF_TIGER_PALM;
 
+    usable_while_casting        = true; // Allow during Spinning Crane Kick
+    use_while_casting           = true;
+
     add_child( eye_of_the_tiger_damage );
     add_child( eye_of_the_tiger_heal );
 
@@ -1619,6 +1637,9 @@ struct rising_sun_kick_t : public monk_melee_attack_t
     affected_by.serenity        = true;
     ap_type                     = attack_power_type::NONE;
 
+    usable_while_casting        = true; // Allow during Spinning Crane Kick
+    use_while_casting           = true;
+
     attack_power_mod.direct = 0;
 
     trigger_attack        = new rising_sun_kick_dmg_t( p, "rising_sun_kick_dmg" );
@@ -1789,6 +1810,9 @@ struct blackout_kick_t : public monk_melee_attack_t
     trigger_bountiful_brew      = true;
     trigger_ww_t28_4p_potential = true;
     trigger_ww_t28_4p_power     = true;
+
+    usable_while_casting        = true; // Allow during Spinning Crane Kick
+    use_while_casting           = true;
 
     if ( p->specialization() == MONK_WINDWALKER )
     {
@@ -2167,6 +2191,10 @@ struct spinning_crane_kick_t : public monk_melee_attack_t
 
     may_crit = may_miss = may_block = may_dodge = may_parry = false;
     tick_zero = hasted_ticks = channeled = interrupt_auto_attack = true;
+
+    // Does not incur channel lag when interrupted by a cast-thru ability
+    ability_lag                     = p->world_lag;
+    ability_lag_stddev              = p->world_lag_stddev;
 
     spell_power_mod.direct = 0.0;
 


### PR DESCRIPTION
[Shadowlands] This fixes the implementation of SCK to allow TP, BoK, and RSK to be cast during the channel and after the GCD of SCK for all specs.