### PR TITLE
[Vengeance] update Soul Cleave conditions

### DIFF
--- a/engine/class_modules/apl/apl_demon_hunter.cpp
+++ b/engine/class_modules/apl/apl_demon_hunter.cpp
@@ -151,10 +151,10 @@ void vengeance( player_t* p )
   default_->add_action( "metamorphosis,if=!buff.metamorphosis.up&!dot.fiery_brand.ticking" );
   default_->add_action( "fel_devastation,if=(!talent.down_in_flames.enabled)" );
   default_->add_action( "spirit_bomb,if=((buff.metamorphosis.up&talent.fracture.enabled&soul_fragments>=3)|soul_fragments>=4&active_enemies>1)" );
-  default_->add_action( "soul_cleave,if=(talent.spirit_bomb.enabled&soul_fragments=0&target>1)|(active_enemies<2&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50)))))|(!talent.spirit_bomb.enabled)&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50))))" );
+  default_->add_action( "soul_cleave,if=(talent.spirit_bomb.enabled&soul_fragments<=1&spell_targets>1)|(active_enemies<2&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50)))))|(!talent.spirit_bomb.enabled)&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50))))" );
   default_->add_action( "immolation_aura,if=(talent.fiery_demise.enabled&fury.deficit>=10&(cooldown.soul_carver.remains>15))|(!talent.fiery_demise.enabled&fury.deficit>=10)" );
   default_->add_action( "felblade,if=fury.deficit>=40" );
-  default_->add_action( "fracture,if=(talent.spirit_bomb.enabled&(soul_fragments<=3&target>1|target<2&fury.deficit>=30))|(!talent.spirit_bomb.enabled&((buff.metamorphosis.up&fury.deficit>=45)|(buff.metamorphosis.down&fury.deficit>=30)))" );
+  default_->add_action( "fracture,if=(talent.spirit_bomb.enabled&(soul_fragments<=3&spell_targets>1|spell_targets<2&fury.deficit>=30))|(!talent.spirit_bomb.enabled&((buff.metamorphosis.up&fury.deficit>=45)|(buff.metamorphosis.down&fury.deficit>=30)))" );
   default_->add_action( "sigil_of_flame,if=fury.deficit>=30" );
   default_->add_action( "shear" );
   default_->add_action( "throw_glaive" );
@@ -163,7 +163,7 @@ void vengeance( player_t* p )
   rampH->add_action( "sigil_of_flame,if=fury.deficit>=30" );
   rampH->add_action( "shear,if=fury.deficit<=90" );
   rampH->add_action( "spirit_bomb,if=soul_fragments>=4&active_enemies>1" );
-  rampH->add_action( "soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
+  rampH->add_action( "soul_cleave,if=(soul_fragments<=1&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
   rampH->add_action( "the_hunt" );
   rampH->add_action( "variable,name=rampH_done,op=setif,value=1,value_else=0,condition=talent.the_hunt.enabled&cooldown.the_hunt.remains" );
 
@@ -171,7 +171,7 @@ void vengeance( player_t* p )
   rampED->add_action( "sigil_of_flame,if=fury.deficit>=30" );
   rampED->add_action( "shear,if=fury.deficit<=90&debuff.frailty.stack>=0" );
   rampED->add_action( "spirit_bomb,if=soul_fragments>=4&active_enemies>1" );
-  rampED->add_action( "soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
+  rampED->add_action( "soul_cleave,if=(soul_fragments<=1&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
   rampED->add_action( "elysian_decree" );
   rampED->add_action( "variable,name=rampED_done,op=setif,value=1,value_else=0,condition=talent.elysian_decree.enabled&cooldown.elysian_decree.remains" );
 
@@ -179,7 +179,7 @@ void vengeance( player_t* p )
   rampSC->add_action( "sigil_of_flame,if=fury.deficit>=30" );
   rampSC->add_action( "shear,if=fury.deficit<=90&debuff.frailty.stack>=0" );
   rampSC->add_action( "spirit_bomb,if=soul_fragments>=4&active_enemies>1" );
-  rampSC->add_action( "soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
+  rampSC->add_action( "soul_cleave,if=(soul_fragments<=1&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0" );
   rampSC->add_action( "soul_carver" );
   rampSC->add_action( "variable,name=rampSC_done,op=setif,value=1,value_else=0,condition=talent.soul_carver.enabled&cooldown.soul_carver.remains&!talent.fiery_demise.enabled" );
 

--- a/engine/class_modules/apl/demon_hunter/vengeance.simc
+++ b/engine/class_modules/apl/demon_hunter/vengeance.simc
@@ -28,10 +28,10 @@ actions+=/run_action_list,name=FD,if=variable.FD_done=0
 actions+=/metamorphosis,if=!buff.metamorphosis.up&!dot.fiery_brand.ticking
 actions+=/fel_devastation,if=(!talent.down_in_flames.enabled)
 actions+=/spirit_bomb,if=((buff.metamorphosis.up&talent.fracture.enabled&soul_fragments>=3)|soul_fragments>=4&active_enemies>1)
-actions+=/soul_cleave,if=(talent.spirit_bomb.enabled&soul_fragments=0&target>1)|(active_enemies<2&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50)))))|(!talent.spirit_bomb.enabled)&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50))))
+actions+=/soul_cleave,if=(talent.spirit_bomb.enabled&soul_fragments<=1&spell_targets>1)|(active_enemies<2&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50)))))|(!talent.spirit_bomb.enabled)&((talent.fracture.enabled&fury>=55)|(!talent.fracture.enabled&fury>=70)|(buff.metamorphosis.up&((talent.fracture.enabled&fury>=35)|(!talent.fracture.enabled&fury>=50))))
 actions+=/immolation_aura,if=(talent.fiery_demise.enabled&fury.deficit>=10&(cooldown.soul_carver.remains>15))|(!talent.fiery_demise.enabled&fury.deficit>=10)
 actions+=/felblade,if=fury.deficit>=40
-actions+=/fracture,if=(talent.spirit_bomb.enabled&(soul_fragments<=3&target>1|target<2&fury.deficit>=30))|(!talent.spirit_bomb.enabled&((buff.metamorphosis.up&fury.deficit>=45)|(buff.metamorphosis.down&fury.deficit>=30)))
+actions+=/fracture,if=(talent.spirit_bomb.enabled&(soul_fragments<=3&spell_targets>1|spell_targets<2&fury.deficit>=30))|(!talent.spirit_bomb.enabled&((buff.metamorphosis.up&fury.deficit>=45)|(buff.metamorphosis.down&fury.deficit>=30)))
 actions+=/sigil_of_flame,if=fury.deficit>=30
 actions+=/shear
 actions+=/throw_glaive
@@ -40,7 +40,7 @@ actions.rampH+=/fracture,if=fury.deficit>=30&debuff.frailty.stack<=5
 actions.rampH+=/sigil_of_flame,if=fury.deficit>=30
 actions.rampH+=/shear,if=fury.deficit<=90
 actions.rampH+=/spirit_bomb,if=soul_fragments>=4&active_enemies>1
-actions.rampH+=/soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
+actions.rampH+=/soul_cleave,if=(soul_fragments<=1&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
 actions.rampH+=/the_hunt
 actions.rampH+=/variable,name=rampH_done,op=setif,value=1,value_else=0,condition=talent.the_hunt.enabled&cooldown.the_hunt.remains
 
@@ -48,7 +48,7 @@ actions.rampED+=/fracture,if=fury.deficit>=30
 actions.rampED+=/sigil_of_flame,if=fury.deficit>=30
 actions.rampED+=/shear,if=fury.deficit<=90&debuff.frailty.stack>=0
 actions.rampED+=/spirit_bomb,if=soul_fragments>=4&active_enemies>1
-actions.rampED+=/soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
+actions.rampED+=/soul_cleave,if=(soul_fragments<=1&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
 actions.rampED+=/elysian_decree
 actions.rampED+=/variable,name=rampED_done,op=setif,value=1,value_else=0,condition=talent.elysian_decree.enabled&cooldown.elysian_decree.remains
 
@@ -56,7 +56,7 @@ actions.rampSC+=/fracture,if=fury.deficit>=30
 actions.rampSC+=/sigil_of_flame,if=fury.deficit>=30
 actions.rampSC+=/shear,if=fury.deficit<=90&debuff.frailty.stack>=0
 actions.rampSC+=/spirit_bomb,if=soul_fragments>=4&active_enemies>1
-actions.rampSC+=/soul_cleave,if=(soul_fragments=0&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
+actions.rampSC+=/soul_cleave,if=(soul_fragments<=1&active_enemies>1)|(active_enemies<2)|debuff.frailty.stack>=0
 actions.rampSC+=/soul_carver
 actions.rampSC+=/variable,name=rampSC_done,op=setif,value=1,value_else=0,condition=talent.soul_carver.enabled&cooldown.soul_carver.remains&!talent.fiery_demise.enabled
 


### PR DESCRIPTION
Soul Sigils was sometimes generating a Soul Fragment and the previous APL would cause us to sit and Throw Glaive forever instead of just pressing Soul Cleave to get rid of it.

Without change: https://www.raidbots.com/simbot/report/pCLiB3WsV1Ly2bSNy36ZX2
![image](https://user-images.githubusercontent.com/1672786/208323835-faefc758-b6e4-4db2-86a3-8b655effdbdf.png)

With change: https://www.raidbots.com/simbot/report/3M4FKVtbR5ySPngV2p2Z8x
![image](https://user-images.githubusercontent.com/1672786/208323845-ae53749a-82d2-43a3-a9de-37935a7abba2.png)
