### PR TITLE
[Havoc] Account for Sigil of Flame damage bug

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2731,7 +2731,7 @@ struct sigil_of_flame_damage_t : public demon_hunter_sigil_t
 
   double action_ta_multiplier() const override
   {
-    double am = demon_hunter_spell_t::action_multiplier();
+    double am = demon_hunter_sigil_t::action_ta_multiplier();
 
     // 2023-05-01 -- Sigil of Flame's DoT currently deals twice the intended damage.
     //               There are currently two Apply Aura: Periodic Damage effects in the spell data

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2729,6 +2729,18 @@ struct sigil_of_flame_damage_t : public demon_hunter_sigil_t
     }
   }
 
+  double action_ta_multiplier() const override
+  {
+    double am = demon_hunter_spell_t::action_multiplier();
+
+    // 2023-05-01 -- Sigil of Flame's DoT currently deals twice the intended damage.
+    //               There are currently two Apply Aura: Periodic Damage effects in the spell data
+    //               (Effects #2 and #3) which could potentially be the reason for this.
+    am *= 2.0;
+
+    return am;
+  }
+
   void impact( action_state_t* s ) override
   {
     // Sigil of Flame can apply Frailty if Frailty is talented

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2736,7 +2736,8 @@ struct sigil_of_flame_damage_t : public demon_hunter_sigil_t
     // 2023-05-01 -- Sigil of Flame's DoT currently deals twice the intended damage.
     //               There are currently two Apply Aura: Periodic Damage effects in the spell data
     //               (Effects #2 and #3) which could potentially be the reason for this.
-    am *= 2.0;
+    if ( p()->bugs )
+      am *= 2.0;
 
     return am;
   }


### PR DESCRIPTION
Sigil of Flame's DoT currently deals twice the intended damage (confirmed to be the case on 10.1 PTR build 49365). 

I fix this with an `action_ta_multiplier` of `2.0`.