### PR TITLE
Feature/dre proc change

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8758,6 +8758,7 @@ void shaman_t::copy_from( player_t* source )
   shaman_t* p  = debug_cast<shaman_t*>( source );
   raptor_glyph = p->raptor_glyph;
   options.rotation = p->options.rotation;
+  options.dre_post_change = p->options.dre_post_change;
 }
 
 // shaman_t::create_special_effects ========================================

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9565,7 +9565,8 @@ void shaman_t::trigger_deeply_rooted_elements( const action_state_t* state )
   }
 
   if ( is_ptr() && options.dre_post_change ) {
-    proc_chance = buff.deeply_rooted_elements_bad_luck->stack_value();
+    // proc curve is pushed down by 2%
+    proc_chance = buff.deeply_rooted_elements_bad_luck->stack_value() - 0.02;
   }
 
   if ( !rng().roll( proc_chance ) )

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9565,16 +9565,13 @@ void shaman_t::trigger_deeply_rooted_elements( const action_state_t* state )
   }
 
   if ( is_ptr() && options.dre_post_change ) {
+    buff.deeply_rooted_elements_bad_luck->increment();
     // proc curve is pushed down by 2%
     proc_chance = buff.deeply_rooted_elements_bad_luck->stack_value() - 0.02;
   }
 
   if ( !rng().roll( proc_chance ) )
   {
-    if ( is_ptr() && options.dre_post_change ) {
-      buff.deeply_rooted_elements_bad_luck->increment();
-    }
-
     return;
   }
 


### PR DESCRIPTION
Deeply Rooted Elements procs differently now.

Based on [this log](https://www.warcraftlogs.com/reports/wD6XTY8Ap3GMa1BL#fight=last&type=damage-done&source=3) it looks like the proc chance increments by 1% each time it tries to proc. While the first two attempts are missed. Which means the attempts have a chance like:
- 0%
- 0%
- 1%
- 2%
- 3%
- ...

The implementation simply substracts 2% and let's the buff stack 1%for each stack of the artificial buff.