### PR TITLE
[Havoc] Expose T30 fury tracking to the APL

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5957,16 +5957,15 @@ std::unique_ptr<expr_t> demon_hunter_t::create_expression( util::string_view nam
   }
   else if ( util::str_compare_ci( name_str, "seething_fury_deficit" ) )
   {
-    return make_fn_expr( "seething_fury_deficit", [ this ] {
-      if ( this->set_bonuses.t30_havoc_2pc->ok() )
-      {
+    if ( this->set_bonuses.t30_havoc_2pc->ok() )
+    {
+      return make_fn_expr( "seething_fury_deficit", [ this ] {
         return this->set_bonuses.t30_havoc_2pc->effectN( 1 ).base_value() - this->set_bonuses.t30_havoc_2pc_fury_tracker;
-      }
-      else
-      {
-        return 0.0;
-      }
-    } );
+      } );
+    } 
+    else {
+      return expr_t::create_constant( "seething_fury_deficit", 0.0 );
+    }
   }
 
   return player_t::create_expression( name_str );

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5952,8 +5952,8 @@ std::unique_ptr<expr_t> demon_hunter_t::create_expression( util::string_view nam
   } 
   else if ( util::str_compare_ci( name_str, "seething_fury_spent" ) )
   {
-    return make_fn_expr( "seething_fury_spent",
-                         [ this ] { return this->set_bonuses.t30_havoc_2pc_fury_tracker; } );
+    return make_mem_fn_expr( "seething_fury_spent", this->set_bonuses,
+                             &demon_hunter_t::set_bonuses_t::t30_havoc_2pc_fury_tracker );
   }
   else if ( util::str_compare_ci( name_str, "seething_fury_deficit" ) )
   {

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5958,7 +5958,14 @@ std::unique_ptr<expr_t> demon_hunter_t::create_expression( util::string_view nam
   else if ( util::str_compare_ci( name_str, "seething_fury_deficit" ) )
   {
     return make_fn_expr( "seething_fury_deficit", [ this ] {
-      return this->set_bonuses.t30_havoc_2pc->effectN( 1 ).base_value() - this->set_bonuses.t30_havoc_2pc_fury_tracker;
+      if ( this->set_bonuses.t30_havoc_2pc->ok() )
+      {
+        return this->set_bonuses.t30_havoc_2pc->effectN( 1 ).base_value() - this->set_bonuses.t30_havoc_2pc_fury_tracker;
+      }
+      else
+      {
+        return 0.0;
+      }
     } );
   }
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5945,6 +5945,22 @@ std::unique_ptr<expr_t> demon_hunter_t::create_expression( util::string_view nam
       return this->get_target_data(*primary_idx)->dots.fiery_brand->is_ticking();
     });
   }
+  else if ( util::str_compare_ci( name_str, "seething_fury_threshold" ) )
+  {
+    return expr_t::create_constant( "seething_fury_threshold",
+                                    this->set_bonuses.t30_havoc_2pc->effectN( 1 ).base_value() );
+  } 
+  else if ( util::str_compare_ci( name_str, "seething_fury_spent" ) )
+  {
+    return make_fn_expr( "seething_fury_spent",
+                         [ this ] { return this->set_bonuses.t30_havoc_2pc_fury_tracker; } );
+  }
+  else if ( util::str_compare_ci( name_str, "seething_fury_deficit" ) )
+  {
+    return make_fn_expr( "seething_fury_deficit", [ this ] {
+      return this->set_bonuses.t30_havoc_2pc->effectN( 1 ).base_value() - this->set_bonuses.t30_havoc_2pc_fury_tracker;
+    } );
+  }
 
   return player_t::create_expression( name_str );
 }


### PR DESCRIPTION
For the T30 2pc, exposes the following values to the APL:
- The total amount of fury required to be spent to proc Seething Fury (`seething_fury_threshold`)
- The current fury spent towards proccing Seething Fury (`seething_fury_spent`)
- The remaining fury until proccing Seething Fury (`seething_fury_deficit`)