### PR TITLE
[Havoc] Use Fel Rush as a generator with Isolated Prey

### DIFF
--- a/engine/class_modules/apl/apl_demon_hunter.cpp
+++ b/engine/class_modules/apl/apl_demon_hunter.cpp
@@ -108,6 +108,7 @@ void havoc( player_t* p )
   default_->add_action( "annihilation,if=!variable.pooling_for_blade_dance" );
   default_->add_action( "throw_glaive,if=talent.serrated_glaive&cooldown.eye_beam.remains<4&!debuff.serrated_glaive.up&!debuff.essence_break.up" );
   default_->add_action( "immolation_aura,if=!buff.immolation_aura.up&(!talent.ragefire|active_enemies>desired_targets|raid_event.adds.in>15)" );
+  default_->add_action( "fel_rush,if=talent.isolated_prey&active_enemies=1&fury.deficit>=35" );
   default_->add_action( "felblade,if=fury.deficit>=40" );
   default_->add_action( "sigil_of_flame,if=active_enemies>desired_targets" );
   default_->add_action( "chaos_strike,if=!variable.pooling_for_blade_dance&!variable.pooling_for_eye_beam" );

--- a/engine/class_modules/apl/demon_hunter/havoc.simc
+++ b/engine/class_modules/apl/demon_hunter/havoc.simc
@@ -38,6 +38,7 @@ actions+=/throw_glaive,if=talent.soulrend&(active_enemies>desired_targets|raid_e
 actions+=/annihilation,if=!variable.pooling_for_blade_dance
 actions+=/throw_glaive,if=talent.serrated_glaive&cooldown.eye_beam.remains<4&!debuff.serrated_glaive.up&!debuff.essence_break.up
 actions+=/immolation_aura,if=!buff.immolation_aura.up&(!talent.ragefire|active_enemies>desired_targets|raid_event.adds.in>15)
+actions+=/fel_rush,if=talent.isolated_prey&active_enemies=1&fury.deficit>=35
 actions+=/felblade,if=fury.deficit>=40
 actions+=/sigil_of_flame,if=active_enemies>desired_targets
 actions+=/chaos_strike,if=!variable.pooling_for_blade_dance&!variable.pooling_for_eye_beam


### PR DESCRIPTION
When talented into Isolated Prey, use Fel Rush as a generator on 1 target over Felblade or Sigil of Flame when low on fury. This results in a 0.3%-1.2% gain depending on build and scenario.