### PR TITLE
[Priest] Pet spells need their own buff apply code

### DIFF
--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -76,17 +76,8 @@ struct shadow_nova_t;
  */
 struct priest_pet_t : public pet_t
 {
-  propagate_const<actions::shadow_spike_t*> shadow_spike;
-  propagate_const<actions::shadow_spike_volley_t*> shadow_spike_volley;
-  propagate_const<actions::shadow_sear_t*> shadow_sear;
-  propagate_const<actions::shadow_nova_t*> shadow_nova;
-
   priest_pet_t( sim_t* sim, priest_t& owner, util::string_view pet_name, bool guardian = false )
-    : pet_t( sim, &owner, pet_name, PET_NONE, guardian ),
-      shadow_spike( nullptr ),
-      shadow_spike_volley( nullptr ),
-      shadow_sear( nullptr ),
-      shadow_nova( nullptr )
+    : pet_t( sim, &owner, pet_name, PET_NONE, guardian )
   {
   }
 
@@ -237,11 +228,277 @@ struct priest_pet_melee_t : public melee_attack_t
 struct priest_pet_spell_t : public spell_t
 {
   bool affected_by_shadow_weaving;
+  // auto parsed dynamic effects
+  using bfun = std::function<bool()>;
+  struct buff_effect_t
+  {
+    buff_t* buff;
+    double value;
+    bool use_stacks;
+    bfun func;
+
+    buff_effect_t( buff_t* b, double v, bool s = true, bfun f = nullptr )
+      : buff( b ), value( v ), use_stacks( s ), func( std::move( f ) )
+    {
+    }
+  };
+
+  std::vector<buff_effect_t> ta_multiplier_buffeffects;
+  std::vector<buff_effect_t> da_multiplier_buffeffects;
+  std::vector<buff_effect_t> execute_time_buffeffects;
+  std::vector<buff_effect_t> dot_duration_buffeffects;
+  std::vector<buff_effect_t> recharge_multiplier_buffeffects;
+  std::vector<buff_effect_t> cost_buffeffects;
+  std::vector<buff_effect_t> crit_chance_buffeffects;
 
   priest_pet_spell_t( util::string_view token, priest_pet_t& p, const spell_data_t* s )
     : spell_t( token, &p, s ), affected_by_shadow_weaving( false )
   {
     may_crit = true;
+
+    if ( data().ok() )
+    {
+      apply_buff_effects();
+    }
+  }
+
+  template <typename T>
+  void parse_spell_effects_mods( double& val, const spell_data_t* base, size_t idx, T mod )
+  {
+    for ( size_t i = 1; i <= mod->effect_count(); i++ )
+    {
+      const auto& eff = mod->effectN( i );
+
+      if ( eff.type() != E_APPLY_AURA )
+        continue;
+
+      if ( ( base->affected_by_all( eff ) &&
+             ( ( eff.misc_value1() == P_EFFECT_1 && idx == 1 ) || ( eff.misc_value1() == P_EFFECT_2 && idx == 2 ) ||
+               ( eff.misc_value1() == P_EFFECT_3 && idx == 3 ) || ( eff.misc_value1() == P_EFFECT_4 && idx == 4 ) ||
+               ( eff.misc_value1() == P_EFFECT_5 && idx == 5 ) ) ) ||
+           ( eff.subtype() == A_PROC_TRIGGER_SPELL_WITH_VALUE && eff.trigger_spell_id() == base->id() && idx == 1 ) )
+      {
+        double pct = eff.percent();
+
+        if ( eff.subtype() == A_ADD_FLAT_MODIFIER || eff.subtype() == A_ADD_FLAT_LABEL_MODIFIER )
+          val += pct;
+        else if ( eff.subtype() == A_ADD_PCT_MODIFIER || eff.subtype() == A_ADD_PCT_LABEL_MODIFIER )
+          val *= 1.0 + pct;
+        else if ( eff.subtype() == A_PROC_TRIGGER_SPELL_WITH_VALUE )
+          val = pct;
+        else
+          continue;
+      }
+    }
+  }
+
+  void parse_spell_effects_mods( double&, const spell_data_t*, size_t )
+  {
+  }
+
+  template <typename T, typename... Ts>
+  void parse_spell_effects_mods( double& val, const spell_data_t* base, size_t idx, T mod, Ts... mods )
+  {
+    parse_spell_effects_mods( val, base, idx, mod );
+    parse_spell_effects_mods( val, base, idx, mods... );
+  }
+
+  // Will parse simple buffs that ONLY target the caster and DO NOT have multiple ranks
+  // 1: Add Percent Modifier to Spell Direct Amount
+  // 2: Add Percent Modifier to Spell Periodic Amount
+  // 3: Add Percent Modifier to Spell Cast Time
+  // 4: Add Percent Modifier to Spell Cooldown
+  // 5: Add Percent Modifier to Spell Resource Cost
+  // 6: Add Flat Modifier to Spell Critical Chance
+  template <typename... Ts>
+  void parse_buff_effect( buff_t* buff, bfun f, const spell_data_t* s_data, size_t i, bool use_stacks, bool use_default,
+                          Ts... mods )
+  {
+    const auto& eff = s_data->effectN( i );
+    double val      = eff.percent();
+
+    auto debug_message = [ & ]( std::string_view type ) {
+      if ( buff )
+      {
+        p().sim->print_debug( "buff-effects: {} ({}) {} modified by {}% with buff {} ({}#{})", name(), id, type,
+                              val * 100.0, buff->name(), buff->data().id(), i );
+      }
+      else if ( f )
+      {
+        p().sim->print_debug( "conditional-effects: {} ({}) {} modified by {}% with condition from {} ({}#{})", name(),
+                              id, type, val * 100.0, s_data->name_cstr(), s_data->id(), i );
+      }
+      else
+      {
+        p().sim->print_debug( "passive-effects: {} ({}) {} modified by {}% from {} ({}#{})", name(), id, type,
+                              val * 100.0, s_data->name_cstr(), s_data->id(), i );
+      }
+    };
+
+    // TODO: more robust logic around 'party' buffs with radius
+    if ( !( eff.type() == E_APPLY_AURA || eff.type() == E_APPLY_AREA_AURA_PARTY ) || eff.radius() )
+      return;
+
+    if ( i <= 5 )
+      parse_spell_effects_mods( val, s_data, i, mods... );
+
+    if ( !data().affected_by_all( eff ) )
+      return;
+
+    if ( use_default && buff )
+      val = buff->default_value;
+
+    if ( !val )
+      return;
+
+    if ( eff.subtype() == A_ADD_PCT_MODIFIER || eff.subtype() == A_ADD_PCT_LABEL_MODIFIER )
+    {
+      switch ( eff.misc_value1() )
+      {
+        case P_GENERIC:
+          da_multiplier_buffeffects.emplace_back( buff, val, use_stacks, f );
+          debug_message( "direct damage" );
+          break;
+        case P_DURATION:
+          dot_duration_buffeffects.emplace_back( buff, val, use_stacks, f );
+          debug_message( "duration" );
+          break;
+        case P_TICK_DAMAGE:
+          ta_multiplier_buffeffects.emplace_back( buff, val, use_stacks, f );
+          debug_message( "tick damage" );
+          break;
+        case P_CAST_TIME:
+          execute_time_buffeffects.emplace_back( buff, val, use_stacks, f );
+          debug_message( "cast time" );
+          break;
+        case P_COOLDOWN:
+          recharge_multiplier_buffeffects.emplace_back( buff, val, use_stacks, f );
+          debug_message( "cooldown" );
+          break;
+        case P_RESOURCE_COST:
+          cost_buffeffects.emplace_back( buff, val, use_stacks, f );
+          debug_message( "cost" );
+          break;
+        default:
+          return;
+      }
+    }
+    else if ( eff.subtype() == A_ADD_FLAT_MODIFIER && eff.misc_value1() == P_CRIT )
+    {
+      crit_chance_buffeffects.emplace_back( buff, val, use_stacks, f );
+      debug_message( "crit chance" );
+    }
+    else
+    {
+      return;
+    }
+  }
+
+  template <typename... Ts>
+  void parse_buff_effects( buff_t* buff, unsigned ignore_mask, bool use_stacks, bool use_default, Ts... mods )
+  {
+    if ( !buff )
+      return;
+
+    const spell_data_t* s_data = &buff->data();
+    for ( size_t i = 1; i <= s_data->effect_count(); i++ )
+    {
+      if ( ignore_mask & 1 << ( i - 1 ) )
+        continue;
+
+      parse_buff_effect( buff, nullptr, s_data, i, use_stacks, use_default, mods... );
+    }
+  }
+
+  template <typename... Ts>
+  void parse_buff_effects( buff_t* buff, unsigned ignore_mask, Ts... mods )
+  {
+    parse_buff_effects<Ts...>( buff, ignore_mask, true, false, mods... );
+  }
+
+  template <typename... Ts>
+  void parse_buff_effects( buff_t* buff, bool stack, bool use_default, Ts... mods )
+  {
+    parse_buff_effects<Ts...>( buff, 0U, stack, use_default, mods... );
+  }
+
+  template <typename... Ts>
+  void parse_buff_effects( buff_t* buff, bool stack, Ts... mods )
+  {
+    parse_buff_effects<Ts...>( buff, 0U, stack, false, mods... );
+  }
+
+  template <typename... Ts>
+  void parse_buff_effects( buff_t* buff, Ts... mods )
+  {
+    parse_buff_effects<Ts...>( buff, 0U, true, false, mods... );
+  }
+
+  void parse_conditional_effects( const spell_data_t* spell, bfun f, unsigned ignore_mask = 0U )
+  {
+    if ( !spell || !spell->ok() )
+      return;
+
+    for ( size_t i = 1; i <= spell->effect_count(); i++ )
+    {
+      if ( ignore_mask & 1 << ( i - 1 ) )
+        continue;
+
+      parse_buff_effect( nullptr, f, spell, i, false, false );
+    }
+  }
+
+  void parse_passive_effects( const spell_data_t* spell, unsigned ignore_mask = 0U )
+  {
+    parse_conditional_effects( spell, nullptr, ignore_mask );
+  }
+
+  double get_buff_effects_value( const std::vector<buff_effect_t>& buffeffects, bool flat = false,
+                                 bool benefit = true ) const
+  {
+    double return_value = flat ? 0.0 : 1.0;
+
+    for ( const auto& i : buffeffects )
+    {
+      double eff_val = i.value;
+      int mod        = 1;
+
+      if ( i.func && !i.func() )
+        continue;  // continue to next effect if conditional effect function is false
+
+      if ( i.buff )
+      {
+        auto stack = benefit ? i.buff->stack() : i.buff->check();
+
+        if ( !stack )
+          continue;  // continue to next effect if stacks == 0 (buff is down)
+
+        mod = i.use_stacks ? stack : 1;
+      }
+
+      if ( flat )
+        return_value += eff_val * mod;
+      else
+        return_value *= 1.0 + eff_val * mod;
+    }
+
+    return return_value;
+  }
+
+  // Syntax: parse_buff_effects[<S[,S...]>]( buff[, ignore_mask|use_stacks[, use_default]][, spell1[,spell2...] )
+  //  buff = buff to be checked for to see if effect applies
+  //  ignore_mask = optional bitmask to skip effect# n corresponding to the n'th bit
+  //  use_stacks = optional, default true, whether to multiply value by stacks
+  //  use_default = optional, default false, whether to use buff's default value over effect's value
+  //  S = optional list of template parameter(s) to indicate spell(s) with redirect effects
+  //  spell = optional list of spell(s) with redirect effects that modify the effects on the buff
+  void apply_buff_effects()
+  {
+    // using S = const spell_data_t*;
+
+    parse_buff_effects( p().o().buffs.voidform );
+    parse_buff_effects( p().o().buffs.shadowform );
+    parse_buff_effects( p().o().buffs.twist_of_fate, p().o().talents.twist_of_fate );
   }
 
   priest_pet_t& p()
@@ -570,6 +827,8 @@ struct shadowflame_rift_t final : public priest_pet_spell_t
 
 // ==========================================================================
 // Inescapable Torment Damage
+// talent=373427
+// ?     =373442
 // ==========================================================================
 struct inescapable_torment_damage_t final : public priest_pet_spell_t
 {
@@ -580,19 +839,14 @@ struct inescapable_torment_damage_t final : public priest_pet_spell_t
     affected_by_shadow_weaving = true;
 
     // This is hard coded in the spell
-    // Depending on Mindbender or Shadowfiend this hits differently
-    switch ( p.fiend_type )
+    // spcoeff * $?a137032[${0.326139}][${0.442}]
+    if ( p.fiend_type == base_fiend_pet_t::fiend_type::Mindbender )
     {
-      case base_fiend_pet_t::fiend_type::Mindbender:
-      {
-        spell_power_mod.direct *= 0.442;
-      }
-      break;
-      default:
-        spell_power_mod.direct *= 0.408;
-        break;
+      spell_power_mod.direct *= 0.442;
     }
 
+    // Negative modifier used for point scaling
+    // Effect#4 [op=set, values=(-50, 0)]
     spell_power_mod.direct *= ( 1 + p.o().talents.shadow.inescapable_torment->effectN( 4 ).percent() );
   }
 };

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -510,6 +510,49 @@ struct priest_pet_spell_t : public spell_t
     return static_cast<priest_pet_t&>( *player );
   }
 
+  double cost() const override
+  {
+    double c = action_t::cost() * std::max( 0.0, get_buff_effects_value( cost_buffeffects, false, false ) );
+    return c;
+  }
+
+  double composite_ta_multiplier( const action_state_t* s ) const override
+  {
+    double ta = action_t::composite_ta_multiplier( s ) * get_buff_effects_value( ta_multiplier_buffeffects );
+    return ta;
+  }
+
+  double composite_da_multiplier( const action_state_t* s ) const override
+  {
+    double da = action_t::composite_da_multiplier( s ) * get_buff_effects_value( da_multiplier_buffeffects );
+    return da;
+  }
+
+  double composite_crit_chance() const override
+  {
+    double cc = action_t::composite_crit_chance() + get_buff_effects_value( crit_chance_buffeffects, true );
+    return cc;
+  }
+
+  timespan_t execute_time() const override
+  {
+    timespan_t et = action_t::execute_time() * get_buff_effects_value( execute_time_buffeffects );
+    return et;
+  }
+
+  timespan_t composite_dot_duration( const action_state_t* s ) const override
+  {
+    timespan_t dd = action_t::composite_dot_duration( s ) * get_buff_effects_value( dot_duration_buffeffects );
+    return dd;
+  }
+
+  double recharge_multiplier( const cooldown_t& cd ) const override
+  {
+    double rm =
+        action_t::recharge_multiplier( cd ) * get_buff_effects_value( recharge_multiplier_buffeffects, false, false );
+    return rm;
+  }
+
   double composite_target_da_multiplier( player_t* t ) const override
   {
     double tdm = action_t::composite_target_da_multiplier( t );
@@ -900,6 +943,9 @@ struct inescapable_torment_t final : public priest_pet_spell_t
 
     impact_action = new inescapable_torment_damage_t( p );
     add_child( impact_action );
+
+    // Base spell also has damage values
+    base_dd_min = base_dd_max = spell_power_mod.direct = 0.0;
   }
 
   void execute() override


### PR DESCRIPTION
- pet spells were not getting auto buffed by things like voidform, twist of fate, or shadowform
- clean up old living shadow actions
- inescapable shadows only works with mindbender, removed switch case
- inescapable shadows was dealing damage twice from new spelldata

Still need to check:
- other buff effects that work with pets?
- potentially add apply_debuff code as well
- Is there a way to use the same functions that priest_spell_t already has? (guessing no since we need to maintain our own list of buffs for pets/base action is different)