### PR TITLE
dbc_extract json speed up on windows

### DIFF
--- a/dbc_extract3/dbc_extract.py
+++ b/dbc_extract3/dbc_extract.py
@@ -244,7 +244,7 @@ elif options.type == 'json':
         for entry, hotfix in cache.entries(dbc_file.parser):
             entries[hotfix['record_id']] = (entry, hotfix)
 
-    str_ = '[\n'
+    list_ = []
     logging.debug(dbc_file)
     if id == None:
         replaced_ids = []
@@ -254,9 +254,10 @@ elif options.type == 'json':
                 data_ = entry.obj()
                 data_['hotfixed'] = True
                 replaced_ids.append(record.id)
-                str_ += '\t{},\n'.format(json.dumps(data_))
+                raw_data = data_
             else:
-                str_ += '\t{},\n'.format(json.dumps(record.obj()))
+                raw_data = record.obj()
+            list_.append(raw_data)
 
         for id, item in entries.items():
             entry, hotfix = item
@@ -266,7 +267,7 @@ elif options.type == 'json':
             data_ = entry.obj()
             data_['hotfixed'] = True
 
-            str_ += '\t{},\n'.format(json.dumps(data_))
+            list_.append(data_)
 
     else:
         if id in entries:
@@ -279,14 +280,11 @@ elif options.type == 'json':
             if id in entries:
                 data_['hotfixed'] = True
 
-            str_ += '\t{},\n'.format(json.dumps(data_))
+            list_.append(data_)
         else:
             print('No record for DBC ID {} found'.format(id))
 
-    str_ = str_[:-2] + '\n'
-    str_ += ']\n'
-
-    print(str_)
+    print(json.dumps(list_, indent=4))
 
 elif options.type == 'csv':
     path = os.path.abspath(os.path.join(options.path, options.args[0]))


### PR DESCRIPTION
This change speeds up the extraction of ItemSparse from 40 minutes to 2 minutes on my machine. While debugging the slowness I noticed that the loop containing `json.dumps` was slowing down over time.

```
D:\\repositories\\simc_support\\env\\Scripts\\python.exe dbc_extract.py -b 10.0.2.46259 -t json -p D:\\repositories\\simc_support\\simc_support\\tmp\\en_US\\10.0.2.46259\\DBFilesClient -f formats ItemSparse >extract.json
[2022-10-30 08:40:52] WARNING: 0 calls
[2022-10-30 08:41:01] WARNING: 10000 calls
[2022-10-30 08:41:29] WARNING: 20000 calls
[2022-10-30 08:42:16] WARNING: 30000 calls
[2022-10-30 08:43:25] WARNING: 40000 calls
[2022-10-30 08:44:55] WARNING: 50000 calls
...
```
With each additional 10k call it was becoming worse and worse:
8s
28s 
47s 
1:09min
1:30min

Working with a list instead and calling `json.dumps` only on the final list removed this slowdown.

## Alternative
I'm not sure which part of the loop exactly is the slow-down. It could also be the string manipulation of an ever-growing string. In that case this code could potentially reach the same speed improvement, if each row was converted to a astring and collected in a list at first, only creating the full string via a join operation after all conversions were done.

I'm not sure who exactly should review this change. Feel free to add others, or remove yourself. :)

## Drawback
Uses more RAM.