### PR TITLE
[gear]Change Flowstone behavior to model random pull state

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -10073,7 +10073,7 @@ void shaman_t::create_buffs()
         }
         if ( t30_proc_possible && !buff.stormkeeper->up() )
         {
-          buff.stormkeeper->trigger( 2 );
+          buff.stormkeeper->trigger( 1 );
           t30_proc_possible = false;
         }
       } );


### PR DESCRIPTION
@Saeldur has been recommended by github so just requesting review from them.

Having the start state always be consistent and always with a readily available buff makes this trinket sim even higher than it would realistically perform as.
I made it so it should better model pulling at a random time, while keeping the old fixed states behind the expansion option.