### PR TITLE
Change warlock default flask to not use Static Empowerment

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -12,7 +12,11 @@ namespace warlock_apl{
 
   std::string flask( const player_t* p )
   {
-    if ( p->true_level >= 70 ) return "phial_of_static_empowerment_3";
+    if ( p->true_level >= 70 )
+    {
+      return ( p->specialization() == WARLOCK_DEMONOLOGY ) ? "phial_of_tepid_versatility_3"
+                                                           : "phial_of_elemental_chaos_3";
+    }
     return ( p->true_level >= 60 ) ? "spectral_flask_of_power" : "disabled";
   }
 


### PR DESCRIPTION
Static Empowerment is too impractical to be the default flask