### PR TITLE
Fixed restoring app position for multiscreen

### DIFF
--- a/qt/MainWindow.cpp
+++ b/qt/MainWindow.cpp
@@ -101,24 +101,7 @@ void SC_MainWindow::loadHistory()
                               tr( "We have reset your configuration settings due to major changes to the GUI" ) );
   }
 
-  // Restoring the ui to a previously stored place that is potentially not the primary monitor causes issues for some users. See https://github.com/simulationcraft/simc/issues/5047
-  // Until we can figure out why this is happening and can be resolved, restoring the ui position is intentionally disabled
-  if constexpr(false)
-  {
-    QVariant size                  = settings.value( "gui/size" );
-    QRect savedApplicationGeometry = geometry();
-    if ( size.isValid() )
-    {
-      savedApplicationGeometry.setSize( size.toSize() );
-    }
-    QVariant pos = settings.value( "gui/position" );
-    if ( pos.isValid() )
-    {
-      savedApplicationGeometry.moveTopLeft( pos.toPoint() );
-    }
-    setGeometry(savedApplicationGeometry);
-  }
-
+  restoreGeometry( settings.value( "gui/geometry" ).toByteArray() );
   QVariant maximized = settings.value( "gui/maximized" );
   if ( maximized.isValid() )
   {
@@ -181,8 +164,7 @@ void SC_MainWindow::saveHistory()
   QSettings settings;
   settings.beginGroup( "gui" );
   settings.setValue( "gui_version_number", SC_GUI_HISTORY_VERSION );
-  settings.setValue( "size", normalGeometry().size() );
-  settings.setValue( "position", normalGeometry().topLeft() );
+  settings.setValue( "geometry", saveGeometry() );
   settings.setValue( "maximized", bool( windowState() & Qt::WindowMaximized ) );
   settings.endGroup();
 


### PR DESCRIPTION
For multiple screens we need to use [QWidget::restoreGeometry()](https://doc.qt.io/qt-6/qwidget.html#restoreGeometry)
Source code: https://codebrowser.dev/qt5/qtbase/src/widgets/kernel/qwidget.cpp.html#7215
and QWidget::setGeometry() for comparison https://codebrowser.dev/qt5/qtbase/src/widgets/kernel/qwidget.cpp.html#7005