### PR TITLE
[Vengeance] add darkglare_boon_cdr_roll expression

### DIFF
--- a/engine/class_modules/apl/apl_demon_hunter.cpp
+++ b/engine/class_modules/apl/apl_demon_hunter.cpp
@@ -133,10 +133,6 @@ void vengeance( player_t* p )
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
 
   default_->add_action( "auto_attack" );
-  default_->add_action( "variable,name=rampH_done,value=0,op=setif,value_else=1,condition=talent.the_hunt.enabled&cooldown.the_hunt.remains<5" );
-  default_->add_action( "variable,name=rampED_done,value=0,op=setif,value_else=1,condition=talent.elysian_decree.enabled&cooldown.elysian_decree.remains<5" );
-  default_->add_action( "variable,name=rampSC_done,value=0,op=setif,value_else=1,condition=talent.soul_carver.enabled&cooldown.soul_carver.remains<5&!talent.fiery_demise.enabled" );
-  default_->add_action( "variable,name=FD_done,value=0,op=setif,value_else=1,condition=talent.fiery_demise.enabled&cooldown.soul_carver.up&cooldown.fiery_brand.up&cooldown.immolation_aura.up&cooldown.fel_devastation.remains<10|dot.fiery_brand.ticking&talent.fiery_demise" );
   default_->add_action( "infernal_strike" );
   default_->add_action( "demon_spikes,if=!buff.demon_spikes.up&!cooldown.pause_action.remains" );
   default_->add_action( "fiery_brand,if=!talent.fiery_demise.enabled&!dot.fiery_brand.ticking" );
@@ -144,10 +140,10 @@ void vengeance( player_t* p )
   default_->add_action( "potion" );
   default_->add_action( "use_item,slot=trinket1" );
   default_->add_action( "use_item,slot=trinket2" );
-  default_->add_action( "run_action_list,name=rampH,if=variable.rampH_done=0&!dot.fiery_brand.ticking" );
-  default_->add_action( "run_action_list,name=rampED,if=variable.rampED_done=0&!dot.fiery_brand.ticking" );
-  default_->add_action( "run_action_list,name=rampSC,if=variable.rampSC_done=0&!dot.fiery_brand.ticking" );
-  default_->add_action( "run_action_list,name=FD,if=variable.FD_done=0" );
+  default_->add_action( "run_action_list,name=rampH,if=talent.the_hunt.enabled&cooldown.the_hunt.remains<5&!dot.fiery_brand.ticking" );
+  default_->add_action( "run_action_list,name=rampED,if=talent.elysian_decree.enabled&cooldown.elysian_decree.remains<5&!dot.fiery_brand.ticking" );
+  default_->add_action( "run_action_list,name=rampSC,if=talent.soul_carver.enabled&cooldown.soul_carver.remains<5&!talent.fiery_demise.enabled&!dot.fiery_brand.ticking" );
+  default_->add_action( "run_action_list,name=FD,if=talent.fiery_demise.enabled&cooldown.soul_carver.up&cooldown.fiery_brand.up&cooldown.immolation_aura.up&cooldown.fel_devastation.remains<10|dot.fiery_brand.ticking&talent.fiery_demise" );
   default_->add_action( "metamorphosis,if=!buff.metamorphosis.up&!dot.fiery_brand.ticking" );
   default_->add_action( "fel_devastation,if=(!talent.down_in_flames.enabled)" );
   default_->add_action( "spirit_bomb,if=((buff.metamorphosis.up&talent.fracture.enabled&soul_fragments>=3)|soul_fragments>=4&active_enemies>1)" );
@@ -165,7 +161,6 @@ void vengeance( player_t* p )
   rampH->add_action( "spirit_bomb,if=soul_fragments>=4&active_enemies>1" );
   rampH->add_action( "soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
   rampH->add_action( "the_hunt" );
-  rampH->add_action( "variable,name=rampH_done,op=setif,value=1,value_else=0,condition=talent.the_hunt.enabled&cooldown.the_hunt.remains" );
 
   rampED->add_action( "fracture,if=fury.deficit>=30" );
   rampED->add_action( "sigil_of_flame,if=fury.deficit>=30" );
@@ -173,7 +168,6 @@ void vengeance( player_t* p )
   rampED->add_action( "spirit_bomb,if=soul_fragments>=4&active_enemies>1" );
   rampED->add_action( "soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
   rampED->add_action( "elysian_decree" );
-  rampED->add_action( "variable,name=rampED_done,op=setif,value=1,value_else=0,condition=talent.elysian_decree.enabled&cooldown.elysian_decree.remains" );
 
   rampSC->add_action( "fracture,if=fury.deficit>=30" );
   rampSC->add_action( "sigil_of_flame,if=fury.deficit>=30" );
@@ -181,8 +175,8 @@ void vengeance( player_t* p )
   rampSC->add_action( "spirit_bomb,if=soul_fragments>=4&active_enemies>1" );
   rampSC->add_action( "soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
   rampSC->add_action( "soul_carver" );
-  rampSC->add_action( "variable,name=rampSC_done,op=setif,value=1,value_else=0,condition=talent.soul_carver.enabled&cooldown.soul_carver.remains&!talent.fiery_demise.enabled" );
 
+  FD->add_action( "variable,name=darkglare_boon_high_roll,op=setif,value=1,value_else=0,condition=darkglare_boon_cdr_roll>=18,if=prev_gcd.1.fel_devastation", "A 'high-roll' from Darkglare boon is any roll that gives us an 18+s reduction on Fel Dev's cooldown." );
   FD->add_action( "fracture,if=fury.deficit>=30&!dot.fiery_brand.ticking" );
   FD->add_action( "fiery_brand,if=!dot.fiery_brand.ticking&fury>=30" );
   FD->add_action( "fel_devastation,if=dot.fiery_brand.remains<=3" );

--- a/engine/class_modules/apl/demon_hunter/vengeance.simc
+++ b/engine/class_modules/apl/demon_hunter/vengeance.simc
@@ -9,11 +9,6 @@ actions.precombat+=/snapshot_stats
 # Executed every time the actor is available.
 
 actions=auto_attack
-actions+=/variable,name=rampH_done,value=0,op=setif,value_else=1,condition=talent.the_hunt.enabled&cooldown.the_hunt.remains<5
-actions+=/variable,name=rampED_done,value=0,op=setif,value_else=1,condition=talent.elysian_decree.enabled&cooldown.elysian_decree.remains<5
-actions+=/variable,name=rampSC_done,value=0,op=setif,value_else=1,condition=talent.soul_carver.enabled&cooldown.soul_carver.remains<5&!talent.fiery_demise.enabled
-actions+=/variable,name=FD_done,value=0,op=setif,value_else=1,condition=talent.fiery_demise.enabled&cooldown.soul_carver.up&cooldown.fiery_brand.up&cooldown.immolation_aura.up&cooldown.fel_devastation.remains<10|dot.fiery_brand.ticking&talent.fiery_demise
-
 actions+=/infernal_strike
 actions+=/demon_spikes,if=!buff.demon_spikes.up&!cooldown.pause_action.remains
 actions+=/fiery_brand,if=!talent.fiery_demise.enabled&!dot.fiery_brand.ticking
@@ -21,10 +16,10 @@ actions+=/bulk_extraction
 actions+=/potion
 actions+=/use_item,slot=trinket1
 actions+=/use_item,slot=trinket2
-actions+=/run_action_list,name=rampH,if=variable.rampH_done=0&!dot.fiery_brand.ticking
-actions+=/run_action_list,name=rampED,if=variable.rampED_done=0&!dot.fiery_brand.ticking
-actions+=/run_action_list,name=rampSC,if=variable.rampSC_done=0&!dot.fiery_brand.ticking
-actions+=/run_action_list,name=FD,if=variable.FD_done=0
+actions+=/run_action_list,name=rampH,if=talent.the_hunt.enabled&cooldown.the_hunt.remains<5&!dot.fiery_brand.ticking
+actions+=/run_action_list,name=rampED,if=talent.elysian_decree.enabled&cooldown.elysian_decree.remains<5&!dot.fiery_brand.ticking
+actions+=/run_action_list,name=rampSC,if=talent.soul_carver.enabled&cooldown.soul_carver.remains<5&!talent.fiery_demise.enabled&!dot.fiery_brand.ticking
+actions+=/run_action_list,name=FD,if=talent.fiery_demise.enabled&cooldown.soul_carver.up&cooldown.fiery_brand.up&cooldown.immolation_aura.up&cooldown.fel_devastation.remains<10|dot.fiery_brand.ticking&talent.fiery_demise
 actions+=/metamorphosis,if=!buff.metamorphosis.up&!dot.fiery_brand.ticking
 actions+=/fel_devastation,if=(!talent.down_in_flames.enabled)
 actions+=/spirit_bomb,if=((buff.metamorphosis.up&talent.fracture.enabled&soul_fragments>=3)|soul_fragments>=4&active_enemies>1)
@@ -36,30 +31,29 @@ actions+=/sigil_of_flame,if=fury.deficit>=30
 actions+=/shear
 actions+=/throw_glaive
 
-actions.rampH+=/fracture,if=fury.deficit>=30&debuff.frailty.stack<=5
+actions.rampH=/fracture,if=fury.deficit>=30&debuff.frailty.stack<=5
 actions.rampH+=/sigil_of_flame,if=fury.deficit>=30
 actions.rampH+=/shear,if=fury.deficit<=90
 actions.rampH+=/spirit_bomb,if=soul_fragments>=4&active_enemies>1
 actions.rampH+=/soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
 actions.rampH+=/the_hunt
-actions.rampH+=/variable,name=rampH_done,op=setif,value=1,value_else=0,condition=talent.the_hunt.enabled&cooldown.the_hunt.remains
 
-actions.rampED+=/fracture,if=fury.deficit>=30
+actions.rampED=/fracture,if=fury.deficit>=30
 actions.rampED+=/sigil_of_flame,if=fury.deficit>=30
 actions.rampED+=/shear,if=fury.deficit<=90&debuff.frailty.stack>=0
 actions.rampED+=/spirit_bomb,if=soul_fragments>=4&active_enemies>1
 actions.rampED+=/soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
 actions.rampED+=/elysian_decree
-actions.rampED+=/variable,name=rampED_done,op=setif,value=1,value_else=0,condition=talent.elysian_decree.enabled&cooldown.elysian_decree.remains
 
-actions.rampSC+=/fracture,if=fury.deficit>=30
+actions.rampSC=/fracture,if=fury.deficit>=30
 actions.rampSC+=/sigil_of_flame,if=fury.deficit>=30
 actions.rampSC+=/shear,if=fury.deficit<=90&debuff.frailty.stack>=0
 actions.rampSC+=/spirit_bomb,if=soul_fragments>=4&active_enemies>1
 actions.rampSC+=/soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
 actions.rampSC+=/soul_carver
-actions.rampSC+=/variable,name=rampSC_done,op=setif,value=1,value_else=0,condition=talent.soul_carver.enabled&cooldown.soul_carver.remains&!talent.fiery_demise.enabled
 
+# A 'high-roll' from Darkglare boon is any roll that gives us an 18+s reduction on Fel Dev's cooldown.
+actions.FD=/variable,name=darkglare_boon_high_roll,op=setif,value=1,value_else=0,condition=darkglare_boon_cdr_roll>=18,if=prev_gcd.1.fel_devastation
 actions.FD+=/fracture,if=fury.deficit>=30&!dot.fiery_brand.ticking
 actions.FD+=/fiery_brand,if=!dot.fiery_brand.ticking&fury>=30
 actions.FD+=/fel_devastation,if=dot.fiery_brand.remains<=3

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -191,6 +191,7 @@ public:
   double ragefire_accumulator;
   unsigned ragefire_crit_accumulator;
   double shattered_destiny_accumulator;
+  double darkglare_boon_cdr_roll;
 
   event_t* exit_melee_event;  // Event to disable melee abilities mid-VR.
 
@@ -2393,6 +2394,9 @@ struct fel_devastation_t : public demon_hunter_spell_t
       double maximum_fury_refund = p()->talent.vengeance.darkglare_boon->effectN( 4 ).base_value();
       double fury_refund         = rng().range( minimum_fury_refund, maximum_fury_refund );
 
+      p()->darkglare_boon_cdr_roll = cdr_reduction.total_seconds();
+      p()->sim->print_debug( "{} rolled {}s of CDR on Fel Devastation from Darkglare Boon", *p(),
+                             p()->darkglare_boon_cdr_roll );
       p()->cooldown.fel_devastation->adjust( -cdr_reduction );
       p()->resource_gain( RESOURCE_FURY, fury_refund, p()->gain.darkglare_boon );
     }
@@ -5382,6 +5386,7 @@ demon_hunter_t::demon_hunter_t(sim_t* sim, util::string_view name, race_e r)
   ragefire_accumulator( 0.0 ),
   ragefire_crit_accumulator( 0 ),
   shattered_destiny_accumulator( 0.0 ),
+  darkglare_boon_cdr_roll(0.0),
   exit_melee_event( nullptr ),
   buff(),
   talent(),
@@ -5729,6 +5734,10 @@ std::unique_ptr<expr_t> demon_hunter_t::create_expression( util::string_view nam
     {
       return this->cooldown.eye_beam->create_expression( "remains" );
     }
+  }
+  else if ( util::str_compare_ci( name_str, "darkglare_boon_cdr_roll" ) )
+  {
+    return make_mem_fn_expr(name_str, *this, &demon_hunter_t::darkglare_boon_cdr_roll);
   }
 
   return player_t::create_expression( name_str );
@@ -7044,6 +7053,7 @@ void demon_hunter_t::reset()
   ragefire_accumulator          = 0.0;
   ragefire_crit_accumulator     = 0;
   shattered_destiny_accumulator = 0.0;
+  darkglare_boon_cdr_roll       = 0.0;
 
   for ( size_t i = 0; i < soul_fragments.size(); i++ )
   {


### PR DESCRIPTION
intended to help ease the development of the Fiery Demise and Down in Flames combination APL, as we're currently operating under the assumption that you would only go into the FD+DiF combination APL if you have a high roll on Darkglare Boon's CDR refund.

@EvanMichaels 