### PR TITLE
[Retribution] Add t29 Profile, Update Default Consumables, APL Optimizations

### DIFF
--- a/engine/class_modules/apl/retribution_apl.inc
+++ b/engine/class_modules/apl/retribution_apl.inc
@@ -7,12 +7,11 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/retribution_aura
 actions.precombat+=/arcane_torrent,if=talent.final_reckoning&talent.seraphim
 actions.precombat+=/shield_of_vengeance
-actions.precombat+=/variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=trinket.1.has_use_buff&(trinket.1.cooldown.duration%%cooldown.crusade.duration=0|cooldown.crusade.duration%%trinket.1.cooldown.duration=0|trinket.1.cooldown.duration%%cooldown.avenging_wrath.duration=0|cooldown.avenging_wrath.duration%%trinket.1.cooldown.duration=0)
-actions.precombat+=/variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=trinket.2.has_use_buff&(trinket.2.cooldown.duration%%cooldown.crusade.duration=0|cooldown.crusade.duration%%trinket.2.cooldown.duration=0|trinket.2.cooldown.duration%%cooldown.avenging_wrath.duration=0|cooldown.avenging_wrath.duration%%trinket.2.cooldown.duration=0)
-actions.precombat+=/variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!trinket.1.has_use_buff&trinket.2.has_use_buff|trinket.2.has_use_buff&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))
 actions.precombat+=/variable,name=trinket_1_buffs,value=trinket.1.has_buff.strength|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit
 actions.precombat+=/variable,name=trinket_2_buffs,value=trinket.2.has_buff.strength|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit
-actions.precombat+=/variable,name=specified_trinket,value=equipped.blazebinders_hoof
+actions.precombat+=/variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=variable.trinket_1_buffs&(trinket.1.cooldown.duration%%cooldown.crusade.duration=0|cooldown.crusade.duration%%trinket.1.cooldown.duration=0|trinket.1.cooldown.duration%%cooldown.avenging_wrath.duration=0|cooldown.avenging_wrath.duration%%trinket.1.cooldown.duration=0)
+actions.precombat+=/variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=variable.trinket_2_buffs&(trinket.2.cooldown.duration%%cooldown.crusade.duration=0|cooldown.crusade.duration%%trinket.2.cooldown.duration=0|trinket.2.cooldown.duration%%cooldown.avenging_wrath.duration=0|cooldown.avenging_wrath.duration%%trinket.2.cooldown.duration=0)
+actions.precombat+=/variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!variable.trinket_1_buffs&variable.trinket_2_buffs|variable.trinket_2_buffs&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))
 
 # Executed every time the actor is available.
 actions=auto_attack
@@ -25,11 +24,11 @@ actions+=/call_action_list,name=generators
 actions.cooldowns=potion,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10|fight_remains<25
 actions.cooldowns+=/lights_judgment,if=spell_targets.lights_judgment>=2|!raid_event.adds.exists|raid_event.adds.in>75|raid_event.adds.up
 actions.cooldowns+=/fireblood,if=(buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10)&!talent.execution_sentence
-actions.cooldowns+=/use_item,name=blazebinders_hoof,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10
+actions.cooldowns+=/use_item,name=algethar_puzzle_box,if=(cooldown.avenging_wrath.remains<5&!talent.crusade|cooldown.crusade.remains<5&talent.crusade)&(holy_power>=5&time<5|holy_power>=3&time>5)
 actions.cooldowns+=/use_item,slot=trinket1,if=(buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10)&(!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1)|trinket.1.proc.any_dps.duration>=fight_remains
 actions.cooldowns+=/use_item,slot=trinket2,if=(buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10)&(!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2)|trinket.2.proc.any_dps.duration>=fight_remains
-actions.cooldowns+=/use_item,slot=trinket1,if=!variable.trinket_1_buffs&!variable.specified_trinket&(trinket.2.cooldown.remains|!variable.trinket_2_buffs|!buff.crusade.up&cooldown.crusade.remains>20|!buff.avenging_wrath.up&cooldown.avenging_wrath.remains>20)
-actions.cooldowns+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&!variable.specified_trinket&(trinket.1.cooldown.remains|!variable.trinket_1_buffs|!buff.crusade.up&cooldown.crusade.remains>20|!buff.avenging_wrath.up&cooldown.avenging_wrath.remains>20)
+actions.cooldowns+=/use_item,slot=trinket1,if=!variable.trinket_1_buffs&(trinket.2.cooldown.remains|!variable.trinket_2_buffs|!buff.crusade.up&cooldown.crusade.remains>20|!buff.avenging_wrath.up&cooldown.avenging_wrath.remains>20)
+actions.cooldowns+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&(trinket.1.cooldown.remains|!variable.trinket_1_buffs|!buff.crusade.up&cooldown.crusade.remains>20|!buff.avenging_wrath.up&cooldown.avenging_wrath.remains>20)
 actions.cooldowns+=/shield_of_vengeance,if=(!talent.execution_sentence|cooldown.execution_sentence.remains<52)&fight_remains>15
 actions.cooldowns+=/avenging_wrath,if=((holy_power>=4&time<5|holy_power>=3&time>5)|talent.holy_avenger&cooldown.holy_avenger.remains=0)&(!talent.seraphim|!talent.final_reckoning|cooldown.seraphim.remains>0)
 actions.cooldowns+=/crusade,if=holy_power>=5&time<5|holy_power>=3&time>5

--- a/engine/class_modules/apl/retribution_apl.inc
+++ b/engine/class_modules/apl/retribution_apl.inc
@@ -12,22 +12,24 @@ actions.precombat+=/variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5
 actions.precombat+=/variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!trinket.1.has_use_buff&trinket.2.has_use_buff|trinket.2.has_use_buff&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))
 actions.precombat+=/variable,name=trinket_1_buffs,value=trinket.1.has_buff.strength|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit
 actions.precombat+=/variable,name=trinket_2_buffs,value=trinket.2.has_buff.strength|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit
+actions.precombat+=/variable,name=specified_trinket,value=equipped.blazebinders_hoof
 
 # Executed every time the actor is available.
 actions=auto_attack
 actions+=/rebuke
 actions+=/call_action_list,name=cooldowns
-actions+=/call_action_list,name=es_fr_pooling,if=(!raid_event.adds.exists|raid_event.adds.up|raid_event.adds.in<9|raid_event.adds.in>30)&(talent.execution_sentence&cooldown.execution_sentence.remains<9&spell_targets.divine_storm<5|talent.final_reckoning&cooldown.final_reckoning.remains<9)&target.time_to_die>8
+actions+=/call_action_list,name=es_fr_pooling,if=(!raid_event.adds.exists|raid_event.adds.up|raid_event.adds.in<9|raid_event.adds.in>30)&(talent.execution_sentence&cooldown.execution_sentence.remains<9&spell_targets.divine_storm<5|talent.final_reckoning&cooldown.final_reckoning.remains<9)&(!buff.crusade.up|buff.crusade.stack=10)&target.time_to_die>8
 actions+=/call_action_list,name=es_fr_active,if=debuff.execution_sentence.up|debuff.final_reckoning.up
 actions+=/call_action_list,name=generators
 
 actions.cooldowns=potion,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10|fight_remains<25
 actions.cooldowns+=/lights_judgment,if=spell_targets.lights_judgment>=2|!raid_event.adds.exists|raid_event.adds.in>75|raid_event.adds.up
 actions.cooldowns+=/fireblood,if=(buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10)&!talent.execution_sentence
+actions.cooldowns+=/use_item,name=blazebinders_hoof,if=buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10
 actions.cooldowns+=/use_item,slot=trinket1,if=(buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10)&(!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1)|trinket.1.proc.any_dps.duration>=fight_remains
 actions.cooldowns+=/use_item,slot=trinket2,if=(buff.avenging_wrath.up|buff.crusade.up&buff.crusade.stack=10)&(!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2)|trinket.2.proc.any_dps.duration>=fight_remains
-actions.cooldowns+=/use_item,slot=trinket1,if=!variable.trinket_1_buffs&(trinket.2.cooldown.remains|!variable.trinket_2_buffs|cooldown.crusade.remains>20|cooldown.avenging_wrath.remains>20)
-actions.cooldowns+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&(trinket.1.cooldown.remains|!variable.trinket_1_buffs|cooldown.crusade.remains>20|cooldown.avenging_wrath.remains>20)
+actions.cooldowns+=/use_item,slot=trinket1,if=!variable.trinket_1_buffs&!variable.specified_trinket&(trinket.2.cooldown.remains|!variable.trinket_2_buffs|!buff.crusade.up&cooldown.crusade.remains>20|!buff.avenging_wrath.up&cooldown.avenging_wrath.remains>20)
+actions.cooldowns+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&!variable.specified_trinket&(trinket.1.cooldown.remains|!variable.trinket_1_buffs|!buff.crusade.up&cooldown.crusade.remains>20|!buff.avenging_wrath.up&cooldown.avenging_wrath.remains>20)
 actions.cooldowns+=/shield_of_vengeance,if=(!talent.execution_sentence|cooldown.execution_sentence.remains<52)&fight_remains>15
 actions.cooldowns+=/avenging_wrath,if=((holy_power>=4&time<5|holy_power>=3&time>5)|talent.holy_avenger&cooldown.holy_avenger.remains=0)&(!talent.seraphim|!talent.final_reckoning|cooldown.seraphim.remains>0)
 actions.cooldowns+=/crusade,if=holy_power>=5&time<5|holy_power>=3&time>5

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -2721,7 +2721,7 @@ void paladin_t::create_buffs()
 
 std::string paladin_t::default_potion() const
 {
-  std::string retribution_pot = ( true_level > 50 ) ? "spectral_strength" : "disabled";
+  std::string retribution_pot = ( true_level > 60 ) ? "elemental_potion_of_ultimate_power_3" : "disabled";
 
   std::string protection_pot = ( true_level > 50 ) ? "spectral_strength" : "disabled";
 
@@ -2744,7 +2744,7 @@ std::string paladin_t::default_potion() const
 
 std::string paladin_t::default_food() const
 {
-  std::string retribution_food = ( true_level > 50 ) ? "feast_of_gluttonous_hedonism" : "disabled";
+  std::string retribution_food = ( true_level > 50 ) ? "fated_fortune_cookie" : "disabled";
 
   std::string protection_food = ( true_level > 50 ) ? "feast_of_gluttonous_hedonism" : "disabled";
 
@@ -2767,7 +2767,7 @@ std::string paladin_t::default_food() const
 
 std::string paladin_t::default_flask() const
 {
-  std::string retribution_flask = ( true_level > 50 ) ? "spectral_flask_of_power" : "disabled";
+  std::string retribution_flask = ( true_level > 60 ) ? "phial_of_tepid_versatility_3" : "disabled";
 
   std::string protection_flask = ( true_level > 50 ) ? "spectral_flask_of_power" : "disabled";
 
@@ -2790,7 +2790,7 @@ std::string paladin_t::default_flask() const
 
 std::string paladin_t::default_rune() const
 {
-  return ( true_level > 50 ) ? "veiled" : "disabled";
+  return ( true_level > 50 ) ? "draconic_augment_rune" : "disabled";
 }
 
 // paladin_t::default_temporary_enchant ================================
@@ -2802,10 +2802,10 @@ std::string paladin_t::default_temporary_enchant() const
     case PALADIN_PROTECTION:
       return "main_hand:shaded_sharpening_stone";
     case PALADIN_RETRIBUTION:
-      return "main_hand:shaded_sharpening_stone";
+      return "main_hand:howling_rune_3";
 
     default:
-      return "main_hand:shadowcore_oil";
+      return "main_hand:howling_rune_3";
   }
 }
 

--- a/profiles/T29_Raid.simc
+++ b/profiles/T29_Raid.simc
@@ -31,7 +31,7 @@ T29_Monk_Windwalker.simc
 T29_Monk_Windwalker_SEF.simc
 
 T29_Paladin_Protection.simc
-# T29_Paladin_Retribution.simc
+T29_Paladin_Retribution.simc
 
 T29_Priest_Shadow.simc
 

--- a/profiles/generators/Tier29/T29_Generate_Paladin.simc
+++ b/profiles/generators/Tier29/T29_Generate_Paladin.simc
@@ -28,31 +28,31 @@ off_hand=,id=195520,bonus_id=4800/4786/1498
 save=T29_Paladin_Protection.simc
 
 
-# paladin="T29_Paladin_Retribution"
-# spec=retribution
-# level=70
-# race=dark_iron_dwarf
-# role=attack
-# position=back
-# talents=1200101
+paladin="T29_Paladin_Retribution"
+spec=retribution
+level=70
+race=dark_iron_dwarf
+role=attack
+position=back
+talents=BYEAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgIKplkIBkkkWKJJRJAAAAAAACRSSaJBJINJJJloEA
 
-# head=luminous_chevaliers_casque,id=188933,bonus_id=1498/7187/6935,gem_id=173128
-# neck=worldkiller_iris,id=189859,bonus_id=1524/7187/6935,gem_id=173128
-# shoulders=luminous_chevaliers_epaulettes,id=188932,bonus_id=1505/7187
-# back=shroud_of_the_sires_chosen,id=189847,bonus_id=1524/7187
-# chest=shadowghast_breastplate,id=171412,bonus_id=6649/6648/6758/7064/1588,enchant=eternal_stats
-# wrists=bracers_of_the_inscrutable_inventor,id=189805,bonus_id=1524/7187/6935,gem_id=173128
-# hands=luminous_chevaliers_gauntlets,id=188928,bonus_id=1505/7187,enchant=eternal_strength
-# waist=shadowghast_waistguard,id=171418,bonus_id=6650/6648/6758/8125/1588/6935,gem_id=173128
-# legs=luminous_chevaliers_robes,id=188931,bonus_id=1505/7187
-# feet=songmad_sabatons,id=189786,bonus_id=1524/7187
-# finger1=rygelons_heraldric_ring,id=189854,bonus_id=1524/7187/6935,gem_id=173128,enchant=tenet_of_haste
-# finger2=loquacious_keepers_peridot,id=189802,bonus_id=1524/7187/6935,gem_id=173128,enchant=tenet_of_haste
-# trinket1=old_warriors_soul,id=186438,bonus_id=4800/4786/1498
-# trinket2=the_first_sigil,id=188271,bonus_id=1524/7187
-# main_hand=gavel_of_the_first_arbiter,id=189862,bonus_id=1524/7187,enchant=sinful_revelation
+head=virtuous_silver_heaume,id=200417,bonus_id=4800/4786/1498/6935,gem_id=192985
+neck=eye_of_the_vengeful_hurricane,id=195496,bonus_id=4800/4786/1498/6935/6935/6935,gem_id=192948/192948/192948
+shoulders=virtuous_silver_pauldrons,id=200419,bonus_id=4800/4786/1498
+back=goldscar_pelt,id=133639,bonus_id=1795/6808/4786/3300
+chest=virtuous_silver_breastplate,id=200414,bonus_id=4800/4786/1498,enchant_id=6625
+wrists=allied_wristguard_of_companionship,id=190526,bonus_id=8836/8802/8960/1498,gem_id=192948
+hands=virtuous_silver_gauntlets,id=200416,bonus_id=4800/4786/1498
+waist=unstable_frostfire_belt,id=191623,,bonus_id=8836/8802/8960/1498,gem_id=192948
+legs=greaves_of_the_godking,id=133630,bonus_id=1795/6808/4786/3300,enchant_id=6490
+feet=stonestep_boots,id=143974,bonus_id=4177/6808/4786/3311
+finger1=seal_of_diurnas_chosen,id=195480,bonus_id=4800/4786/1498/6935,gem_id=192948,enchant_id=6556
+finger2=jeweled_signet_of_melandrus,id=134542,bonus_id=1795/6808/4786/3300,gem_id=192948,enchant_id=6556
+trinket1=manic_grieftorch,id=194308,bonus_id=4800/4786/1498
+trinket2=blazebinders_hoof,id=193762,bonus_id=6808/4786/1643
+main_hand=incarnate_skysplitter,id=195528,bonus_id=4800/4786/1498,enchant_id=6649
 
-# save=T29_Paladin_Retribution.simc
+save=T29_Paladin_Retribution.simc
 
 
 # paladin="T27_Paladin_Holy"


### PR DESCRIPTION
Default Retribution consumables updated to use Dragonflight items.
Small optimizations for the APL for Blazebinder's Hoof and pooling with Execution Sentence and Crusade.
Tier 29 profile added for Retribution.