### PR TITLE
[Priest] Track when expiation has nothing to consume

### DIFF
--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -529,6 +529,7 @@ public:
     propagate_const<proc_t*> shadowy_apparition_ms;
     propagate_const<proc_t*> power_of_the_dark_side;
     propagate_const<proc_t*> power_of_the_dark_side_overflow;
+    propagate_const<proc_t*> expiation_lost_no_dot;
     propagate_const<proc_t*> mind_devourer;
     propagate_const<proc_t*> void_tendril;
     propagate_const<proc_t*> void_lasher;


### PR DESCRIPTION
Adds better tracking for when expiation tries to consume a dot, but there is no dot to consume. Does not change DPS at all, just tracking an additional proc.