### PR TITLE
[Priest] Manually create PTW dot

### DIFF
--- a/engine/class_modules/apl/apl_priest.cpp
+++ b/engine/class_modules/apl/apl_priest.cpp
@@ -209,7 +209,6 @@ void discipline( player_t* p )
   def->add_action( "schism" );
   def->add_action( "mindgames" );
   def->add_action( "mindbender" );
-  def->add_action( "spirit_shell" );
   def->add_action( "purge_the_wicked,if=!ticking" );
   def->add_action( "shadow_word_pain,if=!ticking&!talent.purge_the_wicked.enabled" );
   def->add_action( "shadow_word_death" );

--- a/engine/class_modules/priest/sc_priest_discipline.cpp
+++ b/engine/class_modules/priest/sc_priest_discipline.cpp
@@ -158,10 +158,7 @@ struct purge_the_wicked_t final : public priest_spell_t
     purge_the_wicked_dot_t( priest_t& p )
       : priest_spell_t( "purge_the_wicked", p, p.talents.discipline.purge_the_wicked->effectN( 2 ).trigger() )
     {
-      may_crit = true;
-      // tick_zero = false;
-      energize_type = action_energize::NONE;  // disable resource generation from spell data
-      background    = true;
+      background = true;
 
       apply_affecting_aura( priest().talents.throes_of_pain );
     }
@@ -181,7 +178,6 @@ struct purge_the_wicked_t final : public priest_spell_t
     : priest_spell_t( "purge_the_wicked", p, p.talents.discipline.purge_the_wicked )
   {
     parse_options( options_str );
-    may_crit       = true;
     tick_zero      = false;
     execute_action = new purge_the_wicked_dot_t( p );
   }


### PR DESCRIPTION
1. PTW did not have a ticking event on the spell itself, so manually creating the dot.

2. Remove spirit shell from APL as it is no longer an available spell (and was triggering errors)