### PR TITLE
[Affliction] Grim Reach Double Dips

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2158,6 +2158,10 @@ struct eye_beam_t : public warlock_pet_spell_t
       background = dual = true;
 
       base_dd_min = base_dd_max = 0.0;
+
+      snapshot_flags |= STATE_MUL_DA | STATE_TGT_MUL_DA | STATE_VERSATILITY | STATE_MUL_PET | STATE_TGT_MUL_PET | STATE_MUL_PERSISTENT;
+      update_flags   |= STATE_MUL_DA | STATE_TGT_MUL_DA | STATE_VERSATILITY | STATE_MUL_PET | STATE_TGT_MUL_PET;
+
     }
   };
   
@@ -2201,7 +2205,7 @@ struct eye_beam_t : public warlock_pet_spell_t
 
   void impact( action_state_t* s ) override
   {
-    auto raw_damage = s->result_raw;
+    auto raw_damage = s->result_total;
 
     warlock_pet_spell_t::impact( s );
 


### PR DESCRIPTION
Enables full Double Dipping of all modifiers for Grim Reach.

I was unable to test target damage modifiers such as chaos brand or boss vulnerabilities in my brief testing in-game, but they are included here and likely to work as it's missing the spell data to disable them.

Everything else was fully functional from testing.