### PR TITLE
[Warlock] Pit Lord is not affected by The Expendables

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -2060,6 +2060,10 @@ void warlock_t::expendables_trigger_helper( warlock_pet_t* source )
     if ( lock_pet == source )
       continue;
 
+    // Pit Lord is not affected by The Expendables
+    if ( lock_pet->pet_type == PET_PIT_LORD )
+      continue;
+
     lock_pet->buffs.the_expendables->increment();
   }
 }


### PR DESCRIPTION
This can be verified in game by targeting the Pit Lord, it does not gain The Expendables stacks when imps die. (it has to be checked in game because Expendables is hidden from CLEU)

If this had worked, then when using the typical hybrid build with both Pit Lord and IGB, casting Implosion right after NP ends during lust would have been a small dps gain. But since it doesn't work this is not worth it.