### PR TITLE
[Ele Shaman] Incorporate use of MotE

### DIFF
--- a/profiles/Tier29/T29_Shaman_Elemental.simc
+++ b/profiles/Tier29/T29_Shaman_Elemental.simc
@@ -137,8 +137,10 @@ actions.single_target+=/lightning_bolt,if=buff.stormkeeper.up&buff.surge_of_powe
 actions.single_target+=/lava_beam,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&buff.stormkeeper.up&!talent.surge_of_power.enabled
 # Stormkeeper is strong and should be used.
 actions.single_target+=/chain_lightning,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&buff.stormkeeper.up&!talent.surge_of_power.enabled
+# Buff stormkeeper with MotE when not using Surge
+actions.single_target+=/lava_burst,if=buff.stormkeeper.up&!buff.master_of_the_elements.up&!talent.surge_of_power.enabled&talent.master_of_the_elements.enabled
 # Stormkeeper is strong and should be used.
-actions.single_target+=/lightning_bolt,if=buff.stormkeeper.up&!talent.surge_of_power.enabled
+actions.single_target+=/lightning_bolt,if=buff.stormkeeper.up&!talent.surge_of_power.enabled&(buff.master_of_the_elements.up|!talent.master_of_the_elements.enabled)
 # Surge of Power is strong and should be used.
 actions.single_target+=/lightning_bolt,if=buff.surge_of_power.up
 actions.single_target+=/icefury,if=talent.electrified_shocks.enabled
@@ -149,6 +151,8 @@ actions.single_target+=/lava_beam,if=active_enemies>1&(spell_targets.chain_light
 actions.single_target+=/lava_burst,if=buff.windspeakers_lava_resurgence.up
 # Lava Surge is neat. Utilize it.
 actions.single_target+=/lava_burst,if=cooldown_react&buff.lava_surge.up
+# Buff your next Maelstrom Spender with MotE if it won't cap your maelstrom
+actions.single_target+=/lava_burst,if=talent.master_of_the_elements.enabled&!buff.master_of_the_elements.up&maelstrom>=50&(!talent.swelling_maelstrom.enabled&maelstrom<=80|talent.swelling_maelstrom.enabled&maelstrom<=130)
 # Use the talents you selected. Did you invest only 1 point in it? In this case this'll be a DPS decrease. Additionally Elemental Blast is stronger than EoGS. In this case don't use Earthquake on single target.
 actions.single_target+=/earthquake,if=buff.echoes_of_great_sundering.up&(!talent.elemental_blast.enabled&active_enemies<2|active_enemies>1)
 # Use Earthquake against two enemies unless you have to alternate because of Echoes of Great Sundering.
@@ -168,6 +172,9 @@ actions.single_target+=/lightning_bolt,if=buff.power_of_the_maelstrom.up&talent.
 actions.single_target+=/icefury
 # Spam Lightning Bolt if Storm Elemental is active. But honor all previous priorities.
 actions.single_target+=/lightning_bolt,if=pet.storm_elemental.active&debuff.lightning_rod.up&(debuff.electrified_shocks.up|buff.power_of_the_maelstrom.up)
+# If you have MotE up and aren't at risk of capping LvB, spend MotE on FS/LB
+actions.single_target+=/frost_shock,if=buff.icefury.up&buff.master_of_the_elements.up&!buff.lava_surge.up&!talent.electrified_shocks.enabled&!talent.flux_melting.enabled&(cooldown.lava_burst.charges_fractional<1.0&talent.echoes_of_the_elements.enabled)
+actions.single_target+=/lightning_bolt,if=buff.master_of_the_elements.up&!buff.lava_surge.up&(cooldown.lava_burst.charges_fractional<1.0&talent.echoes_of_the_elements.enabled)
 actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2
 # Use your Icefury buffs if you didn't improve the talent.
 actions.single_target+=/frost_shock,if=buff.icefury.up&!talent.electrified_shocks.enabled&!talent.flux_melting.enabled


### PR DESCRIPTION
- when not using SoP, cast lava burst before using a SK-buffed lightning bolt to buff it with MotE
- if we have enough Maelstrom to spend, cast Lava Burst to gain MotE if it would not cap Maelstrom
- With EotE, if MotE is up and we have one LvB charge with no Surge, use Icefury FS or LB before spending the LvB charge (very minor increase)

These changes show a 608~ dps increase on the T29 profile according to raidbots:
[Standard APL](https://www.raidbots.com/simbot/report/hFAA2sUDN5ucJg9NnNJyW4) 84,500 DPS
[Custom APL from this PR](https://www.raidbots.com/simbot/report/gbMqgoA954gyXaTc9koAx2) 85,108 DPS

The DPS increase is much lower with Surge of Power (~50dps), and higher on Lightning Bolt builds that don't use Surge of Power (approaching 1000).