### PR TITLE
Split damage multipliers into list vs school based

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -2536,7 +2536,7 @@ void action_t::init()
   if ( may_crit || tick_may_crit )
     snapshot_flags |= STATE_CRIT | STATE_TGT_CRIT;
 
-  if ( ( base_td > 0 || spell_power_mod.tick > 0 || attack_power_mod.tick > 0 ) && dot_duration > timespan_t::zero() )
+  if ( ( base_td > 0 || spell_power_mod.tick > 0 || attack_power_mod.tick > 0 ) && dot_duration > 0_ms )
     snapshot_flags |= STATE_MUL_TA | STATE_TGT_MUL_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
 
   if ( base_dd_min > 0 || ( spell_power_mod.direct > 0 || attack_power_mod.direct > 0 ) || weapon_multiplier > 0 )
@@ -2554,7 +2554,7 @@ void action_t::init()
   if ( data().flags( spell_attribute::SX_DISABLE_PLAYER_MULT ) ||
        data().flags( spell_attribute::SX_DISABLE_PLAYER_HEALING_MULT ) )
   {
-    snapshot_flags &= ~( STATE_VERSATILITY );
+    snapshot_flags &= ~( STATE_VERSATILITY | STATE_MUL_PLAYER_DAM );
   }
 
   if ( data().flags( spell_attribute::SX_DISABLE_TARGET_MULT ) )
@@ -4000,11 +4000,14 @@ void action_t::snapshot_internal( action_state_t* state, unsigned flags, result_
   if ( flags & STATE_VERSATILITY )
     state->versatility = composite_versatility( state );
 
-  if ( flags & STATE_MUL_DA )
-    state->da_multiplier = composite_da_multiplier( state );
+  if ( flags & STATE_MUL_SPELL_DA )
+   state->da_multiplier = composite_da_multiplier( state );
 
-  if ( flags & STATE_MUL_TA )
-    state->ta_multiplier = composite_ta_multiplier( state );
+  if ( flags & STATE_MUL_SPELL_TA )
+   state->ta_multiplier = composite_ta_multiplier( state );
+
+  if ( flags & STATE_MUL_PLAYER_DAM )
+    state->player_multiplier = composite_player_multiplier( state );
 
   if ( flags & STATE_MUL_PERSISTENT )
     state->persistent_multiplier = composite_persistent_multiplier( state );
@@ -4517,40 +4520,29 @@ double action_t::composite_total_corruption() const
   return player->composite_total_corruption();
 }
 
-double action_t::composite_da_multiplier(const action_state_t*) const
+double action_t::composite_player_multiplier( const action_state_t* ) const
 {
-  double base_multiplier = action_multiplier();
-  double direct_multiplier = action_da_multiplier();
   double player_school_multiplier = 0.0;
   double tmp;
 
-  for (auto base_school : base_schools)
+  for ( auto base_school : base_schools )
   {
-    tmp = player->cache.player_multiplier(base_school);
-    if (tmp > player_school_multiplier) player_school_multiplier = tmp;
+    tmp = player->cache.player_multiplier( base_school );
+    if ( tmp > player_school_multiplier )
+      player_school_multiplier = tmp;
   }
 
-  return base_multiplier * direct_multiplier * player_school_multiplier *
-    player->composite_player_dd_multiplier(get_school(), this);
+  return player_school_multiplier;
 }
 
-/// Normal ticking modifiers that are updated every tick
-
-double action_t::composite_ta_multiplier(const action_state_t*) const
+double action_t::composite_da_multiplier( const action_state_t* ) const
 {
-  double base_multiplier = action_multiplier();
-  double tick_multiplier = action_ta_multiplier();
-  double player_school_multiplier = 0.0;
-  double tmp;
+  return action_multiplier() * action_da_multiplier();
+}
 
-  for (auto base_school : base_schools)
-  {
-    tmp = player->cache.player_multiplier(base_school);
-    if (tmp > player_school_multiplier) player_school_multiplier = tmp;
-  }
-
-  return base_multiplier * tick_multiplier * player_school_multiplier *
-    player->composite_player_td_multiplier(get_school(), this);
+double action_t::composite_ta_multiplier( const action_state_t* ) const
+{
+  return action_multiplier() * action_ta_multiplier();
 }
 
 /// Persistent modifiers that are snapshot at the start of the spell cast

--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -878,13 +878,17 @@ public:
   virtual double composite_target_ta_multiplier( player_t* target ) const
   { return composite_target_multiplier( target ); }
 
-  virtual double composite_da_multiplier(const action_state_t* /* s */) const;
+  /// School-based generic damage multipliers that affect all player damage
+  virtual double composite_player_multiplier( const action_state_t* ) const;
 
-  /// Normal ticking modifiers that are updated every tick
-  virtual double composite_ta_multiplier(const action_state_t* /* s */) const;
+  /// List-based direct damage multipliers that specifically affect the action
+  virtual double composite_da_multiplier( const action_state_t* ) const;
+
+  /// List-based tick damage multipliers that specifically affect the action
+  virtual double composite_ta_multiplier( const action_state_t* ) const;
 
   /// Persistent modifiers that are snapshot at the start of the spell cast
-  virtual double composite_persistent_multiplier(const action_state_t*) const;
+  virtual double composite_persistent_multiplier( const action_state_t* ) const;
 
   /**
    * @brief Generic aoe multiplier for the action.
@@ -895,9 +899,9 @@ public:
   virtual double composite_aoe_multiplier( const action_state_t* ) const
   { return 1.0; }
 
-  virtual double composite_target_mitigation(player_t* t, school_e s) const;
+  virtual double composite_target_mitigation( player_t* t, school_e s ) const;
 
-  virtual double composite_player_critical_multiplier(const action_state_t* s) const;
+  virtual double composite_player_critical_multiplier( const action_state_t* s ) const;
 
   /// Action proc type, needed for dynamic aoe stuff and such.
   virtual proc_types proc_type() const

--- a/engine/action/action_state.cpp
+++ b/engine/action/action_state.cpp
@@ -102,6 +102,7 @@ void action_state_t::copy_state( const action_state_t* o )
   versatility           = o->versatility;
   da_multiplier         = o->da_multiplier;
   ta_multiplier         = o->ta_multiplier;
+  player_multiplier     = o->player_multiplier;
   persistent_multiplier = o->persistent_multiplier;
   pet_multiplier        = o->pet_multiplier;
 
@@ -141,6 +142,7 @@ action_state_t::action_state_t( action_t* a, player_t* t )
     versatility( 1.0 ),
     da_multiplier( 1.0 ),
     ta_multiplier( 1.0 ),
+    player_multiplier( 1.0 ),
     persistent_multiplier( 1.0 ),
     pet_multiplier( 1.0 ),
     target_da_multiplier( 1.0 ),
@@ -216,6 +218,7 @@ std::ostringstream& action_state_t::debug_str( std::ostringstream& s )
   s << " versatility=" << versatility;
   s << " da_mul=" << da_multiplier;
   s << " ta_mul=" << ta_multiplier;
+  s << " ply_mul=" << player_multiplier;
   s << " per_mul=" << persistent_multiplier;
   if ( action->player->is_pet() )
   {

--- a/engine/action/action_state.hpp
+++ b/engine/action/action_state.hpp
@@ -50,6 +50,7 @@ struct action_state_t : private noncopyable
   double          versatility;
   double          da_multiplier;
   double          ta_multiplier;
+  double          player_multiplier;
   double          persistent_multiplier;
   double          pet_multiplier; // Owner -> pet multiplier
   double          target_da_multiplier;
@@ -85,10 +86,16 @@ struct action_state_t : private noncopyable
   { return versatility; }
 
   virtual double composite_da_multiplier() const
-  { return da_multiplier * persistent_multiplier * target_da_multiplier * versatility * pet_multiplier * target_pet_multiplier; }
+  {
+    return da_multiplier * player_multiplier * persistent_multiplier * target_da_multiplier * versatility *
+           pet_multiplier * target_pet_multiplier;
+  }
 
   virtual double composite_ta_multiplier() const
-  { return ta_multiplier * persistent_multiplier * target_ta_multiplier * versatility * pet_multiplier * target_pet_multiplier; }
+  {
+    return ta_multiplier * player_multiplier * persistent_multiplier * target_ta_multiplier * versatility *
+           pet_multiplier * target_pet_multiplier;
+  }
 
   virtual double composite_target_mitigation_da_multiplier() const
   { return target_mitigation_da_multiplier; }

--- a/engine/class_modules/apl/apl_death_knight.cpp
+++ b/engine/class_modules/apl/apl_death_knight.cpp
@@ -27,7 +27,7 @@ std::string potion( const player_t* p )
 
 std::string flask( const player_t* p )
 {
-  std::string flask_name = ( p->true_level >= 61 ) ? "iced_phial_of_corrupting_rage_3" : "spectral_flask_of_power";
+  std::string flask_name = ( p->true_level >= 61 ) ? "phial_of_tepid_versatility_3" : "spectral_flask_of_power";
 
   // All specs use a strength flask as default
   return flask_name;

--- a/engine/class_modules/apl/apl_priest.cpp
+++ b/engine/class_modules/apl/apl_priest.cpp
@@ -50,7 +50,7 @@ void shadow( player_t* p )
   action_priority_list_t* filler = p->get_action_priority_list( "filler" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask", "otion=elemental_potion_of_ultimate_power_ lask=iced_phial_of_corrupting_rage_ ood=fated_fortune_cooki ugmentation=draconic_augment_run emporary_enchant=main_hand:howling_rune_" );
+  precombat->add_action( "flask" );
   precombat->add_action( "food" );
   precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );

--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -268,9 +268,9 @@ void destruction( player_t* p )
   default_->add_action( "conflagrate,if=(talent.roaring_blaze&debuff.conflagrate.remains<1.5)|charges=max_charges" );
   default_->add_action( "dimensional_rift,if=soul_shard<4.7&(charges>2|time_to_die<cooldown.dimensional_rift.duration)" );
   default_->add_action( "cataclysm,if=raid_event.adds.in>15" );
-  default_->add_action( "channel_demonfire,if=talent.raging_demonfire" );
+  default_->add_action( "channel_demonfire,if=talent.raging_demonfire&(dot.immolate.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))>cast_time&(debuff.conflagrate.remains>execute_time|!talent.roaring_blaze)" );
   default_->add_action( "soul_fire,if=soul_shard<=3.5&(debuff.conflagrate.remains>cast_time+travel_time|!talent.roaring_blaze&buff.backdraft.up)" );
-  default_->add_action( "immolate,if=((dot.immolate.refreshable&talent.internal_combustion)|dot.immolate.remains<3)&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>dot.immolate.remains)&target.time_to_die>8" );
+  default_->add_action( "immolate,if=(((dot.immolate.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.immolate.duration*0.3)|dot.immolate.remains<3|(dot.immolate.remains-action.chaos_bolt.execute_time)<5&talent.infernal_combustion&action.chaos_bolt.usable)&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.immolate.remains-5*talent.internal_combustion))&target.time_to_die>8" );
   default_->add_action( "havoc,if=talent.cry_havoc&((buff.ritual_of_ruin.up&pet.infernal.active&talent.burn_to_ashes)|((buff.ritual_of_ruin.up|pet.infernal.active)&!talent.burn_to_ashes))" );
   default_->add_action( "channel_demonfire,if=dot.immolate.remains>cast_time&set_bonus.tier30_4pc" );
   default_->add_action( "chaos_bolt,if=pet.infernal.active|pet.blasphemy.active|soul_shard>=4" );

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -668,12 +668,20 @@ namespace monk
       double composite_ta_multiplier( const action_state_t *s ) const override
       {
         double ta = ab::composite_ta_multiplier( s ) * get_buff_effects_value( ta_multiplier_buffeffects );
+
+        if ( ab::data().affected_by( p()->passives.hit_combo->effectN( 2 ) ) )
+          da *= 1.0 + p()->buff.hit_combo->check() * p()->passives.hit_combo->effectN( 2 ).percent();
+
         return ta;
       }
 
       double composite_da_multiplier( const action_state_t *s ) const override
       {
         double da = ab::composite_da_multiplier( s ) * get_buff_effects_value( da_multiplier_buffeffects );
+
+        if ( ab::data().affected_by( p()->passives.hit_combo->effectN( 1 ) ) )
+          da *= 1.0 + p()->buff.hit_combo->check() * p()->passives.hit_combo->effectN( 1 ).percent();
+
         return da;
       }
 
@@ -8984,26 +8992,10 @@ namespace monk
     return active;
   }
 
-  // monk_t::composite_player_dd_multiplier ================================
-  double monk_t::composite_player_dd_multiplier( school_e school, const action_t *action ) const
+  // monk_t::composite_player_multiplier ==================================
+  double monk_t::composite_player_multiplier( school_e school ) const
   {
-    double multiplier = player_t::composite_player_dd_multiplier( school, action );
-
-    if ( action->data().affected_by( passives.hit_combo->effectN( 1 ) ) )
-      multiplier *= 1 + buff.hit_combo->check() * passives.hit_combo->effectN( 1 ).percent();
-
-    multiplier *= 1 + talent.general.ferocity_of_xuen->effectN( 1 ).percent();
-
-    return multiplier;
-  }
-
-  // monk_t::composite_player_td_multiplier ================================
-  double monk_t::composite_player_td_multiplier( school_e school, const action_t *action ) const
-  {
-    double multiplier = player_t::composite_player_td_multiplier( school, action );
-
-    if ( action->data().affected_by( passives.hit_combo->effectN( 2 ) ) )
-      multiplier *= 1 + buff.hit_combo->check() * passives.hit_combo->effectN( 2 ).percent();
+    double multiplier = player_t::composite_player_multiplier( school );
 
     multiplier *= 1 + talent.general.ferocity_of_xuen->effectN( 1 ).percent();
 

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -1002,8 +1002,7 @@ public:
   double composite_damage_versatility() const override;
   double composite_crit_avoidance() const override;
   double temporary_movement_modifier() const override;
-  double composite_player_dd_multiplier( school_e, const action_t* action ) const override;
-  double composite_player_td_multiplier( school_e, const action_t* action ) const override;
+  double composite_player_multiplier( school_e ) const override;
   double composite_player_target_multiplier( player_t* target, school_e school ) const override;
   double composite_player_pet_damage_multiplier( const action_state_t*, bool guardian ) const override;
   double composite_player_target_pet_damage_multiplier( player_t* target, bool guardian ) const override;

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -4857,11 +4857,6 @@ double player_t::composite_player_multiplier( school_e school ) const
   return m;
 }
 
-double player_t::composite_player_td_multiplier( school_e /* school */, const action_t* /* a */ ) const
-{
-  return 1.0;
-}
-
 double player_t::composite_player_target_multiplier( player_t* target, school_e /* school */ ) const
 {
   double m = 1.0;

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -1059,17 +1059,17 @@ public:
   virtual double composite_crit_avoidance() const;
   virtual double composite_attack_power_multiplier() const;
   virtual double composite_spell_power_multiplier() const;
-  virtual double matching_gear_multiplier( attribute_e /* attr */ ) const
-  { return 0; }
-  virtual double composite_player_multiplier   ( school_e ) const;
-  virtual double composite_player_dd_multiplier( school_e,  const action_t* /* a */ = nullptr ) const { return 1; }
-  virtual double composite_player_td_multiplier( school_e,  const action_t* a = nullptr ) const;
+  virtual double matching_gear_multiplier( attribute_e /* attr */ ) const { return 0; }
+  virtual double composite_player_multiplier( school_e ) const;
+  /// These are here for future-proofing in case school based player multipliers are ever specified for direct vs
+  /// periodic. Currently they should be unused and are not cached.
+  virtual double composite_player_dd_multiplier( school_e, const action_t* a = nullptr ) const { return 1.0; }
+  virtual double composite_player_td_multiplier( school_e, const action_t* a = nullptr ) const { return 1.0; }
   /// Persistent multipliers that are snapshot at the beginning of the spell application/execution
-  virtual double composite_persistent_multiplier( school_e ) const
-  { return 1.0; }
+  virtual double composite_persistent_multiplier( school_e ) const { return 1.0; }
   virtual double composite_player_target_multiplier( player_t* target, school_e school ) const;
   virtual double composite_player_heal_multiplier( const action_state_t* s ) const;
-  virtual double composite_player_dh_multiplier( school_e ) const { return 1; }
+  virtual double composite_player_dh_multiplier( school_e ) const { return 1.0; }
   virtual double composite_player_th_multiplier( school_e ) const;
   virtual double composite_player_absorb_multiplier( const action_state_t* s ) const;
   virtual double composite_player_pet_damage_multiplier( const action_state_t*, bool guardian ) const;

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -4529,6 +4529,27 @@ void heart_of_thunder ( special_effect_t& e )
   new dbc_proc_callback_t( e.player, e );
 }
 
+// 407895 driver
+// 407896 damage
+void drogbar_rocks( special_effect_t& effect ) {
+  effect.proc_flags2_ = PF2_CRIT;
+  
+  auto proc = create_proc_action<generic_proc_t>( "drogbar_rocks", effect, "drogbar_rocks", effect.trigger() );
+  effect.execute_action = proc;
+  new dbc_proc_callback_t( effect.player, effect );
+}
+
+// 408607 driver
+// 408984 spawned moth
+// 408983 primary stat buff
+void underlight_globe( special_effect_t& effect )
+{
+  effect.custom_buff = create_buff<stat_buff_t>( effect.player, effect.player -> find_spell( 408983 ) )
+    ->add_stat_from_effect( 1, effect.driver() -> effectN(1).average( effect.item ) );
+
+  new dbc_proc_callback_t( effect.player, effect );
+}
+
 // Weapons
 void bronzed_grip_wrappings( special_effect_t& effect )
 {
@@ -6659,6 +6680,8 @@ void register_special_effects()
   register_special_effect( 395175, items::treemouths_festering_splinter );
   register_special_effect( 401395, items::vessel_of_searing_shadow );
   register_special_effect( 413419, items::heart_of_thunder );
+  register_special_effect( 407895, items::drogbar_rocks );
+  register_special_effect( 408607, items::underlight_globe );
 
   // Weapons
   register_special_effect( 396442, items::bronzed_grip_wrappings );             // bronzed grip wrappings embellishment

--- a/engine/sc_enums.hpp
+++ b/engine/sc_enums.hpp
@@ -1324,14 +1324,19 @@ enum snapshot_state_e
   STATE_AP             = 0x000004,
   STATE_SP             = 0x000008,
 
-  STATE_MUL_DA         = 0x000010,
-  STATE_MUL_TA         = 0x000020,
+  STATE_MUL_SPELL_DA   = 0x000010,  // Add Percent Modifier (108): Spell Direct Amount (0) list-based multiplier
+  STATE_MUL_SPELL_TA   = 0x000020,  // Add Percent Modifier (108): Spell Periodic Amount (22) list-based multiplier
   STATE_VERSATILITY    = 0x000040,
   STATE_MUL_PERSISTENT = 0x000080,  // Persistent modifier for the few abilities that snapshot
 
   STATE_TGT_CRIT       = 0x000100,
   STATE_TGT_MUL_DA     = 0x000200,
   STATE_TGT_MUL_TA     = 0x000400,
+
+  STATE_MUL_PLAYER_DAM = 0x000800,  // Modify Damage Done% (79) school-based player-wide multiplier
+
+  STATE_MUL_DA         = STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM,
+  STATE_MUL_TA         = STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM,
 
   // User-defined state flags
   STATE_USER_1         = 0x001000,

--- a/profiles/PreRaids/PR_Death_Knight_Frost.simc
+++ b/profiles/PreRaids/PR_Death_Knight_Frost.simc
@@ -9,7 +9,7 @@ talents=BsPAAAAAAAAAAAAAAAAAAAAAAkIAkIJJkISEhIJhQiIRECIhkIJJJJJplAAAAAAAAAAAAA
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic
 temporary_enchant=main_hand:buzzing_rune_3/off_hand:buzzing_rune_3

--- a/profiles/PreRaids/PR_Death_Knight_Unholy.simc
+++ b/profiles/PreRaids/PR_Death_Knight_Unholy.simc
@@ -9,7 +9,7 @@ talents=BwPAAAAAAAAAAAAAAAAAAAAAAAAIIJRSLSAJJRIkkkEBAAAAAAAAAKJJhIAAgkESLRSSikA
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic
 temporary_enchant=main_hand:howling_rune_3

--- a/profiles/PreRaids/PR_Priest_Shadow.simc
+++ b/profiles/PreRaids/PR_Priest_Shadow.simc
@@ -21,7 +21,6 @@ temporary_enchant=main_hand:howling_rune_3
 # SimulationCraft is always looking for updates and improvements to the default action lists.
 
 # Executed before combat begins. Accepts non-harmful actions only.
-# otion=elemental_potion_of_ultimate_power_ lask=iced_phial_of_corrupting_rage_ ood=fated_fortune_cooki ugmentation=draconic_augment_run emporary_enchant=main_hand:howling_rune_
 actions.precombat=flask
 actions.precombat+=/food
 actions.precombat+=/augmentation
@@ -52,12 +51,10 @@ actions.aoe+=/void_bolt
 # Use Devouring Plague to maximize uptime. Short circuit if you are capping on Insanity within 20 or to get out an extra Void Bolt by extending Voidform. With Distorted Reality can maintain more than one at a time in multi-target.
 actions.aoe+=/devouring_plague,target_if=refreshable|!talent.distorted_reality,if=refreshable&!variable.pool_for_cds|insanity.deficit<=20|buff.voidform.up&cooldown.void_bolt.remains>buff.voidform.remains&cooldown.void_bolt.remains<(buff.voidform.remains+2)
 actions.aoe+=/vampiric_touch,target_if=refreshable&target.time_to_die>=18&(dot.vampiric_touch.ticking|!variable.vts_applied),if=variable.max_vts>0&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains|variable.holding_crash)&!action.shadow_crash.in_flight|!talent.whispering_shadows
-# High priority Shadow Word: Death action during execute, while Mindbender is active with Inescapable Torment, or Deathspeaker is active
-actions.aoe+=/shadow_word_death,target_if=target.health.pct<20&(cooldown.fiend.remains>=10|!talent.inescapable_torment)|pet.fiend.active>1&talent.inescapable_torment|buff.deathspeaker.up
 # High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
 actions.aoe+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
-actions.aoe+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&(!pet.fiend.active)&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
+actions.aoe+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # # Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption
 actions.aoe+=/mind_blast,if=variable.vts_applied&(!buff.mind_devourer.up|cooldown.void_eruption.up&talent.void_eruption)
 # Void Torrent action list for AoE
@@ -96,11 +93,12 @@ actions.cds+=/desperate_prayer,if=health.pct<=75
 
 # Cast Vampiric Touch to consume Unfurling Darkness, prefering the target with the lowest DoT duration active
 actions.filler=vampiric_touch,target_if=min:remains,if=buff.unfurling_darkness.up
+actions.filler+=/shadow_word_death,target_if=target.health.pct<20|buff.deathspeaker.up
 actions.filler+=/mind_spike_insanity
 actions.filler+=/mind_flay,if=buff.mind_flay_insanity.up
 # Save up to 20s if adds are coming soon.
 actions.filler+=/halo,if=raid_event.adds.in>20
-actions.filler+=/shadow_word_death,target_if=min:target.time_to_die,if=target.health.pct<20&active_enemies<4|talent.inescapable_torment&pet.fiend.active
+actions.filler+=/shadow_word_death,target_if=min:target.time_to_die,if=talent.inescapable_torment&pet.fiend.active
 # Save up to 10s if adds are coming soon.
 actions.filler+=/divine_star,if=raid_event.adds.in>10
 actions.filler+=/devouring_plague,if=buff.voidform.up&variable.dots_up
@@ -130,12 +128,10 @@ actions.main+=/devouring_plague,target_if=refreshable|!talent.distorted_reality,
 actions.main+=/shadow_crash,if=!variable.holding_crash&dot.vampiric_touch.refreshable
 # Put out Vampiric Touch on enemies that will live at least 12s and Shadow Crash is not available soon
 actions.main+=/vampiric_touch,target_if=min:remains,if=refreshable&target.time_to_die>=12&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains&!action.shadow_crash.in_flight|variable.holding_crash|!talent.whispering_shadows)
-# High priority Shadow Word: Death action during execute, while Mindbender is active with Inescapable Torment, or Deathspeaker is active
-actions.main+=/shadow_word_death,target_if=target.health.pct<20&(cooldown.fiend.remains>=10|!talent.inescapable_torment)|pet.fiend.active>1&talent.inescapable_torment|buff.deathspeaker.up
-# High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
+# High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
 actions.main+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
-# High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
-actions.main+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&(!pet.fiend.active)&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
+# High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
+actions.main+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption
 actions.main+=/mind_blast,if=variable.dots_up&(!buff.mind_devourer.up|cooldown.void_eruption.up&talent.void_eruption)
 # Void Torrent if you are not holding Shadow Crash for an add pack coming, prefer the target with the most DoTs active. Only cast if Devouring Plague is on that target and will last at least 2 seconds
@@ -154,7 +150,7 @@ actions.pl_torrent+=/vampiric_touch,if=remains<=6&cooldown.void_torrent.remains<
 actions.pl_torrent+=/devouring_plague,if=remains<=4&cooldown.void_torrent.remains<gcd*2
 actions.pl_torrent+=/mind_blast,if=!talent.mindgames|cooldown.mindgames.remains>=3&!prev_gcd.1.mind_blast
 actions.pl_torrent+=/void_torrent,if=dot.vampiric_touch.ticking&dot.shadow_word_pain.ticking|buff.voidform.up
-actions.pl_torrent+=/mindgames,target_if=variable.all_dots_up|buff.voidform.up
+actions.pl_torrent+=/mindgames,if=dot.vampiric_touch.ticking&dot.shadow_word_pain.ticking&dot.devouring_plague.ticking|buff.voidform.up
 
 actions.trinkets=use_item,name=voidmenders_shadowgem,if=buff.power_infusion.up|fight_remains<20
 actions.trinkets+=/use_item,name=darkmoon_deck_box_inferno

--- a/profiles/T30_Raid.simc
+++ b/profiles/T30_Raid.simc
@@ -23,7 +23,7 @@ T30_Hunter_Survival.simc
 
 # T30_Mage_Fire.simc
 # T30_Mage_Frost.simc
-# T30_Mage_Arcane.simc
+T30_Mage_Arcane.simc
 
 # T30_Monk_Brewmaster.simc
 T30_Monk_Windwalker.simc
@@ -42,10 +42,10 @@ T30_Shaman_Elemental.simc
 T30_Shaman_Enhancement.simc
 T30_Shaman_Enhancement_Storm.simc
 
-# T30_Warlock_Affliction.simc
-# T30_Warlock_Demonology.simc
-# T30_Warlock_Destruction.simc
+T30_Warlock_Affliction.simc
+T30_Warlock_Demonology.simc
+T30_Warlock_Destruction.simc
 
-# T30_Warrior_Arms.simc
-# T30_Warrior_Fury.simc
+T30_Warrior_Arms.simc
+T30_Warrior_Fury.simc
 # T30_Warrior_Protection.simc

--- a/profiles/Tier29/T29_Priest_Shadow.simc
+++ b/profiles/Tier29/T29_Priest_Shadow.simc
@@ -9,7 +9,7 @@ talents=BIQAAAAAAAAAAAAAAAAAAAAAAgkQSAAAAAAAAAAAAACp4ARSSLIJJRkIINSSSkGBJIki0CJB
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic_augment_rune
 temporary_enchant=main_hand:howling_rune_3
@@ -21,7 +21,6 @@ temporary_enchant=main_hand:howling_rune_3
 # SimulationCraft is always looking for updates and improvements to the default action lists.
 
 # Executed before combat begins. Accepts non-harmful actions only.
-# otion=elemental_potion_of_ultimate_power_ lask=iced_phial_of_corrupting_rage_ ood=fated_fortune_cooki ugmentation=draconic_augment_run emporary_enchant=main_hand:howling_rune_
 actions.precombat=flask
 actions.precombat+=/food
 actions.precombat+=/augmentation
@@ -52,12 +51,10 @@ actions.aoe+=/void_bolt
 # Use Devouring Plague to maximize uptime. Short circuit if you are capping on Insanity within 20 or to get out an extra Void Bolt by extending Voidform. With Distorted Reality can maintain more than one at a time in multi-target.
 actions.aoe+=/devouring_plague,target_if=refreshable|!talent.distorted_reality,if=refreshable&!variable.pool_for_cds|insanity.deficit<=20|buff.voidform.up&cooldown.void_bolt.remains>buff.voidform.remains&cooldown.void_bolt.remains<(buff.voidform.remains+2)
 actions.aoe+=/vampiric_touch,target_if=refreshable&target.time_to_die>=18&(dot.vampiric_touch.ticking|!variable.vts_applied),if=variable.max_vts>0&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains|variable.holding_crash)&!action.shadow_crash.in_flight|!talent.whispering_shadows
-# High priority Shadow Word: Death action during execute, while Mindbender is active with Inescapable Torment, or Deathspeaker is active
-actions.aoe+=/shadow_word_death,target_if=target.health.pct<20&(cooldown.fiend.remains>=10|!talent.inescapable_torment)|pet.fiend.active>1&talent.inescapable_torment|buff.deathspeaker.up
 # High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
 actions.aoe+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
-actions.aoe+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&(!pet.fiend.active)&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
+actions.aoe+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # # Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption
 actions.aoe+=/mind_blast,if=variable.vts_applied&(!buff.mind_devourer.up|cooldown.void_eruption.up&talent.void_eruption)
 # Void Torrent action list for AoE
@@ -96,11 +93,12 @@ actions.cds+=/desperate_prayer,if=health.pct<=75
 
 # Cast Vampiric Touch to consume Unfurling Darkness, prefering the target with the lowest DoT duration active
 actions.filler=vampiric_touch,target_if=min:remains,if=buff.unfurling_darkness.up
+actions.filler+=/shadow_word_death,target_if=target.health.pct<20|buff.deathspeaker.up
 actions.filler+=/mind_spike_insanity
 actions.filler+=/mind_flay,if=buff.mind_flay_insanity.up
 # Save up to 20s if adds are coming soon.
 actions.filler+=/halo,if=raid_event.adds.in>20
-actions.filler+=/shadow_word_death,target_if=min:target.time_to_die,if=target.health.pct<20&active_enemies<4|talent.inescapable_torment&pet.fiend.active
+actions.filler+=/shadow_word_death,target_if=min:target.time_to_die,if=talent.inescapable_torment&pet.fiend.active
 # Save up to 10s if adds are coming soon.
 actions.filler+=/divine_star,if=raid_event.adds.in>10
 actions.filler+=/devouring_plague,if=buff.voidform.up&variable.dots_up
@@ -130,12 +128,10 @@ actions.main+=/devouring_plague,target_if=refreshable|!talent.distorted_reality,
 actions.main+=/shadow_crash,if=!variable.holding_crash&dot.vampiric_touch.refreshable
 # Put out Vampiric Touch on enemies that will live at least 12s and Shadow Crash is not available soon
 actions.main+=/vampiric_touch,target_if=min:remains,if=refreshable&target.time_to_die>=12&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains&!action.shadow_crash.in_flight|variable.holding_crash|!talent.whispering_shadows)
-# High priority Shadow Word: Death action during execute, while Mindbender is active with Inescapable Torment, or Deathspeaker is active
-actions.main+=/shadow_word_death,target_if=target.health.pct<20&(cooldown.fiend.remains>=10|!talent.inescapable_torment)|pet.fiend.active>1&talent.inescapable_torment|buff.deathspeaker.up
-# High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
+# High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
 actions.main+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
-# High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
-actions.main+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&(!pet.fiend.active)&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
+# High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
+actions.main+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption
 actions.main+=/mind_blast,if=variable.dots_up&(!buff.mind_devourer.up|cooldown.void_eruption.up&talent.void_eruption)
 # Void Torrent if you are not holding Shadow Crash for an add pack coming, prefer the target with the most DoTs active. Only cast if Devouring Plague is on that target and will last at least 2 seconds
@@ -154,7 +150,7 @@ actions.pl_torrent+=/vampiric_touch,if=remains<=6&cooldown.void_torrent.remains<
 actions.pl_torrent+=/devouring_plague,if=remains<=4&cooldown.void_torrent.remains<gcd*2
 actions.pl_torrent+=/mind_blast,if=!talent.mindgames|cooldown.mindgames.remains>=3&!prev_gcd.1.mind_blast
 actions.pl_torrent+=/void_torrent,if=dot.vampiric_touch.ticking&dot.shadow_word_pain.ticking|buff.voidform.up
-actions.pl_torrent+=/mindgames,target_if=variable.all_dots_up|buff.voidform.up
+actions.pl_torrent+=/mindgames,if=dot.vampiric_touch.ticking&dot.shadow_word_pain.ticking&dot.devouring_plague.ticking|buff.voidform.up
 
 actions.trinkets=use_item,name=voidmenders_shadowgem,if=buff.power_infusion.up|fight_remains<20
 actions.trinkets+=/use_item,name=darkmoon_deck_box_inferno

--- a/profiles/Tier30/T30_Death_Knight_Frost.simc
+++ b/profiles/Tier30/T30_Death_Knight_Frost.simc
@@ -11,7 +11,7 @@ dragonflight.ominous_chromatic_essence_allies=azure/bronze/obsidian/ruby
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic
 temporary_enchant=main_hand:buzzing_rune_3/off_hand:buzzing_rune_3

--- a/profiles/Tier30/T30_Death_Knight_Frost_2h.simc
+++ b/profiles/Tier30/T30_Death_Knight_Frost_2h.simc
@@ -9,7 +9,7 @@ talents=BsPAAAAAAAAAAAAAAAAAAAAAAICAJkkQSLSQIJJhQiIRkggESSEJJJJpkEAAAAAAAAAAAAA
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic
 temporary_enchant=main_hand:buzzing_rune_3/off_hand:buzzing_rune_3

--- a/profiles/Tier30/T30_Death_Knight_Unholy.simc
+++ b/profiles/Tier30/T30_Death_Knight_Unholy.simc
@@ -9,7 +9,7 @@ talents=BwPAAAAAAAAAAAAAAAAAAAAAAAAIIJRSLSAJJRIkkkEBAAAAAAAAAKJJhIAAgkESLRSSikA
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic
 temporary_enchant=main_hand:howling_rune_3

--- a/profiles/Tier30/T30_Evoker_Devastation.simc
+++ b/profiles/Tier30/T30_Evoker_Devastation.simc
@@ -9,7 +9,7 @@ talents=BsbBAAAAAAAAAAAAAAAAAAAAAAkAAAAAAApkWkIHQCCJJJlkENINkIRSIhkEJSkkEB
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic_augment_rune
 temporary_enchant=main_hand:buzzing_rune_3

--- a/profiles/Tier30/T30_Mage_Arcane.simc
+++ b/profiles/Tier30/T30_Mage_Arcane.simc
@@ -1,0 +1,208 @@
+mage="T30_Mage_Arcane"
+source=default
+spec=arcane
+level=70
+race=tauren
+role=spell
+position=back
+talents=B4DAAAAAAAAAAAAAAAAAAAAAAQCgWiIJSRQSLhIiIJSCkWQSLJAAAAAAAAAAAARSSSIJJJHA
+
+# Default consumables
+potion=elemental_potion_of_ultimate_power_3
+flask=phial_of_static_empowerment_3
+food=fated_fortune_cookie
+augmentation=draconic
+temporary_enchant=main_hand:buzzing_rune_3
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+actions.precombat=flask
+actions.precombat+=/food
+actions.precombat+=/augmentation
+actions.precombat+=/arcane_intellect
+actions.precombat+=/arcane_familiar
+actions.precombat+=/conjure_mana_gem
+actions.precombat+=/variable,name=aoe_target_count,op=reset,default=3
+actions.precombat+=/variable,name=conserve_mana,op=set,value=0
+actions.precombat+=/variable,name=opener,op=set,value=1
+actions.precombat+=/variable,name=opener_min_mana,default=-1,op=set,if=variable.opener_min_mana=-1,value=225000-(25000*!talent.arcane_harmony)
+actions.precombat+=/variable,name=steroid_trinket_equipped,op=set,value=equipped.gladiators_badge|equipped.irideus_fragment|equipped.erupting_spear_fragment|equipped.spoils_of_neltharus|equipped.tome_of_unstable_power|equipped.timebreaching_talon|equipped.horn_of_valor
+actions.precombat+=/snapshot_stats
+actions.precombat+=/mirror_image
+actions.precombat+=/arcane_blast,if=!talent.siphon_storm
+actions.precombat+=/evocation,if=talent.siphon_storm
+
+# Executed every time the actor is available.
+actions=counterspell
+actions+=/potion,if=cooldown.arcane_surge.ready
+actions+=/time_warp,if=talent.temporal_warp&buff.exhaustion.up&(cooldown.arcane_surge.ready|fight_remains<=40|buff.arcane_surge.up&fight_remains<=80)
+actions+=/lights_judgment,if=buff.arcane_surge.down&buff.rune_of_power.down&debuff.touch_of_the_magi.down
+actions+=/berserking,if=(prev_gcd.1.arcane_surge&!(buff.temporal_warp.up&buff.bloodlust.up))|(buff.arcane_surge.up&debuff.touch_of_the_magi.up)
+actions+=/blood_fury,if=prev_gcd.1.arcane_surge
+actions+=/fireblood,if=prev_gcd.1.arcane_surge
+actions+=/ancestral_call,if=prev_gcd.1.arcane_surge
+actions+=/invoke_external_buff,name=power_infusion,if=!talent.radiant_spark&prev_gcd.1.arcane_surge
+actions+=/use_items,if=prev_gcd.1.arcane_surge
+actions+=/use_item,name=tinker_breath_of_neltharion,if=cooldown.arcane_surge.remains&buff.rune_of_power.down&buff.arcane_surge.down&debuff.touch_of_the_magi.down
+actions+=/use_item,name=conjured_chillglobe,if=mana.pct>65&(!variable.steroid_trinket_equipped|cooldown.arcane_surge.remains>20)
+actions+=/use_item,name=darkmoon_deck_rime,if=!variable.steroid_trinket_equipped|cooldown.arcane_surge.remains>20
+actions+=/use_item,name=darkmoon_deck_dance,if=!variable.steroid_trinket_equipped|cooldown.arcane_surge.remains>20
+actions+=/use_item,name=darkmoon_deck_inferno,if=!variable.steroid_trinket_equipped|cooldown.arcane_surge.remains>20
+actions+=/use_item,name=desperate_invokers_codex,if=!variable.steroid_trinket_equipped|cooldown.arcane_surge.remains>20
+actions+=/use_item,name=iceblood_deathsnare,if=!variable.steroid_trinket_equipped|cooldown.arcane_surge.remains>20
+actions+=/variable,name=aoe_spark_phase,op=set,value=1,if=active_enemies>=variable.aoe_target_count&(action.arcane_orb.charges>0|buff.arcane_charge.stack>=3)&(!talent.rune_of_power|cooldown.rune_of_power.ready)&cooldown.radiant_spark.ready&cooldown.touch_of_the_magi.remains<=(gcd.max*2)
+actions+=/variable,name=aoe_spark_phase,op=set,value=0,if=variable.aoe_spark_phase&debuff.radiant_spark_vulnerability.down&dot.radiant_spark.remains<5&cooldown.radiant_spark.remains
+actions+=/variable,name=spark_phase,op=set,value=1,if=buff.arcane_charge.stack>=3&active_enemies<variable.aoe_target_count&(!talent.rune_of_power|cooldown.rune_of_power.ready)&cooldown.radiant_spark.ready&cooldown.touch_of_the_magi.remains<=(gcd.max*7)
+actions+=/variable,name=spark_phase,op=set,value=0,if=variable.spark_phase&debuff.radiant_spark_vulnerability.down&dot.radiant_spark.remains<5&cooldown.radiant_spark.remains
+actions+=/variable,name=rop_phase,op=set,value=1,if=talent.rune_of_power&!talent.radiant_spark&buff.arcane_charge.stack>=3&cooldown.rune_of_power.ready&active_enemies<variable.aoe_target_count
+actions+=/variable,name=rop_phase,op=set,value=0,if=debuff.touch_of_the_magi.up|!talent.rune_of_power
+actions+=/variable,name=opener,op=set,if=debuff.touch_of_the_magi.up&variable.opener,value=0
+actions+=/cancel_action,if=action.evocation.channeling&mana.pct>=95&!talent.siphon_storm
+actions+=/cancel_action,if=action.evocation.channeling&(mana.pct>fight_remains*4)&!(fight_remains>10&cooldown.arcane_surge.remains<1)
+actions+=/arcane_barrage,if=fight_remains<2
+actions+=/evocation,if=buff.rune_of_power.down&buff.arcane_surge.down&debuff.touch_of_the_magi.down&((mana.pct<10&cooldown.touch_of_the_magi.remains<25)|cooldown.touch_of_the_magi.remains<20)&(mana.pct<fight_remains*4)
+actions+=/conjure_mana_gem,if=buff.rune_of_power.down&debuff.touch_of_the_magi.down&buff.arcane_surge.down&cooldown.arcane_surge.remains<fight_remains&!mana_gem_charges
+actions+=/use_mana_gem,if=talent.cascading_power&buff.clearcasting.stack<2&buff.arcane_surge.up
+actions+=/use_mana_gem,if=!talent.cascading_power&prev_gcd.1.arcane_surge
+actions+=/call_action_list,name=aoe_spark_phase,if=talent.radiant_spark&variable.aoe_spark_phase
+actions+=/call_action_list,name=spark_phase,if=talent.radiant_spark&variable.spark_phase
+actions+=/call_action_list,name=aoe_touch_phase,if=debuff.touch_of_the_magi.up&active_enemies>=variable.aoe_target_count
+actions+=/call_action_list,name=touch_phase,if=debuff.touch_of_the_magi.up&active_enemies<variable.aoe_target_count
+actions+=/call_action_list,name=rop_phase,if=variable.rop_phase
+actions+=/call_action_list,name=standard_cooldowns,if=!talent.radiant_spark&(!talent.rune_of_power|active_enemies>=variable.aoe_target_count)
+actions+=/call_action_list,name=aoe_rotation,if=active_enemies>=variable.aoe_target_count
+actions+=/call_action_list,name=rotation
+
+actions.aoe_rotation=arcane_orb,if=buff.arcane_charge.stack<2
+actions.aoe_rotation+=/shifting_power,if=(!talent.evocation|cooldown.evocation.remains>12)&(!talent.arcane_surge|cooldown.arcane_surge.remains>12)&(!talent.touch_of_the_magi|cooldown.touch_of_the_magi.remains>12)&buff.arcane_surge.down
+actions.aoe_rotation+=/ice_nova,if=buff.arcane_surge.down
+actions.aoe_rotation+=/nether_tempest,if=(refreshable|!ticking)&buff.arcane_charge.stack=buff.arcane_charge.max_stack&buff.arcane_surge.down
+actions.aoe_rotation+=/arcane_missiles,if=buff.clearcasting.react&talent.arcane_harmony&talent.rune_of_power&cooldown.rune_of_power.remains<(gcd.max*2)
+actions.aoe_rotation+=/arcane_barrage,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack|mana.pct<10
+actions.aoe_rotation+=/arcane_explosion
+
+actions.aoe_spark_phase=cancel_buff,name=presence_of_mind,if=prev_gcd.1.arcane_blast&cooldown.arcane_surge.remains>75
+actions.aoe_spark_phase+=/rune_of_power,if=cooldown.arcane_surge.remains<75&cooldown.arcane_surge.remains>30
+actions.aoe_spark_phase+=/radiant_spark
+actions.aoe_spark_phase+=/use_item,name=timebreaching_talon,if=cooldown.arcane_surge.remains<=(gcd.max*2)
+actions.aoe_spark_phase+=/arcane_explosion,if=buff.arcane_charge.stack>=3&prev_gcd.1.radiant_spark
+actions.aoe_spark_phase+=/arcane_orb,if=buff.arcane_charge.stack<3,line_cd=15
+actions.aoe_spark_phase+=/nether_tempest,if=talent.arcane_echo,line_cd=15
+actions.aoe_spark_phase+=/arcane_surge
+actions.aoe_spark_phase+=/wait,sec=0.05,if=cooldown.arcane_surge.remains>75&prev_gcd.1.arcane_blast&!talent.presence_of_mind,line_cd=15
+actions.aoe_spark_phase+=/wait,sec=0.05,if=prev_gcd.1.arcane_surge,line_cd=15
+actions.aoe_spark_phase+=/wait,sec=0.05,if=cooldown.arcane_surge.remains<75&debuff.radiant_spark_vulnerability.stack=3&!talent.presence_of_mind,line_cd=15
+actions.aoe_spark_phase+=/arcane_barrage,if=cooldown.arcane_surge.remains<75&debuff.radiant_spark_vulnerability.stack=4
+actions.aoe_spark_phase+=/arcane_barrage,if=(debuff.radiant_spark_vulnerability.stack=2&cooldown.arcane_surge.remains>75)|(debuff.radiant_spark_vulnerability.stack=1&cooldown.arcane_surge.remains<75)
+actions.aoe_spark_phase+=/touch_of_the_magi,use_off_gcd=1,if=prev_gcd.1.arcane_barrage
+actions.aoe_spark_phase+=/presence_of_mind
+actions.aoe_spark_phase+=/arcane_blast,if=debuff.radiant_spark_vulnerability.stack=2|debuff.radiant_spark_vulnerability.stack=3
+actions.aoe_spark_phase+=/arcane_barrage,if=(debuff.radiant_spark_vulnerability.stack=4&buff.arcane_surge.up)|(debuff.radiant_spark_vulnerability.stack=3&buff.arcane_surge.down)
+
+actions.aoe_touch_phase=variable,name=conserve_mana,op=set,if=debuff.touch_of_the_magi.remains>9,value=1-variable.conserve_mana
+actions.aoe_touch_phase+=/meteor
+actions.aoe_touch_phase+=/arcane_barrage,if=talent.arcane_bombardment&target.health.pct<35&debuff.touch_of_the_magi.remains<=gcd.max
+actions.aoe_touch_phase+=/arcane_barrage,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack&active_enemies>=variable.aoe_target_count&cooldown.arcane_orb.remains<=execute_time
+actions.aoe_touch_phase+=/arcane_missiles,if=buff.clearcasting.react&(talent.arcane_echo|talent.arcane_harmony),chain=1
+actions.aoe_touch_phase+=/arcane_missiles,if=buff.clearcasting.stack>1&talent.conjure_mana_gem&cooldown.use_mana_gem.ready,chain=1
+actions.aoe_touch_phase+=/arcane_orb,if=buff.arcane_charge.stack<2
+actions.aoe_touch_phase+=/arcane_barrage,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack
+actions.aoe_touch_phase+=/arcane_explosion
+
+actions.rop_phase=rune_of_power
+actions.rop_phase+=/arcane_blast,if=prev_gcd.1.rune_of_power
+actions.rop_phase+=/arcane_blast,if=prev_gcd.1.arcane_blast&prev_gcd.2.rune_of_power
+actions.rop_phase+=/arcane_blast,if=prev_gcd.1.arcane_blast&prev_gcd.3.rune_of_power
+actions.rop_phase+=/arcane_surge
+actions.rop_phase+=/arcane_blast,if=prev_gcd.1.arcane_blast&prev_gcd.4.rune_of_power
+actions.rop_phase+=/nether_tempest,if=talent.arcane_echo,line_cd=15
+actions.rop_phase+=/meteor
+actions.rop_phase+=/arcane_barrage
+actions.rop_phase+=/touch_of_the_magi,use_off_gcd=1,if=prev_gcd.1.arcane_barrage
+
+actions.rotation=arcane_orb,if=buff.arcane_charge.stack<3&(buff.bloodlust.down|mana.pct>70|cooldown.touch_of_the_magi.remains>30)
+actions.rotation+=/shifting_power,if=(!talent.evocation|cooldown.evocation.remains>12)&(!talent.arcane_surge|cooldown.arcane_surge.remains>12)&(!talent.touch_of_the_magi|cooldown.touch_of_the_magi.remains>12)&buff.arcane_surge.down&fight_remains>15
+actions.rotation+=/presence_of_mind,if=buff.arcane_charge.stack<3&target.health.pct<35&talent.arcane_bombardment
+actions.rotation+=/arcane_blast,if=buff.presence_of_mind.up&target.health.pct<35&talent.arcane_bombardment&buff.arcane_charge.stack<3
+actions.rotation+=/arcane_missiles,if=buff.clearcasting.react&buff.clearcasting.stack=buff.clearcasting.max_stack
+actions.rotation+=/nether_tempest,if=(refreshable|!ticking)&buff.arcane_charge.stack=buff.arcane_charge.max_stack&(buff.temporal_warp.up|mana.pct<10|!talent.shifting_power)&buff.arcane_surge.down&fight_remains>=12
+actions.rotation+=/arcane_barrage,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack&mana.pct<50&!talent.evocation&fight_remains>20
+actions.rotation+=/arcane_barrage,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack&mana.pct<70&variable.conserve_mana&buff.bloodlust.up&cooldown.touch_of_the_magi.remains>5&fight_remains>20
+actions.rotation+=/arcane_missiles,if=buff.clearcasting.react&buff.concentration.up&buff.arcane_charge.stack=buff.arcane_charge.max_stack
+actions.rotation+=/arcane_blast,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack&buff.nether_precision.up
+actions.rotation+=/arcane_barrage,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack&mana.pct<60&variable.conserve_mana&(!talent.rune_of_power|cooldown.rune_of_power.remains>5)&cooldown.touch_of_the_magi.remains>10&cooldown.evocation.remains>40&fight_remains>20
+actions.rotation+=/arcane_missiles,if=buff.clearcasting.react&buff.nether_precision.down
+actions.rotation+=/arcane_blast
+actions.rotation+=/arcane_barrage
+
+actions.spark_phase=nether_tempest,if=!ticking&variable.opener&buff.bloodlust.up,line_cd=45
+actions.spark_phase+=/rune_of_power
+actions.spark_phase+=/arcane_blast,if=variable.opener&cooldown.arcane_surge.ready&buff.bloodlust.up&mana>=variable.opener_min_mana&buff.rune_of_power.remains>gcd.max*4
+actions.spark_phase+=/arcane_missiles,if=variable.opener&buff.bloodlust.up&buff.clearcasting.react&buff.clearcasting.stack>=2&cooldown.radiant_spark.remains<5&buff.nether_precision.down,chain=1
+actions.spark_phase+=/arcane_missiles,if=talent.arcane_harmony&buff.arcane_harmony.stack<15&((variable.opener&buff.bloodlust.up)|buff.clearcasting.react&cooldown.radiant_spark.remains<5)&cooldown.arcane_surge.remains<30,chain=1
+actions.spark_phase+=/radiant_spark
+actions.spark_phase+=/use_item,name=timebreaching_talon,if=cooldown.arcane_surge.remains<=(gcd.max*3)
+actions.spark_phase+=/invoke_external_buff,name=power_infusion,if=prev_gcd.1.radiant_spark&cooldown.arcane_surge.remains<=(gcd.max*3)
+actions.spark_phase+=/nether_tempest,if=(prev_gcd.4.radiant_spark&cooldown.arcane_surge.remains<=execute_time)|prev_gcd.5.radiant_spark,line_cd=15
+actions.spark_phase+=/arcane_surge,if=(!talent.nether_tempest&prev_gcd.4.radiant_spark)|prev_gcd.1.nether_tempest
+actions.spark_phase+=/meteor,if=(talent.nether_tempest&prev_gcd.6.radiant_spark)|(!talent.nether_tempest&prev_gcd.5.radiant_spark)
+actions.spark_phase+=/arcane_blast,if=cast_time>=gcd&execute_time<debuff.radiant_spark_vulnerability.remains&(!talent.arcane_bombardment|target.health.pct>=35)&(talent.nether_tempest&prev_gcd.6.radiant_spark|!talent.nether_tempest&prev_gcd.5.radiant_spark)&!talent.meteor
+actions.spark_phase+=/wait,sec=0.05,if=!talent.meteor&(talent.nether_tempest&prev_gcd.6.radiant_spark)|(!talent.nether_tempest&prev_gcd.5.radiant_spark),line_cd=15
+actions.spark_phase+=/arcane_barrage,if=debuff.radiant_spark_vulnerability.stack=4
+actions.spark_phase+=/touch_of_the_magi,use_off_gcd=1,if=prev_gcd.1.arcane_barrage&(action.arcane_barrage.in_flight_remains<=0.2|gcd.remains<=0.2)
+actions.spark_phase+=/arcane_blast
+actions.spark_phase+=/arcane_barrage
+
+actions.standard_cooldowns=arcane_surge,if=buff.arcane_charge.stack=buff.arcane_charge.max_stack
+actions.standard_cooldowns+=/nether_tempest,if=prev_gcd.1.arcane_surge&talent.arcane_echo
+actions.standard_cooldowns+=/meteor,if=buff.arcane_surge.up&cooldown.touch_of_the_magi.ready
+actions.standard_cooldowns+=/arcane_barrage,if=buff.arcane_surge.up&cooldown.touch_of_the_magi.ready
+actions.standard_cooldowns+=/rune_of_power,if=cooldown.touch_of_the_magi.remains<=(gcd.max*2)&buff.arcane_charge.stack=buff.arcane_charge.max_stack
+actions.standard_cooldowns+=/meteor,if=cooldown.touch_of_the_magi.remains<=(gcd.max*2)&buff.arcane_charge.stack=buff.arcane_charge.max_stack
+actions.standard_cooldowns+=/touch_of_the_magi,use_off_gcd=1,if=prev_gcd.1.arcane_barrage
+
+actions.touch_phase=variable,name=conserve_mana,op=set,if=debuff.touch_of_the_magi.remains>9,value=1-variable.conserve_mana
+actions.touch_phase+=/meteor
+actions.touch_phase+=/presence_of_mind,if=(!talent.arcane_bombardment|target.health.pct>35)&buff.arcane_surge.up&debuff.touch_of_the_magi.remains<=gcd.max
+actions.touch_phase+=/arcane_blast,if=buff.presence_of_mind.up&buff.arcane_charge.stack=buff.arcane_charge.max_stack
+actions.touch_phase+=/arcane_barrage,if=(buff.arcane_harmony.up|(talent.arcane_bombardment&target.health.pct<35))&debuff.touch_of_the_magi.remains<=gcd.max
+actions.touch_phase+=/arcane_missiles,if=buff.clearcasting.stack>1&talent.conjure_mana_gem&cooldown.use_mana_gem.ready,chain=1
+actions.touch_phase+=/arcane_blast,if=buff.nether_precision.up
+actions.touch_phase+=/cancel_action,if=debuff.touch_of_the_magi.up&action.arcane_missiles.channeling&gcd.remains=0&(buff.arcane_surge.up|talent.conjure_mana_gem|set_bonus.tier30_4pc)&mana.pct>30
+actions.touch_phase+=/arcane_missiles,if=buff.clearcasting.react&(debuff.touch_of_the_magi.remains>execute_time|!talent.presence_of_mind),chain=1
+actions.touch_phase+=/arcane_blast
+actions.touch_phase+=/arcane_barrage
+
+head=underlight_conjurers_arcanocowl,id=202551,bonus_id=9321/7979/6652/9414/9229/1472/8767,ilevel=447,gem_id=192988
+neck=chain_of_the_underking,id=134495,bonus_id=8782,ilevel=447,gem_id=192961/192961/192961
+shoulders=underlight_conjurers_aurora,id=202549,ilevel=450
+back=voice_of_the_silent_star,id=204465,bonus_id=6652/9330/7979/1485/8767,ilevel=457
+chest=underlight_conjurers_vestment,id=202554,bonus_id=9321/7979/6652/9231/1466/8767,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=9379/8780,ilevel=447,gem_id=192961,enchant_id=6580,crafted_stats=40/32
+hands=underlight_conjurers_gloves,id=202552,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=9379/8780,ilevel=447,gem_id=192961,crafted_stats=36/49
+legs=underlight_conjurers_trousers,id=202550,ilevel=450,enchant_id=6544
+feet=underlight_conjurers_treads,id=202553,ilevel=450
+finger1=bloodied_wedding_ring,id=193671,bonus_id=8780,ilevel=447,gem_id=192961,enchant=devotion_of_mastery_3
+finger2=onyx_impostors_birthright,id=204398,bonus_id=8780,ilevel=450,gem_id=192961,enchant=devotion_of_mastery_3
+trinket1=irideus_fragment,id=193743,ilevel=447
+trinket2=igneous_flowstone,id=203996,ilevel=447
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant=sophic_devotion_3,enchant_id=6655
+
+# Gear Summary
+# gear_ilvl=448.67
+# gear_stamina=22482
+# gear_intellect=8508
+# gear_crit_rating=4374
+# gear_haste_rating=2373
+# gear_mastery_rating=5048
+# gear_versatility_rating=1577
+# gear_leech_rating=200
+# gear_armor=2452
+# set_bonus=tier30_2pc=1
+# set_bonus=tier30_4pc=1

--- a/profiles/Tier30/T30_Priest_Shadow.simc
+++ b/profiles/Tier30/T30_Priest_Shadow.simc
@@ -9,7 +9,7 @@ talents=BIQAAAAAAAAAAAAAAAAAAAAAAgkQSAAAAAAAAAAAAACp4ARSSLIJJRkIINSSSkGBJIki0CJB
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
-flask=iced_phial_of_corrupting_rage_3
+flask=phial_of_tepid_versatility_3
 food=fated_fortune_cookie
 augmentation=draconic_augment_rune
 temporary_enchant=main_hand:howling_rune_3
@@ -21,7 +21,6 @@ temporary_enchant=main_hand:howling_rune_3
 # SimulationCraft is always looking for updates and improvements to the default action lists.
 
 # Executed before combat begins. Accepts non-harmful actions only.
-# otion=elemental_potion_of_ultimate_power_ lask=iced_phial_of_corrupting_rage_ ood=fated_fortune_cooki ugmentation=draconic_augment_run emporary_enchant=main_hand:howling_rune_
 actions.precombat=flask
 actions.precombat+=/food
 actions.precombat+=/augmentation
@@ -52,12 +51,10 @@ actions.aoe+=/void_bolt
 # Use Devouring Plague to maximize uptime. Short circuit if you are capping on Insanity within 20 or to get out an extra Void Bolt by extending Voidform. With Distorted Reality can maintain more than one at a time in multi-target.
 actions.aoe+=/devouring_plague,target_if=refreshable|!talent.distorted_reality,if=refreshable&!variable.pool_for_cds|insanity.deficit<=20|buff.voidform.up&cooldown.void_bolt.remains>buff.voidform.remains&cooldown.void_bolt.remains<(buff.voidform.remains+2)
 actions.aoe+=/vampiric_touch,target_if=refreshable&target.time_to_die>=18&(dot.vampiric_touch.ticking|!variable.vts_applied),if=variable.max_vts>0&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains|variable.holding_crash)&!action.shadow_crash.in_flight|!talent.whispering_shadows
-# High priority Shadow Word: Death action during execute, while Mindbender is active with Inescapable Torment, or Deathspeaker is active
-actions.aoe+=/shadow_word_death,target_if=target.health.pct<20&(cooldown.fiend.remains>=10|!talent.inescapable_torment)|pet.fiend.active>1&talent.inescapable_torment|buff.deathspeaker.up
 # High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
 actions.aoe+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
-actions.aoe+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&(!pet.fiend.active)&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
+actions.aoe+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # # Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption
 actions.aoe+=/mind_blast,if=variable.vts_applied&(!buff.mind_devourer.up|cooldown.void_eruption.up&talent.void_eruption)
 # Void Torrent action list for AoE
@@ -96,11 +93,12 @@ actions.cds+=/desperate_prayer,if=health.pct<=75
 
 # Cast Vampiric Touch to consume Unfurling Darkness, prefering the target with the lowest DoT duration active
 actions.filler=vampiric_touch,target_if=min:remains,if=buff.unfurling_darkness.up
+actions.filler+=/shadow_word_death,target_if=target.health.pct<20|buff.deathspeaker.up
 actions.filler+=/mind_spike_insanity
 actions.filler+=/mind_flay,if=buff.mind_flay_insanity.up
 # Save up to 20s if adds are coming soon.
 actions.filler+=/halo,if=raid_event.adds.in>20
-actions.filler+=/shadow_word_death,target_if=min:target.time_to_die,if=target.health.pct<20&active_enemies<4|talent.inescapable_torment&pet.fiend.active
+actions.filler+=/shadow_word_death,target_if=min:target.time_to_die,if=talent.inescapable_torment&pet.fiend.active
 # Save up to 10s if adds are coming soon.
 actions.filler+=/divine_star,if=raid_event.adds.in>10
 actions.filler+=/devouring_plague,if=buff.voidform.up&variable.dots_up
@@ -130,12 +128,10 @@ actions.main+=/devouring_plague,target_if=refreshable|!talent.distorted_reality,
 actions.main+=/shadow_crash,if=!variable.holding_crash&dot.vampiric_touch.refreshable
 # Put out Vampiric Touch on enemies that will live at least 12s and Shadow Crash is not available soon
 actions.main+=/vampiric_touch,target_if=min:remains,if=refreshable&target.time_to_die>=12&(cooldown.shadow_crash.remains>=dot.vampiric_touch.remains&!action.shadow_crash.in_flight|variable.holding_crash|!talent.whispering_shadows)
-# High priority Shadow Word: Death action during execute, while Mindbender is active with Inescapable Torment, or Deathspeaker is active
-actions.main+=/shadow_word_death,target_if=target.health.pct<20&(cooldown.fiend.remains>=10|!talent.inescapable_torment)|pet.fiend.active>1&talent.inescapable_torment|buff.deathspeaker.up
-# High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
+# High Priority Mind Spike: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
 actions.main+=/mind_spike_insanity,if=variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
-# High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available and Mindbender is not active
-actions.main+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&(!pet.fiend.active)&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
+# High Priority Mind Flay: Insanity to fish for C'Thun procs when Mind Blast is not capped and Void Torrent is not available
+actions.main+=/mind_flay,if=buff.mind_flay_insanity.up&variable.dots_up&cooldown.mind_blast.full_recharge_time>=gcd*3&talent.idol_of_cthun&(!cooldown.void_torrent.up|!talent.void_torrent)
 # Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption
 actions.main+=/mind_blast,if=variable.dots_up&(!buff.mind_devourer.up|cooldown.void_eruption.up&talent.void_eruption)
 # Void Torrent if you are not holding Shadow Crash for an add pack coming, prefer the target with the most DoTs active. Only cast if Devouring Plague is on that target and will last at least 2 seconds
@@ -154,7 +150,7 @@ actions.pl_torrent+=/vampiric_touch,if=remains<=6&cooldown.void_torrent.remains<
 actions.pl_torrent+=/devouring_plague,if=remains<=4&cooldown.void_torrent.remains<gcd*2
 actions.pl_torrent+=/mind_blast,if=!talent.mindgames|cooldown.mindgames.remains>=3&!prev_gcd.1.mind_blast
 actions.pl_torrent+=/void_torrent,if=dot.vampiric_touch.ticking&dot.shadow_word_pain.ticking|buff.voidform.up
-actions.pl_torrent+=/mindgames,target_if=variable.all_dots_up|buff.voidform.up
+actions.pl_torrent+=/mindgames,if=dot.vampiric_touch.ticking&dot.shadow_word_pain.ticking&dot.devouring_plague.ticking|buff.voidform.up
 
 actions.trinkets=use_item,name=voidmenders_shadowgem,if=buff.power_infusion.up|fight_remains<20
 actions.trinkets+=/use_item,name=darkmoon_deck_box_inferno

--- a/profiles/Tier30/T30_Warlock_Affliction.simc
+++ b/profiles/Tier30/T30_Warlock_Affliction.simc
@@ -1,0 +1,161 @@
+warlock="T30_Warlock_Affliction"
+source=default
+spec=affliction
+level=70
+race=mechagnome
+role=spell
+position=ranged_back
+talents=BkQAAAAAAAAAAAAAAAAAAAAAAgQSSkkAppAplkESLAAAAQjEAAAAAAIR0CRSikIplQAAJ
+
+# Default consumables
+potion=elemental_potion_of_ultimate_power_3
+flask=phial_of_tepid_versatility_3
+food=fated_fortune_cookie
+augmentation=draconic_augment_rune
+temporary_enchant=main_hand:howling_rune_3
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+actions.precombat=flask
+actions.precombat+=/food
+actions.precombat+=/augmentation
+actions.precombat+=/summon_pet
+actions.precombat+=/variable,name=cleave_apl,default=0,op=reset
+actions.precombat+=/grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled
+actions.precombat+=/snapshot_stats
+actions.precombat+=/seed_of_corruption,if=spell_targets.seed_of_corruption_aoe>3
+actions.precombat+=/haunt
+actions.precombat+=/unstable_affliction,if=!talent.soul_swap
+actions.precombat+=/shadow_bolt
+
+# Executed every time the actor is available.
+actions=call_action_list,name=variables
+actions+=/call_action_list,name=cleave,if=active_enemies!=1&active_enemies<4|variable.cleave_apl
+actions+=/call_action_list,name=aoe,if=active_enemies>3
+actions+=/call_action_list,name=ogcd
+actions+=/call_action_list,name=items
+actions+=/malefic_rapture,if=talent.dread_touch&talent.malefic_affliction&debuff.dread_touch.remains<2&buff.malefic_affliction.stack=3
+actions+=/unstable_affliction,if=remains<5
+actions+=/agony,if=remains<5
+actions+=/corruption,if=remains<5
+actions+=/siphon_life,if=remains<5
+actions+=/haunt
+actions+=/drain_soul,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<3)
+actions+=/shadow_bolt,if=talent.shadow_embrace&(debuff.shadow_embrace.stack<3|debuff.shadow_embrace.remains<3)
+actions+=/phantom_singularity,if=!talent.soul_rot|cooldown.soul_rot.remains<=execute_time|cooldown.soul_rot.remains>=25
+actions+=/vile_taint,if=!talent.soul_rot|cooldown.soul_rot.remains<=execute_time|talent.souleaters_gluttony.rank<2&cooldown.soul_rot.remains>=12
+actions+=/soul_rot,if=variable.vt_up&variable.ps_up
+actions+=/summon_darkglare,if=variable.ps_up&variable.vt_up&variable.sr_up|cooldown.invoke_power_infusion_0.duration>0&cooldown.invoke_power_infusion_0.up&!talent.soul_rot
+actions+=/malefic_rapture,if=soul_shard>4|(talent.tormented_crescendo&buff.tormented_crescendo.stack=1&soul_shard>3)
+actions+=/malefic_rapture,if=talent.malefic_affliction&buff.malefic_affliction.stack<3
+actions+=/malefic_rapture,if=talent.tormented_crescendo&buff.tormented_crescendo.react&!debuff.dread_touch.react
+actions+=/malefic_rapture,if=talent.tormented_crescendo&buff.tormented_crescendo.stack=2
+actions+=/malefic_rapture,if=variable.cd_dots_up|variable.vt_up&soul_shard>1
+actions+=/malefic_rapture,if=talent.tormented_crescendo&talent.nightfall&buff.tormented_crescendo.react&buff.nightfall.react
+actions+=/drain_life,if=buff.inevitable_demise.stack>48|buff.inevitable_demise.stack>20&time_to_die<4
+actions+=/drain_soul,if=buff.nightfall.react
+actions+=/shadow_bolt,if=buff.nightfall.react
+actions+=/agony,if=refreshable
+actions+=/corruption,if=refreshable
+actions+=/drain_soul,interrupt=1
+actions+=/shadow_bolt
+
+actions.aoe=call_action_list,name=ogcd
+actions.aoe+=/call_action_list,name=items
+actions.aoe+=/haunt
+actions.aoe+=/vile_taint
+actions.aoe+=/phantom_singularity
+actions.aoe+=/soul_rot
+actions.aoe+=/unstable_affliction,if=remains<5
+actions.aoe+=/seed_of_corruption,if=dot.corruption.remains<5
+actions.aoe+=/malefic_rapture,if=talent.malefic_affliction&buff.malefic_affliction.stack<3&talent.doom_blossom
+actions.aoe+=/agony,target_if=remains<5,if=active_dot.agony<5
+actions.aoe+=/summon_darkglare
+actions.aoe+=/seed_of_corruption,if=talent.sow_the_seeds
+actions.aoe+=/malefic_rapture
+actions.aoe+=/drain_life,if=(buff.soul_rot.up|!talent.soul_rot)&buff.inevitable_demise.stack>10
+actions.aoe+=/summon_soulkeeper,if=buff.tormented_soul.stack=10|buff.tormented_soul.stack>3&time_to_die<10
+actions.aoe+=/siphon_life,target_if=remains<5,if=active_dot.siphon_life<3
+actions.aoe+=/drain_soul,interrupt_global=1
+actions.aoe+=/shadow_bolt
+
+actions.cleave=call_action_list,name=ogcd
+actions.cleave+=/call_action_list,name=items
+actions.cleave+=/malefic_rapture,if=soul_shard=5
+actions.cleave+=/haunt
+actions.cleave+=/unstable_affliction,if=remains<5
+actions.cleave+=/agony,if=remains<5
+actions.cleave+=/agony,target_if=!(target=self.target)&remains<5
+actions.cleave+=/siphon_life,if=remains<5
+actions.cleave+=/siphon_life,target_if=!(target=self.target)&remains<3
+actions.cleave+=/seed_of_corruption,if=!talent.absolute_corruption&dot.corruption.remains<5
+actions.cleave+=/corruption,target_if=remains<5&(talent.absolute_corruption|!talent.seed_of_corruption)
+actions.cleave+=/phantom_singularity
+actions.cleave+=/vile_taint
+actions.cleave+=/soul_rot
+actions.cleave+=/summon_darkglare
+actions.cleave+=/malefic_rapture,if=talent.malefic_affliction&buff.malefic_affliction.stack<3
+actions.cleave+=/malefic_rapture,if=talent.dread_touch&debuff.dread_touch.remains<gcd
+actions.cleave+=/malefic_rapture,if=!talent.dread_touch&buff.tormented_crescendo.up
+actions.cleave+=/malefic_rapture,if=!talent.dread_touch&(dot.soul_rot.remains>cast_time|dot.phantom_singularity.remains>cast_time|dot.vile_taint_dot.remains>cast_time|pet.darkglare.active)
+actions.cleave+=/drain_soul,if=buff.nightfall.react
+actions.cleave+=/shadow_bolt,if=buff.nightfall.react
+actions.cleave+=/drain_life,if=buff.inevitable_demise.stack>48|buff.inevitable_demise.stack>20&time_to_die<4
+actions.cleave+=/drain_life,if=buff.soul_rot.up&buff.inevitable_demise.stack>10
+actions.cleave+=/agony,target_if=refreshable
+actions.cleave+=/corruption,target_if=refreshable
+actions.cleave+=/drain_soul,interrupt_global=1
+actions.cleave+=/shadow_bolt
+
+actions.items=use_items,if=variable.cds_active
+actions.items+=/use_item,name=desperate_invokers_codex
+actions.items+=/use_item,name=conjured_chillglobe
+
+actions.ogcd=potion,if=variable.cds_active
+actions.ogcd+=/berserking,if=variable.cds_active
+actions.ogcd+=/blood_fury,if=variable.cds_active
+actions.ogcd+=/invoke_external_buff,name=power_infusion,if=variable.cds_active
+actions.ogcd+=/fireblood,if=variable.cds_active
+
+actions.variables=variable,name=ps_up,op=set,value=dot.phantom_singularity.ticking|!talent.phantom_singularity
+actions.variables+=/variable,name=vt_up,op=set,value=dot.vile_taint_dot.ticking|!talent.vile_taint
+actions.variables+=/variable,name=sr_up,op=set,value=dot.soul_rot.ticking|!talent.soul_rot
+actions.variables+=/variable,name=cd_dots_up,op=set,value=variable.ps_up&variable.vt_up&variable.sr_up
+actions.variables+=/variable,name=has_cds,op=set,value=talent.phantom_singularity|talent.vile_taint|talent.soul_rot|talent.summon_darkglare
+actions.variables+=/variable,name=cds_active,op=set,value=!variable.has_cds|(pet.darkglare.active|variable.cd_dots_up|buff.power_infusion.react)
+
+head=grimhorns_of_the_sinister_savant,id=202533,bonus_id=8780,ilevel=447,gem_id=192985
+neck=magmoraxs_fourth_collar,id=204397,bonus_id=8782,ilevel=447,gem_id=192961/192961/192961
+shoulders=amice_of_the_sinister_savant,id=202531,ilevel=450
+back=voice_of_the_silent_star,id=204465,ilevel=457
+chest=cursed_robes_of_the_sinister_savant,id=202536,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=8836/8840/8902/8780/8802/8846/8793/9379,ilevel=447,gem_id=192961,enchant_id=6574,crafted_stats=40/32
+hands=grips_of_the_sinister_savant,id=202534,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=8780/9379/8960,ilevel=447,gem_id=192961,crafted_stats=36/49
+legs=coattails_of_the_rightful_heir,id=202585,ilevel=450,enchant_id=6541
+feet=treads_of_fractured_realities,id=204392,ilevel=450,enchant_id=6607
+finger1=signet_of_titanic_insight,id=192999,bonus_id=8780/8793/8960,ilevel=447,gem_id=192961,enchant_id=6562
+finger2=scalebane_signet,id=193768,bonus_id=8780,ilevel=447,gem_id=192961,enchant_id=6556
+trinket1=igneous_flowstone,id=203996,ilevel=447
+trinket2=neltharions_call_to_dominance,id=204202,ilevel=457
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant_id=6643
+
+# Gear Summary
+# gear_ilvl=449.13
+# gear_stamina=22563
+# gear_intellect=8508
+# gear_crit_rating=1542
+# gear_haste_rating=4920
+# gear_mastery_rating=5034
+# gear_versatility_rating=1878
+# gear_speed_rating=250
+# gear_avoidance_rating=200
+# gear_armor=2452
+# set_bonus=tier30_2pc=1
+# set_bonus=tier30_4pc=1
+default_pet=imp

--- a/profiles/Tier30/T30_Warlock_Demonology.simc
+++ b/profiles/Tier30/T30_Warlock_Demonology.simc
@@ -1,0 +1,124 @@
+warlock="T30_Warlock_Demonology"
+source=default
+spec=demonology
+level=70
+race=troll
+role=spell
+position=ranged_back
+talents=BoQAAAAAAAAAAAAAAAAAAAAAAAIJRSCkWKHQkmkESJAAAAAokIJSIgQikDkiWSSOABAAAAAAJ
+
+# Default consumables
+potion=elemental_potion_of_ultimate_power_3
+flask=phial_of_tepid_versatility_3
+food=fated_fortune_cookie
+augmentation=draconic_augment_rune
+temporary_enchant=main_hand:howling_rune_3
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+actions.precombat=flask
+actions.precombat+=/food
+actions.precombat+=/augmentation
+actions.precombat+=/summon_pet
+actions.precombat+=/snapshot_stats
+actions.precombat+=/variable,name=tyrant_prep_start,op=set,value=12
+actions.precombat+=/variable,name=next_tyrant,op=set,value=14+talent.grimoire_felguard+talent.summon_vilefiend
+actions.precombat+=/variable,name=shadow_timings,default=0,op=reset
+actions.precombat+=/variable,name=shadow_timings,op=set,value=0,if=cooldown.invoke_power_infusion_0.duration!=120
+actions.precombat+=/power_siphon
+actions.precombat+=/demonbolt,if=!buff.power_siphon.up
+actions.precombat+=/shadow_bolt
+
+# Executed every time the actor is available.
+actions=call_action_list,name=variables
+actions+=/call_action_list,name=tyrant,if=talent.summon_demonic_tyrant&(time-variable.next_tyrant)<=(variable.tyrant_prep_start+2)&cooldown.summon_demonic_tyrant.up&variable.np_condition
+actions+=/call_action_list,name=tyrant,if=talent.summon_demonic_tyrant&(variable.tyrant_cd<=variable.tyrant_prep_start|cooldown.summon_demonic_tyrant.up&(buff.power_infusion.up|buff.nether_portal.up))&variable.np_condition
+actions+=/invoke_external_buff,name=power_infusion,if=!talent.nether_portal&!talent.summon_demonic_tyrant|time_to_die<25|(buff.tyrant.up&variable.shadow_timings)
+actions+=/implosion,if=time_to_die<2*gcd
+actions+=/nether_portal,if=!talent.summon_demonic_tyrant&soul_shard>2|time_to_die<30
+actions+=/hand_of_guldan,if=buff.nether_portal.up
+actions+=/call_action_list,name=items
+actions+=/call_action_list,name=ogcd,if=buff.demonic_power.up|!talent.summon_demonic_tyrant&(buff.nether_portal.up|!talent.nether_portal)
+actions+=/call_dreadstalkers,if=variable.tyrant_cd>cooldown+8*variable.shadow_timings
+actions+=/call_dreadstalkers,if=!talent.summon_demonic_tyrant|time_to_die<14
+actions+=/grimoire_felguard,if=!talent.summon_demonic_tyrant|time_to_die<cooldown.summon_demonic_tyrant.remains_expected
+actions+=/summon_vilefiend,if=!talent.summon_demonic_tyrant|variable.tyrant_cd>cooldown+variable.tyrant_prep_start|time_to_die<cooldown.summon_demonic_tyrant.remains_expected
+actions+=/guillotine,if=cooldown.demonic_strength.remains
+actions+=/demonic_strength
+actions+=/bilescourge_bombers,if=!pet.demonic_tyrant.active
+actions+=/shadow_bolt,if=soul_shard<5&talent.fel_covenant&buff.fel_covenant.remains<5
+actions+=/implosion,if=two_cast_imps>0&buff.tyrant.down&active_enemies>1+(talent.sacrificed_souls.enabled)
+actions+=/implosion,if=buff.wild_imps.stack>9&buff.tyrant.up&active_enemies>2+(1*talent.sacrificed_souls.enabled)&cooldown.call_dreadstalkers.remains>17&talent.the_expendables
+actions+=/soul_strike,if=soul_shard<5&active_enemies>1
+actions+=/summon_soulkeeper,if=buff.tormented_soul.stack=10&active_enemies>1
+actions+=/demonbolt,if=buff.demonic_core.up&soul_shard<4&variable.tyrant_cd>5
+actions+=/power_siphon,if=buff.demonic_core.stack<2&(buff.dreadstalkers.remains>gcd*3|buff.dreadstalkers.down)
+actions+=/hand_of_guldan,if=soul_shard>2&(!talent.summon_demonic_tyrant|variable.tyrant_cd>variable.tyrant_prep_start+2)&(buff.demonic_calling.up|soul_shard>4|cooldown.call_dreadstalkers.remains>gcd)
+actions+=/doom,target_if=refreshable
+actions+=/soul_strike,if=soul_shard<5
+actions+=/shadow_bolt
+
+actions.items=use_item,name=timebreaching_talon,if=buff.demonic_power.up|!talent.summon_demonic_tyrant&(buff.nether_portal.up|!talent.nether_portal)
+actions.items+=/use_items,if=buff.demonic_power.up|!talent.summon_demonic_tyrant&(buff.nether_portal.up|!talent.nether_portal)
+actions.items+=/use_item,name=voidmenders_shadowgem,if=!variable.shadow_timings|(variable.shadow_timings&(buff.demonic_power.up|!talent.summon_demonic_tyrant&(buff.nether_portal.up|!talent.nether_portal)))
+
+actions.ogcd=potion
+actions.ogcd+=/berserking
+actions.ogcd+=/blood_fury
+actions.ogcd+=/fireblood
+
+actions.tyrant=variable,name=next_tyrant,op=set,value=time+13+cooldown.grimoire_felguard.ready+cooldown.summon_vilefiend.ready,if=variable.next_tyrant<=time&!equipped.neltharions_call_to_dominance
+actions.tyrant+=/invoke_external_buff,name=power_infusion,if=(buff.nether_portal.up&buff.nether_portal.remains<8&talent.nether_portal)|(buff.dreadstalkers.up&variable.next_tyrant-time<=6&(!talent.nether_portal|variable.shadow_timings))
+actions.tyrant+=/shadow_bolt,if=time<2&soul_shard<5
+actions.tyrant+=/nether_portal
+actions.tyrant+=/variable,name=next_tyrant,op=set,value=time+13+cooldown.grimoire_felguard.ready+cooldown.summon_vilefiend.ready,if=variable.next_tyrant<=time&equipped.neltharions_call_to_dominance
+actions.tyrant+=/grimoire_felguard
+actions.tyrant+=/summon_vilefiend
+actions.tyrant+=/call_dreadstalkers
+actions.tyrant+=/soulburn,if=buff.nether_portal.up&soul_shard>=2,line_cd=40
+actions.tyrant+=/hand_of_guldan,if=variable.next_tyrant-time>2&(buff.nether_portal.up|soul_shard>2&variable.next_tyrant-time<12|soul_shard=5)&!cooldown.call_dreadstalkers.up
+actions.tyrant+=/hand_of_guldan,if=talent.soulbound_tyrant&variable.next_tyrant-time<4&variable.next_tyrant-time>action.summon_demonic_tyrant.cast_time
+actions.tyrant+=/summon_demonic_tyrant,if=variable.next_tyrant-time<cast_time*2+1|(buff.dreadstalkers.remains<cast_time+gcd&buff.dreadstalkers.up)
+actions.tyrant+=/demonbolt,if=buff.demonic_core.up
+actions.tyrant+=/power_siphon,if=buff.wild_imps.stack>1&!buff.nether_portal.up
+actions.tyrant+=/soul_strike
+actions.tyrant+=/shadow_bolt
+
+actions.variables=variable,name=tyrant_cd,op=setif,value=cooldown.invoke_power_infusion_0.remains,value_else=cooldown.summon_demonic_tyrant.remains_expected,condition=((((fight_remains+time)%%120<=75&(fight_remains+time)%%120>=15)|time>=210)&variable.shadow_timings)&cooldown.invoke_power_infusion_0.duration>0&!talent.grand_warlocks_design
+actions.variables+=/variable,name=np_condition,op=set,value=cooldown.nether_portal.up|buff.nether_portal.up|pet.pit_lord.active|!talent.nether_portal|cooldown.nether_portal.remains>30
+
+head=cragshapers_fitted_hood,id=137341,bonus_id=8780,ilevel=447,gem_id=192985
+neck=magmoraxs_fourth_collar,id=204397,bonus_id=8782,ilevel=447,gem_id=192945/192945/192945
+shoulders=amice_of_the_sinister_savant,id=202531,ilevel=450
+back=voice_of_the_silent_star,id=204465,ilevel=457
+chest=cursed_robes_of_the_sinister_savant,id=202536,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=8836/8840/8902/8780/8802/8846/8793/9379,ilevel=447,gem_id=192945,enchant_id=6574,crafted_stats=40/32
+hands=grips_of_the_sinister_savant,id=202534,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=9379/8960/8780,ilevel=447,gem_id=192945,crafted_stats=36/49
+legs=leggings_of_the_sinister_savant,id=205849,ilevel=450,enchant_id=6541
+feet=treads_of_fractured_realities,id=204392,ilevel=450,enchant_id=6607
+finger1=loop_of_pulsing_veins,id=159463,bonus_id=8780,ilevel=447,gem_id=192945,enchant_id=6550
+finger2=seal_of_questionable_loyalties,id=158314,bonus_id=8780,ilevel=447,gem_id=192945,enchant_id=6550
+trinket1=irideus_fragment,id=193743,bonus_id=6652/1643/8767,ilevel=447
+trinket2=neltharions_call_to_dominance,id=204202,ilevel=457
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant_id=6643
+
+# Gear Summary
+# gear_ilvl=449.13
+# gear_stamina=22563
+# gear_intellect=7905
+# gear_crit_rating=2609
+# gear_haste_rating=6149
+# gear_mastery_rating=3633
+# gear_versatility_rating=1607
+# gear_speed_rating=250
+# gear_avoidance_rating=200
+# gear_armor=2452
+# set_bonus=tier30_2pc=1
+# set_bonus=tier30_4pc=1
+default_pet=felguard

--- a/profiles/Tier30/T30_Warlock_Destruction.simc
+++ b/profiles/Tier30/T30_Warlock_Destruction.simc
@@ -1,11 +1,11 @@
-warlock="T29_Warlock_Destruction"
+warlock="T30_Warlock_Destruction"
 source=default
 spec=destruction
 level=70
-race=human
+race=mechagnome
 role=spell
 position=ranged_back
-talents=BsQAAAAAAAAAAAAAAAAAAAAAAggkEJJQaKEpdgkESLwBSUSSSCSalmkAAAAAAAAAAAAIgSSkA
+talents=BsQAAAAAAAAAAAAAAAAAAAAAAggkEJJQaKEpdgkESJwBSUSSkAatmkAAAAAAAAAAAAIIpkEJ
 
 # Default consumables
 potion=elemental_potion_of_ultimate_power_3
@@ -144,34 +144,33 @@ actions.ogcd+=/berserking,if=pet.infernal.active|!talent.summon_infernal|(fight_
 actions.ogcd+=/blood_fury,if=pet.infernal.active|!talent.summon_infernal|(fight_remains<cooldown.summon_infernal.remains+10+cooldown.blood_fury.duration&fight_remains>cooldown.blood_fury.duration)|fight_remains<cooldown.summon_infernal.remains
 actions.ogcd+=/fireblood,if=pet.infernal.active|!talent.summon_infernal|(fight_remains<cooldown.summon_infernal.remains+10+cooldown.fireblood.duration&fight_remains>cooldown.fireblood.duration)|fight_remains<cooldown.summon_infernal.remains
 
-head=scalesworn_cultists_scorn,id=200336,bonus_id=6514,ilevel=424,gem_id=192985
-neck=elemental_lariat,id=193001,bonus_id=1540/8793/6652/7936/7979/8767/8782,ilevel=418,gem_id=192948/192948/192948
-shoulders=amice_of_the_blue,id=193526,bonus_id=8960/8840/8836/8902/1508
-back=fireproof_drape,id=193763,ilevel=421,enchant_id=6604
-chest=scalesworn_cultists_frock,id=200333,ilevel=421,enchant_id=6625
-wrists=manawracker_bindings,id=134310,bonus_id=6514,ilevel=421,gem_id=192948,enchant_id=6580
-hands=scalesworn_cultists_gloves,id=200335,ilevel=421
-waist=magathas_spiritual_sash,id=195515,bonus_id=6514,ilevel=421,gem_id=192948
-legs=scalesworn_cultists_culottes,id=200337,ilevel=421,enchant_id=6541
-feet=sandals_of_the_wild_sovereign,id=195532,ilevel=424,enchant_id=6607
-finger1=seal_of_filial_duty,id=195526,bonus_id=6514,ilevel=430,gem_id=192948,enchant_id=6556
-finger2=seal_of_diurnas_chosen,id=195480,bonus_id=6652/8783/8784/7936/7937/4800/4786/1498,gem_id=192945,enchant_id=6556
-trinket1=whispering_incarnate_icon,id=194301,ilevel=421
-trinket2=furious_ragefeather,id=193677,bonus_id=6808/4786/1643
-main_hand=stormlashs_last_resort,id=195529,ilevel=424,enchant_id=6643
-off_hand=scripture_of_primal_devotion,id=195513,ilevel=421
+head=grimhorns_of_the_sinister_savant,id=202533,bonus_id=8780,ilevel=447,gem_id=192988
+neck=torc_of_passed_time,id=201759,bonus_id=8836/8840/8902/9477/8782/9405/8793/9366,ilevel=447,gem_id=192961/192961/192961,crafted_stats=36/32
+shoulders=amice_of_the_sinister_savant,id=202531,ilevel=450
+back=voice_of_the_silent_star,id=204465,ilevel=457
+chest=cursed_robes_of_the_sinister_savant,id=202536,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=8836/8840/8902/8780/8802/8846/8793/9379,ilevel=447,gem_id=192961,enchant_id=6574,crafted_stats=40/32
+hands=grips_of_the_sinister_savant,id=202534,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=8780/9379/8960,ilevel=447,gem_id=192961,crafted_stats=36/49
+legs=coattails_of_the_rightful_heir,id=202585,ilevel=450,enchant_id=6541
+feet=treads_of_fractured_realities,id=204392,ilevel=450,enchant_id=6607
+finger1=loop_of_pulsing_veins,id=159463,bonus_id=8780,ilevel=447,gem_id=192961,enchant_id=6556
+finger2=signet_of_titanic_insight,id=192999,bonus_id=8780/8793/8960,ilevel=447,gem_id=192961,enchant_id=6562
+trinket1=igneous_flowstone,id=203996,ilevel=447
+trinket2=ominous_chromatic_essence,id=203729,bonus_id=4800/1498
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant_id=6643
 
 # Gear Summary
-# gear_ilvl=421.75
-# gear_stamina=17369
-# gear_intellect=7166
-# gear_crit_rating=1685
-# gear_haste_rating=4361
-# gear_mastery_rating=3986
-# gear_versatility_rating=1219
-# gear_leech_rating=200
-# gear_speed_rating=375
-# gear_armor=2040
-# set_bonus=tier29_2pc=1
-# set_bonus=tier29_4pc=1
+# gear_ilvl=448.27
+# gear_stamina=22563
+# gear_intellect=9095
+# gear_crit_rating=1092
+# gear_haste_rating=5796
+# gear_mastery_rating=4306
+# gear_versatility_rating=1530
+# gear_speed_rating=250
+# gear_avoidance_rating=200
+# gear_armor=2452
+# set_bonus=tier30_2pc=1
+# set_bonus=tier30_4pc=1
 default_pet=imp

--- a/profiles/Tier30/T30_Warrior_Arms.simc
+++ b/profiles/Tier30/T30_Warrior_Arms.simc
@@ -1,0 +1,156 @@
+warrior="T30_Arms_Warrior"
+source=default
+spec=arms
+level=70
+race=human
+role=attack
+position=back
+professions=blacksmithing=100/engineering=65
+talents=BcEAAAAAAAAAAAAAAAAAAAAAAAQplIRkQOQiSrkEAAAAQQkIKEQREQiQSoJRIAhECAAAAAAAAJBJJgQ0QA
+dragonflight.ominous_chromatic_essence_dragonflight=azure
+dragonflight.ominous_chromatic_essence_allies=ruby/bronze/emerald/obsidian
+
+# Default consumables
+potion=elemental_potion_of_ultimate_power_3
+flask=phial_of_tepid_versatility_3
+food=fated_fortune_cookie
+augmentation=draconic
+temporary_enchant=main_hand:howling_rune_3
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+actions.precombat=flask
+actions.precombat+=/food
+actions.precombat+=/augmentation
+actions.precombat+=/battle_stance,toggle=on
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/use_item,name=algethar_puzzle_box
+
+# Executed every time the actor is available.
+actions=charge,if=time<=0.5|movement.distance>5
+actions+=/auto_attack
+actions+=/potion,if=gcd.remains=0&debuff.colossus_smash.remains>8|target.time_to_die<25
+actions+=/pummel,if=target.debuff.casting.react
+actions+=/use_item,name=beacon_to_the_beyond
+actions+=/blood_fury,if=debuff.colossus_smash.up
+actions+=/berserking,if=debuff.colossus_smash.remains>6
+actions+=/arcane_torrent,if=cooldown.mortal_strike.remains>1.5&rage<50
+actions+=/lights_judgment,if=debuff.colossus_smash.down&cooldown.mortal_strike.remains
+actions+=/fireblood,if=debuff.colossus_smash.up
+actions+=/ancestral_call,if=debuff.colossus_smash.up
+actions+=/bag_of_tricks,if=debuff.colossus_smash.down&cooldown.mortal_strike.remains
+actions+=/run_action_list,name=hac,if=raid_event.adds.exists|active_enemies>2
+actions+=/call_action_list,name=execute,target_if=min:target.health.pct,if=(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20
+actions+=/run_action_list,name=single_target,if=!raid_event.adds.exists
+
+actions.execute=sweeping_strikes,if=spell_targets.whirlwind>1
+actions.execute+=/rend,if=remains<=gcd&(!talent.warbreaker&cooldown.colossus_smash.remains<4|talent.warbreaker&cooldown.warbreaker.remains<4)&target.time_to_die>12
+actions.execute+=/avatar,if=cooldown.colossus_smash.ready|debuff.colossus_smash.up|target.time_to_die<20
+actions.execute+=/warbreaker
+actions.execute+=/colossus_smash
+actions.execute+=/thunderous_roar,if=buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up
+actions.execute+=/spear_of_bastion,if=debuff.colossus_smash.up|buff.test_of_might.up
+actions.execute+=/skullsplitter,if=rage<40
+actions.execute+=/cleave,if=spell_targets.whirlwind>2&dot.deep_wounds.remains<gcd
+actions.execute+=/overpower,if=rage<40&buff.martial_prowess.stack<2
+actions.execute+=/mortal_strike,if=debuff.executioners_precision.stack=2|dot.deep_wounds.remains<=gcd
+actions.execute+=/execute
+actions.execute+=/shockwave,if=talent.sonic_boom
+actions.execute+=/overpower
+actions.execute+=/bladestorm
+
+actions.hac=execute,if=buff.juggernaut.up&buff.juggernaut.remains<gcd
+actions.hac+=/thunder_clap,if=active_enemies>2&talent.thunder_clap&talent.blood_and_thunder&talent.rend&dot.rend.remains<=dot.rend.duration*0.3
+actions.hac+=/sweeping_strikes,if=active_enemies>=2&(cooldown.bladestorm.remains>15|!talent.bladestorm)
+actions.hac+=/rend,if=active_enemies=1&remains<=gcd&(target.health.pct>20|talent.massacre&target.health.pct>35)|talent.tide_of_blood&cooldown.skullsplitter.remains<=gcd&(cooldown.colossus_smash.remains<=gcd|debuff.colossus_smash.up)&dot.rend.remains<dot.rend.duration*0.85
+actions.hac+=/avatar,if=raid_event.adds.in>15|talent.blademasters_torment&active_enemies>1|target.time_to_die<20
+actions.hac+=/warbreaker,if=raid_event.adds.in>22|active_enemies>1
+actions.hac+=/colossus_smash,cycle_targets=1,if=(target.health.pct<20|talent.massacre&target.health.pct<35)
+actions.hac+=/colossus_smash
+actions.hac+=/thunderous_roar,if=(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)&raid_event.adds.in>15|active_enemies>1&dot.deep_wounds.remains
+actions.hac+=/spear_of_bastion,if=(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)&raid_event.adds.in>15
+actions.hac+=/bladestorm,if=talent.unhinged&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)
+actions.hac+=/bladestorm,if=active_enemies>1&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)&raid_event.adds.in>30|active_enemies>1&dot.deep_wounds.remains
+actions.hac+=/cleave,if=active_enemies>2|!talent.battlelord&buff.merciless_bonegrinder.up&cooldown.mortal_strike.remains>gcd
+actions.hac+=/whirlwind,if=active_enemies>2|talent.storm_of_swords&(buff.merciless_bonegrinder.up|buff.hurricane.up)
+actions.hac+=/skullsplitter,if=rage<40|talent.tide_of_blood&dot.rend.remains&(buff.sweeping_strikes.up&active_enemies>=2|debuff.colossus_smash.up|buff.test_of_might.up)
+actions.hac+=/mortal_strike,if=buff.sweeping_strikes.up&buff.crushing_advance.stack=3,if=set_bonus.tier30_4pc
+actions.hac+=/overpower,if=buff.sweeping_strikes.up&talent.dreadnaught
+actions.hac+=/mortal_strike,cycle_targets=1,if=debuff.executioners_precision.stack=2|dot.deep_wounds.remains<=gcd|talent.dreadnaught&talent.battlelord&active_enemies<=2
+actions.hac+=/execute,cycle_targets=1,if=buff.sudden_death.react|active_enemies<=2&(target.health.pct<20|talent.massacre&target.health.pct<35)|buff.sweeping_strikes.up
+actions.hac+=/thunderous_roar,if=raid_event.adds.in>15
+actions.hac+=/shockwave,if=active_enemies>2&talent.sonic_boom
+actions.hac+=/overpower,if=active_enemies=1&(charges=2&!talent.battlelord&(debuff.colossus_smash.down|rage.pct<25)|talent.battlelord)
+actions.hac+=/slam,if=active_enemies=1&!talent.battlelord&rage.pct>70
+actions.hac+=/overpower,if=charges=2&(!talent.test_of_might|talent.test_of_might&debuff.colossus_smash.down|talent.battlelord)|rage<70
+actions.hac+=/thunder_clap,if=active_enemies>2
+actions.hac+=/mortal_strike
+actions.hac+=/rend,if=active_enemies=1&dot.rend.remains<duration*0.3
+actions.hac+=/whirlwind,if=talent.storm_of_swords|talent.fervor_of_battle&active_enemies>1
+actions.hac+=/cleave,if=!talent.crushing_force
+actions.hac+=/ignore_pain,if=talent.battlelord&talent.anger_management&rage>30&(target.health.pct>20|talent.massacre&target.health.pct>35)
+actions.hac+=/slam,if=talent.crushing_force&rage>30&(talent.fervor_of_battle&active_enemies=1|!talent.fervor_of_battle)
+actions.hac+=/shockwave,if=talent.sonic_boom
+actions.hac+=/bladestorm,if=raid_event.adds.in>30
+actions.hac+=/wrecking_throw
+
+actions.single_target=sweeping_strikes,if=spell_targets.whirlwind>1
+actions.single_target+=/mortal_strike
+actions.single_target+=/rend,if=remains<=gcd|talent.tide_of_blood&cooldown.skullsplitter.remains<=gcd&(cooldown.colossus_smash.remains<=gcd|debuff.colossus_smash.up)&dot.rend.remains<dot.rend.duration*0.85
+actions.single_target+=/avatar,if=talent.warlords_torment&rage.pct<33&(cooldown.colossus_smash.ready|debuff.colossus_smash.up|buff.test_of_might.up)|!talent.warlords_torment&(cooldown.colossus_smash.ready|debuff.colossus_smash.up)
+actions.single_target+=/spear_of_bastion,if=cooldown.colossus_smash.remains<=gcd|cooldown.warbreaker.remains<=gcd
+actions.single_target+=/warbreaker
+actions.single_target+=/colossus_smash
+actions.single_target+=/thunderous_roar,if=buff.test_of_might.up|talent.test_of_might&debuff.colossus_smash.up&rage.pct<33|!talent.test_of_might&debuff.colossus_smash.up
+actions.single_target+=/bladestorm,if=talent.hurricane&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)|talent.unhinged&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)
+actions.single_target+=/skullsplitter,if=talent.tide_of_blood&dot.rend.remains&(debuff.colossus_smash.up|cooldown.colossus_smash.remains>gcd*4&buff.test_of_might.up|!talent.test_of_might&cooldown.colossus_smash.remains>gcd*4)|rage<30
+actions.single_target+=/execute,if=buff.sudden_death.react
+actions.single_target+=/shockwave,if=talent.sonic_boom.enabled
+actions.single_target+=/ignore_pain,if=talent.anger_management|talent.test_of_might&debuff.colossus_smash.up
+actions.single_target+=/whirlwind,if=talent.storm_of_swords&talent.battlelord&rage.pct>80&debuff.colossus_smash.up
+actions.single_target+=/overpower,if=charges=2&!talent.battlelord&(debuff.colossus_smash.down|rage.pct<25)|talent.battlelord
+actions.single_target+=/whirlwind,if=talent.storm_of_swords|talent.fervor_of_battle&active_enemies>1
+actions.single_target+=/thunder_clap,if=talent.battlelord&talent.blood_and_thunder
+actions.single_target+=/overpower,if=debuff.colossus_smash.down&rage.pct<50&!talent.battlelord|rage.pct<25
+actions.single_target+=/whirlwind,if=buff.merciless_bonegrinder.up
+actions.single_target+=/cleave,if=set_bonus.tier29_2pc&!talent.crushing_force
+actions.single_target+=/slam,if=rage>30&(!talent.fervor_of_battle|talent.fervor_of_battle&active_enemies=1)
+actions.single_target+=/bladestorm
+actions.single_target+=/cleave
+actions.single_target+=/wrecking_throw
+actions.single_target+=/rend,if=remains<duration*0.3
+
+head=thraexhelm_of_the_onyx_crucible,id=202443,bonus_id=4800/4786/1504/6935,gem_id=192988
+neck=torc_of_passed_time,id=201759,bonus_id=8840/8836/8902/1537,gem_id=192948/192948/192948,crafted_stats=32/36
+shoulders=pauldrons_of_the_onyx_crucible,id=202441,bonus_id=4800/4786/1507
+back=voice_of_the_silent_star,id=204465,bonus_id=4800/4786/1498
+chest=battlechest_of_the_onyx_crucible,id=202446,bonus_id=4800/4786/1501,enchant_id=6625
+wrists=bonds_of_desperate_ascension,id=204390,bonus_id=4800/4786/1498/6935,gem_id=192948
+hands=handguards_of_the_onyx_crucible,id=202444,bonus_id=4800/4786/1501
+waist=primal_molten_greatbelt,id=190501,bonus_id=8840/8836/8902/1537,gem_id=192919,crafted_stats=32/36
+legs=primal_molten_legplates,id=190499,bonus_id=8840/8836/8902/1537/9379/8960,enchant_id=6496,crafted_stats=32/36
+feet=primal_molten_sabatons,id=190496,bonus_id=8840/8836/8902/1537/9379/8960,crafted_stats=32/36
+finger1=signet_of_titanic_insight,id=192999,bonus_id=8840/8836/8902/8783/8784/8780/1537,gem_id=192948,enchant_id=6556,crafted_stats=32/36
+finger2=ringbound_hourglass,id=193000,bonus_id=8840/8836/8902/8783/8784/8780/1537,gem_id=192948,enchant_id=6556,crafted_stats=32/36
+trinket1=ominous_chromatic_essence,id=203729,bonus_id=4800/4786/1498
+trinket2=beacon_to_the_beyond,id=203963,bonus_id=4800/4786/1498
+main_hand=ashkandur_fall_of_the_brotherhood,id=202606,bonus_id=4800/4786/1498,enchant=wafting_devotion_3
+
+# Gear Summary
+# gear_ilvl=448.67
+# gear_strength=6254
+# gear_stamina=22482
+# gear_crit_rating=4965
+# gear_haste_rating=5618
+# gear_mastery_rating=2582
+# gear_versatility_rating=199
+# gear_armor=8558
+# gear_bonus_armor=141
+# set_bonus=tier30_2pc=1
+# set_bonus=tier30_4pc=1

--- a/profiles/Tier30/T30_Warrior_Fury.simc
+++ b/profiles/Tier30/T30_Warrior_Fury.simc
@@ -1,0 +1,146 @@
+warrior="T30_Fury_Warrior"
+source=default
+spec=fury
+level=70
+race=human
+role=attack
+position=back
+professions=blacksmithing=100/engineering=65
+talents=BgEAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAChIoEARQICEFIhIQkEJJpFRSSQCJJJRKBIJkEAAAAEE
+dragonflight.ominous_chromatic_essence_dragonflight=ruby
+dragonflight.ominous_chromatic_essence_allies=azure/bronze/emerald/obsidian
+
+# Default consumables
+potion=elemental_potion_of_ultimate_power_3
+flask=phial_of_tepid_versatility_3
+food=fated_fortune_cookie
+augmentation=draconic
+temporary_enchant=main_hand:hissing_rune_3/off_hand:hissing_rune_3
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+actions.precombat=flask
+actions.precombat+=/food
+actions.precombat+=/augmentation
+actions.precombat+=/berserker_stance,toggle=on
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/use_item,name=algethar_puzzle_box
+actions.precombat+=/avatar,if=!talent.titans_torment
+actions.precombat+=/recklessness,if=!talent.reckless_abandon
+
+# Executed every time the actor is available.
+actions=auto_attack
+actions+=/charge,if=time<=0.5|movement.distance>5
+actions+=/heroic_leap,if=(raid_event.movement.distance>25&raid_event.movement.in>45)
+actions+=/potion
+actions+=/pummel,if=target.debuff.casting.react
+actions+=/use_item,name=screaming_black_dragonscale
+actions+=/ravager,if=cooldown.recklessness.remains<3|buff.recklessness.up
+actions+=/blood_fury
+actions+=/berserking,if=buff.recklessness.up
+actions+=/lights_judgment,if=buff.recklessness.down
+actions+=/fireblood
+actions+=/ancestral_call
+actions+=/bag_of_tricks
+actions+=/avatar,if=talent.titans_torment&buff.enrage.up&raid_event.adds.in>15|!talent.titans_torment&(buff.recklessness.up|target.time_to_die<20)
+actions+=/recklessness,if=!raid_event.adds.exists&(talent.annihilator&cooldown.avatar.remains<1|cooldown.avatar.remains>40|!talent.avatar|target.time_to_die<12)
+actions+=/recklessness,if=!raid_event.adds.exists&!talent.annihilator|target.time_to_die<12
+actions+=/spear_of_bastion,if=buff.enrage.up&(buff.recklessness.up|buff.avatar.up|target.time_to_die<20|active_enemies>1)&raid_event.adds.in>15
+actions+=/call_action_list,name=multi_target,if=raid_event.adds.exists|active_enemies>2
+actions+=/call_action_list,name=single_target,if=!raid_event.adds.exists
+
+actions.multi_target=recklessness,if=raid_event.adds.in>15|active_enemies>1|target.time_to_die<12
+actions.multi_target+=/odyns_fury,if=active_enemies>1&talent.titanic_rage&(!buff.meat_cleaver.up|buff.avatar.up|buff.recklessness.up)
+actions.multi_target+=/whirlwind,if=spell_targets.whirlwind>1&talent.improved_whirlwind&!buff.meat_cleaver.up|raid_event.adds.in<2&talent.improved_whirlwind&!buff.meat_cleaver.up
+actions.multi_target+=/execute,if=buff.ashen_juggernaut.up&buff.ashen_juggernaut.remains<gcd
+actions.multi_target+=/thunderous_roar,if=buff.enrage.up&(spell_targets.whirlwind>1|raid_event.adds.in>15)
+actions.multi_target+=/odyns_fury,if=active_enemies>1&buff.enrage.up&raid_event.adds.in>15
+actions.multi_target+=/bloodbath,if=action.bloodbath.crit_pct_current>=95|!talent.cold_steel_hot_blood&set_bonus.tier30_4pc
+actions.multi_target+=/bloodthirst,if=action.bloodthirst.crit_pct_current>=95|!talent.cold_steel_hot_blood&set_bonus.tier30_4pc
+actions.multi_target+=/crushing_blow,if=talent.wrath_and_fury&buff.enrage.up
+actions.multi_target+=/execute,if=buff.enrage.up
+actions.multi_target+=/odyns_fury,if=buff.enrage.up&raid_event.adds.in>15
+actions.multi_target+=/rampage,if=buff.recklessness.up|buff.enrage.remains<gcd|(rage>110&talent.overwhelming_rage)|(rage>80&!talent.overwhelming_rage)
+actions.multi_target+=/execute
+actions.multi_target+=/bloodbath,if=buff.enrage.up&talent.reckless_abandon&!talent.wrath_and_fury
+actions.multi_target+=/bloodthirst,if=buff.enrage.down|(talent.annihilator&!buff.recklessness.up)
+actions.multi_target+=/onslaught,if=!talent.annihilator&buff.enrage.up|talent.tenderize
+actions.multi_target+=/raging_blow,if=charges>1&talent.wrath_and_fury
+actions.multi_target+=/crushing_blow,if=charges>1&talent.wrath_and_fury
+actions.multi_target+=/bloodbath,if=buff.enrage.down|!talent.wrath_and_fury
+actions.multi_target+=/crushing_blow,if=buff.enrage.up&talent.reckless_abandon
+actions.multi_target+=/bloodthirst,if=!talent.wrath_and_fury
+actions.multi_target+=/raging_blow,if=charges>=1
+actions.multi_target+=/rampage
+actions.multi_target+=/slam,if=talent.annihilator
+actions.multi_target+=/bloodbath
+actions.multi_target+=/raging_blow
+actions.multi_target+=/crushing_blow
+actions.multi_target+=/whirlwind
+
+actions.single_target=whirlwind,if=spell_targets.whirlwind>1&talent.improved_whirlwind&!buff.meat_cleaver.up|raid_event.adds.in<2&talent.improved_whirlwind&!buff.meat_cleaver.up
+actions.single_target+=/execute,if=buff.ashen_juggernaut.up&buff.ashen_juggernaut.remains<gcd
+actions.single_target+=/thunderous_roar,if=buff.enrage.up&(spell_targets.whirlwind>1|raid_event.adds.in>15)
+actions.single_target+=/odyns_fury,if=buff.enrage.up&(spell_targets.whirlwind>1|raid_event.adds.in>15)&(talent.dancing_blades&buff.dancing_blades.remains<5|!talent.dancing_blades)
+actions.single_target+=/rampage,if=talent.anger_management&(buff.recklessness.up|buff.enrage.remains<gcd|rage.pct>85)
+actions.single_target+=/bloodbath,if=action.bloodbath.crit_pct_current>=95|!talent.cold_steel_hot_blood&set_bonus.tier30_4pc
+actions.single_target+=/bloodthirst,if=action.bloodthirst.crit_pct_current>=95|!talent.cold_steel_hot_blood&set_bonus.tier30_4pc
+actions.single_target+=/execute,if=buff.enrage.up
+actions.single_target+=/onslaught,if=buff.enrage.up|talent.tenderize
+actions.single_target+=/crushing_blow,if=talent.wrath_and_fury&buff.enrage.up
+actions.single_target+=/rampage,if=talent.reckless_abandon&(buff.recklessness.up|buff.enrage.remains<gcd|rage.pct>85)
+actions.single_target+=/rampage,if=talent.anger_management
+actions.single_target+=/execute
+actions.single_target+=/bloodbath,if=buff.enrage.up&talent.reckless_abandon&!talent.wrath_and_fury
+actions.single_target+=/bloodthirst,if=buff.enrage.down|(talent.annihilator&!buff.recklessness.up)
+actions.single_target+=/raging_blow,if=charges>1&talent.wrath_and_fury
+actions.single_target+=/crushing_blow,if=charges>1&talent.wrath_and_fury
+actions.single_target+=/bloodbath,if=buff.enrage.down|!talent.wrath_and_fury
+actions.single_target+=/crushing_blow,if=buff.enrage.up&talent.reckless_abandon
+actions.single_target+=/bloodthirst,if=!talent.wrath_and_fury
+actions.single_target+=/raging_blow,if=charges>1
+actions.single_target+=/rampage
+actions.single_target+=/slam,if=talent.annihilator
+actions.single_target+=/bloodbath
+actions.single_target+=/raging_blow
+actions.single_target+=/crushing_blow
+actions.single_target+=/bloodthirst
+actions.single_target+=/whirlwind
+actions.single_target+=/wrecking_throw
+actions.single_target+=/storm_bolt
+
+head=thraexhelm_of_the_onyx_crucible,id=202443,bonus_id=4800/4786/1504/6935,gem_id=192988
+neck=torc_of_passed_time,id=201759,bonus_id=8840/8836/8902/1537,gem_id=192961/192961/192961,crafted_stats=36/49
+shoulders=pauldrons_of_the_onyx_crucible,id=202441,bonus_id=4800/4786/1507
+back=voice_of_the_silent_star,id=204465,bonus_id=4800/4786/1498
+chest=battlechest_of_the_onyx_crucible,id=202446,bonus_id=4800/4786/1501,enchant_id=6625
+wrists=bonds_of_desperate_ascension,id=204390,bonus_id=4800/4786/1498/6935,gem_id=192961
+hands=handguards_of_the_onyx_crucible,id=202444,bonus_id=4800/4786/1501
+waist=primal_molten_greatbelt,id=190501,bonus_id=8840/8836/8902/1537,gem_id=192961,crafted_stats=36/49
+legs=primal_molten_legplates,id=190499,bonus_id=8840/8836/8902/1537/9379,enchant_id=6496,crafted_stats=36/49
+feet=primal_molten_sabatons,id=190496,bonus_id=8840/8836/8902/1537/9379,crafted_stats=36/49
+finger1=signet_of_titanic_insight,id=192999,bonus_id=8840/8836/8902/8783/8784/8780/1537,gem_id=192961,enchant_id=6562,crafted_stats=36/49
+finger2=seal_of_diurnas_chosen,id=195480,bonus_id=4800/4786/1498,gem_id=192961,enchant_id=6568
+trinket1=ominous_chromatic_essence,id=203729,bonus_id=4800/4786/1498
+trinket2=screaming_black_dragonscale,id=202612,bonus_id=4800/4786/1498
+main_hand=ashkandur_fall_of_the_brotherhood,id=202606,bonus_id=4800/4786/1498,enchant_id=6827
+off_hand=obsidian_seared_claymore,id=190514,bonus_id=8840/8836/8902/8783/8784/1537,enchant_id=6655,crafted_stats=36/49
+
+# Gear Summary
+# gear_ilvl=446.75
+# gear_strength=7492
+# gear_stamina=24506
+# gear_crit_rating=1952
+# gear_haste_rating=4642
+# gear_mastery_rating=5908
+# gear_versatility_rating=1190
+# gear_armor=8558
+# gear_bonus_armor=141
+# set_bonus=tier30_2pc=1
+# set_bonus=tier30_4pc=1

--- a/profiles/generators/Tier30/T30_Generate_Mage.simc
+++ b/profiles/generators/Tier30/T30_Generate_Mage.simc
@@ -1,4 +1,4 @@
-# mage="T30_Mage_Arcane"
+mage="T30_Mage_Arcane"
 level=70
 race=tauren
 role=spell

--- a/profiles/generators/Tier30/T30_Generate_Warlock.simc
+++ b/profiles/generators/Tier30/T30_Generate_Warlock.simc
@@ -1,80 +1,77 @@
-# warlock="T30_Warlock_Affliction"
-# level=70
-# spec=affliction
-# race=mechagnome
-# role=spell
-# position=ranged_back
-# talents=BkQAAAAAAAAAAAAAAAAAAAAAAgQSSkkAppAplkESLAAAAQjEAAAAAAIR0CRSikIplQAAJ
+warlock="T30_Warlock_Affliction"
+level=70
+spec=affliction
+race=mechagnome
+role=spell
+position=ranged_back
+talents=BkQAAAAAAAAAAAAAAAAAAAAAAgQSSkkAppAplkESLAAAAQjEAAAAAAIR0CRSikIplQAAJ
 
-# head=scalesworn_cultists_scorn,id=200336,bonus_id=6514,ilevel=424,gem_id=192988
-# neck=elemental_lariat,id=193001,bonus_id=1540/8793/6652/7936/7979/8767/8782,ilevel=418,gem_id=192948/192948/192948
-# shoulders=amice_of_the_blue,id=193526,bonus_id=8960/8840/8836/8902/1508
-# back=fireproof_drape,id=193763,ilevel=421,enchant_id=6604
-# chest=scalesworn_cultists_frock,id=200333,ilevel=421,enchant_id=6625
-# wrists=manawracker_bindings,id=134310,bonus_id=6514,ilevel=421,gem_id=192948,enchant_id=6580
-# hands=scalesworn_cultists_gloves,id=200335,ilevel=421
-# waist=magathas_spiritual_sash,id=195515,bonus_id=6514,ilevel=421,gem_id=192948
-# legs=scalesworn_cultists_culottes,id=200337,bonus_id=4800/4786/1498,enchant_id=6541
-# feet=cushioned_treads_of_glory,id=136774,bonus_id=1795/6808/4786/3300,enchant_id=6607
-# finger1=seal_of_filial_duty,id=195526,bonus_id=6514,ilevel=430,gem_id=192948,enchant=devotion_of_mastery_3,enchant_id=6562
-# finger2=unstable_arcane_loop,id=193633,bonus_id=6514,ilevel=421,gem_id=192948,enchant=devotion_of_mastery_3,enchant_id=6562
-# trinket1=furious_ragefeather,id=193677,bonus_id=6808/4786/1643
-# trinket2=whispering_incarnate_icon,id=194301,bonus_id=4800/4786/1498
-# main_hand=stormlashs_last_resort,id=195529,ilevel=424,enchant_id=6643
-# off_hand=scripture_of_primal_devotion,id=195513,ilevel=421
+head=grimhorns_of_the_sinister_savant,id=202533,bonus_id=8780,ilevel=447,gem_id=192985
+neck=magmoraxs_fourth_collar,id=204397,bonus_id=8782,ilevel=447,gem_id=192961/192961/192961
+shoulders=amice_of_the_sinister_savant,id=202531,ilevel=450
+back=voice_of_the_silent_star,id=204465,ilevel=457
+chest=cursed_robes_of_the_sinister_savant,id=202536,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=8836/8840/8902/8780/8802/8846/8793/9379,ilevel=447,gem_id=192961,enchant_id=6574,crafted_stats=40/32
+hands=grips_of_the_sinister_savant,id=202534,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=8780/9379/8960,ilevel=447,gem_id=192961,crafted_stats=36/49
+legs=coattails_of_the_rightful_heir,id=202585,ilevel=450,enchant_id=6541
+feet=treads_of_fractured_realities,id=204392,ilevel=450,enchant_id=6607
+finger1=signet_of_titanic_insight,id=192999,bonus_id=8780/8793/8960,ilevel=447,gem_id=192961,enchant_id=6562
+finger2=scalebane_signet,id=193768,bonus_id=8780,ilevel=447,gem_id=192961,enchant_id=6556
+trinket1=igneous_flowstone,id=203996,ilevel=447
+trinket2=neltharions_call_to_dominance,id=204202,ilevel=457
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant_id=6643
 
-# save=T30_Warlock_Affliction.simc
+save=T30_Warlock_Affliction.simc
 
-# warlock="T30_Warlock_Demonology"
-# level=70
-# spec=demonology
-# race=orc
-# role=spell
-# position=ranged_back
-# talents=BoQAAAAAAAAAAAAAAAAAAAAAAggkEJJQaKQaJJh0CAAAAAKJSiECIRiEpolkkDQAAAAAAQC
+warlock="T30_Warlock_Demonology"
+level=70
+spec=demonology
+race=troll
+role=spell
+position=ranged_back
+talents=BoQAAAAAAAAAAAAAAAAAAAAAAAIJRSCkWKHQkmkESJAAAAAokIJSIgQikDkiWSSOABAAAAAAJ
 
-# head=scalesworn_cultists_scorn,id=200336,bonus_id=523,ilevel=424,gem_id=192985
-# neck=elemental_lariat,id=193001,bonus_id=8836/8840/8902/8960/8783/8782/8802/8793/8846,gem_id=192945/192945/192945,crafted_stats=32/40
-# shoulders=amice_of_the_blue,id=193526,bonus_id=8836/8840/8902/8960/8802/8846
-# back=fireproof_drape,id=193763,bonus_id=9130/7977/6652/8822/8819/9144/1643/8767,enchant_id=6592
-# chest=scalesworn_cultists_frock,id=200333,bonus_id=7981/6652/8830/1498/8767,enchant_id=6625
-# wrists=manawracker_bindings,id=134310,bonus_id=523,ilevel=421,gem_id=192945,enchant_id=6574
-# hands=scalesworn_cultists_gloves,id=200335,bonus_id=6652/8817/7981/8823/8095/8829/1501
-# waist=scalesworn_cultists_girdle,id=200339,bonus_id=523,ilevel=421,gem_id=192945
-# legs=scalesworn_cultists_culottes,id=200337,ilevel=421,enchant_id=6541
-# feet=sandals_of_the_wild_sovereign,id=195532,ilevel=424,enchant_id=6607
-# finger1=seal_of_diurnas_chosen,id=195480,bonus_id=523,ilevel=421,gem_id=192945,enchant_id=6556
-# finger2=unstable_arcane_loop,id=193633,bonus_id=523,ilevel=421,gem_id=192945,enchant_id=6556
-# trinket1=whispering_incarnate_icon,id=194301,ilevel=421
-# trinket2=voidmenders_shadowgem,id=110007,ilevel=421
-# main_hand=stormlashs_last_resort,id=195529,bonus_id=6652/7981/1498/8767,enchant_id=6643
-# off_hand=scripture_of_primal_devotion,id=195513,bonus_id=6652/7981/1498/8767
+head=cragshapers_fitted_hood,id=137341,bonus_id=8780,ilevel=447,gem_id=192985
+neck=magmoraxs_fourth_collar,id=204397,bonus_id=8782,ilevel=447,gem_id=192945/192945/192945
+shoulders=amice_of_the_sinister_savant,id=202531,ilevel=450
+back=voice_of_the_silent_star,id=204465,ilevel=457
+chest=cursed_robes_of_the_sinister_savant,id=202536,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=8836/8840/8902/8780/8802/8846/8793/9379,ilevel=447,gem_id=192945,enchant_id=6574,crafted_stats=40/32
+hands=grips_of_the_sinister_savant,id=202534,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=9379/8960/8780,ilevel=447,gem_id=192945,crafted_stats=36/49
+legs=leggings_of_the_sinister_savant,id=205849,ilevel=450,enchant_id=6541
+feet=treads_of_fractured_realities,id=204392,ilevel=450,enchant_id=6607
+finger1=loop_of_pulsing_veins,id=159463,bonus_id=8780,ilevel=447,gem_id=192945,enchant_id=6550
+finger2=seal_of_questionable_loyalties,id=158314,bonus_id=8780,ilevel=447,gem_id=192945,enchant_id=6550
+trinket1=irideus_fragment,id=193743,bonus_id=6652/1643/8767,ilevel=447
+trinket2=neltharions_call_to_dominance,id=204202,ilevel=457
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant_id=6643
 
-# save=T30_Warlock_Demonology.simc
+save=T30_Warlock_Demonology.simc
 
-# warlock="T30_Warlock_Destruction"
-# level=70
-# spec=destruction
-# race=human
-# role=spell
-# position=ranged_back
-# talents=BsQAAAAAAAAAAAAAAAAAAAAAAggkEJJQaKEpdgkESLwBSUSSSCSalmkAAAAAAAAAAAAIgSSkA
+warlock="T30_Warlock_Destruction"
+level=70
+spec=destruction
+race=mechagnome
+role=spell
+position=ranged_back
+talents=BsQAAAAAAAAAAAAAAAAAAAAAAggkEJJQaKEpdgkESJwBSUSSkAatmkAAAAAAAAAAAAIIpkEJ
 
-# head=scalesworn_cultists_scorn,id=200336,bonus_id=6514,ilevel=424,gem_id=192985
-# neck=elemental_lariat,id=193001,bonus_id=1540/8793/6652/7936/7979/8767/8782,ilevel=418,gem_id=192948/192948/192948
-# shoulders=amice_of_the_blue,id=193526,bonus_id=8960/8840/8836/8902/1508
-# back=fireproof_drape,id=193763,ilevel=421,enchant_id=6604
-# chest=scalesworn_cultists_frock,id=200333,ilevel=421,enchant_id=6625
-# wrists=manawracker_bindings,id=134310,bonus_id=6514,ilevel=421,gem_id=192948,enchant_id=6580
-# hands=scalesworn_cultists_gloves,id=200335,ilevel=421
-# waist=magathas_spiritual_sash,id=195515,bonus_id=6514,ilevel=421,gem_id=192948
-# legs=scalesworn_cultists_culottes,id=200337,ilevel=421,enchant_id=6541
-# feet=sandals_of_the_wild_sovereign,id=195532,ilevel=424,enchant_id=6607
-# finger1=seal_of_filial_duty,id=195526,bonus_id=6514,ilevel=430,gem_id=192948,enchant_id=6556
-# finger2=seal_of_diurnas_chosen,id=195480,bonus_id=6652/8783/8784/7936/7937/4800/4786/1498,gem_id=192945,enchant_id=6556
-# trinket1=whispering_incarnate_icon,id=194301,ilevel=421
-# trinket2=furious_ragefeather,id=193677,bonus_id=6808/4786/1643
-# main_hand=stormlashs_last_resort,id=195529,ilevel=424,enchant_id=6643
-# off_hand=scripture_of_primal_devotion,id=195513,ilevel=421
+head=grimhorns_of_the_sinister_savant,id=202533,bonus_id=8780,ilevel=447,gem_id=192988
+neck=torc_of_passed_time,id=201759,bonus_id=8836/8840/8902/9477/8782/9405/8793/9366,ilevel=447,gem_id=192961/192961/192961,crafted_stats=36/32
+shoulders=amice_of_the_sinister_savant,id=202531,ilevel=450
+back=voice_of_the_silent_star,id=204465,ilevel=457
+chest=cursed_robes_of_the_sinister_savant,id=202536,ilevel=447,enchant_id=6625
+wrists=vibrant_wildercloth_wristwraps,id=193510,bonus_id=8836/8840/8902/8780/8802/8846/8793/9379,ilevel=447,gem_id=192961,enchant_id=6574,crafted_stats=40/32
+hands=grips_of_the_sinister_savant,id=202534,ilevel=447
+waist=vibrant_wildercloth_girdle,id=193516,bonus_id=8780/9379/8960,ilevel=447,gem_id=192961,crafted_stats=36/49
+legs=coattails_of_the_rightful_heir,id=202585,ilevel=450,enchant_id=6541
+feet=treads_of_fractured_realities,id=204392,ilevel=450,enchant_id=6607
+finger1=loop_of_pulsing_veins,id=159463,bonus_id=8780,ilevel=447,gem_id=192961,enchant_id=6556
+finger2=signet_of_titanic_insight,id=192999,bonus_id=8780/8793/8960,ilevel=447,gem_id=192961,enchant_id=6562
+trinket1=igneous_flowstone,id=203996,ilevel=447
+trinket2=ominous_chromatic_essence,id=203729,bonus_id=4800/1498
+main_hand=erethos_the_empty_promise,id=202565,ilevel=450,enchant_id=6643
 
-# save=T30_Warlock_Destruction.simc
+save=T30_Warlock_Destruction.simc

--- a/profiles/generators/Tier30/T30_Generate_Warrior.simc
+++ b/profiles/generators/Tier30/T30_Generate_Warrior.simc
@@ -1,58 +1,62 @@
-# warrior="T30_Arms_Warrior"
-# spec=arms
-# level=70
-# race=human
-# role=attack
-# position=back
-# professions=blacksmithing=100/engineering=65
-# talents=BcEAAAAAAAAAAAAAAAAAAAAAAAQplIRkQkkSrkEAAAAQQkIKEQREQiQSoJRIAhECAAAAAAAAJBJJgQ0QA
+warrior="T30_Arms_Warrior"
+spec=arms
+level=70
+race=human
+role=attack
+position=back
+professions=blacksmithing=100/engineering=65
+talents=BcEAAAAAAAAAAAAAAAAAAAAAAAQplIRkQOQiSrkEAAAAQQkIKEQREQiQSoJRIAhECAAAAAAAAJBJJgQ0QA
+dragonflight.ominous_chromatic_essence_dragonflight=azure
+dragonflight.ominous_chromatic_essence_allies=ruby/bronze/emerald/obsidian
 
-# head=casque_of_the_walking_mountain,id=200426,bonus_id=4800/4786/1498/7935,ilevel=424,gem_id=192985
-# neck=elemental_lariat,id=193001,bonus_id=8782/8960,crafted_stats=32/36,ilevel=418,gem_id=192919/192919/192919
-# shoulder=peaks_of_the_walking_mountain,id=200428,bonus_id=4800/4786/1498
-# back=decorated_commanders_cindercloak,id=195482,bonus_id=4800/4786/1498
-# chest=datheas_cyclonic_cage,id=195494,bonus_id=4800/4786/1498,enchant_id=6625
-# wrist=allied_wristguard_of_companionship,id=190526,bonus_id=7935/8960,ilevel=418,gem_id=192919
-# hands=gauntlets_of_the_walking_mountain,id=200425,bonus_id=4800/4786/1498
-# waist=matriarchs_opulent_girdle,id=195524,bonus_id=4800/4786/1498/7935,gem_id=192919
-# legs=poleyns_of_the_walking_mountain,id=200427,bonus_id=4800/4786/1498,enchant_id=6496
-# feet=kurogs_thunderhooves,id=195517,bonus_id=4800/4786/1498
-# finger1=jeweled_signet_of_melandrus,id=134542,bonus_id=6652/8811/8812/6808/4786/1808/3300,gem_id=192919,enchant_id=6556
-# finger2=emissarys_flamewrought_seal,id=201992,bonus_id=4800/4786/1498/7935,gem_id=192919,enchant_id=6556
-# trinket1=whispering_incarnate_icon,id=194301,bonus_id=4800/4786/1498
-# trinket2=manic_grieftorch,id=194308,bonus_id=4800/4786/1498
-# main_hand=incarnate_skysplitter,id=195528,bonus_id=4800/4786/1498,enchant_id=6649
+head=thraexhelm_of_the_onyx_crucible,id=202443,bonus_id=4800/4786/1504/6935,gem_id=192988
+neck=torc_of_passed_time,id=201759,bonus_id=8840/8836/8902/1537,gem_id=192948/192948/192948,crafted_stats=32/36
+shoulder=pauldrons_of_the_onyx_crucible,id=202441,bonus_id=4800/4786/1507
+back=voice_of_the_silent_star,id=204465,bonus_id=4800/4786/1498
+chest=battlechest_of_the_onyx_crucible,id=202446,bonus_id=4800/4786/1501,enchant_id=6625
+wrist=bonds_of_desperate_ascension,id=204390,bonus_id=4800/4786/1498/6935,gem_id=192948
+hands=handguards_of_the_onyx_crucible,id=202444,bonus_id=4800/4786/1501
+waist=primal_molten_greatbelt,id=190501,bonus_id=8840/8836/8902/1537,crafted_stats=32/36,gem_id=192919
+legs=primal_molten_legplates,id=190499,bonus_id=8840/8836/8902/1537/9379/8960,crafted_stats=32/36,enchant_id=6496
+feet=primal_molten_sabatons,id=190496,bonus_id=8840/8836/8902/1537/9379/8960,crafted_stats=32/36
+finger1=signet_of_titanic_insight,id=192999,bonus_id=8840/8836/8902/8783/8784/8780/1537,crafted_stats=32/36,enchant_id=6556,gem_id=192948
+finger2=ringbound_hourglass,id=193000,bonus_id=8840/8836/8902/8783/8784/8780/1537,crafted_stats=32/36,enchant_id=6556,gem_id=192948
+trinket1=ominous_chromatic_essence,id=203729,bonus_id=4800/4786/1498
+trinket2=beacon_to_the_beyond,id=203963,bonus_id=4800/4786/1498
+main_hand=ashkandur_fall_of_the_brotherhood,id=202606,bonus_id=4800/4786/1498,enchant=wafting_devotion_3
 
-# save=T30_Warrior_Arms.simc
+save=T30_Warrior_Arms.simc
 
 
-# warrior="T30_Fury_Warrior"
-# spec=fury
-# level=70
-# race=human
-# role=attack
-# position=back
-# professions=blacksmithing=100/engineering=65
-# talents=BgEAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAChIoEARQISQUgEiARSIJpFRSkgQSSSkSASSkEAAAAEE
+warrior="T30_Fury_Warrior"
+spec=fury
+level=70
+race=human
+role=attack
+position=back
+professions=blacksmithing=100/engineering=65
+talents=BgEAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAChIoEARQICEFIhIQkEJJpFRSSQCJJJRKBIJkEAAAAEE
+dragonflight.ominous_chromatic_essence_dragonflight=ruby
+dragonflight.ominous_chromatic_essence_allies=azure/bronze/emerald/obsidian
 
-# head=casque_of_the_walking_mountain,id=200426,bonus_id=4800/4786/1498/7935,ilevel=424,gem_id=192988
-# neck=elemental_lariat,id=193001,bonus_id=8782/8960,crafted_stats=32/49,ilevel=418,gem_id=192961/192961/192961
-# shoulders=peaks_of_the_walking_mountain,id=200428,bonus_id=4800/4786/1498
-# back=acidproof_webbing,id=195511,bonus_id=4800/4786/1498
-# chest=datheas_cyclonic_cage,id=195494,bonus_id=4800/4786/1498,enchant_id=6625
-# wrists=allied_wristguard_of_companionship,id=190526,bonus_id=7935/8960,ilevel=418,gem_id=192961
-# hands=gauntlets_of_the_walking_mountain,id=200425,bonus_id=4800/4786/1498
-# waist=matriarchs_opulent_girdle,id=195524,bonus_id=4800/4786/1498/7935,gem_id=192961
-# legs=poleyns_of_the_walking_mountain,id=200427,bonus_id=4800/4786/1498,enchant_id=6496
-# feet=kurogs_thunderhooves,id=195517,bonus_id=4800/4786/1498
-# finger1=jeweled_signet_of_melandrus,id=134542,bonus_id=6652/8811/8812/6808/4786/1808/3300,gem_id=192961,enchant_id=6562
-# finger2=seal_of_filial_duty,id=195526,bonus_id=4800/4786/1498/7935,gem_id=192961,enchant_id=6562
-# trinket1=whispering_incarnate_icon,id=194301,bonus_id=4800/4786/1498
-# trinket2=manic_grieftorch,id=194308,bonus_id=4800/4786/1498
-# main_hand=incarnate_skysplitter,id=195528,bonus_id=4800/4786/1498,enchant_id=6649
-# off_hand=incarnate_skysplitter,id=195528,bonus_id=4800/4786/1498,enchant_id=6649
+head=thraexhelm_of_the_onyx_crucible,id=202443,bonus_id=4800/4786/1504/6935,gem_id=192988
+neck=torc_of_passed_time,id=201759,bonus_id=8840/8836/8902/1537,gem_id=192961/192961/192961,crafted_stats=36/49
+shoulder=pauldrons_of_the_onyx_crucible,id=202441,bonus_id=4800/4786/1507
+back=voice_of_the_silent_star,id=204465,bonus_id=4800/4786/1498
+chest=battlechest_of_the_onyx_crucible,id=202446,bonus_id=4800/4786/1501,enchant_id=6625
+wrist=bonds_of_desperate_ascension,id=204390,bonus_id=4800/4786/1498/6935,gem_id=192961
+hands=handguards_of_the_onyx_crucible,id=202444,bonus_id=4800/4786/1501
+waist=primal_molten_greatbelt,id=190501,bonus_id=8840/8836/8902/1537,crafted_stats=36/49,gem_id=192961
+legs=primal_molten_legplates,id=190499,bonus_id=8840/8836/8902/1537/9379,crafted_stats=36/49,enchant_id=6496
+feet=primal_molten_sabatons,id=190496,bonus_id=8840/8836/8902/1537/9379,crafted_stats=36/49
+finger1=signet_of_titanic_insight,id=192999,bonus_id=8840/8836/8902/8783/8784/8780/1537,crafted_stats=36/49,enchant_id=6562,gem_id=192961
+finger2=seal_of_diurnas_chosen,id=195480,bonus_id=4800/4786/1498,enchant_id=6568,gem_id=192961
+trinket1=ominous_chromatic_essence,id=203729,bonus_id=4800/4786/1498
+trinket2=screaming_black_dragonscale,id=202612,bonus_id=4800/4786/1498
+main_hand=ashkandur_fall_of_the_brotherhood,id=202606,bonus_id=4800/4786/1498,enchant_id=6827
+off_hand=obsidian_seared_claymore,id=190514,bonus_id=8840/8836/8902/8783/8784/1537,enchant_id=6655,crafted_stats=36/49
 
-# save=T30_Warrior_Fury.simc
+save=T30_Warrior_Fury.simc
 
 # warrior="T30_Warrior_Protection"
 # source=default


### PR DESCRIPTION
The game engine makes a distinction between damage multipliers based on
1) school via `Modify Damage Done% (79)` effect which applies to all damage by the player
2) lists via `Add Percent Modifier (108): Spell Direct Amount (0)` and `Spell Periodic Amount (22)` effects which applies only to specific spells

Primarily this affects the `Ignore Caster Damage Modifier (221)` spell attribute which causes the spell to ignore 1) but account for 2).