### PR TITLE
Run CI tests on gcc built binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,9 +131,8 @@ jobs:
             tests
           key: ubuntu-clang-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
-
   ubuntu-run:
-    name: ubuntu-clang-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
+    name: ubuntu-${{ github.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ubuntu-20.04
     needs: [ ubuntu-clang-build ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
           key: ubuntu-clang-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-run:
-    name: ubuntu-${{ github.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
+    name: ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ubuntu-20.04
     needs: [ ubuntu-clang-build ]
 
@@ -159,7 +159,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
-          key: ubuntu-${{ github.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+          key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
       - name: Run
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,11 +167,6 @@ jobs:
             tests
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
-      - name: Install deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libstdc++6
-
       - name: Run
         env:
           UBSAN_OPTIONS: print_stacktrace=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ env:
   ccache-generation: 0 # bump if you need to "clean" ccache
 
 jobs:
-  ubuntu-gcc:
-    name: ubuntu-${{ matrix.cc }}-C++${{ matrix.cppVersion }}
+  ubuntu-gcc-build:
+    name: ubuntu-${{ matrix.cc }}-cpp${{ matrix.cppVersion }}-build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -28,10 +28,12 @@ jobs:
             cxx: g++-7
             packages: gcc-7 g++-7
             os: ubuntu-18.04
+            upload: false
           - cc: gcc-12
             cxx: g++-12
             packages: gcc-12 g++-12
             os: ubuntu-22.04
+            upload: true
         exclude:
           - cc: gcc-7
             cppVersion: 20   
@@ -70,6 +72,7 @@ jobs:
           ccache -s
           
       - uses: actions/cache@v3
+        if: ${{ matrix.upload }}
         with:
           path: |
             ${{ runner.workspace }}/b/ninja/simc
@@ -133,7 +136,7 @@ jobs:
   ubuntu-run:
     name: ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ubuntu-20.04
-    needs: [ ubuntu-clang-build ]
+    needs: [ ubuntu-clang-build, ubuntu-gcc-build ]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,6 @@ jobs:
           ccache -s
           
       - uses: actions/cache@v3
-        if: ${{ github.ref_name == env.MAIN_BRANCH }}
         with:
           path: |
             ${{ runner.workspace }}/b/ninja/simc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
 
   ubuntu-run:
     name: ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     needs: [ ubuntu-clang-build, ubuntu-gcc-build ]
 
     strategy:
@@ -153,6 +153,10 @@ jobs:
             simc_flags: $SIMC_PROFILE iterations=10 cleanup_threads=1
           - type: dungeon_slice
             simc_flags: $SIMC_PROFILE iterations=10 fight_style=DungeonSlice cleanup_threads=1
+          - compiler: clang
+            os: ubuntu-20.04
+          - compiler: gcc
+            os: ubuntu-22.04
 
     steps:
       - uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libstdc++6
+          sudo apt-get install -y libstdc++12
 
       - name: Run
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,11 @@ jobs:
             tests
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libstdc++6
+
       - name: Run
         env:
           UBSAN_OPTIONS: print_stacktrace=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libstdc++12
+          sudo apt-get install -y libstdc++6
 
       - name: Run
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
       - 'casc_extract/**'
 
 env:
-  MAIN_BRANCH: dragonflight # env is not accessible at jobs.if context so must be manually edited in ubuntu-clang-run and simc-tests
   SIMC_PROFILE: profiles/CI.simc
   CCACHE_COMPRESS: true # always enable ccache compression
   ccache-generation: 0 # bump if you need to "clean" ccache
@@ -125,7 +124,6 @@ jobs:
           ccache -s
 
       - uses: actions/cache@v3
-        if: ${{ github.ref_name == env.MAIN_BRANCH }}
         with:
           path: |
             ${{ runner.workspace }}/b/ninja/simc
@@ -135,7 +133,6 @@ jobs:
 
 
   ubuntu-run:
-    if: ${{ github.ref_name == 'dragonflight' }}
     name: ubuntu-clang-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ubuntu-20.04
     needs: [ ubuntu-clang-build ]
@@ -171,7 +168,6 @@ jobs:
         run: ${{ runner.workspace }}/b/ninja/simc output=/dev/null html=/dev/null json2=/dev/null json3=/dev/null ${{ matrix.simc_flags }}
 
   simc-tests:
-    if: ${{ github.ref_name == 'dragonflight' }}
     name: test-${{ matrix.tier }}-${{ matrix.spec }}
     runs-on: ubuntu-20.04
     needs: [ ubuntu-clang-build ]
@@ -228,7 +224,6 @@ jobs:
         run: make SANITIZE=1 -C engine debug -j 2
 
       - name: Smoke Test
-        if: ${{ github.ref_name == env.MAIN_BRANCH }}
         run: ./engine/simc $SIMC_PROFILE iterations=5 output=/dev/null html=/dev/null json2=/dev/null cleanup_threads=1
 
   windows-VS:
@@ -265,5 +260,5 @@ jobs:
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
 
       - name: Smoke Test
-        if: ${{ matrix.runSmokeTest && github.ref_name == env.MAIN_BRANCH }}
+        if: ${{ matrix.runSmokeTest }}
         run: ${{ env.CMAKE_BUILD_DIR }}/simc.exe $env:SIMC_PROFILE iterations=5 output=nul html=nul json2=nul cleanup_threads=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,16 +69,15 @@ jobs:
           ccache -z
           ninja -C '${{ runner.workspace }}/b/ninja'
           ccache -s
-
-      - name: Smoke Test
+          
+      - uses: actions/cache@v3
         if: ${{ github.ref_name == env.MAIN_BRANCH }}
-        run: ${{ runner.workspace }}/b/ninja/simc $SIMC_PROFILE iterations=20
-              output=/dev/null html=/dev/null json2=/dev/null
-
-      - name: Spell Query
-        if: ${{ github.ref_name == env.MAIN_BRANCH }}
-        run: ${{ runner.workspace }}/b/ninja/simc spell_query=spell.name=auto_shot
-
+        with:
+          path: |
+            ${{ runner.workspace }}/b/ninja/simc
+            profiles
+            tests
+          key: ubuntu-gcc-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-clang-build:
     name: ubuntu-clang-build
@@ -135,7 +134,7 @@ jobs:
           key: ubuntu-clang-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
 
-  ubuntu-clang-run:
+  ubuntu-run:
     if: ${{ github.ref_name == 'dragonflight' }}
     name: ubuntu-clang-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ubuntu-20.04
@@ -145,6 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
+        compiler: [clang, gcc]
         type: [spell_query, log_debug, patchwerk, dungeon_slice]
         include:
           - type: spell_query
@@ -163,7 +163,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
-          key: ubuntu-clang-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+          key: ubuntu-${{ github.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
       - name: Run
         env:


### PR DESCRIPTION
As requested by @navv1234 , we want to have tests run for both gcc and clang, in particular so that both a libstdc++ and libc++ build is covered.

Also enable all jobs without branch restrictions, bringing checks back to pull requests.