### PR TITLE
[Unholy DK] Fix Festermight Stacking

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9108,11 +9108,6 @@ void death_knight_t::burst_festering_wound( player_t* target, unsigned n )
           dk -> cooldown.apocalypse -> adjust( -timespan_t::from_seconds(
           dk -> conduits.convocation_of_the_dead -> effectN( 2 ).base_value() / 10 ) );
         }
-
-        if ( dk-> talent.unholy.festermight.ok() )
-        {
-          dk->buffs.festermight->trigger();
-        }
       }
 
       // Triggers once per target per player action:
@@ -9122,7 +9117,12 @@ void death_knight_t::burst_festering_wound( player_t* target, unsigned n )
       {
         dk -> trigger_runic_corruption( dk -> procs.pp_runic_corruption, 0, dk -> talent.unholy.pestilent_pustules -> effectN( 1 ).percent() * n, false );
       }
-      td -> debuff.festering_wound -> decrement( n_executes );
+      td -> debuff.festering_wound -> decrement( n_executes ); 
+
+      if ( dk-> talent.unholy.festermight.ok() )
+      {
+        dk->buffs.festermight->trigger( n_executes );
+      }
     }
   };
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9111,7 +9111,7 @@ void death_knight_t::burst_festering_wound( player_t* target, unsigned n )
 
         if ( dk-> talent.unholy.festermight.ok() )
         {
-          dk->buffs.festermight->trigger( n_executes );
+          dk->buffs.festermight->trigger();
         }
       }
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9117,12 +9117,13 @@ void death_knight_t::burst_festering_wound( player_t* target, unsigned n )
       {
         dk -> trigger_runic_corruption( dk -> procs.pp_runic_corruption, 0, dk -> talent.unholy.pestilent_pustules -> effectN( 1 ).percent() * n, false );
       }
-      td -> debuff.festering_wound -> decrement( n_executes ); 
 
       if ( dk-> talent.unholy.festermight.ok() )
       {
         dk->buffs.festermight->trigger( n_executes );
       }
+
+      td -> debuff.festering_wound -> decrement( n_executes ); 
     }
   };
 


### PR DESCRIPTION
was placed in a for loop with n_executes already, causing it to increment stacks much faster than intended when multiple wounds popped. 