### PR TITLE
[Priest] Add talents modifying Purge the Wicked damage

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -110,6 +110,7 @@ public:
     propagate_const<buff_t*> power_of_the_dark_side;
     propagate_const<buff_t*> sins_of_the_many;
     propagate_const<buff_t*> shadow_covenant;
+    propagate_const<buff_t*> revel_in_purity;
 
     // Holy
     propagate_const<buff_t*> apotheosis;
@@ -319,6 +320,7 @@ public:
       // Row 6
       player_talent_t embrace_shadow;
       player_talent_t twilight_corruption;
+      player_talent_t revel_in_purity;
       // Row 8
       player_talent_t lights_wrath;
     } discipline;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -321,6 +321,7 @@ public:
       player_talent_t embrace_shadow;
       player_talent_t twilight_corruption;
       player_talent_t revel_in_purity;
+      player_talent_t pain_and_suffering;
       // Row 8
       player_talent_t lights_wrath;
     } discipline;

--- a/engine/class_modules/priest/sc_priest_discipline.cpp
+++ b/engine/class_modules/priest/sc_priest_discipline.cpp
@@ -197,9 +197,12 @@ struct purge_the_wicked_t final : public priest_spell_t
       : priest_spell_t( "purge_the_wicked", p, p.talents.discipline.purge_the_wicked->effectN( 2 ).trigger() )
     {
       background = true;
+      // 3% / 5% damage increase
       apply_affecting_aura( priest().talents.throes_of_pain );
       // 5% damage increase
       apply_affecting_aura( p.talents.discipline.revel_in_purity );
+      // 8% / 15% damage increase
+      apply_affecting_aura( priest().talents.discipline.pain_and_suffering );
     }
 
     void tick( dot_t* d ) override
@@ -219,8 +222,12 @@ struct purge_the_wicked_t final : public priest_spell_t
     parse_options( options_str );
     tick_zero      = false;
     execute_action = new purge_the_wicked_dot_t( p );
+    // 3% / 5% damage increase
+    apply_affecting_aura( priest().talents.throes_of_pain );
     // 5% damage increase
     apply_affecting_aura( priest().talents.discipline.revel_in_purity );
+    // 8% / 15% damage increase
+    apply_affecting_aura( priest().talents.discipline.pain_and_suffering );
   }
 };
 
@@ -326,7 +333,8 @@ void priest_t::init_spells_discipline()
   // Row 6
   talents.discipline.embrace_shadow      = ST( "Embrace Shadow" );
   talents.discipline.twilight_corruption = ST( "Twilight Corruption" );
-  talents.discipline.revel_in_purity     = ST( "Revel In Purity" );
+  talents.discipline.revel_in_purity     = ST( "Revel in Purity" );
+  talents.discipline.pain_and_suffering  = ST( "Pain and Suffering" );
   // Row 7
   // Row 8
   talents.discipline.lights_wrath = ST( "Light's Wrath" );

--- a/engine/class_modules/priest/sc_priest_discipline.cpp
+++ b/engine/class_modules/priest/sc_priest_discipline.cpp
@@ -200,6 +200,7 @@ struct purge_the_wicked_t final : public priest_spell_t
       // 3% / 5% damage increase
       apply_affecting_aura( priest().talents.throes_of_pain );
       // 5% damage increase
+      // TODO: Implement the spreading of Purge the Wicked via penance
       apply_affecting_aura( p.talents.discipline.revel_in_purity );
       // 8% / 15% damage increase
       apply_affecting_aura( priest().talents.discipline.pain_and_suffering );

--- a/engine/class_modules/priest/sc_priest_discipline.cpp
+++ b/engine/class_modules/priest/sc_priest_discipline.cpp
@@ -198,6 +198,8 @@ struct purge_the_wicked_t final : public priest_spell_t
     {
       background = true;
       apply_affecting_aura( priest().talents.throes_of_pain );
+      // 5% damage increase
+      apply_affecting_aura( p.talents.discipline.revel_in_purity );
     }
 
     void tick( dot_t* d ) override
@@ -217,6 +219,8 @@ struct purge_the_wicked_t final : public priest_spell_t
     parse_options( options_str );
     tick_zero      = false;
     execute_action = new purge_the_wicked_dot_t( p );
+    // 5% damage increase
+    apply_affecting_aura( priest().talents.discipline.revel_in_purity );
   }
 };
 
@@ -322,6 +326,7 @@ void priest_t::init_spells_discipline()
   // Row 6
   talents.discipline.embrace_shadow      = ST( "Embrace Shadow" );
   talents.discipline.twilight_corruption = ST( "Twilight Corruption" );
+  talents.discipline.revel_in_purity     = ST( "Revel In Purity" );
   // Row 7
   // Row 8
   talents.discipline.lights_wrath = ST( "Light's Wrath" );

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -583,6 +583,8 @@ struct shadow_word_pain_t final : public priest_spell_t
       dot_duration += priest().talents.shadow.misery->effectN( 2 ).time_value();
     }
 
+    // Discipline: 8% / 15% damage increase
+    apply_affecting_aura( priest().talents.discipline.pain_and_suffering );
     // Spell Direct and Periodic 3%/5% gain
     apply_affecting_aura( priest().talents.throes_of_pain );
 


### PR DESCRIPTION
- Added the damage component of Revel in Purity (spreading of dot is a todo item)
- Added pain and suffering to both PTW and SW:P

Damage testing aligned correctly, debug shows talents being applied.