### PR TITLE
[Monk] ChP and BoF

### DIFF
--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -934,7 +934,6 @@ public:
     double faeline_stomp_uptime;
     int chi_burst_healing_targets;
     int motc_override;
-    int no_bof_dot;
     double squirm_frequency;
   } user_options;
 


### PR DESCRIPTION
BoF variable now does exactly what I was looking for and cleaned up the old stuff.

ChP was simming for 1/10th of what it should, so removing the additional multiplier works.

@Hinalover
Do you still have those changes to make Niuzao stomp not always pretend the Improved Niuzao talent is active?