### PR TITLE
[Fire] Invoke Power Infusion

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -272,6 +272,7 @@ void fire( player_t* p )
   combustion_cooldowns->add_action( "berserking,if=buff.combustion.up" );
   combustion_cooldowns->add_action( "fireblood" );
   combustion_cooldowns->add_action( "ancestral_call" );
+  combustion_cooldowns->add_action( "invoke_external_buff,name=power_infusion,if=!buff.power_infusion.up" );
   combustion_cooldowns->add_action( "time_warp,if=talent.temporal_warp&buff.exhaustion.up" );
   combustion_cooldowns->add_action( "use_item,effect_name=gladiators_badge" );
   combustion_cooldowns->add_action( "use_item,name=irideus_fragment" );


### PR DESCRIPTION
Add an invoke power infusion to fire mage
This logic works fine up to two power infusions, going over is likely to cause issues but handling that isn't really supported by the invoke feature at this time.

https://www.raidbots.com/simbot/report/o1mg6ghN7i9YxSn71Ms1nc

Only uses PI if PI are in the invoke pool.
E.g. above sim uses
```
copy="1 PI"
external_buffs.pool=power_infusion:120

copy="2 PI"
external_buffs.pool=power_infusion:120:2