### PR TITLE
[DoT] consume costs for DoT end events

### DIFF
--- a/engine/action/dot.cpp
+++ b/engine/action/dot.cpp
@@ -1091,6 +1091,8 @@ void dot_t::dot_end_event_t::execute()
     dot->tick();
   }
 
+  dot->current_action->consume_cost_per_tick( *dot );
+
   dot->last_tick();
 }
 

--- a/engine/action/dot.cpp
+++ b/engine/action/dot.cpp
@@ -1089,9 +1089,8 @@ void dot_t::dot_end_event_t::execute()
   {
     dot->current_tick++;
     dot->tick();
+    dot->current_action->consume_cost_per_tick( *dot );
   }
-
-  dot->current_action->consume_cost_per_tick( *dot );
 
   dot->last_tick();
 }


### PR DESCRIPTION
After implementing the redesigned Mind Sear I noticed that it was skipping cost consumption for the last tick of the channel, leading to inaccurate Insanity at the end of a channel. This would cause you to have leftover insanity where you shouldn't.

```
Name             : Mind Sear (id=48045) [Spell Family (6)] 
Talent Entry     : Shadow [tree=spec, row=3, col=5, max_rank=1, req_points=0]
Class            : Priest
School           : Shadow
Spell Type       : Magic
Resource         : 0 Insanity (13) and 25 Insanity (13) per tick (id=265629)
```

example issue:
```
7.228 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=75).
7.228 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337

7.823 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=50).
7.823 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337

8.418 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=25).
8.418 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337

(should consume 25 again for this tick)
9.013 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337

a bit later you can see it did not since it gained 5 insanity to put it at 30, should be 5
10.294 Base gains 5.00 (5.00) insanity from Whispers of the Damned (30.00/100.00)
```

Generally this seems to not be used much in the game but adding this line from @EvanMichaels in seems to fix the issue:
```
7.215 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=75).
7.215 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337 

7.810 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=50).
7.810 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337

8.405 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=25).
8.405 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337

9.000 Player 'Base' Action mind_sear consumes ticking cost 25 (25) insanity (current=0).
9.000 Dot mind_sear fades from Player 'Fluffy_Pillow'
9.000 Base Decreasing mind_sear dot count to 0
9.000 Player 'Base' direct amount for Action mind_sear_tick: amount=916.4468115800337
```