### PR TITLE
[Affliction] Fix Vile Taint Dot Target Data

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -907,7 +907,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
   dots_siphon_life         = target->get_dot( "siphon_life", &p );
   dots_seed_of_corruption  = target->get_dot( "seed_of_corruption", &p );
   dots_unstable_affliction = target->get_dot( "unstable_affliction", &p );
-  dots_vile_taint          = target->get_dot( "vile_taint", &p );
+  dots_vile_taint          = target->get_dot( "vile_taint_dot", &p );
 
   debuffs_haunt = make_buff( *this, "haunt", p.talents.haunt )
                       ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC )


### PR DESCRIPTION
Vile Taint Dot Target data is wrong, causing it to not be extended by darkglare or used for malefic rapture calculations. The dot on individual targets is vile_taint_dot and vile_taint is just the aoe driver.

This would appear to have been broken for a long time causing incorrect sim results.