### PR TITLE
[Core] Change Pet Spawners to return References

### DIFF
--- a/engine/player/pet_spawner.hpp
+++ b/engine/player/pet_spawner.hpp
@@ -185,11 +185,11 @@ public:
   // Access
 
   /// All pets
-  std::vector<T*> pets();
+  std::vector<T*>& pets();
   /// All pets (read only)
-  std::vector<const T*> pets() const;
+  std::vector<const T*>& pets() const;
   /// All currently active pets
-  std::vector<T*> active_pets();
+  std::vector<T*>& active_pets();
   /// Access the zero-indexth created pet, nullptr if no pets are created
   T* pet( size_t index = 0 ) const;
   /// Access the zero-indexth active pet, nullptr if no pet of index active

--- a/engine/player/pet_spawner_impl.hpp
+++ b/engine/player/pet_spawner_impl.hpp
@@ -423,23 +423,23 @@ std::vector<T*> pet_spawner_t<T, O>::spawn( timespan_t duration, unsigned n )
 // Access
 
 template <typename T, typename O>
-std::vector<T*> pet_spawner_t<T, O>::active_pets()
+std::vector<T*>& pet_spawner_t<T, O>::active_pets()
 {
   update_state();
 
-  return { m_active_pets };
+  return m_active_pets;
 }
 
 template <typename T, typename O>
-std::vector<T*> pet_spawner_t<T, O>::pets()
+std::vector<T*>& pet_spawner_t<T, O>::pets()
 {
-  return { m_pets };
+  return m_pets;
 }
 
 template <typename T, typename O>
-std::vector<const T*> pet_spawner_t<T, O>::pets() const
+std::vector<const T*>& pet_spawner_t<T, O>::pets() const
 {
-  return { m_pets };
+  return m_pets;
 }
 
 template <typename T, typename O>


### PR DESCRIPTION
Pet Spawners currently create copies of the active pet lists (at least with VStudio's Compiler) when asking for ->pets() or ->active_pets()

This was causing pretty high CPU usage inside of priest due to constantly having to allocate new vectors.

Priest code still works fine after the change, not sure who else uses Pet Spawners, and those who do use active_pet.
A Brief look shows: Priests (ours works), Hunters (?), Shamans (Enhance), Warlock (Demonlogy) hence tagging you all to make sure nothing broke.

Also raid_events use it for spawning pets.
DungeonRoute Sims still worked what appears to be correct.

I don't see hunter/shaman code having any issues with how it works, however demonology likely breaks. 

Demonology would be usable as is if you use a copy, however it's possible to adapt the code there to not need a copy.

Should be pretty noticeable performance gains for anyone that regularly calls it, I don't expect any issues.

Alternatively, this can be left as is, returning copies, preferably with annotations indicating as such so people don't make mistakes, with a suggestion to use the iterator.
Then places incorrectly using the copy can be swapped to the iterator to save time (Which does not return a copy).