### PR TITLE
Split damage multipliers into school v list based

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -4001,10 +4001,10 @@ void action_t::snapshot_internal( action_state_t* state, unsigned flags, result_
     state->versatility = composite_versatility( state );
 
   if ( flags & STATE_MUL_SPELL_DA )
-   state->da_multiplier = composite_da_multiplier( state );
+    state->da_multiplier = composite_da_multiplier( state );
 
   if ( flags & STATE_MUL_SPELL_TA )
-   state->ta_multiplier = composite_ta_multiplier( state );
+    state->ta_multiplier = composite_ta_multiplier( state );
 
   if ( flags & STATE_MUL_PLAYER_DAM )
     state->player_multiplier = composite_player_multiplier( state );

--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -2536,7 +2536,7 @@ void action_t::init()
   if ( may_crit || tick_may_crit )
     snapshot_flags |= STATE_CRIT | STATE_TGT_CRIT;
 
-  if ( ( base_td > 0 || spell_power_mod.tick > 0 || attack_power_mod.tick > 0 ) && dot_duration > timespan_t::zero() )
+  if ( ( base_td > 0 || spell_power_mod.tick > 0 || attack_power_mod.tick > 0 ) && dot_duration > 0_ms )
     snapshot_flags |= STATE_MUL_TA | STATE_TGT_MUL_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
 
   if ( base_dd_min > 0 || ( spell_power_mod.direct > 0 || attack_power_mod.direct > 0 ) || weapon_multiplier > 0 )
@@ -2554,7 +2554,7 @@ void action_t::init()
   if ( data().flags( spell_attribute::SX_DISABLE_PLAYER_MULT ) ||
        data().flags( spell_attribute::SX_DISABLE_PLAYER_HEALING_MULT ) )
   {
-    snapshot_flags &= ~( STATE_VERSATILITY );
+    snapshot_flags &= ~( STATE_VERSATILITY | STATE_MUL_PLAYER_DAM );
   }
 
   if ( data().flags( spell_attribute::SX_DISABLE_TARGET_MULT ) )
@@ -4000,11 +4000,14 @@ void action_t::snapshot_internal( action_state_t* state, unsigned flags, result_
   if ( flags & STATE_VERSATILITY )
     state->versatility = composite_versatility( state );
 
-  if ( flags & STATE_MUL_DA )
-    state->da_multiplier = composite_da_multiplier( state );
+  if ( flags & STATE_MUL_SPELL_DA )
+   state->da_multiplier = composite_da_multiplier( state );
 
-  if ( flags & STATE_MUL_TA )
-    state->ta_multiplier = composite_ta_multiplier( state );
+  if ( flags & STATE_MUL_SPELL_TA )
+   state->ta_multiplier = composite_ta_multiplier( state );
+
+  if ( flags & STATE_MUL_PLAYER_DAM )
+    state->player_multiplier = composite_player_multiplier( state );
 
   if ( flags & STATE_MUL_PERSISTENT )
     state->persistent_multiplier = composite_persistent_multiplier( state );
@@ -4517,40 +4520,29 @@ double action_t::composite_total_corruption() const
   return player->composite_total_corruption();
 }
 
-double action_t::composite_da_multiplier(const action_state_t*) const
+double action_t::composite_player_multiplier( const action_state_t* ) const
 {
-  double base_multiplier = action_multiplier();
-  double direct_multiplier = action_da_multiplier();
   double player_school_multiplier = 0.0;
   double tmp;
 
-  for (auto base_school : base_schools)
+  for ( auto base_school : base_schools )
   {
-    tmp = player->cache.player_multiplier(base_school);
-    if (tmp > player_school_multiplier) player_school_multiplier = tmp;
+    tmp = player->cache.player_multiplier( base_school );
+    if ( tmp > player_school_multiplier )
+      player_school_multiplier = tmp;
   }
 
-  return base_multiplier * direct_multiplier * player_school_multiplier *
-    player->composite_player_dd_multiplier(get_school(), this);
+  return player_school_multiplier;
 }
 
-/// Normal ticking modifiers that are updated every tick
-
-double action_t::composite_ta_multiplier(const action_state_t*) const
+double action_t::composite_da_multiplier( const action_state_t* ) const
 {
-  double base_multiplier = action_multiplier();
-  double tick_multiplier = action_ta_multiplier();
-  double player_school_multiplier = 0.0;
-  double tmp;
+  return action_multiplier() * action_da_multiplier();
+}
 
-  for (auto base_school : base_schools)
-  {
-    tmp = player->cache.player_multiplier(base_school);
-    if (tmp > player_school_multiplier) player_school_multiplier = tmp;
-  }
-
-  return base_multiplier * tick_multiplier * player_school_multiplier *
-    player->composite_player_td_multiplier(get_school(), this);
+double action_t::composite_ta_multiplier( const action_state_t* ) const
+{
+  return action_multiplier() * action_ta_multiplier();
 }
 
 /// Persistent modifiers that are snapshot at the start of the spell cast

--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -878,13 +878,17 @@ public:
   virtual double composite_target_ta_multiplier( player_t* target ) const
   { return composite_target_multiplier( target ); }
 
-  virtual double composite_da_multiplier(const action_state_t* /* s */) const;
+  /// School-based generic damage multipliers that affect all player damage
+  virtual double composite_player_multiplier( const action_state_t* ) const;
 
-  /// Normal ticking modifiers that are updated every tick
-  virtual double composite_ta_multiplier(const action_state_t* /* s */) const;
+  /// List-based direct damage multipliers that specifically affect the action
+  virtual double composite_da_multiplier( const action_state_t* ) const;
+
+  /// List-based tick damage multipliers that specifically affect the action
+  virtual double composite_ta_multiplier( const action_state_t* ) const;
 
   /// Persistent modifiers that are snapshot at the start of the spell cast
-  virtual double composite_persistent_multiplier(const action_state_t*) const;
+  virtual double composite_persistent_multiplier( const action_state_t* ) const;
 
   /**
    * @brief Generic aoe multiplier for the action.
@@ -895,9 +899,9 @@ public:
   virtual double composite_aoe_multiplier( const action_state_t* ) const
   { return 1.0; }
 
-  virtual double composite_target_mitigation(player_t* t, school_e s) const;
+  virtual double composite_target_mitigation( player_t* t, school_e s ) const;
 
-  virtual double composite_player_critical_multiplier(const action_state_t* s) const;
+  virtual double composite_player_critical_multiplier( const action_state_t* s ) const;
 
   /// Action proc type, needed for dynamic aoe stuff and such.
   virtual proc_types proc_type() const

--- a/engine/action/action_state.cpp
+++ b/engine/action/action_state.cpp
@@ -102,6 +102,7 @@ void action_state_t::copy_state( const action_state_t* o )
   versatility           = o->versatility;
   da_multiplier         = o->da_multiplier;
   ta_multiplier         = o->ta_multiplier;
+  player_multiplier     = o->player_multiplier;
   persistent_multiplier = o->persistent_multiplier;
   pet_multiplier        = o->pet_multiplier;
 
@@ -141,6 +142,7 @@ action_state_t::action_state_t( action_t* a, player_t* t )
     versatility( 1.0 ),
     da_multiplier( 1.0 ),
     ta_multiplier( 1.0 ),
+    player_multiplier( 1.0 ),
     persistent_multiplier( 1.0 ),
     pet_multiplier( 1.0 ),
     target_da_multiplier( 1.0 ),
@@ -216,6 +218,7 @@ std::ostringstream& action_state_t::debug_str( std::ostringstream& s )
   s << " versatility=" << versatility;
   s << " da_mul=" << da_multiplier;
   s << " ta_mul=" << ta_multiplier;
+  s << " ply_mul=" << player_multiplier;
   s << " per_mul=" << persistent_multiplier;
   if ( action->player->is_pet() )
   {

--- a/engine/action/action_state.cpp
+++ b/engine/action/action_state.cpp
@@ -295,8 +295,10 @@ std::string action_state_t::flags_to_str( unsigned flags )
   concat_flag_str( str, "HST", STATE_HASTE );
   concat_flag_str( str, "CRIT", STATE_CRIT );
   concat_flag_str( str, "VERS", STATE_VERSATILITY );
-  concat_flag_str( str, "MUL_DA", STATE_MUL_DA );
-  concat_flag_str( str, "MUL_TA", STATE_MUL_TA );
+
+  concat_flag_str( str, "MUL_DA", STATE_MUL_SPELL_DA );
+  concat_flag_str( str, "MUL_TA", STATE_MUL_SPELL_TA );
+  concat_flag_str( str, "MUL_PLY", STATE_MUL_PLAYER_DAM );
   concat_flag_str( str, "MUL_PER", STATE_MUL_PERSISTENT );
   concat_flag_str( str, "MUL_PET", STATE_MUL_PET );
 
@@ -313,6 +315,11 @@ std::string action_state_t::flags_to_str( unsigned flags )
   concat_flag_str( str, "TGT_MIT_DA", STATE_TGT_MITG_DA );
   concat_flag_str( str, "TGT_MIT_TA", STATE_TGT_MITG_TA );
   concat_flag_str( str, "TGT_ARMOR", STATE_TGT_ARMOR );
+
+  concat_flag_str( str, "TGT_USR1", STATE_TGT_USER_1 );
+  concat_flag_str( str, "TGT_USR2", STATE_TGT_USER_2 );
+  concat_flag_str( str, "TGT_USR3", STATE_TGT_USER_3 );
+  concat_flag_str( str, "TGT_USR4", STATE_TGT_USER_4 );
 
   return str;
 }

--- a/engine/action/action_state.hpp
+++ b/engine/action/action_state.hpp
@@ -50,6 +50,7 @@ struct action_state_t : private noncopyable
   double          versatility;
   double          da_multiplier;
   double          ta_multiplier;
+  double          player_multiplier;
   double          persistent_multiplier;
   double          pet_multiplier; // Owner -> pet multiplier
   double          target_da_multiplier;
@@ -85,10 +86,16 @@ struct action_state_t : private noncopyable
   { return versatility; }
 
   virtual double composite_da_multiplier() const
-  { return da_multiplier * persistent_multiplier * target_da_multiplier * versatility * pet_multiplier * target_pet_multiplier; }
+  {
+    return da_multiplier * player_multiplier * persistent_multiplier * target_da_multiplier * versatility *
+           pet_multiplier * target_pet_multiplier;
+  }
 
   virtual double composite_ta_multiplier() const
-  { return ta_multiplier * persistent_multiplier * target_ta_multiplier * versatility * pet_multiplier * target_pet_multiplier; }
+  {
+    return ta_multiplier * player_multiplier * persistent_multiplier * target_ta_multiplier * versatility *
+           pet_multiplier * target_pet_multiplier;
+  }
 
   virtual double composite_target_mitigation_da_multiplier() const
   { return target_mitigation_da_multiplier; }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -670,7 +670,7 @@ namespace monk
         double ta = ab::composite_ta_multiplier( s ) * get_buff_effects_value( ta_multiplier_buffeffects );
 
         if ( ab::data().affected_by( p()->passives.hit_combo->effectN( 2 ) ) )
-          da *= 1.0 + p()->buff.hit_combo->check() * p()->passives.hit_combo->effectN( 2 ).percent();
+          ta *= 1.0 + p()->buff.hit_combo->check() * p()->passives.hit_combo->effectN( 2 ).percent();
 
         return ta;
       }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -668,12 +668,20 @@ namespace monk
       double composite_ta_multiplier( const action_state_t *s ) const override
       {
         double ta = ab::composite_ta_multiplier( s ) * get_buff_effects_value( ta_multiplier_buffeffects );
+
+        if ( ab::data().affected_by( p()->passives.hit_combo->effectN( 2 ) ) )
+          da *= 1.0 + p()->buff.hit_combo->check() * p()->passives.hit_combo->effectN( 2 ).percent();
+
         return ta;
       }
 
       double composite_da_multiplier( const action_state_t *s ) const override
       {
         double da = ab::composite_da_multiplier( s ) * get_buff_effects_value( da_multiplier_buffeffects );
+
+        if ( ab::data().affected_by( p()->passives.hit_combo->effectN( 1 ) ) )
+          da *= 1.0 + p()->buff.hit_combo->check() * p()->passives.hit_combo->effectN( 1 ).percent();
+
         return da;
       }
 
@@ -8984,26 +8992,10 @@ namespace monk
     return active;
   }
 
-  // monk_t::composite_player_dd_multiplier ================================
-  double monk_t::composite_player_dd_multiplier( school_e school, const action_t *action ) const
+  // monk_t::composite_player_multiplier ==================================
+  double monk_t::composite_player_multiplier( school_e school ) const
   {
-    double multiplier = player_t::composite_player_dd_multiplier( school, action );
-
-    if ( action->data().affected_by( passives.hit_combo->effectN( 1 ) ) )
-      multiplier *= 1 + buff.hit_combo->check() * passives.hit_combo->effectN( 1 ).percent();
-
-    multiplier *= 1 + talent.general.ferocity_of_xuen->effectN( 1 ).percent();
-
-    return multiplier;
-  }
-
-  // monk_t::composite_player_td_multiplier ================================
-  double monk_t::composite_player_td_multiplier( school_e school, const action_t *action ) const
-  {
-    double multiplier = player_t::composite_player_td_multiplier( school, action );
-
-    if ( action->data().affected_by( passives.hit_combo->effectN( 2 ) ) )
-      multiplier *= 1 + buff.hit_combo->check() * passives.hit_combo->effectN( 2 ).percent();
+    double multiplier = player_t::composite_player_multiplier( school );
 
     multiplier *= 1 + talent.general.ferocity_of_xuen->effectN( 1 ).percent();
 

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -1002,8 +1002,7 @@ public:
   double composite_damage_versatility() const override;
   double composite_crit_avoidance() const override;
   double temporary_movement_modifier() const override;
-  double composite_player_dd_multiplier( school_e, const action_t* action ) const override;
-  double composite_player_td_multiplier( school_e, const action_t* action ) const override;
+  double composite_player_multiplier( school_e ) const override;
   double composite_player_target_multiplier( player_t* target, school_e school ) const override;
   double composite_player_pet_damage_multiplier( const action_state_t*, bool guardian ) const override;
   double composite_player_target_pet_damage_multiplier( player_t* target, bool guardian ) const override;

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -4857,11 +4857,6 @@ double player_t::composite_player_multiplier( school_e school ) const
   return m;
 }
 
-double player_t::composite_player_td_multiplier( school_e /* school */, const action_t* /* a */ ) const
-{
-  return 1.0;
-}
-
 double player_t::composite_player_target_multiplier( player_t* target, school_e /* school */ ) const
 {
   double m = 1.0;

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -1060,11 +1060,8 @@ public:
   virtual double composite_attack_power_multiplier() const;
   virtual double composite_spell_power_multiplier() const;
   virtual double matching_gear_multiplier( attribute_e /* attr */ ) const { return 0; }
+  /// Player-wide school based multipliers
   virtual double composite_player_multiplier( school_e ) const;
-  /// These are here for future-proofing in case school based player multipliers are ever specified for direct vs
-  /// periodic. Currently they should be unused and are not cached.
-  virtual double composite_player_dd_multiplier( school_e, const action_t* a = nullptr ) const { return 1.0; }
-  virtual double composite_player_td_multiplier( school_e, const action_t* a = nullptr ) const { return 1.0; }
   /// Persistent multipliers that are snapshot at the beginning of the spell application/execution
   virtual double composite_persistent_multiplier( school_e ) const { return 1.0; }
   virtual double composite_player_target_multiplier( player_t* target, school_e school ) const;

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -1059,17 +1059,17 @@ public:
   virtual double composite_crit_avoidance() const;
   virtual double composite_attack_power_multiplier() const;
   virtual double composite_spell_power_multiplier() const;
-  virtual double matching_gear_multiplier( attribute_e /* attr */ ) const
-  { return 0; }
-  virtual double composite_player_multiplier   ( school_e ) const;
-  virtual double composite_player_dd_multiplier( school_e,  const action_t* /* a */ = nullptr ) const { return 1; }
-  virtual double composite_player_td_multiplier( school_e,  const action_t* a = nullptr ) const;
+  virtual double matching_gear_multiplier( attribute_e /* attr */ ) const { return 0; }
+  virtual double composite_player_multiplier( school_e ) const;
+  /// These are here for future-proofing in case school based player multipliers are ever specified for direct vs
+  /// periodic. Currently they should be unused and are not cached.
+  virtual double composite_player_dd_multiplier( school_e, const action_t* a = nullptr ) const { return 1.0; }
+  virtual double composite_player_td_multiplier( school_e, const action_t* a = nullptr ) const { return 1.0; }
   /// Persistent multipliers that are snapshot at the beginning of the spell application/execution
-  virtual double composite_persistent_multiplier( school_e ) const
-  { return 1.0; }
+  virtual double composite_persistent_multiplier( school_e ) const { return 1.0; }
   virtual double composite_player_target_multiplier( player_t* target, school_e school ) const;
   virtual double composite_player_heal_multiplier( const action_state_t* s ) const;
-  virtual double composite_player_dh_multiplier( school_e ) const { return 1; }
+  virtual double composite_player_dh_multiplier( school_e ) const { return 1.0; }
   virtual double composite_player_th_multiplier( school_e ) const;
   virtual double composite_player_absorb_multiplier( const action_state_t* s ) const;
   virtual double composite_player_pet_damage_multiplier( const action_state_t*, bool guardian ) const;

--- a/engine/sc_enums.hpp
+++ b/engine/sc_enums.hpp
@@ -1324,14 +1324,19 @@ enum snapshot_state_e
   STATE_AP             = 0x000004,
   STATE_SP             = 0x000008,
 
-  STATE_MUL_DA         = 0x000010,
-  STATE_MUL_TA         = 0x000020,
+  STATE_MUL_SPELL_DA   = 0x000010,  // Add Percent Modifier (108): Spell Direct Amount (0) list-based multiplier
+  STATE_MUL_SPELL_TA   = 0x000020,  // Add Percent Modifier (108): Spell Periodic Amount (22) list-based multiplier
   STATE_VERSATILITY    = 0x000040,
   STATE_MUL_PERSISTENT = 0x000080,  // Persistent modifier for the few abilities that snapshot
 
   STATE_TGT_CRIT       = 0x000100,
   STATE_TGT_MUL_DA     = 0x000200,
   STATE_TGT_MUL_TA     = 0x000400,
+
+  STATE_MUL_PLAYER_DAM = 0x000800,  // Modify Damage Done% (79) school-based player-wide multiplier
+
+  STATE_MUL_DA         = STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM,
+  STATE_MUL_TA         = STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM,
 
   // User-defined state flags
   STATE_USER_1         = 0x001000,

--- a/engine/sc_enums.hpp
+++ b/engine/sc_enums.hpp
@@ -1279,28 +1279,27 @@ enum role_e
 enum save_e : unsigned
 {
   // Specifies the type of profile data to be saved
-  SAVE_GEAR = 0x1,
+  SAVE_GEAR    = 0x1,
   SAVE_TALENTS = 0x2,
   SAVE_ACTIONS = 0x4,
-  SAVE_PLAYER = 0x8,
-  SAVE_ALL = SAVE_GEAR | SAVE_TALENTS | SAVE_ACTIONS | SAVE_PLAYER,
+  SAVE_PLAYER  = 0x8,
+  SAVE_ALL     = SAVE_GEAR | SAVE_TALENTS | SAVE_ACTIONS | SAVE_PLAYER,
 };
 
 enum power_e
 {
-  POWER_HEALTH      = -2,
-  POWER_MANA        = 0,
-  POWER_RAGE        = 1,
-  POWER_FOCUS       = 2,
-  POWER_ENERGY      = 3,
-  POWER_COMBO_POINT = 4,
-  POWER_RUNE        = 5,
-  POWER_RUNIC_POWER = 6,
-  POWER_SOUL_SHARDS = 7,
-  POWER_ASTRAL_POWER = 8,
-  POWER_HOLY_POWER = 9,
+  POWER_HEALTH        = -2,
+  POWER_MANA          = 0,
+  POWER_RAGE          = 1,
+  POWER_FOCUS         = 2,
+  POWER_ENERGY        = 3,
+  POWER_COMBO_POINT   = 4,
+  POWER_RUNE          = 5,
+  POWER_RUNIC_POWER   = 6,
+  POWER_SOUL_SHARDS   = 7,
+  POWER_ASTRAL_POWER  = 8,
+  POWER_HOLY_POWER    = 9,
   // Not yet used (MoP Monk deprecated resource #1)
-  // Not yet used
   POWER_MAELSTROM     = 11,
   POWER_CHI           = 12,
   POWER_INSANITY      = 13,
@@ -1312,8 +1311,8 @@ enum power_e
   POWER_ESSENSE       = 19,
   // Helpers
   POWER_MAX,
-  POWER_NONE   = 0xFFFFFFFF,  // None.
-  POWER_OFFSET = 2,
+  POWER_NONE          = 0xFFFFFFFF,  // None.
+  POWER_OFFSET        = 2,
 };
 
 // New stuff
@@ -1362,16 +1361,15 @@ enum snapshot_state_e
    * No multiplier helper, use in action_t::init() (after parent init) by issuing snapshot_flags &= STATE_NO_MULTIPLIER
    * (and/or update_flags &= STATE_NO_MULTIPLIER if a dot). This disables all multipliers, including versatility, and
    * any/all persistent multipliers the action would use. */
-  STATE_NO_MULTIPLIER = ~( STATE_MUL_DA | STATE_MUL_TA | STATE_VERSATILITY | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA |
-                           STATE_TGT_MUL_TA | STATE_TGT_ARMOR | STATE_MUL_PET | STATE_TGT_MUL_PET ),
+  STATE_NO_MULTIPLIER  = ~( STATE_MUL_DA | STATE_MUL_TA | STATE_VERSATILITY | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA |
+                            STATE_TGT_MUL_TA | STATE_TGT_ARMOR | STATE_MUL_PET | STATE_TGT_MUL_PET ),
 
   /// Target-specific state variables, excluding the pet damage multiplier
-  STATE_TARGET_NO_PET =
-      ( STATE_TGT_CRIT | STATE_TGT_MUL_DA | STATE_TGT_MUL_TA | STATE_TGT_ARMOR | STATE_TGT_MITG_DA | STATE_TGT_MITG_TA |
-        STATE_TGT_USER_1 | STATE_TGT_USER_2 | STATE_TGT_USER_3 | STATE_TGT_USER_4 ),
+  STATE_TARGET_NO_PET  = ( STATE_TGT_CRIT | STATE_TGT_MUL_DA | STATE_TGT_MUL_TA | STATE_TGT_ARMOR | STATE_TGT_MITG_DA |
+                           STATE_TGT_MITG_TA | STATE_TGT_USER_1 | STATE_TGT_USER_2 | STATE_TGT_USER_3 | STATE_TGT_USER_4 ),
 
   /// Target-specific state variables
-  STATE_TARGET = STATE_TARGET_NO_PET | STATE_TGT_MUL_PET
+  STATE_TARGET         = STATE_TARGET_NO_PET | STATE_TGT_MUL_PET
 };
 
 enum ready_e


### PR DESCRIPTION
The game engine makes a distinction between damage multipliers based on
1) school via `Modify Damage Done% (79)` effect which applies to all damage by the player
2) lists via `Add Percent Modifier (108): Spell Direct Amount (0)` and `Spell Periodic Amount (22)` effects which applies only to specific spells

Primarily this affects the `Ignore Caster Damage Modifier (221)` spell attribute which causes the spell to ignore 1) but account for 2).