### PR TITLE
Change rime base duration from 5 to 4 seconds

### DIFF
--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -894,7 +894,7 @@ void darkmoon_deck_rime( special_effect_t& effect )
 
     timespan_t get_duration( size_t index ) const
     {
-      return 5_s + timespan_t::from_seconds( index );
+      return 4_s + timespan_t::from_seconds( index );
     }
 
     void impact( action_state_t* s ) override


### PR DESCRIPTION
It appears to me that darkmoon rime was changed from 4 to 5 seconds when someone was adding a different trinket, and I believe it's an error based on the tooltip for the trinket. 

```
Deal 3845 Frost damage and apply Awakening Rime to your target for 4-12s. If the target dies while Awakening Rime is active, it explodes for 10572 Frost damage split between enemies in a 10 yard radius. Duration is determined by the top-most card of the deck.
```

https://www.wowhead.com/spell=386624/awakening-rime
