### PR TITLE
CI: adjust used gcc/clang versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,15 +79,15 @@ jobs:
     strategy:
       matrix:
         cppVersion: [17, 20]
-        cc: [clang++-5.0, clang++-14]
+        cc: [clang++-7, clang++-14]
         include:
-          - cc: clang++-5.0
-            packages: clang-5.0
+          - cc: clang++-7
+            packages: clang-7
             os: ubuntu-20.04
           - cc: clang++-14
             os: ubuntu-22.04
         exclude:
-          - cc: clang++-5.0
+          - cc: clang++-7
             cppVersion: 20
 
     steps:
@@ -145,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-5.0, clang++-14, gcc-9, gcc-12]
+        compiler: [clang++-7, clang++-14, gcc-9, gcc-12]
         type: [spell_query, log_debug, patchwerk, dungeon_slice]
         include:
           - type: spell_query
@@ -156,7 +156,7 @@ jobs:
             simc_flags: $SIMC_PROFILE iterations=10 cleanup_threads=1
           - type: dungeon_slice
             simc_flags: $SIMC_PROFILE iterations=10 fight_style=DungeonSlice cleanup_threads=1
-          - compiler: clang++-5.0
+          - compiler: clang++-7
             os: ubuntu-20.04
           - compiler: clang++-14
             os: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
             os: ubuntu-20.04
           - cc: clang++-14
             os: ubuntu-22.04
+            enable_file_prefix_map: true
         exclude:
           - cc: clang++-7
             cppVersion: 20
@@ -111,7 +112,7 @@ jobs:
         run: cmake -H. -B'${{ runner.workspace }}/b/ninja' -GNinja -DBUILD_GUI=OFF
               -DCMAKE_BUILD_TYPE=Debug
               -DCMAKE_CXX_COMPILER=${{ matrix.cc }}
-              -DCMAKE_CXX_FLAGS="-Og -ffile-prefix-map=${{ runner.workspace }}/=/
+              -DCMAKE_CXX_FLAGS="-Og ${{ matrix.enable_file_prefix_map && format('-ffile-prefix-map={0}/=/', runner.workspace) || ''}}
                 -fno-omit-frame-pointer -fsanitize=address,undefined
                 -fsanitize-undefined-strip-path-components=$UBSAN_STRIP_COUNT"
               -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld -fsanitize=address,undefined"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,17 +74,21 @@ jobs:
           key: ubuntu-${{ matrix.cc }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-clang-build:
-    name: ubuntu-clang-build
+    name: ubuntu-build-${{ matrix.cc }}-C++${{ matrix.cppVersion }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         cppVersion: [17, 20]
-        cc: [clang++-12, clang++-14]
+        cc: [clang++-5.0, clang++-14]
         include:
-          - cc: clang++-12
+          - cc: clang++-5.0
+            packages: clang-5.0
             os: ubuntu-20.04
           - cc: clang++-14
             os: ubuntu-22.04
+        exclude:
+          - cc: clang++-5.0
+            cppVersion: 20
 
     steps:
       - uses: actions/checkout@v3
@@ -99,7 +103,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev ninja-build ccache
+          sudo apt-get install -y libcurl4-openssl-dev ninja-build ccache ${{ matrix.packages }}
 
       - name: Configure
         env:
@@ -141,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-12, clang++-14, gcc-9, gcc-12]
+        compiler: [clang++-5.0, clang++-14, gcc-9, gcc-12]
         type: [spell_query, log_debug, patchwerk, dungeon_slice]
         include:
           - type: spell_query
@@ -152,7 +156,7 @@ jobs:
             simc_flags: $SIMC_PROFILE iterations=10 cleanup_threads=1
           - type: dungeon_slice
             simc_flags: $SIMC_PROFILE iterations=10 fight_style=DungeonSlice cleanup_threads=1
-          - compiler: clang++-12
+          - compiler: clang++-5.0
             os: ubuntu-20.04
           - compiler: clang++-14
             os: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,30 +17,30 @@ env:
 
 jobs:
   ubuntu-gcc-build:
-    name: ubuntu-${{ matrix.cc }}-cpp${{ matrix.cppVersion }}-build
+    name: ubuntu-${{ matrix.compiler }}-cpp${{ matrix.cppVersion }}-build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cc: [gcc-12, gcc-7]
+        compiler: [gcc-12, gcc-7]
         cppVersion: [17, 20]
         include:
-          - cc: gcc-7
+          - compiler: gcc-7
             cxx: g++-7
             packages: gcc-7 g++-7
             os: ubuntu-20.04
-          - cc: gcc-12
+          - compiler: gcc-12
             cxx: g++-12
             packages: gcc-12 g++-12
             os: ubuntu-22.04
         exclude:
-          - cc: gcc-7
+          - compiler: gcc-7
             cppVersion: 20
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
-        env: { ccache-prefix: 'ubuntu-${{ matrix.cc }}-cpp-${{ matrix.cppVersion }}-ccache-${{ env.ccache-generation }}' }
+        env: { ccache-prefix: 'ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-ccache-${{ env.ccache-generation }}' }
         with:
           path: ${{ runner.workspace }}/.ccache
           key: ${{ env.ccache-prefix }}-${{ github.sha }}
@@ -54,7 +54,7 @@ jobs:
       - name: Configure
         run: cmake -H. -B'${{ runner.workspace }}/b/ninja' -GNinja -DBUILD_GUI=OFF
               -DCMAKE_BUILD_TYPE=Debug
-              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DCMAKE_C_COMPILER=${{ matrix.cc }}
+              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DCMAKE_C_COMPILER=${{ matrix.compiler }}
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
               -DCMAKE_CXX_STANDARD=${{ matrix.cppVersion }} 
 
@@ -74,32 +74,32 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
-          key: ubuntu-${{ matrix.cc }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+          key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-clang-build:
-    name: ubuntu-build-${{ matrix.cc }}-C++${{ matrix.cppVersion }}
+    name: ubuntu-build-${{ matrix.compiler }}-C++${{ matrix.cppVersion }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         cppVersion: [17, 20]
-        cc: [clang++-7, clang++-15]
+        compiler: [clang++-7, clang++-15]
         include:
-          - cc: clang++-7
+          - compiler: clang++-7
             os: ubuntu-20.04
             packages: clang-7 lld-7
-          - cc: clang++-15
+          - compiler: clang++-15
             os: ubuntu-22.04
             packages: clang-15 lld-15
             enable_file_prefix_map: true
         exclude:
-          - cc: clang++-7
+          - compiler: clang++-7
             cppVersion: 20
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
-        env: { ccache-prefix: 'ubuntu-${{ matrix.cc }}-cpp-${{ matrix.cppVersion }}-ccache-${{ env.ccache-generation }}' }
+        env: { ccache-prefix: 'ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-ccache-${{ env.ccache-generation }}' }
         with:
           path: ${{ runner.workspace }}/.ccache
           key: ${{ env.ccache-prefix }}-${{ github.sha }}
@@ -115,7 +115,7 @@ jobs:
           UBSAN_STRIP_COUNT: "`echo \"${{ runner.workspace }}//\" | grep -o '/' - | wc -l`"
         run: cmake -H. -B'${{ runner.workspace }}/b/ninja' -GNinja -DBUILD_GUI=OFF
               -DCMAKE_BUILD_TYPE=Debug
-              -DCMAKE_CXX_COMPILER=${{ matrix.cc }}
+              -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
               -DCMAKE_CXX_FLAGS="-Og ${{ matrix.enable_file_prefix_map && format('-ffile-prefix-map={0}/=/', runner.workspace) || ''}}
                 -fno-omit-frame-pointer -fsanitize=address,undefined
                 -fsanitize-undefined-strip-path-components=$UBSAN_STRIP_COUNT"
@@ -139,7 +139,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
-          key: ubuntu-${{ matrix.cc }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+          key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-run:
     name: ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
@@ -169,6 +169,11 @@ jobs:
             os: ubuntu-22.04
           - compiler: gcc-7
             os: ubuntu-20.04
+        exclude:
+          - compiler: clang++-7
+            cppVersion: 20
+          - compiler: gcc-7
+            cppVersion: 20
 
     steps:
       - uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,13 +79,14 @@ jobs:
     strategy:
       matrix:
         cppVersion: [17, 20]
-        cc: [clang++-7, clang++-14]
+        cc: [clang++-7, clang++-15]
         include:
           - cc: clang++-7
-            packages: clang-7 lld-7
             os: ubuntu-20.04
-          - cc: clang++-14
+            packages: clang-7 lld-7
+          - cc: clang++-15
             os: ubuntu-22.04
+            packages: clang-15 lld-15
             enable_file_prefix_map: true
         exclude:
           - cc: clang++-7
@@ -146,7 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-7, clang++-14, gcc-9, gcc-12]
+        compiler: [clang++-7, clang++-15, gcc-9, gcc-12]
         type: [spell_query, log_debug, patchwerk, dungeon_slice]
         include:
           - type: spell_query
@@ -159,7 +160,7 @@ jobs:
             simc_flags: $SIMC_PROFILE iterations=10 fight_style=DungeonSlice cleanup_threads=1
           - compiler: clang++-7
             os: ubuntu-20.04
-          - compiler: clang++-14
+          - compiler: clang++-15
             os: ubuntu-22.04
           - compiler: gcc-12
             os: ubuntu-22.04
@@ -190,7 +191,7 @@ jobs:
       matrix:
         cppVersion: [17]
         tier: [ Tier29, Tier30 ]
-        compiler: [clang++-14]
+        compiler: [clang++-15]
         spec: [
             Death_Knight_Blood, Death_Knight_Frost, Death_Knight_Unholy,
             Demon_Hunter_Havoc, Demon_Hunter_Vengeance,
@@ -207,7 +208,7 @@ jobs:
             Warrior_Arms, Warrior_Fury, Warrior_Protection,
           ]
         include:
-          - compiler: clang++-14
+          - compiler: clang++-15
             os: ubuntu-22.04
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,17 +21,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cc: [gcc-12, gcc-9]
+        cc: [gcc-12, gcc-7]
         cppVersion: [17, 20]
         include:
-          - cc: gcc-9
-            cxx: g++-9
-            packages: gcc-9 g++-9
+          - cc: gcc-7
+            cxx: g++-7
+            packages: gcc-7 g++-7
             os: ubuntu-20.04
           - cc: gcc-12
             cxx: g++-12
             packages: gcc-12 g++-12
             os: ubuntu-22.04
+        exclude:
+          - cc: gcc-7
+            cppVersion: 20
 
     steps:
       - uses: actions/checkout@v3
@@ -147,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-7, clang++-15, gcc-9, gcc-12]
+        compiler: [clang++-7, clang++-15, gcc-7, gcc-12]
         type: [spell_query, log_debug, patchwerk, dungeon_slice]
         include:
           - type: spell_query
@@ -164,7 +167,7 @@ jobs:
             os: ubuntu-22.04
           - compiler: gcc-12
             os: ubuntu-22.04
-          - compiler: gcc-9
+          - compiler: gcc-7
             os: ubuntu-20.04
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
         cc: [clang++-7, clang++-14]
         include:
           - cc: clang++-7
-            packages: clang-7
+            packages: clang-7 lld-7
             os: ubuntu-20.04
           - cc: clang++-14
             os: ubuntu-22.04

--- a/engine/config.hpp
+++ b/engine/config.hpp
@@ -60,12 +60,16 @@
 // ==========================================================================
 
 
-// Last updated 2021-06: Support gcc7 / clang 5 / MSVS 19.14 which have (~full) C++17 support
+// Last updated 2023-09: Support gcc7 / clang 5 / MSVS 19.14 which have (~full) C++17 support
 // Ubuntu LTS EOL is +5 years, Debian has ~+3year EOL, +5 years with separate LTS support
-// Ubuntu 18.04: gcc 7.3 clang 6.0
 // Debian 10 (Buster) (Release 2019-07): gcc 8.3 clang 7
 // Ubuntu 20.04: gcc 9.3 clang 10
-// Debian 11 (Bullseye) (Planned Release 2021): gcc 10.2 clang 11
+// Debian 11 (Bullseye) (Release 2021-08): gcc 10.2 clang 11
+// Ubuntu 22.04: gcc 11.2 clang 14
+// Debian 12 (Bookworm) (Release 2023-06): gcc 12.2 clang 14
+//
+// CI setup currently only supports Ubuntu 20.04+, which has clang 7 as the lowest installable version
+// GCC-7 is available on ubuntu 20.04 (but currently only gcc-9 is used as the lowest compiler in CI)
 #if defined( SC_CLANG ) && SC_CLANG < 50000
 #  error "clang++ below version 5 not supported"
 #endif

--- a/engine/config.hpp
+++ b/engine/config.hpp
@@ -68,8 +68,8 @@
 // Ubuntu 22.04: gcc 11.2 clang 14
 // Debian 12 (Bookworm) (Release 2023-06): gcc 12.2 clang 14
 //
-// CI setup currently only supports Ubuntu 20.04+, which has clang 7 as the lowest installable version
-// GCC-7 is available on ubuntu 20.04 (but currently only gcc-9 is used as the lowest compiler in CI)
+// CI setup currently only supports Ubuntu 20.04+, which has clang 7 as the lowest installable version -
+// so clang 5/6 builds are not actually tested in CI.
 #if defined( SC_CLANG ) && SC_CLANG < 50000
 #  error "clang++ below version 5 not supported"
 #endif


### PR DESCRIPTION
Upgrade the main CI run to use clang-15 (upgraded from clang-14).

At the same try, attempt to use the lowest clang/gcc versions easily available in CI to cover the older versions, as long as we still not "disallow" them in our `config.hpp` setup.
The lowest clang version is 7, and gcc is 7 as well.

While clang-5 would be the minimum version we enforce, clang-7 is the lowest version available on the ubuntu 20.04 github actions runner.