### PR TITLE
[Warlock] Talent fix to the BiS profile

### DIFF
--- a/profiles/Tier29/T29_Warlock_Affliction.simc
+++ b/profiles/Tier29/T29_Warlock_Affliction.simc
@@ -5,7 +5,7 @@ level=70
 race=orc
 role=spell
 position=ranged_back
-talents=BkQAAAAAAAAAAAAAAAAAAAAAAgcARSSiEINtIItkkQKBAAAAakAAAAAAAJSKIcgkkEJNhAAA
+talents=BkQAAAAAAAAAAAAAAAAAAAAAAgcARSSiEINtIItkkQKBAAAAakAAAAAAAJyBKIikkEJtECAA
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3


### PR DESCRIPTION
Current: https://www.raidbots.com/simbot/report/boUwUb4tf2fxeM7auND1v3

New: https://www.raidbots.com/simbot/report/7dWbJBNmT6X8DoaKTQWuut

Changes to reflect the new talent changes (GoSac/FM + the swapping of positions for Soulkeeper and Eye)