### PR TITLE
[Mage] Clip AM channel

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -159,6 +159,7 @@ void arcane( player_t* p )
   touch_phase->add_action( "arcane_barrage,if=(buff.arcane_harmony.up|(talent.arcane_bombardment&target.health.pct<35))&debuff.touch_of_the_magi.remains<=gcd.max" );
   touch_phase->add_action( "arcane_missiles,if=buff.clearcasting.stack>1&talent.conjure_mana_gem&cooldown.use_mana_gem.ready,chain=1" );
   touch_phase->add_action( "arcane_blast,if=buff.nether_precision.up" );
+  touch_phase->add_action( "cancel_action,if=debuff.touch_of_the_magi.up&action.arcane_missiles.channeling&gcd.remains=0&(buff.arcane_surge.up|talent.conjure_mana_gem|set_bonus.tier30_4pc)&mana.pct>30" );
   touch_phase->add_action( "arcane_missiles,if=buff.clearcasting.react&(debuff.touch_of_the_magi.remains>execute_time|!talent.presence_of_mind),chain=1" );
   touch_phase->add_action( "arcane_blast" );
   touch_phase->add_action( "arcane_barrage" );


### PR DESCRIPTION
Clip missiles with Arcane Blast during touch windows where you will have mana regen to not oom from doing so from 4pct30, mana gem, or surge buff. 30% mana seemed to be the best cutoff for this action.