### PR TITLE
[Priest] properly handle Echoing Void demise

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -29,6 +29,7 @@ struct psychic_link_t;
 struct pain_of_death_t;
 struct shadow_weaving_t;
 struct echoing_void_t;
+struct echoing_void_demise_t;
 struct idol_of_cthun_t;
 struct shadow_word_pain_t;
 struct mental_fortitude_t;
@@ -562,6 +563,7 @@ public:
     propagate_const<actions::spells::shadow_weaving_t*> shadow_weaving;
     propagate_const<actions::spells::shadowy_apparition_spell_t*> shadowy_apparitions;
     propagate_const<actions::spells::echoing_void_t*> echoing_void;
+    propagate_const<actions::spells::echoing_void_demise_t*> echoing_void_demise;
     propagate_const<actions::spells::idol_of_cthun_t*> idol_of_cthun;
     propagate_const<actions::spells::shadow_word_pain_t*> shadow_word_pain;
     propagate_const<actions::spells::mental_fortitude_t*> mental_fortitude;
@@ -1012,7 +1014,7 @@ struct priest_spell_t : public priest_action_t<spell_t>
     : base_t( name, player, s ), affected_by_shadow_weaving( false ), ignores_automatic_mastery( false )
   {
     weapon_multiplier = 0.0;
-    
+
     track_cd_waste = data().cooldown() > 0_ms || data().charge_cooldown() > 0_ms;
   }
 


### PR DESCRIPTION
When a target dies with Echoing Void stacks it should trigger a single event that hits every target EXCEPT the one that dies based on how many stacks it detonated. Currently the implementation will be oversimming slightly (0.1% dps) as it does not correctly remove the original target from the target list.

This adds a new action to handle demise triggers only that adjusts the multiplier depending on how many stacks it detonated with and removes the "main" target. We still call the action on the main target so that we get proper positioning data.

This PR should also dramatically reduce the number of events firing, what could have been 10 events per target that dies at a given time should now be 1 event per target hit after a death. This was likely causing the [sim to get stuck if you had too many targets die at a similar time](https://www.raidbots.com/simbot/report/3ePqKNoX7TgbX2TodGKCho).