### PR TITLE
[Warlock] New CB/RoF rules and Cry havoc in cleave

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -140,14 +140,13 @@ void destruction( player_t* p )
   default_->add_action( "channel_demonfire,if=talent.raging_demonfire" );
   default_->add_action( "soul_fire,if=soul_shard<=4" );
   default_->add_action( "immolate,if=((dot.immolate.refreshable&talent.internal_combustion)|dot.immolate.remains<3)&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&(!talent.soul_fire|cooldown.soul_fire.remains>dot.immolate.remains)" );
-  default_->add_action( "havoc,if=pet.infernal.active" );
+  default_->add_action( "havoc,if=talent.cry_havoc&(buff.ritual_of_ruin.up|pet.infernal.active)" );
   default_->add_action( "chaos_bolt,if=pet.infernal.active|pet.blasphemy.active|soul_shard>=4" );
   default_->add_action( "summon_infernal" );
   default_->add_action( "channel_demonfire,if=talent.ruin.rank>1&!(talent.diabolic_embers&talent.avatar_of_destruction&(talent.burn_to_ashes|talent.chaos_incarnate))" );
-  default_->add_action( "conflagrate,if=buff.backdraft.down&soul_shard>=1.5" );
+  default_->add_action( "conflagrate,if=buff.backdraft.down&soul_shard>=1.5&!talent.roaring_blaze" );
   default_->add_action( "chaos_bolt,if=buff.rain_of_chaos.remains>cast_time" );
-  default_->add_action( "chaos_bolt,if=buff.backdraft.up" );
-  default_->add_action( "chaos_bolt,if=talent.eradication&debuff.eradication.remains<cast_time&!action.chaos_bolt.in_flight" );
+  default_->add_action( "chaos_bolt,if=buff.backdraft.up&!talent.eradication&!talent.madness_of_the_azjaqir" );
   default_->add_action( "chaos_bolt,if=buff.madness_cb.up" );
   default_->add_action( "channel_demonfire,if=!(talent.diabolic_embers&talent.avatar_of_destruction&(talent.burn_to_ashes|talent.chaos_incarnate))" );
   default_->add_action( "dimensional_rift" );

--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -132,15 +132,16 @@ void destruction( player_t* p )
 
   default_->add_action( "call_action_list,name=cleave,if=active_enemies!=1&active_enemies<=2+(!talent.inferno&talent.madness_of_the_azjaqir&talent.ashen_remains)|variable.cleave_apl" );
   default_->add_action( "call_action_list,name=aoe,if=active_enemies>=3" );
+  default_->add_action( "call_action_list,name=items" );
+  default_->add_action( "call_action_list,name=ogcd" );
   default_->add_action( "conflagrate,if=(talent.roaring_blaze&debuff.conflagrate.remains<1.5)|charges=max_charges" );
   default_->add_action( "dimensional_rift,if=soul_shard<4.7&(charges>2|time_to_die<cooldown.dimensional_rift.duration)" );
   default_->add_action( "cataclysm" );
   default_->add_action( "channel_demonfire,if=talent.raging_demonfire" );
   default_->add_action( "soul_fire,if=soul_shard<=4" );
   default_->add_action( "immolate,if=((dot.immolate.refreshable&talent.internal_combustion)|dot.immolate.remains<3)&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&(!talent.soul_fire|cooldown.soul_fire.remains>dot.immolate.remains)" );
+  default_->add_action( "havoc,if=pet.infernal.active" );
   default_->add_action( "chaos_bolt,if=pet.infernal.active|pet.blasphemy.active|soul_shard>=4" );
-  default_->add_action( "call_action_list,name=items" );
-  default_->add_action( "call_action_list,name=ogcd" );
   default_->add_action( "summon_infernal" );
   default_->add_action( "channel_demonfire,if=talent.ruin.rank>1&!(talent.diabolic_embers&talent.avatar_of_destruction&(talent.burn_to_ashes|talent.chaos_incarnate))" );
   default_->add_action( "conflagrate,if=buff.backdraft.down&soul_shard>=1.5" );
@@ -156,21 +157,23 @@ void destruction( player_t* p )
   default_->add_action( "conflagrate,if=charges>(max_charges-1)|time_to_die<gcd*charges" );
   default_->add_action( "incinerate" );
 
-  aoe->add_action( "call_action_list,name=havoc,if=havoc_active&havoc_remains>gcd&active_enemies<5" );
+  aoe->add_action( "call_action_list,name=ogcd" );
+  aoe->add_action( "call_action_list,name=items" );
+  aoe->add_action( "call_action_list,name=havoc,if=havoc_active&havoc_remains>gcd&active_enemies<5+(talent.cry_havoc&!talent.inferno)" );
   aoe->add_action( "rain_of_fire,if=pet.infernal.active" );
   aoe->add_action( "rain_of_fire,if=talent.avatar_of_destruction" );
   aoe->add_action( "rain_of_fire,if=soul_shard=5" );
   aoe->add_action( "chaos_bolt,if=soul_shard>3.5-(0.1*active_enemies)&!talent.rain_of_fire" );
   aoe->add_action( "cataclysm" );
-  aoe->add_action( "channel_demonfire,if=dot.immolate.remains>cast_time&(talent.raging_demonfire.rank+talent.roaring_blaze.rank)>1" );
+  aoe->add_action( "channel_demonfire,if=dot.immolate.remains>cast_time&talent.raging_demonfire" );
   aoe->add_action( "immolate,cycle_targets=1,if=dot.immolate.remains<5&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.immolate.remains)&active_dot.immolate<=6" );
   aoe->add_action( "havoc,cycle_targets=1,if=!(self.target=target)&!talent.rain_of_fire" );
-  aoe->add_action( "call_action_list,name=items" );
   aoe->add_action( "summon_soulkeeper,if=buff.tormented_soul.stack=10" );
   aoe->add_action( "call_action_list,name=ogcd" );
   aoe->add_action( "summon_infernal" );
   aoe->add_action( "rain_of_fire" );
   aoe->add_action( "havoc,cycle_targets=1,if=!(self.target=target)" );
+  aoe->add_action( "channel_demonfire,if=dot.immolate.remains>cast_time" );
   aoe->add_action( "immolate,cycle_targets=1,if=dot.immolate.remains<5&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.immolate.remains)" );
   aoe->add_action( "soul_fire,if=buff.backdraft.up" );
   aoe->add_action( "incinerate,if=talent.fire_and_brimstone.enabled&buff.backdraft.up" );
@@ -179,6 +182,8 @@ void destruction( player_t* p )
   aoe->add_action( "immolate,if=dot.immolate.refreshable" );
   aoe->add_action( "incinerate" );
 
+  cleave->add_action( "call_action_list,name=items" );
+  cleave->add_action( "call_action_list,name=ogcd" );
   cleave->add_action( "call_action_list,name=havoc,if=havoc_active&havoc_remains>gcd" );
   cleave->add_action( "variable,name=pool_soul_shards,value=cooldown.havoc.remains<=10|talent.mayhem" );
   cleave->add_action( "conflagrate,if=(talent.roaring_blaze.enabled&debuff.conflagrate.remains<1.5)|charges=max_charges" );
@@ -189,8 +194,6 @@ void destruction( player_t* p )
   cleave->add_action( "immolate,cycle_targets=1,if=((talent.internal_combustion&dot.immolate.refreshable)|dot.immolate.remains<3)&(!talent.cataclysm|cooldown.cataclysm.remains>remains)&(!talent.soul_fire|cooldown.soul_fire.remains>remains)" );
   cleave->add_action( "havoc,cycle_targets=1,if=!(target=self.target)&(!cooldown.summon_infernal.up|!talent.summon_infernal)" );
   cleave->add_action( "chaos_bolt,if=pet.infernal.active|pet.blasphemy.active|soul_shard>=4" );
-  cleave->add_action( "call_action_list,name=items" );
-  cleave->add_action( "call_action_list,name=ogcd" );
   cleave->add_action( "summon_infernal" );
   cleave->add_action( "channel_demonfire,if=talent.ruin.rank>1&!(talent.diabolic_embers&talent.avatar_of_destruction&(talent.burn_to_ashes|talent.chaos_incarnate))" );
   cleave->add_action( "conflagrate,if=buff.backdraft.down&soul_shard>=1.5&!variable.pool_soul_shards" );
@@ -211,8 +214,10 @@ void destruction( player_t* p )
   havoc->add_action( "soul_fire,if=cast_time<havoc_remains&soul_shard<3" );
   havoc->add_action( "channel_demonfire,if=soul_shard<4.5&talent.raging_demonfire.rank=2&active_enemies>2" );
   havoc->add_action( "immolate,cycle_targets=1,if=dot.immolate.refreshable&dot.immolate.remains<havoc_remains&soul_shard<4.5&(debuff.havoc.down|!dot.immolate.ticking)" );
-  havoc->add_action( "chaos_bolt,if=cast_time<havoc_remains&(active_enemies<4-talent.inferno+talent.madness_of_the_azjaqir+(!talent.inferno&talent.ashen_remains))" );
-  havoc->add_action( "rain_of_fire,if=(active_enemies>=4-talent.inferno+talent.madness_of_the_azjaqir+(!talent.inferno&talent.ashen_remains))" );
+  havoc->add_action( "chaos_bolt,if=talent.cry_havoc&!talent.inferno&cast_time<havoc_remains" );
+  havoc->add_action( "chaos_bolt,if=cast_time<havoc_remains&(active_enemies<4-talent.inferno+talent.madness_of_the_azjaqir-(talent.inferno&(talent.rain_of_chaos|talent.avatar_of_destruction)&buff.rain_of_chaos.up))" );
+  havoc->add_action( "rain_of_fire,if=(active_enemies>=4-talent.inferno+talent.madness_of_the_azjaqir)" );
+  havoc->add_action( "rain_of_fire,if=active_enemies>1&(talent.avatar_of_destruction|(talent.rain_of_chaos&buff.rain_of_chaos.up))&talent.inferno.enabled" );
   havoc->add_action( "conflagrate,if=!talent.backdraft" );
   havoc->add_action( "incinerate,if=cast_time<havoc_remains" );
 


### PR DESCRIPTION
After the hotfix I had to change some rules that were not perfect anyway.

Also I added Cry Havoc rules in the APL as it's a nice dps in 3-6 target cleave.