### PR TITLE
[Priest] Mind Sear never consumes less than 25 insanity

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -130,8 +130,8 @@ struct mind_sear_t final : public priest_spell_t
 
     if ( priest().buffs.mind_devourer_ms_active->check() )
     {
-      player->sim->print_debug( "{} {} consumes ticking cost 0 insanity (current={}).", priest(), *this,
-                                player->resources.current[ RESOURCE_INSANITY ] );
+      player->sim->print_debug( "{} {} consumes ticking cost 0 insanity (current={}) from mind_devourer.", priest(),
+                                *this, player->resources.current[ RESOURCE_INSANITY ] );
       return true;
     }
 
@@ -183,6 +183,17 @@ struct mind_sear_t final : public priest_spell_t
       {
         priest().trigger_shadowy_apparitions( priest().procs.shadowy_apparition_ms, false );
       }
+    }
+
+    double insanity_after_tick = player->resources.current[ RESOURCE_INSANITY ] - cost_per_tick( RESOURCE_INSANITY );
+
+    // Mind Sear will only ever consume 25 Insanity, no partial amounts
+    // Cancel the channel after the ticks happen
+    if ( insanity_after_tick < cost_per_tick( RESOURCE_INSANITY ) )
+    {
+      player->sim->print_debug( "{} {} will be cancelled. Ran out of Insanity for next tick, insanity_after_tick={}.",
+                                priest(), *this, insanity_after_tick );
+      make_event( *sim, 10_ms, [ this ] { this->cancel(); } );
     }
   }
 };
@@ -2669,7 +2680,8 @@ void priest_t::trigger_idol_of_nzoth( player_t* target, proc_t* proc )
 
   auto td = get_target_data( target );
 
-  if ( !td || !td->buffs.echoing_void->up() && number_of_echoing_voids_active() == talents.shadow.idol_of_nzoth->effectN( 1 ).base_value() )
+  if ( !td || !td->buffs.echoing_void->up() &&
+                  number_of_echoing_voids_active() == talents.shadow.idol_of_nzoth->effectN( 1 ).base_value() )
     return;
 
   if ( rng().roll( talents.shadow.idol_of_nzoth->proc_chance() ) )


### PR DESCRIPTION
Mind Sear does not behave like a typical channel does. Recently it was changed such that it will never consume less than the ticking cost of insanity. This PR changes the behavior to match this:

### Before
- Insanity Before: 55
- Ticks: 3 (25 + 25 + 5)
- Insanity After: 0

### After
- Insanity Before: 55
- Ticks: 2 (25 + 25)
- Insanity After: 5