### PR TITLE
[Affliction] Implement 10.0.7 PTR Changes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1684,6 +1684,7 @@ void warlock_t::init_spells()
   talents.soulburn = find_talent_spell( talent_tree::CLASS, "Soulburn" ); // Should be ID 385899
 
   version_10_0_5_data = find_spell( 399668 ); // For 10.0.5 version checking, new Focused Malignancy talent data
+  version_10_0_7_data = find_spell( 405955 );  // For 10.0.7 version checking, new Sargerei Technique talent data
 }
 
 void warlock_t::init_rng()
@@ -2053,6 +2054,8 @@ bool warlock_t::min_version_check( version_check_e version ) const
   {
     case VERSION_PTR:
       return is_ptr();
+    case VERSION_10_0_7:
+      return !( version_10_0_7_data == spell_data_t::not_found() );
     case VERSION_10_0_5:
       return !( version_10_0_5_data == spell_data_t::not_found() );
     case VERSION_10_0_0:

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1666,6 +1666,9 @@ void warlock_t::init_spells()
   talents.grimoire_of_synergy = find_talent_spell( talent_tree::CLASS, "Grimoire of Synergy" ); // Should be ID 171975
   talents.demonic_synergy = find_spell( 171982 );
 
+  talents.socrethars_guile   = find_talent_spell( talent_tree::CLASS, "Socrethar's Guile" ); // Should be ID 405936 //405955
+  talents.sargerei_technique = find_talent_spell( talent_tree::CLASS, "Sargerei Technique" );  // Should be ID 405955
+
   talents.soul_conduit = find_talent_spell( talent_tree::CLASS, "Soul Conduit" ); // Should be ID 215941
 
   talents.grim_feast = find_talent_spell( talent_tree::CLASS, "Grim Feast" ); // Should be ID 386689
@@ -2314,6 +2317,12 @@ void warlock_t::apply_affecting_auras( action_t& action )
   {
     action.apply_affecting_aura( warlock_base.affliction_warlock );
   }
+
+  action.apply_affecting_aura( talents.socrethars_guile );
+  action.apply_affecting_aura( talents.sargerei_technique );
+  action.apply_affecting_aura( talents.dark_virtuosity );
+  action.apply_affecting_aura( talents.kindled_malice );
+
 }
 
 struct warlock_module_t : public module_t

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -286,10 +286,24 @@ struct corruption_t : public warlock_spell_t
 
     spell_power_mod.direct = 0; // By default, Corruption does not deal instant damage
 
-    if ( p->talents.xavian_teachings->ok() && !seed_action )
+    if ( !seed_action )
     {
-      spell_power_mod.direct = data().effectN( 3 ).sp_coeff(); // Talent uses this effect in base spell for damage
-      base_execute_time *= 1.0 + p->talents.xavian_teachings->effectN( 1 ).percent();
+      if ( p->min_version_check( VERSION_10_0_7 ) )
+      {
+        if ( p->warlock_base.xavian_teachings->ok() )
+        {
+          spell_power_mod.direct = data().effectN( 3 ).sp_coeff();  // It uses this effect in base spell for damage
+          base_execute_time *= 1.0 + p->warlock_base.xavian_teachings->effectN( 1 ).percent();
+        }
+      }
+      else
+      {
+        if ( p->talents.xavian_teachings->ok() )
+        {
+          spell_power_mod.direct = data().effectN( 3 ).sp_coeff();  // Talent uses this effect in base spell for damage
+          base_execute_time *= 1.0 + p->talents.xavian_teachings->effectN( 1 ).percent();
+        }
+      }
     }
   }
 
@@ -1621,6 +1635,7 @@ void warlock_t::init_spells()
   // Affliction
   warlock_base.agony = find_class_spell( "Agony" ); // Should be ID 980
   warlock_base.agony_2 = find_spell( 231792 ); // Rank 2, +4 to max stacks
+  warlock_base.xavian_teachings   = find_specialization_spell( "Xavian Teachings", WARLOCK_AFFLICTION ); // Instant cast corruption and direct damage. Direct damage is in the base corruption spell on effect 3. Should be ID 317031.
   warlock_base.potent_afflictions = find_mastery_spell( WARLOCK_AFFLICTION ); // Should be ID 77215
   warlock_base.affliction_warlock = find_specialization_spell( "Affliction Warlock", WARLOCK_AFFLICTION ); // Should be ID 137043
 

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -124,6 +124,7 @@ public:
     // Affliction
     const spell_data_t* agony;
     const spell_data_t* agony_2; // Rank 2 still a separate spell (learned automatically). Grants increased max stacks
+    const spell_data_t* xavian_teachings;  // Seperate Spell (Learned automatically). Instant cast data in this spell, talent points to base Corruption spell (172) for the direct damage
     const spell_data_t* potent_afflictions; // Affliction Mastery - Increased DoT and Malefic Rapture damage
     const spell_data_t* affliction_warlock; // Spec aura
 

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -13,6 +13,7 @@ struct warlock_t;
 enum version_check_e
 {
   VERSION_PTR,
+  VERSION_10_0_7,
   VERSION_10_0_5,
   VERSION_10_0_0,
   VERSION_ANY
@@ -638,6 +639,7 @@ public:
   std::string default_pet;
   shuffled_rng_t* rain_of_chaos_rng;
   const spell_data_t* version_10_0_5_data;
+  const spell_data_t* version_10_0_7_data;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );
 

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -190,6 +190,8 @@ public:
     player_talent_t wrathful_minion; // Pet damage buff on Soul Shard fill
     player_talent_t grimoire_of_synergy; // Note: Does not trigger when using Grimoire of Sacrifice
     const spell_data_t* demonic_synergy; // Buff from Grimoire of Synergy
+    player_talent_t socrethars_guile;
+    player_talent_t sargerei_technique;
     player_talent_t soul_conduit;
     player_talent_t grim_feast; // Faster Drain Life
     player_talent_t summon_soulkeeper; // Active ground AoE which spends hidden stacking buff. NOT A PET
@@ -229,6 +231,8 @@ public:
     player_talent_t shadow_embrace;
     const spell_data_t* shadow_embrace_debuff; // Default values set from talent data, but contains debuff info
     player_talent_t harvester_of_souls;
+    player_talent_t dark_virtuosity;
+    player_talent_t kindled_malice;
     const spell_data_t* harvester_of_souls_dmg; // Talent only controls proc, damage is in separate spell
     player_talent_t writhe_in_agony;
     player_talent_t agonizing_corruption; // Only applies to targets which already have Agony

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -890,6 +890,10 @@ void warlock_t::init_spells_affliction()
   talents.shadow_embrace = find_talent_spell( talent_tree::SPECIALIZATION, "Shadow Embrace" ); // Should be ID 32388
   talents.shadow_embrace_debuff = find_spell( 32390 );
 
+  talents.dark_virtuosity = find_talent_spell( talent_tree::SPECIALIZATION, "Dark Virtuosity" ); // Should be ID 405327
+
+  talents.kindled_malice = find_talent_spell( talent_tree::SPECIALIZATION, "Kindled Malice" );  // Should be ID 405330
+
   talents.harvester_of_souls = find_talent_spell( talent_tree::SPECIALIZATION, "Harvester of Souls" ); // Should be ID 201424
   talents.harvester_of_souls_dmg = find_spell( 218615 ); // Damage and projectile data
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2220,15 +2220,22 @@ struct eye_beam_t : public warlock_pet_spell_t
     grim_reach = new grim_reach_t( p );
   }
 
-  double action_multiplier() const override
+  double composite_target_multiplier( player_t* target ) const
   {
-    double m = warlock_pet_spell_t::action_multiplier();
+    double m = warlock_pet_spell_t::composite_target_multiplier( target );
 
     double dots = 0.0;
 
-    for ( player_t* target : sim->target_non_sleeping_list )
+    if ( p()->o()->min_version_check( VERSION_10_0_7 ) )
     {
       dots += p()->o()->get_target_data( target )->count_affliction_dots();
+    }
+    else
+    {
+      for ( player_t* t : sim->target_non_sleeping_list )
+      {
+        dots += p()->o()->get_target_data( t )->count_affliction_dots();
+      }
     }
 
     double dot_multiplier = p()->o()->talents.summon_darkglare->effectN( 3 ).percent();


### PR DESCRIPTION
Add a 10.0.7 Version check to be used for Summon Darkglare's Altered Functionality
Using apply_affecting_aura for the new talents, they're well built talents using correct modifiers with whitelists.
This will automatically apply the two class ones for Demonology and Destruction as well, in the case where the spells contain no data apply affecting automatically returns immediately and should cause no issues.