### PR TITLE
[Havoc] Trigger initiative when killing fodder demon

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3437,6 +3437,13 @@ struct fodder_to_the_flame_cb_t : public dbc_proc_callback_t
     void execute() override
     {
       demon_hunter_spell_t::execute();
+
+      // Simulate triggering initiative from hitting the demon
+      if ( p()->talent.havoc.initiative->ok() )
+      {
+        p()->buff.initiative->trigger();
+      }
+
       p()->spawn_soul_fragment( soul_fragment::EMPOWERED_DEMON );
     }
   };


### PR DESCRIPTION
Fodder to the flame spawns a demon when it procs, this demon will proc initiative when hit. The current implementation doesn't create an enemy for the demon, so this interaction never happens.

This fix causes initiative to be procced when the demon is "killed" (does damage and spawns a demon soul) in order to approximate that interaction.

This results in a ~0.8% DPS increase in both ST and AOE.