### PR TITLE
[Warlock] [Demonology] Power Infusion Invoke External 

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -180,6 +180,7 @@ void demonology( player_t* p )
 
   default_->add_action( "call_action_list,name=tyrant,if=talent.summon_demonic_tyrant&(time-variable.next_tyrant)<=(variable.tyrant_prep_start+2)&cooldown.summon_demonic_tyrant.up" );
   default_->add_action( "call_action_list,name=tyrant,if=talent.summon_demonic_tyrant&cooldown.summon_demonic_tyrant.remains_expected<=variable.tyrant_prep_start" );
+  default_->add_action( "actions+=/invoke_external_buff,name=power_infusion,if=!talent.nether_portal&!talent.summon_demonic_tyrant|time_to_die<25" );
   default_->add_action( "implosion,if=time_to_die<2*gcd" );
   default_->add_action( "nether_portal,if=!talent.summon_demonic_tyrant&soul_shard>2|time_to_die<30" );
   default_->add_action( "hand_of_guldan,if=buff.nether_portal.up" );
@@ -212,6 +213,7 @@ void demonology( player_t* p )
   ogcd->add_action( "fireblood" );
 
   tyrant->add_action( "variable,name=next_tyrant,op=set,value=time+14+cooldown.grimoire_felguard.ready+cooldown.summon_vilefiend.ready,if=variable.next_tyrant<=time" );
+  tyrant->add_action( "invoke_external_buff,name=power_infusion,if=(buff.nether_portal.up&buff.nether_portal.remains<8&talent.nether_portal)|(buff.dreadstalkers.up&variable.next_tyrant-time<=6&!talent.nether_portal)" );
   tyrant->add_action( "shadow_bolt,if=time<2&soul_shard<5" );
   tyrant->add_action( "nether_portal" );
   tyrant->add_action( "grimoire_felguard" );

--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -180,7 +180,7 @@ void demonology( player_t* p )
 
   default_->add_action( "call_action_list,name=tyrant,if=talent.summon_demonic_tyrant&(time-variable.next_tyrant)<=(variable.tyrant_prep_start+2)&cooldown.summon_demonic_tyrant.up" );
   default_->add_action( "call_action_list,name=tyrant,if=talent.summon_demonic_tyrant&cooldown.summon_demonic_tyrant.remains_expected<=variable.tyrant_prep_start" );
-  default_->add_action( "actions+=/invoke_external_buff,name=power_infusion,if=!talent.nether_portal&!talent.summon_demonic_tyrant|time_to_die<25" );
+  default_->add_action( "invoke_external_buff,name=power_infusion,if=!talent.nether_portal&!talent.summon_demonic_tyrant|time_to_die<25" );
   default_->add_action( "implosion,if=time_to_die<2*gcd" );
   default_->add_action( "nether_portal,if=!talent.summon_demonic_tyrant&soul_shard>2|time_to_die<30" );
   default_->add_action( "hand_of_guldan,if=buff.nether_portal.up" );


### PR DESCRIPTION
Introduces PI Lines for Nether Portal, Tyrant and non NP/Tyrants alongside a TTD PI. 

It's not the most optimal usage of PI, to obtain that we would start to talk about moving Cooldowns to match PI and that would be fight_length dependent something that i couldn't do in a way that would be agnostic among every situation. 

