### PR TITLE
[Paladin] Added support for Executioner's Will talent in Retribution Paladin APL

### DIFF
--- a/engine/class_modules/apl/apl_paladin.cpp
+++ b/engine/class_modules/apl/apl_paladin.cpp
@@ -44,7 +44,7 @@ void retribution( player_t* p )
   cooldowns->add_action( "shield_of_vengeance,if=fight_remains>15" );
   cooldowns->add_action( "avenging_wrath,if=holy_power>=4&time<5|holy_power>=3&time>5|holy_power>=2&talent.divine_auxiliary&(cooldown.execution.remains=0|cooldown.final_reckoning.remains=0)" );
   cooldowns->add_action( "crusade,if=holy_power>=5&time<5|holy_power>=3&time>5" );
-  cooldowns->add_action( "execution_sentence,if=(!buff.crusade.up&cooldown.crusade.remains>10|buff.crusade.stack=10|cooldown.avenging_wrath.remains>10)&(holy_power>=3|holy_power>=2&talent.divine_auxiliary)&target.time_to_die>8" );
+  cooldowns->add_action( "execution_sentence,if=(!buff.crusade.up&cooldown.crusade.remains>10|buff.crusade.stack=10|cooldown.avenging_wrath.remains>10)&(holy_power>=3|holy_power>=2&talent.divine_auxiliary)&(target.time_to_die>8|target.time_to_die>12&talent.executioners_will)" );
   cooldowns->add_action( "final_reckoning,if=(holy_power>=4&time<8|holy_power>=3&time>=8|holy_power>=2&talent.divine_auxiliary)&(cooldown.avenging_wrath.remains>gcd|cooldown.crusade.remains&(!buff.crusade.up|buff.crusade.stack>=10))&(time_to_hpg>0|holy_power=5|holy_power>=2&talent.divine_auxiliary)&(!raid_event.adds.exists|raid_event.adds.up|raid_event.adds.in>40)" );
 
   finishers->add_action( "variable,name=ds_castable,value=spell_targets.divine_storm>=2|buff.empyrean_power.up" );

--- a/engine/class_modules/apl/retribution_apl.inc
+++ b/engine/class_modules/apl/retribution_apl.inc
@@ -30,7 +30,7 @@ actions.cooldowns+=/use_item,slot=trinket2,if=!variable.trinket_2_buffs&(!variab
 actions.cooldowns+=/shield_of_vengeance,if=fight_remains>15
 actions.cooldowns+=/avenging_wrath,if=holy_power>=4&time<5|holy_power>=3&time>5|holy_power>=2&talent.divine_auxiliary&(cooldown.execution.remains=0|cooldown.final_reckoning.remains=0)
 actions.cooldowns+=/crusade,if=holy_power>=5&time<5|holy_power>=3&time>5
-actions.cooldowns+=/execution_sentence,if=(!buff.crusade.up&cooldown.crusade.remains>10|buff.crusade.stack=10|cooldown.avenging_wrath.remains>10)&(holy_power>=3|holy_power>=2&talent.divine_auxiliary)&target.time_to_die>8
+actions.cooldowns+=/execution_sentence,if=(!buff.crusade.up&cooldown.crusade.remains>10|buff.crusade.stack=10|cooldown.avenging_wrath.remains>10)&(holy_power>=3|holy_power>=2&talent.divine_auxiliary)&(target.time_to_die>8|target.time_to_die>12&talent.executioners_will)
 actions.cooldowns+=/final_reckoning,if=(holy_power>=4&time<8|holy_power>=3&time>=8|holy_power>=2&talent.divine_auxiliary)&(cooldown.avenging_wrath.remains>gcd|cooldown.crusade.remains&(!buff.crusade.up|buff.crusade.stack>=10))&(time_to_hpg>0|holy_power=5|holy_power>=2&talent.divine_auxiliary)&(!raid_event.adds.exists|raid_event.adds.up|raid_event.adds.in>40)
 
 actions.finishers=variable,name=ds_castable,value=spell_targets.divine_storm>=2|buff.empyrean_power.up


### PR DESCRIPTION
Executioner's Will is a talent extending the duration of Execution Sentence from 8s to 12s.
Just added a check for it in the APL so that sims don't try to cast a 12s Execution Sentence _(which might do 0 damage if the target dies too fast)_ when `target.time_to_die` is between **8s** and **12s**.
The impact should be very minimal (the current APL has around `(4s x 2 casts per minute) / 60s` = 13.3% chance to cast an ES that won't do any damage at the end of a single-target fight; a bit more on fight styles with adds)