### PR TITLE
[Warlock] Havoc ST rule change

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -265,7 +265,7 @@ void destruction( player_t* p )
   default_->add_action( "channel_demonfire,if=talent.raging_demonfire" );
   default_->add_action( "soul_fire,if=soul_shard<=4" );
   default_->add_action( "immolate,if=((dot.immolate.refreshable&talent.internal_combustion)|dot.immolate.remains<3)&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&(!talent.soul_fire|cooldown.soul_fire.remains>dot.immolate.remains)" );
-  default_->add_action( "havoc,if=talent.cry_havoc&(buff.ritual_of_ruin.up|pet.infernal.active)" );
+  default_->add_action( "havoc,if=talent.cry_havoc&((buff.ritual_of_ruin.up&pet.infernal.active&talent.burn_to_ashes)|((buff.ritual_of_ruin.up|pet.infernal.active)&!talent.burn_to_ashes))" );
   default_->add_action( "chaos_bolt,if=pet.infernal.active|pet.blasphemy.active|soul_shard>=4" );
   default_->add_action( "summon_infernal" );
   default_->add_action( "channel_demonfire,if=talent.ruin.rank>1&!(talent.diabolic_embers&talent.avatar_of_destruction&(talent.burn_to_ashes|talent.chaos_incarnate))&dot.immolate.remains>cast_time" );


### PR DESCRIPTION
After last week's hotfix, it's it not worth anymore to use havoc outside of infernal if burn to ashes is talented.