### PR TITLE
Adding Ascendance duration checks for LvBm lines

### DIFF
--- a/profiles/Tier29/T29_Shaman_Elemental.simc
+++ b/profiles/Tier29/T29_Shaman_Elemental.simc
@@ -91,17 +91,17 @@ actions.aoe+=/lava_beam,if=buff.stormkeeper.up
 # Stormkeeper is strong and should be used.
 actions.aoe+=/chain_lightning,if=buff.stormkeeper.up
 # Power of the Maelstrom is strong and should be used.
-actions.aoe+=/lava_beam,if=buff.power_of_the_maelstrom.up
+actions.aoe+=/lava_beam,if=buff.power_of_the_maelstrom.up&buff.ascendance.remains>cast_time
 # Power of the Maelstrom is strong and should be used.
 actions.aoe+=/chain_lightning,if=buff.power_of_the_maelstrom.up
 # Against 6 targets or more Surge of Power should be used with Lava Beam rather than Lava Burst.
-actions.aoe+=/lava_beam,if=active_enemies>=6&buff.surge_of_power.up
+actions.aoe+=/lava_beam,if=active_enemies>=6&buff.surge_of_power.up&buff.ascendance.remains>cast_time
 # Against 6 targets or more Surge of Power should be used with Chain Lightning rather than Lava Burst.
 actions.aoe+=/chain_lightning,if=active_enemies>=6&buff.surge_of_power.up
 # Proc Deeply Rooted Elements against 3 targets.
 actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=buff.lava_surge.up&talent.deeply_rooted_elements.enabled&buff.windspeakers_lava_resurgence.up
 # Consume Master of the Elements with Lava Beam.
-actions.aoe+=/lava_beam,if=buff.master_of_the_elements.up
+actions.aoe+=/lava_beam,if=buff.master_of_the_elements.up&buff.ascendance.remains>cast_time
 # Proc Master of the Elements against 3 targets.
 actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=enemies=3&talent.master_of_the_elements.enabled
 # Gamble away for Deeply Rooted Elements procs whenever Lava Surge makes Lava Burst more efficient.
@@ -110,7 +110,7 @@ actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=buff.lava_surge.up
 actions.aoe+=/icefury,if=talent.electrified_shocks.enabled&active_enemies<5
 # Spread out your Frost Shock casts to empower as many Chain Lightnings as possible.
 actions.aoe+=/frost_shock,if=buff.icefury.up&talent.electrified_shocks.enabled&!debuff.electrified_shocks.up&active_enemies<5
-actions.aoe+=/lava_beam
+actions.aoe+=/lava_beam,if=buff.ascendance.remains>cast_time
 actions.aoe+=/chain_lightning
 actions.aoe+=/flame_shock,moving=1,target_if=refreshable
 actions.aoe+=/frost_shock,moving=1
@@ -147,7 +147,7 @@ actions.single_target+=/lightning_bolt,if=buff.surge_of_power.up
 actions.single_target+=/icefury,if=talent.electrified_shocks.enabled
 actions.single_target+=/frost_shock,if=buff.icefury.up&talent.electrified_shocks.enabled&(!debuff.electrified_shocks.up|buff.icefury.remains<=gcd)
 actions.single_target+=/frost_shock,if=buff.icefury.up&talent.electrified_shocks.enabled&maelstrom>=50&debuff.electrified_shocks.remains<2*gcd&buff.stormkeeper.up
-actions.single_target+=/lava_beam,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&buff.power_of_the_maelstrom.up
+actions.single_target+=/lava_beam,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&buff.power_of_the_maelstrom.up&buff.ascendance.remains>cast_time
 # Windspeaker's Lava Resurgence is strong. Don't sit on it.
 actions.single_target+=/lava_burst,if=buff.windspeakers_lava_resurgence.up
 # Lava Surge is neat. Utilize it.
@@ -182,8 +182,10 @@ actions.single_target+=/lightning_bolt,if=buff.master_of_the_elements.up&!buff.l
 actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2
 # Use your Icefury buffs if you didn't improve the talent.
 actions.single_target+=/frost_shock,if=buff.icefury.up&!talent.electrified_shocks.enabled&!talent.flux_melting.enabled
-# Casting Chain Lightning at two targets is mor efficient than Lightning Bolt.
-actions.single_target+=/chain_lightning,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)
+# Casting Lava Beam at two targets is more efficient than Lightning Bolt
+actions.single_target+=/lava_beam,if=active_enemies>1&spell_targets.lava_beam>1&buff.ascendance.remains>cast_time
+# Casting Chain Lightning at two targets is more efficient than Lightning Bolt.
+actions.single_target+=/chain_lightning,if=active_enemies>1&spell_targets.chain_lightning>1
 # Filler spell. Always available. Always the bottom line.
 actions.single_target+=/lightning_bolt
 actions.single_target+=/flame_shock,moving=1,target_if=refreshable


### PR DESCRIPTION
adding buff.ascendance.remains>cast_time (credit Hawk) to lines that include LvBm to prevent waiting time, for both aoe section and single target section which handles 2 targets.