### PR TITLE
[Priest] refactor Ancient Madness for upcoming PTR changes

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -202,7 +202,7 @@ public:
       {
         priest().generate_insanity(
             priest().sets->set( PRIEST_SHADOW, T30, B2 )->effectN( 2 ).resource( RESOURCE_INSANITY ),
-                                    priest().gains.insanity_t30_2pc, s->action );
+            priest().gains.insanity_t30_2pc, s->action );
       }
 
       priest().buffs.coalescing_shadows->expire();
@@ -1753,7 +1753,7 @@ double priest_t::composite_spell_crit_chance() const
 {
   double sc = player_t::composite_spell_crit_chance();
 
-  if ( talents.shadow.ancient_madness.enabled() )
+  if ( talents.shadow.ancient_madness.enabled() && !is_ptr() )
   {
     if ( buffs.ancient_madness->check() )
     {

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -776,7 +776,7 @@ public:
   {
     // using S = const spell_data_t*;
 
-    parse_buff_effects( p().buffs.voidform );
+    parse_buff_effects( p().buffs.voidform, 0x4U, false, false );  // Skip E3 for AM
     parse_buff_effects( p().buffs.shadowform );
     parse_buff_effects( p().buffs.twist_of_fate, p().talents.twist_of_fate );
     parse_buff_effects( p().buffs.mind_devourer );
@@ -788,13 +788,26 @@ public:
                           p().talents.shadow.mind_melt );  // Mind Blast instant cast and Crit increase
 
       parse_buff_effects( p().buffs.deathspeaker );
+
+      if ( p().talents.shadow.ancient_madness.enabled() )
+      {
+        // We use DA or VF spelldata to construct Ancient Madness to use the correct spell pass-list
+        if ( p().talents.shadow.dark_ascension.enabled() )
+        {
+          parse_buff_effects( p().buffs.ancient_madness, 0b0001U, true, true );  // Skip E1
+        }
+        else
+        {
+          parse_buff_effects( p().buffs.ancient_madness, 0b0011U, true, true );  // Skip E1 and E2
+        }
+      }
     }
     else
     {
       parse_buff_effects( p().buffs.mind_melt );  // Mind Blast instant cast and Crit increase
     }
     // TODO: check why we cant use_default=true to get the value correct
-    parse_buff_effects( p().buffs.dark_ascension );  // Buffs corresponding non-periodic spells
+    parse_buff_effects( p().buffs.dark_ascension, 0b1000U, false, false );  // Buffs non-periodic spells - Skip E4
     parse_buff_effects( p().buffs.coalescing_shadows );
     parse_buff_effects( p().buffs.coalescing_shadows_dot );
     parse_buff_effects( p().buffs.words_of_the_pious );  // Spell Direct amount for Smite and Holy Nova

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -244,11 +244,27 @@ struct priest_pet_spell_t : public spell_t, public parse_buff_effects_t<priest_t
   {
     // using S = const spell_data_t*;
 
-    parse_buff_effects( p().o().buffs.voidform );
+    parse_buff_effects( p().o().buffs.voidform, 0x4U, false, false );  // Skip E3 for AM
     parse_buff_effects( p().o().buffs.shadowform );
     parse_buff_effects( p().o().buffs.twist_of_fate, p().o().talents.twist_of_fate );
     parse_buff_effects( p().o().buffs.devoured_pride );
-    parse_buff_effects( p().o().buffs.dark_ascension, true );  // Buffs corresponding non-periodic spells
+    parse_buff_effects( p().o().buffs.dark_ascension, 0b1000U, false, false );  // Buffs non-periodic spells - Skip E4
+
+    if ( p().o().is_ptr() )
+    {
+      if ( p().o().talents.shadow.ancient_madness.enabled() )
+      {
+        // We use DA or VF spelldata to construct Ancient Madness to use the correct spell pass-list
+        if ( p().o().talents.shadow.dark_ascension.enabled() )
+        {
+          parse_buff_effects( p().o().buffs.ancient_madness, 0b0001U, true, true );  // Skip E1
+        }
+        else
+        {
+          parse_buff_effects( p().o().buffs.ancient_madness, 0b0011U, true, true );  // Skip E1 and E2
+        }
+      }
+    }
   }
 
   priest_pet_t& p()
@@ -738,7 +754,7 @@ struct void_tendril_mind_flay_t final : public priest_pet_spell_t
 
     // BUG: This talent is cursed
     // https://github.com/SimCMinMax/WoW-BugTracker/issues/1029
-    if ( p.o().bugs && !p.o().is_ptr())
+    if ( p.o().bugs && !p.o().is_ptr() )
     {
       if ( p.o().level() == 70 )
       {
@@ -1051,14 +1067,13 @@ spawner::pet_spawner_t<pet_t, priest_t>* get_current_main_pet( priest_t& priest 
 
 namespace priestspace
 {
-
 void priest_t::trigger_inescapable_torment( player_t* target )
 {
   if ( !talents.shadow.inescapable_torment.enabled() )
     return;
 
   auto current_pets = get_current_main_pet( *this );
-  
+
   if ( is_ptr() )
   {
     auto extend = talents.shadow.inescapable_torment->effectN( 2 ).time_value();

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -2394,7 +2394,7 @@ struct ancient_madness_t final : public priest_buff_t<buff_t>
 
     if ( p.talents.shadow.void_eruption.enabled() )
     {
-      set_period( p.specs.voidform->effectN( 4 ).period() );
+      set_period( p.specs.voidform->effectN( p.is_ptr() ? 4 : 5 ).period() );
       set_duration( p.specs.voidform->duration() );
     }
 

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -2406,11 +2406,11 @@ struct ancient_madness_t final : public priest_buff_t<buff_t>
 
     if ( p.is_ptr() )
     {
-      set_default_value( data().effectN( 2 ).percent() / 10 );
+      set_default_value( priest().talents.shadow.ancient_madness->effectN( 2 ).percent() / 10 );
     }
     else
     {
-      set_default_value( data().effectN( 2 ).percent() );
+      set_default_value( priest().talents.shadow.ancient_madness->effectN( 2 ).percent() );
     }
   }
 };

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1434,7 +1434,6 @@ struct devouring_plague_t final : public priest_spell_t
     {
       priest().buffs.weakening_reality->trigger();
     }
-
   }
 
   timespan_t calculate_dot_refresh_duration( const dot_t* d, timespan_t duration ) const override
@@ -2379,22 +2378,40 @@ struct shadowy_insight_t final : public priest_buff_t<buff_t>
 // ==========================================================================
 struct ancient_madness_t final : public priest_buff_t<buff_t>
 {
-  ancient_madness_t( priest_t& p ) : base_t( p, "ancient_madness", p.talents.shadow.ancient_madness )
+  ancient_madness_t( priest_t& p, const spell_data_t* s ) : base_t( p, "ancient_madness", s )
   {
     if ( !data().ok() )
       return;
 
+    // Since we are using data from VF/DA make sure the name in the report does not confuse people
+    s_data_reporting = p.talents.shadow.ancient_madness.spell();
+
+    if ( p.talents.shadow.dark_ascension.enabled() )
+    {
+      set_period( p.talents.shadow.dark_ascension->effectN( 3 ).period() );
+      set_duration( p.talents.shadow.dark_ascension->duration() );
+    }
+
+    if ( p.talents.shadow.void_eruption.enabled() )
+    {
+      set_period( p.specs.voidform->effectN( 4 ).period() );
+      set_duration( p.specs.voidform->duration() );
+    }
+
     add_invalidate( CACHE_CRIT_CHANCE );
     add_invalidate( CACHE_SPELL_CRIT_CHANCE );
     set_reverse( true );
-    set_period( timespan_t::from_seconds( 1 ) );
-    set_duration( p.specs.voidform->duration() );  // Uses the same duration as Voidform for tooltip
+    set_max_stack( 20 );
+    cooldown->duration = 0_s;
 
     if ( p.is_ptr() )
-      set_default_value( data().effectN( 2 ).percent() / 10 );  // 0.5%/1%
+    {
+      set_default_value( data().effectN( 2 ).percent() / 10 );
+    }
     else
-      set_default_value( data().effectN( 2 ).percent() );  // 0.5%/1%
-    set_max_stack( 20 );                                   // 20/20;
+    {
+      set_default_value( data().effectN( 2 ).percent() );
+    }
   }
 };
 
@@ -2477,7 +2494,15 @@ void priest_t::create_buffs_shadow()
   buffs.dispersion       = make_buff<buffs::dispersion_t>( *this );
 
   // Talents
-  buffs.ancient_madness        = make_buff<buffs::ancient_madness_t>( *this );
+  if ( talents.shadow.dark_ascension.enabled() )
+  {
+    buffs.ancient_madness = make_buff<buffs::ancient_madness_t>( *this, talents.shadow.dark_ascension );
+  }
+  else
+  {
+    buffs.ancient_madness = make_buff<buffs::ancient_madness_t>( *this, specs.voidform );
+  }
+
   buffs.death_and_madness_buff = make_buff<buffs::death_and_madness_buff_t>( *this );
   buffs.unfurling_darkness =
       make_buff( this, "unfurling_darkness", talents.shadow.unfurling_darkness->effectN( 1 ).trigger() );
@@ -2536,7 +2561,6 @@ void priest_t::create_buffs_shadow()
   if ( !is_ptr() )
     buffs.devoured_pride->set_duration( 0_ms );
 
-
   buffs.devoured_despair = make_buff<buffs::devoured_despair_buff_t>( *this );
 
   buffs.mind_melt = make_buff( this, "mind_melt", talents.shadow.mind_melt->effectN( is_ptr() ? 2 : 1 ).trigger() )
@@ -2592,8 +2616,7 @@ void priest_t::create_buffs_shadow()
           } );
 
   if ( weakening_reality->ok() )
-    buffs.weakening_reality->set_expire_at_max_stack( true ); // Avoid sim warning
-
+    buffs.weakening_reality->set_expire_at_max_stack( true );  // Avoid sim warning
 }
 
 void priest_t::init_rng_shadow()


### PR DESCRIPTION
another attempt at refactoring AM for the upcoming passlist changes on PTR, this time using a different buff but inheriting spelldata

local:
![image](https://user-images.githubusercontent.com/10604059/227424532-09c6fc8d-3cb0-43ae-9490-a97248b8a84f.png)

[raidbots pre-change](https://www.raidbots.com/simbot/report/nPr9QV7RNNouKxCzQrJnvm):
![image](https://user-images.githubusercontent.com/10604059/227424580-a7cbf296-88d4-4d17-9497-4ae722b5b9b2.png)

