### PR TITLE
[Warlock] Implosion rules

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -177,7 +177,9 @@ void demonology( player_t* p )
   default_->add_action( "demonic_strength" );
   default_->add_action( "bilescourge_bombers,if=!pet.demonic_tyrant.active" );
   default_->add_action( "shadow_bolt,if=soul_shard<5&talent.fel_covenant&buff.fel_covenant.remains<5" );
-  default_->add_action( "implosion,if=active_enemies>2&buff.wild_imps.stack>=6" );
+  default_->add_action( "implosion,if=two_cast_imps>0&buff.tyrant.down&active_enemies>1+(talent.sacrificed_souls.enabled)" );
+  default_->add_action( "implosion,if=buff.wild_imps.stack>9&buff.tyrant.up&active_enemies>2+(1*talent.sacrificed_souls.enabled)&cooldown.call_dreadstalkers.remains>17&talent.the_expendables" );
+  default_->add_action( "implosion,if=active_enemies=1&last_cast_imps>0&buff.tyrant.down&talent.imp_gang_boss.enabled&!talent.sacrificed_souls" );
   default_->add_action( "soul_strike,if=soul_shard<5&active_enemies>1" );
   default_->add_action( "summon_soulkeeper,if=active_enemies>1&buff.tormented_soul.stack=10" );
   default_->add_action( "demonbolt,if=buff.demonic_core.up&soul_shard<4" );


### PR DESCRIPTION
https://www.raidbots.com/simbot/report/vSkAAtsEeKN9iLX4bXwsdy   For the "actions+=/implosion,if=two_cast_imps>0&buff.tyrant.down&active_enemies>1+(talent.sacrificed_souls.enabled)" Line  

It's a change that avoids Implosion while Tyrant is Up, allows Implosion at 2 targets or more when you don't have Sacrificed Souls Talented and handles implosion based on remaining casts of imps and not Imp Quantity. 

------------------------------------
https://www.raidbots.com/simbot/report/4Kn33tx45tWcCtGkhF3w5C this one is for "actions+=/implosion,if=active_enemies=1&last_cast_imps>0&buff.tyrant.down&talent.imp_gang_boss.enabled&!talent.sacrificed_souls"

This line add's support for Single Target Implosions when Imp Gang Boss is talented and you do not have Sacrificed Souls.

It should be handling implosion in 2 situations : When Tyrant Expires and outside of tyrant when you have 1 or more wild imps with only 2 casts remaining.

 -----------------------------------------

https://www.raidbots.com/simbot/report/abMcthRSJmVK9BkitV29i1 This is for actions+=/implosion,if=buff.wild_imps.stack>9&buff.tyrant.up&active_enemies>2+(1*talent.sacrificed_souls.enabled)&cooldown.call_dreadstalkers.remains>17&talent.the_expendables

This Line is a complement to the first one, Introduces a Implosion inside Tyrant and after dogs to Dreadstalkers and other demons 9 stacks of expendables while tyrant is active.