### PR TITLE
[RaidEvents] make LightMovement less aggresive

### DIFF
--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2297,7 +2297,7 @@ void sim_t::init_fight_style()
     break;
     
     case FIGHT_STYLE_LIGHT_MOVEMENT:
-      raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=5,distance=10,distance_min=5,distance_max=20,first=15";
+      raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=5,distance=15,distance_min=10,distance_max=20,first=15";
       break;
     
     case FIGHT_STYLE_HEAVY_MOVEMENT:

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2297,7 +2297,7 @@ void sim_t::init_fight_style()
     break;
     
     case FIGHT_STYLE_LIGHT_MOVEMENT:
-      raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=5,distance=15,distance_min=10,distance_max=20,first=15";
+      raid_events_str += "/movement,players_only=1,cooldown=40,cooldown_stddev=10,distance=15,distance_min=10,distance_max=20,first=15";
       break;
     
     case FIGHT_STYLE_HEAVY_MOVEMENT:

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2297,7 +2297,7 @@ void sim_t::init_fight_style()
     break;
     
     case FIGHT_STYLE_LIGHT_MOVEMENT:
-      raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=15,distance=25,distance_min=20,distance_max=30,first=15";
+      raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=5,distance=10,distance_min=5,distance_max=20,first=15";
       break;
     
     case FIGHT_STYLE_HEAVY_MOVEMENT:


### PR DESCRIPTION
In my opinion Light Movement is a bit too aggressive. Having a movement event in simc called "light" should equate to having to move for a small mechanic semi-often and this change seems to be more aligned with that expectation.