### PR TITLE
[Priest] manually adjust pet modifiers to match in-game results

### DIFF
--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -423,7 +423,13 @@ struct shadowfiend_pet_t final : public base_fiend_pet_t
       power_leech_insanity( o().find_spell( 262485 )->effectN( 1 ).resource( RESOURCE_INSANITY ) )
   {
     direct_power_mod = 0.408;  // New modifier after Spec Spell has been 0'd -- Anshlun 2020-10-06
-    npc_id           = 19668;
+
+    // Empirically tested to match 3/10/2023, actual value not available in spell data
+    if ( owner.specialization() == PRIEST_DISCIPLINE )
+    {
+      direct_power_mod = 0.445;
+    }
+    npc_id = 19668;
 
     main_hand_weapon.min_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;
     main_hand_weapon.max_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;
@@ -459,7 +465,13 @@ struct mindbender_pet_t final : public base_fiend_pet_t
       power_leech_insanity( o().find_spell( 200010 )->effectN( 1 ).resource( RESOURCE_INSANITY ) )
   {
     direct_power_mod = 0.442;  // New modifier after Spec Spell has been 0'd -- Anshlun 2020-10-06
-    npc_id           = 62982;
+
+    // Empirically tested to match 3/10/2023, actual value not available in spell data
+    if ( owner.specialization() == PRIEST_DISCIPLINE )
+    {
+      direct_power_mod = 0.326;
+    }
+    npc_id = 62982;
 
     main_hand_weapon.min_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;
     main_hand_weapon.max_dmg = owner.dbc->spell_scaling( owner.type, owner.level() ) * 2;


### PR DESCRIPTION
Mindbender and shadowfiend for discipline spec deal different damage than for shadow, but respond to the same talents as shadow. Performed some empirical testing (naked, alone) and updated values to approximate more closely.