### PR TITLE
[Warrior/Fury] Handle trinkets better

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -8596,9 +8596,9 @@ void warrior_t::apl_fury()
           "|!talent.avatar)|fight_remains<5" },
         { "algethar_puzzle_box",
           ",if=cooldown.recklessness.remains<3|(talent.anger_management&cooldown.avatar.remains<3)|fight_remains<25" },
-        { "decoration_of_flame", ",if=buff.recklessness.down&cooldown.recklessness.remains>20&raid_event.adds.in>15" },
-        { "stormeaters_boon", ",if=buff.recklessness.down&cooldown.recklessness.remains>20&raid_event.adds.in>15" },
-        { "windscar_whetstone", ",if=buff.recklessness.down&cooldown.recklessness.remains>20&raid_event.adds.in>15" },
+        { "decoration_of_flame", ",if=buff.recklessness.down&cooldown.recklessness.remains>20&raid_event.adds.in>15|fight_remains<31" },
+        { "stormeaters_boon", ",if=buff.recklessness.down&cooldown.recklessness.remains>20&raid_event.adds.in>15|fight_remains<11" },
+        { "windscar_whetstone", ",if=buff.recklessness.down&cooldown.recklessness.remains>20&raid_event.adds.in>15|fight_remains<7" },
 
         // Defaults:
         { "ITEM_STAT_BUFF", ",if=buff.recklessness.remains>10" },

--- a/profiles/Tier29/T29_Warrior_Fury.simc
+++ b/profiles/Tier29/T29_Warrior_Fury.simc
@@ -38,7 +38,7 @@ actions+=/charge,if=time<=0.5|movement.distance>5
 actions+=/heroic_leap,if=(raid_event.movement.distance>25&raid_event.movement.in>45)
 actions+=/potion
 actions+=/pummel,if=target.debuff.casting.react
-actions+=/use_item,name=manic_grieftorch,if=buff.avatar.down
+actions+=/use_item,name=manic_grieftorch,if=buff.recklessness.down&cooldown.recklessness.remains>20&buff.avatar.down&(cooldown.avatar.remains>20|!talent.avatar)|fight_remains<5
 actions+=/ravager,if=cooldown.recklessness.remains<3|buff.recklessness.up
 actions+=/blood_fury
 actions+=/berserking,if=buff.recklessness.up

--- a/profiles/Tier29/T29_Warrior_Fury.simc
+++ b/profiles/Tier29/T29_Warrior_Fury.simc
@@ -38,7 +38,7 @@ actions+=/charge,if=time<=0.5|movement.distance>5
 actions+=/heroic_leap,if=(raid_event.movement.distance>25&raid_event.movement.in>45)
 actions+=/potion
 actions+=/pummel,if=target.debuff.casting.react
-actions+=/use_item,name=manic_grieftorch,if=buff.recklessness.down&cooldown.recklessness.remains>20&buff.avatar.down&(cooldown.avatar.remains>20|!talent.avatar)|fight_remains<5
+actions+=/use_item,name=manic_grieftorch,if=buff.recklessness.down&cooldown.recklessness.remains>20&buff.avatar.down&(cooldown.avatar.remains>20|!talent.avatar)|fight_remains<duration
 actions+=/ravager,if=cooldown.recklessness.remains<3|buff.recklessness.up
 actions+=/blood_fury
 actions+=/berserking,if=buff.recklessness.up


### PR DESCRIPTION
I noticed that Trinket combinations was being weird. On-use damage trinkets were being used irregardless of recklessness burn phases, and stat trinkets were not used in Recklessness which means they'll be less efficient.

I found and copied a lot of what @JeremyMonk did for Windwalker in #7074 with some success. Tried lot's of combinations of trinkets and compared to the default APL and saw a good increase.