### PR TITLE
[Vengeance] rename Spirit Bomb healing to Frailty

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -186,8 +186,8 @@ public:
   auto_dispose<std::vector<soul_fragment_t*>> soul_fragments;
   event_t* soul_fragment_pick_up;
 
-  double spirit_bomb_accumulator;  // Spirit Bomb healing accumulator
-  event_t* spirit_bomb_driver;
+  double frailty_accumulator;  // Frailty healing accumulator
+  event_t* frailty_driver;
 
   double ragefire_accumulator;
   unsigned ragefire_crit_accumulator;
@@ -685,7 +685,7 @@ public:
 
     // Vengeance
     spell_t* infernal_armor = nullptr;
-    heal_t* spirit_bomb_heal = nullptr;
+    heal_t* frailty_heal    = nullptr;
   } active;
 
   // Pets
@@ -1709,7 +1709,7 @@ public:
       return;
 
     const double multiplier = target_data->debuffs.frailty->stack_value();
-    p()->spirit_bomb_accumulator += s->result_amount * multiplier;
+    p()->frailty_accumulator += s->result_amount * multiplier;
   }
 
   void accumulate_ragefire( action_state_t* s )
@@ -2019,12 +2019,12 @@ struct soul_cleave_heal_t : public demon_hunter_heal_t
   }
 };
 
-// Spirit Bomb ==============================================================
+// Frailty ==============================================================
 
-struct spirit_bomb_heal_t : public demon_hunter_heal_t
+struct frailty_heal_t : public demon_hunter_heal_t
 {
-  spirit_bomb_heal_t( demon_hunter_t* p )
-    : demon_hunter_heal_t( "spirit_bomb_heal", p, p->find_spell( 227255 ) )
+  frailty_heal_t( demon_hunter_t* p )
+    : demon_hunter_heal_t( "frailty_heal", p, p->find_spell( 227255 ) )
   {
     background = true;
     may_crit   = false;
@@ -2678,6 +2678,10 @@ struct sigil_of_flame_t : public demon_hunter_spell_t
       energize_amount = p->spell.sigil_of_flame_fury->effectN( 1 ).resource();
     }
 
+    if ( !p->active.frailty_heal )
+    {
+      p->active.frailty_heal = new heals::frailty_heal_t( p );
+    }
     // Add damage modifiers in sigil_of_flame_damage_t, not here.
   }
 
@@ -3382,9 +3386,9 @@ struct spirit_bomb_t : public demon_hunter_spell_t
     damage = p->get_background_action<spirit_bomb_damage_t>( "spirit_bomb_damage" );
     damage->stats = stats;
 
-    if (!p->active.spirit_bomb_heal)
+    if ( !p->active.frailty_heal )
     {
-      p->active.spirit_bomb_heal = new heals::spirit_bomb_heal_t(p);
+      p->active.frailty_heal = new heals::frailty_heal_t( p );
     }
   }
 
@@ -4904,6 +4908,10 @@ struct soul_cleave_t : public demon_hunter_attack_t
       heal = p->get_background_action<heals::soul_cleave_heal_t>( "soul_cleave_heal" );
     }
 
+    if ( p->talent.vengeance.void_reaver->ok() && !p->active.frailty_heal )
+    {
+      p->active.frailty_heal = new heals::frailty_heal_t( p );
+    }
     // Add damage modifiers in soul_cleave_damage_t, not here.
   }
 
@@ -5354,13 +5362,13 @@ struct demon_spikes_t : public demon_hunter_buff_t<buff_t>
 // Misc. Events and Structs
 // ==========================================================================
 
-// Spirit Bomb event ========================================================
+// Frailty event ========================================================
 
-struct spirit_bomb_event_t : public event_t
+struct frailty_event_t : public event_t
 {
   demon_hunter_t* dh;
 
-  spirit_bomb_event_t( demon_hunter_t* p, bool initial = false )
+  frailty_event_t( demon_hunter_t* p, bool initial = false )
     : event_t( *p), dh( p )
   {
     timespan_t delta_time = timespan_t::from_seconds( 1.0 );
@@ -5373,23 +5381,23 @@ struct spirit_bomb_event_t : public event_t
 
   const char* name() const override
   {
-    return "spirit_bomb_driver";
+    return "frailty_driver";
   }
 
   void execute() override
   {
-    assert( dh ->spirit_bomb_accumulator >= 0.0 );
+    assert( dh ->frailty_accumulator >= 0.0 );
 
-    if ( dh->spirit_bomb_accumulator > 0 )
+    if ( dh->frailty_accumulator > 0 )
     {
-      action_t* a = dh->active.spirit_bomb_heal;
-      a->base_dd_min = a->base_dd_max = dh->spirit_bomb_accumulator;
+      action_t* a = dh->active.frailty_heal;
+      a->base_dd_min = a->base_dd_max = dh->frailty_accumulator;
       a->execute();
 
-      dh->spirit_bomb_accumulator = 0.0;
+      dh->frailty_accumulator = 0.0;
     }
 
-    dh->spirit_bomb_driver = make_event<spirit_bomb_event_t>( sim(), dh );
+    dh->frailty_driver = make_event<frailty_event_t>( sim(), dh );
   }
 };
 
@@ -5476,8 +5484,8 @@ demon_hunter_t::demon_hunter_t(sim_t* sim, util::string_view name, race_e r)
   melee_off_hand( nullptr ),
   next_fragment_spawn( 0 ),
   soul_fragments(),
-  spirit_bomb_accumulator( 0.0 ),
-  spirit_bomb_driver( nullptr ),
+    frailty_accumulator( 0.0 ),
+    frailty_driver( nullptr ),
   ragefire_accumulator( 0.0 ),
   ragefire_crit_accumulator( 0 ),
   shattered_destiny_accumulator( 0.0 ),
@@ -7061,7 +7069,7 @@ void demon_hunter_t::combat_begin()
   // Start event drivers
   if ( talent.vengeance.spirit_bomb->ok() )
   {
-    spirit_bomb_driver = make_event<spirit_bomb_event_t>( *sim, this, true );
+    frailty_driver = make_event<frailty_event_t>( *sim, this, true );
   }
 }
 
@@ -7197,11 +7205,11 @@ void demon_hunter_t::reset()
   base_t::reset();
 
   soul_fragment_pick_up         = nullptr;
-  spirit_bomb_driver            = nullptr;
+  frailty_driver                = nullptr;
   exit_melee_event              = nullptr;
   next_fragment_spawn           = 0;
   metamorphosis_health          = 0;
-  spirit_bomb_accumulator       = 0.0;
+  frailty_accumulator           = 0.0;
   ragefire_accumulator          = 0.0;
   ragefire_crit_accumulator     = 0;
   shattered_destiny_accumulator = 0.0;


### PR DESCRIPTION
Spirit Bomb isn't the only possible source of Frailty healing; sims could crash if given a custom APL that did not include Spirit Bomb but included Sigil of Flame or Soul Cleave (with Void Reaver).

This just renames the previous references to Spirit Bomb to Frailty and also ensures that SoF and SCleave will create the heal instance as appropriate.

@EvanMichaels 