### PR TITLE
[Paladin] Fix Sentinel

### DIFF
--- a/engine/class_modules/apl/apl_paladin.cpp
+++ b/engine/class_modules/apl/apl_paladin.cpp
@@ -128,7 +128,7 @@ void protection( player_t* p )
   precombat->add_action( "lights_judgment" );
   precombat->add_action( "arcane_torrent" );
   precombat->add_action( "consecration" );
-  // TODO: Trinkets break if you have no MoG talented
+  // TODO: Trinkets break if you have no MoG talented 
   precombat->add_action( "variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=trinket.1.has_use_buff&(talent.moment_of_glory&trinket.1.cooldown.duration%%cooldown.moment_of_glory.duration=0|(talent.avenging_wrath&!talent.moment_of_glory)&trinket.1.cooldown.duration%%cooldown.avenging_wrath.duration<=20)", "Evaluates a trinkets cooldown, divided by moment of glory or avenging wraths's cooldown. If it's value has no remainder return 1, else return 0.5." );
   precombat->add_action( "variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=trinket.2.has_use_buff&(talent.moment_of_glory&trinket.2.cooldown.duration%%cooldown.moment_of_glory.duration=0|(talent.avenging_wrath&!talent.moment_of_glory)&trinket.2.cooldown.duration%%cooldown.avenging_wrath.duration<=20)" );
   precombat->add_action( "variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!trinket.1.has_use_buff&trinket.2.has_use_buff|trinket.2.has_use_buff&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))" );

--- a/engine/class_modules/apl/apl_paladin.cpp
+++ b/engine/class_modules/apl/apl_paladin.cpp
@@ -128,6 +128,7 @@ void protection( player_t* p )
   precombat->add_action( "lights_judgment" );
   precombat->add_action( "arcane_torrent" );
   precombat->add_action( "consecration" );
+  // TODO: Trinkets break if you have no MoG talented
   precombat->add_action( "variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=trinket.1.has_use_buff&(talent.moment_of_glory&trinket.1.cooldown.duration%%cooldown.moment_of_glory.duration=0|(talent.avenging_wrath&!talent.moment_of_glory)&trinket.1.cooldown.duration%%cooldown.avenging_wrath.duration<=20)", "Evaluates a trinkets cooldown, divided by moment of glory or avenging wraths's cooldown. If it's value has no remainder return 1, else return 0.5." );
   precombat->add_action( "variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=trinket.2.has_use_buff&(talent.moment_of_glory&trinket.2.cooldown.duration%%cooldown.moment_of_glory.duration=0|(talent.avenging_wrath&!talent.moment_of_glory)&trinket.2.cooldown.duration%%cooldown.avenging_wrath.duration<=20)" );
   precombat->add_action( "variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!trinket.1.has_use_buff&trinket.2.has_use_buff|trinket.2.has_use_buff&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))" );
@@ -143,10 +144,10 @@ void protection( player_t* p )
   cooldowns->add_action( "seraphim" );
   cooldowns->add_action( "avenging_wrath,if=(buff.seraphim.up|!talent.seraphim.enabled)" );
   cooldowns->add_action( "sentinel,if=(buff.seraphim.up|!talent.seraphim.enabled)" );
-  cooldowns->add_action( "potion,if=buff.avenging_wrath.up|variable.might_or_sentinel" );
-  cooldowns->add_action( "moment_of_glory,if=(buff.avenging_wrath.remains<15|(time>10|(cooldown.avenging_wrath.remains>15))&(cooldown.avengers_shield.remains&cooldown.judgment.remains&cooldown.hammer_of_wrath.remains))" );
-  cooldowns->add_action( "holy_avenger,if=buff.avenging_wrath.up|variable.might_or_sentinel|cooldown.avenging_wrath.remains>60" );
-  cooldowns->add_action( "bastion_of_light,if=buff.avenging_wrath.up" );
+  cooldowns->add_action( "potion,if=buff.avenging_wrath.up|buff.sentinel.up|variable.might_or_sentinel" );
+  cooldowns->add_action( "moment_of_glory,if=(buff.avenging_wrath.remains<15|buff.sentinel.remains<15|(time>10|(cooldown.avenging_wrath.remains>15|cooldown.sentinel.remains>15))&(cooldown.avengers_shield.remains&cooldown.judgment.remains&cooldown.hammer_of_wrath.remains))" );
+  cooldowns->add_action( "holy_avenger,if=buff.avenging_wrath.up|buff.sentinel.up|variable.might_or_sentinel|cooldown.avenging_wrath.remains>60|cooldown.sentinel.remains>60" );
+  cooldowns->add_action( "bastion_of_light,if=buff.avenging_wrath.up|buff.sentinel.up" );
 
   trinkets->add_action( "use_item,slot=trinket1,if=buff.moment_of_glory.up&(!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1)|trinket.1.proc.any_dps.duration>=fight_remains" );
   trinkets->add_action( "use_item,slot=trinket2,if=buff.moment_of_glory.up&(!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2)|trinket.2.proc.any_dps.duration>=fight_remains" );
@@ -155,9 +156,9 @@ void protection( player_t* p )
 
   standard->add_action( "shield_of_the_righteous,if=(cooldown.seraphim.remains>=5|!talent.seraphim.enabled)&(((holy_power=3&!buff.blessing_of_dusk.up&!buff.holy_avenger.up)|(holy_power=5)|buff.bastion_of_light.up|buff.divine_purpose.up))" );
   standard->add_action( "avengers_shield,if=buff.moment_of_glory.up|!talent.moment_of_glory.enabled" );
-  standard->add_action( "hammer_of_wrath,if=buff.avenging_wrath.up|(!talent.avenging_wrath.enabled&(!talent.avenging_wrath_might.enabled|talent.sentinel_enabled))" );
+  standard->add_action( "hammer_of_wrath,if=buff.avenging_wrath.up|buff.sentinel.up|(!talent.avenging_wrath.enabled&(!talent.avenging_wrath_might.enabled|talent.sentinel.enabled))" );
   standard->add_action( "judgment,target_if=min:debuff.judgment.remains,if=charges=2|!talent.crusaders_judgment.enabled" );
-  standard->add_action( "divine_toll,if=time>20|((!talent.seraphim.enabled|buff.seraphim.up)&(buff.avenging_wrath.up|(!talent.avenging_wrath.enabled&(!talent.avenging_wrath_might.enabled|talent.sentinel_enabled)))&(buff.moment_of_glory.up|!talent.moment_of_glory.enabled))" );
+  standard->add_action( "divine_toll,if=time>20|((!talent.seraphim.enabled|buff.seraphim.up)&(buff.avenging_wrath.up|buff.sentinel.up|(!talent.avenging_wrath.enabled&(!talent.avenging_wrath_might.enabled|talent.sentinel.enabled)))&(buff.moment_of_glory.up|!talent.moment_of_glory.enabled))" );
   standard->add_action( "avengers_shield" );
   standard->add_action( "hammer_of_wrath" );
   standard->add_action( "judgment,target_if=min:debuff.judgment.remains" );

--- a/engine/class_modules/apl/apl_paladin.cpp
+++ b/engine/class_modules/apl/apl_paladin.cpp
@@ -142,6 +142,7 @@ void protection( player_t* p )
 
   cooldowns->add_action( "seraphim" );
   cooldowns->add_action( "avenging_wrath,if=(buff.seraphim.up|!talent.seraphim.enabled)" );
+  cooldowns->add_action( "sentinel,if=(buff.seraphim.up|!talent.seraphim.enabled)" );
   cooldowns->add_action( "potion,if=buff.avenging_wrath.up|variable.might_or_sentinel" );
   cooldowns->add_action( "moment_of_glory,if=(buff.avenging_wrath.remains<15|(time>10|(cooldown.avenging_wrath.remains>15))&(cooldown.avengers_shield.remains&cooldown.judgment.remains&cooldown.hammer_of_wrath.remains))" );
   cooldowns->add_action( "holy_avenger,if=buff.avenging_wrath.up|variable.might_or_sentinel|cooldown.avenging_wrath.remains>60" );

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -1490,11 +1490,10 @@ struct holy_power_consumer_t : public Base
         p -> buffs.shining_light_free -> expire();
     }
 
-    if (p -> buffs.bastion_of_light -> check() )
+    if (p -> buffs.bastion_of_light -> check() && should_continue)
     {
-      // 2022-08-11 Bastion of Light stacks get eaten despite having a free spender available
-      if (p->bugs || !isFreeSLDPSpender )
-        p -> buffs.bastion_of_light->decrement();
+      p -> buffs.bastion_of_light->decrement();
+      should_continue = false;
     }
 
     if ( p->buffs.sentinel->up() && p->buffs.sentinel_decay->up() )

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -1082,17 +1082,13 @@ public:
         am *= 1.0 + p() -> sets -> set( PALADIN_RETRIBUTION, T29, B4 ) -> effectN( 1 ).percent();
       }
     }
-    if ( p()->specialization()==PALADIN_PROTECTION )
-    {
-      if ( affected_by.sentinel && p()->buffs.sentinel->up() )
-      {
-        am *= 1.0 + p()->buffs.sentinel->get_damage_mod();
-      }
-    }
 
-    if ( affected_by.avenging_wrath && p() -> buffs.avenging_wrath -> up() )
+    // Class talent's Avenging Wrath damage multiplier affects only if base talent is talented (Could still use AW with
+    // only Sentinel/AWM/Crusade/AC talented)
+    if ( affected_by.avenging_wrath && p()->talents.avenging_wrath->ok() &&
+         ( p()->buffs.avenging_wrath->up() || p()->buffs.sentinel->up() ) )
     {
-      am *= 1.0 + p() -> buffs.avenging_wrath -> get_damage_mod();
+      am *= 1.0 + p()->buffs.avenging_wrath->get_damage_mod();
     }
 
     if ( affected_by.avenging_crusader )

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -1427,12 +1427,6 @@ struct holy_power_consumer_t : public Base
       && !ab::background 
       && p->cooldowns.righteous_protector_icd->up())
     {
-      // Righteous Protector is not triggered by Bastion of Light-spenders. It's still triggered if it was a DP or SL spender
-      if (!(p->bugs 
-         && p->buffs.bastion_of_light->up() 
-         && !isFreeSLDPSpender
-           ))
-        {
         timespan_t reduction = timespan_t::from_seconds(
             // Why is this in deciseconds?
             -1.0 * p->talents.righteous_protector->effectN( 1 ).base_value() / 10 );
@@ -1441,16 +1435,11 @@ struct holy_power_consumer_t : public Base
             "Righteous protector reduced the cooldown of Avenging Wrath and Guardian of Ancient Kings by {} sec",
             num_hopo_spent );
 
-          p->cooldowns.avenging_wrath->adjust( reduction );
-        // 2022-11-08 Sentinel's cooldown is only reduced if it wasn't a free holy power spender
-        if ( !( p->bugs && isFreeSLDPSpender ) )
-        {
-          p->cooldowns.sentinel->adjust( reduction );
-        }
+        p->cooldowns.avenging_wrath->adjust( reduction );
+        p->cooldowns.sentinel->adjust( reduction );
         p->cooldowns.guardian_of_ancient_kings->adjust( reduction );
 
         p->cooldowns.righteous_protector_icd->start();
-      }
     }
 
     // 2022-10-25 Resolute Defender, spend 3 HP to reduce AD/DS cooldown

--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -603,7 +603,7 @@ struct judgment_prot_t : public judgment_t
       int hopo = 0;
       if ( p() -> spec.judgment_3 -> ok() )
         hopo += judge_holy_power;
-      if ( p() -> talents.sanctified_wrath -> ok() && p() -> buffs.avenging_wrath -> up() )
+      if ( p() -> talents.sanctified_wrath -> ok() && (p() -> buffs.avenging_wrath -> up() || p() -> buffs.sentinel -> up() ))
         hopo += sw_holy_power;
       if( hopo > 0 )
         p() -> resource_gain( RESOURCE_HOLY_POWER, hopo, p() -> gains.judgment );


### PR DESCRIPTION
Sentinel was never used in the APL, because it's a new spell. Fixed Sentinel (and other) talents to no longer grant 20% Damage/Heal when not being talented into Avenging Wrath. Also fixed Sentinel to grant this when talented into Avenging Wrath.