### PR TITLE
[Havoc] Use Algeth'ar Puzzle Box in precombat

### DIFF
--- a/engine/class_modules/apl/demon_hunter/havoc.simc
+++ b/engine/class_modules/apl/demon_hunter/havoc.simc
@@ -7,6 +7,7 @@ actions.precombat+=/snapshot_stats
 actions.precombat+=/variable,name=trinket_sync_slot,value=1,if=trinket.1.has_stat.any_dps&(!trinket.2.has_stat.any_dps|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)
 actions.precombat+=/variable,name=trinket_sync_slot,value=2,if=trinket.2.has_stat.any_dps&(!trinket.1.has_stat.any_dps|trinket.2.cooldown.duration>trinket.1.cooldown.duration)
 actions.precombat+=/arcane_torrent
+actions.precombat+=/use_item,name=algethar_puzzle_box
 
 # Executed every time the actor is available.
 actions=auto_attack


### PR DESCRIPTION
Now that pre-combat puzzle box is implemented (#7111), it's a slight (<1%) increase to builds using puzzle box to channel it precombat.

Some comparisons:
Ragefire ST (+0.6%): https://www.raidbots.com/simbot/report/e8t1qiqNxgRoJgzXUWCUdq
Ragefire 7T (+0.8%): https://www.raidbots.com/simbot/report/6jYApEDdFfD8DVKijJ5K7a
Raid SD ST (+0.3%): https://www.raidbots.com/simbot/report/cWGCNHSCC45hRBBPaiP5Wi
Raid SD 7T (+0.9%): https://www.raidbots.com/simbot/report/2LStmXbrFH4xje2JXkq1D3