### PR TITLE
[Marksmanship] Add Puzzlebox usage

### DIFF
--- a/engine/class_modules/apl/hunter/mm.txt
+++ b/engine/class_modules/apl/hunter/mm.txt
@@ -4,6 +4,7 @@ actions.precombat+=/food
 actions.precombat+=/summon_pet,if=talent.kill_command|talent.beast_master
 actions.precombat+=/snapshot_stats
 actions.precombat+=/double_tap,precast_time=10
+actions.precombat+=/use_item,name=algethar_puzzle_box
 # Precast Aimed Shot on one or two targets unless we could cleave it with Volley on two targets.
 actions.precombat+=/aimed_shot,if=active_enemies<3&(!talent.volley|active_enemies<2)
 actions.precombat+=/wailing_arrow,if=active_enemies>2|!talent.steady_focus
@@ -13,6 +14,7 @@ actions.precombat+=/steady_shot,if=active_enemies>2|talent.volley&active_enemies
 # Executed every time the actor is available.
 actions=/auto_shot
 # New trinket lines are under construction.
+actions+=/use_item,name=algethar_puzzle_box,if=cooldown.trueshot.remains<2|fight_remains<22
 actions+=/use_items,slots=trinket1,if=!trinket.1.has_use_buff|buff.trueshot.up
 actions+=/use_items,slots=trinket2,if=!trinket.2.has_use_buff|buff.trueshot.up
 actions+=/use_items


### PR DESCRIPTION
Algeth'ar Puzzle Box wasn't used optimally with the current Trinket APL.
- Added precombat usage.
- Added specific line to use Puzzlebox before trueshot.