### PR TITLE
Implement a strawman version of Ret Aura

### DIFF
--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -446,6 +446,8 @@ struct player_t : public actor_t
     buff_t* berserking;
     buff_t* bloodlust;
     buff_t* windfury_totem;
+    buff_t* retribution_aura;
+    buff_t* retribution_aura_proc;
 
     buff_t* cooldown_reduction;
     buff_t* amplification;

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -214,6 +214,7 @@ struct sim_t : private sc_thread_t
     int mark_of_the_wild;
     int power_word_fortitude;
     int windfury_totem;
+    int retribution_aura;
 
     // Debuff overrides
     int chaos_brand;
@@ -225,6 +226,7 @@ struct sim_t : private sc_thread_t
     int    bloodlust;
     std::vector<uint64_t> target_health;
   } overrides;
+  double retribution_aura_proc_per_tick;
 
   struct auras_t
   {
@@ -232,6 +234,7 @@ struct sim_t : private sc_thread_t
     buff_t* battle_shout;
     buff_t* mark_of_the_wild;
     buff_t* power_word_fortitude;
+    buff_t* retribution_aura;
   } auras;
 
   // Expansion specific custom parameters. Defaults in the constructor.
@@ -597,7 +600,7 @@ struct sim_t : private sc_thread_t
   std::vector<sim_t*> children; // Manual delete!
   int thread_index;
   computer_process::priority_e process_priority;
-  
+
   std::shared_ptr<work_queue_t> work_queue;
 
   // Related Simulations


### PR DESCRIPTION
This is more or less the thing lightly mentioned in Discord, though I haven't touched the core global buffs before so figure it's worth getting feedback.

The approach here is that every player will, once a second, roll for whether ret aura procced that second or not - and we can customize the roll probability. 15% was completely arbitrarily chosen; we could pick a real estimated value to approximate what logs estimate the uptime to be - or we could just not have this proc at all by default, since (unlike the personal Retribution Aura from 10.0.0) it seems unlikely that it will meaningfully affect character optimization choices and may be less misleading than assuming a high uptime.

What do y'all think? Do we bother with this?