### PR TITLE
Allow Class Modules to define DungeonSlice

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -14473,3 +14473,19 @@ bool player_t::is_ptr() const
 {
   return maybe_ptr(dbc->ptr);
 }
+
+void player_t::init_dungeon_fight_style( sim_t *sim )
+{
+  // Based on the Hero Dungeon setup
+  sim->desired_targets = 1;
+  sim->max_time = timespan_t::from_seconds( 360.0 );
+
+  sim->shadowlands_opts.enable_rune_words = false;
+  sim->ignore_invulnerable_targets = true;
+
+  sim->raid_events_str +=
+    "/invulnerable,cooldown=500,duration=500,retarget=1"
+    "/adds,name=Boss,count=1,cooldown=500,duration=135,type=add_boss,duration_stddev=1"
+    "/adds,name=SmallAdd,count=5,count_range=1,first=140,cooldown=45,duration=15,duration_stddev=2"
+    "/adds,name=BigAdd,count=2,count_range=1,first=160,cooldown=50,duration=30,duration_stddev=2";
+}

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -937,6 +937,7 @@ public:
   virtual void create_buffs();
   virtual void create_special_effects();
   virtual void init_special_effects();
+  virtual void init_dungeon_fight_style( sim_t *sim );
   /// Modify generic special effect initialization
   ///
   /// Intended to allow modifications to some aspects of the special effect (or buffs,

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2261,18 +2261,7 @@ void sim_t::init_fight_style()
     break;
     
     case FIGHT_STYLE_DUNGEON_SLICE:
-      //Based on the Hero Dungeon setup
-      desired_targets = 1;
-      max_time = timespan_t::from_seconds( 360.0 );
-
-      shadowlands_opts.enable_rune_words = false;
-      ignore_invulnerable_targets = true;
-
-      raid_events_str +=
-        "/invulnerable,cooldown=500,duration=500,retarget=1"
-        "/adds,name=Boss,count=1,cooldown=500,duration=135,type=add_boss,duration_stddev=1"
-        "/adds,name=SmallAdd,count=5,count_range=1,first=140,cooldown=45,duration=15,duration_stddev=2"
-        "/adds,name=BigAdd,count=2,count_range=1,first=160,cooldown=50,duration=30,duration_stddev=2";
+        active_player->init_dungeon_fight_style( this );
       break;
     
     case FIGHT_STYLE_DUNGEON_ROUTE:


### PR DESCRIPTION
It's still pretty scattered on which specs "support" DungeonSlice and DungeonRoute sims and the accuracy varies per module. The best fight style for dungeons is typically determined by the spec community.