### PR TITLE
[Havoc] Update Chaos Theory and Serrated Glaive

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4218,6 +4218,7 @@ struct chaos_strike_base_t : public demon_hunter_attack_t
     void execute() override
     {
       demon_hunter_attack_t::execute();
+      
       if ( may_refund )
       {
         // Technically this appears to have a 0.5s ICD, but this is handled elsewhere

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4217,6 +4217,7 @@ struct chaos_strike_base_t : public demon_hunter_attack_t
 
     void execute() override
     {
+      demon_hunter_attack_t::execute();
       if ( may_refund )
       {
         // Technically this appears to have a 0.5s ICD, but this is handled elsewhere
@@ -4225,15 +4226,12 @@ struct chaos_strike_base_t : public demon_hunter_attack_t
         {
           p()->resource_gain( RESOURCE_FURY, p()->spec.chaos_strike_fury->effectN( 1 ).resource( RESOURCE_FURY ), parent->gain );
         }
-
-        // 2023-01-07 -- Logs show the refund and Chaos Theory buff fade happens before damage is dealt
+                
         if ( p()->talent.havoc.chaos_theory->ok() )
         {
           p()->buff.chaos_theory->expire();
         }
       }
-
-      demon_hunter_attack_t::execute();
     }
 
     void impact( action_state_t* s ) override

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5595,6 +5595,7 @@ demon_hunter_td_t::demon_hunter_td_t( player_t* target, demon_hunter_t& p )
   dots.the_hunt = target->get_dot( "the_hunt_dot", &p );
 
   debuffs.serrated_glaive = make_buff( *this, "serrated_glaive", p.spec.serrated_glaive_debuff )
+    ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC )
     ->set_default_value( p.talent.havoc.serrated_glaive->effectN( 1 ).percent() );
 
   target->register_on_demise_callback( &p, [this]( player_t* ) { target_demise(); } );


### PR DESCRIPTION
The following changes have been announced on 4/28 (https://us.forums.blizzard.com/en/wow/t/class-tuning-incoming-with-embers-of-neltharion-patch/1577047/1):
* Serrated glaive now pandemics
* Chaos theory now correctly affects both hits of Chaos Strike/Annihilation