### PR TITLE
[Shaman/Elemental] Prevent wasting Master of the Elements on Flame Shock

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -10674,7 +10674,9 @@ void shaman_t::init_action_list_elemental()
     single_target->add_action(
         "primordial_wave,target_if=min:dot.flame_shock.remains,if=!buff.primordial_wave.up&!buff.splintered_elements.up",
         "Use Primordial Wave as much as possible without wasting buffs." );
-    single_target->add_action( "flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies=1&refreshable&!buff.surge_of_power.up" );
+    single_target->add_action(
+        "flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies=1&refreshable&!buff.surge_of_power.up&(!buff.master_of_the_elements.up|(buff.master_of_the_elements.up&!buff.stormkeeper.up&(talent.elemental_blast.enabled&maelstrom<75)|maelstrom<50))",
+        "Maintain Flame Shock unless if it will waste precious buffs." );
     single_target->add_action( "flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&refreshable&!buff.surge_of_power.up&(talent.deeply_rooted_elements.enabled|talent.ascendance.enabled|talent.primordial_wave.enabled|talent.searing_flames.enabled|talent.magma_chamber.enabled),cycle_targets=1", "Spread Flame Shock to multiple targets only if talents were selected that benefit from it." );
     single_target->add_action( "stormkeeper,if=!buff.ascendance.up&!buff.stormkeeper.up&maelstrom>=116&talent.elemental_blast.enabled&talent.surge_of_power.enabled&talent.swelling_maelstrom.enabled&!talent.lava_surge.enabled&!talent.echo_of_the_elements.enabled&!talent.primordial_surge.enabled", "{EB/Swelling/SoP Lighting build} Start SK window if you have enough maelstrom to: EB > SoP SK_LB > LvB > EB." );
     single_target->add_action( "stormkeeper,if=!buff.ascendance.up&!buff.stormkeeper.up&buff.surge_of_power.up&!talent.lava_surge.enabled&!talent.echo_of_the_elements.enabled&!talent.primordial_surge.enabled", "{EB/SoP Lightning builds} Use Stormkeeper if you already got Surge of Power buff rolling." );

--- a/profiles/Tier30/T30_Shaman_Elemental.simc
+++ b/profiles/Tier30/T30_Shaman_Elemental.simc
@@ -135,6 +135,7 @@ actions.single_target+=/totemic_recall,if=cooldown.liquid_magma_totem.remains>45
 actions.single_target+=/liquid_magma_totem
 # Use Primordial Wave as much as possible without wasting buffs.
 actions.single_target+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=!buff.primordial_wave.up&!buff.splintered_elements.up
+# Maintain Flame Shock unless if it will waste precious buffs.
 actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies=1&refreshable&!buff.surge_of_power.up&(!buff.master_of_the_elements.up|(buff.master_of_the_elements.up&!buff.stormkeeper.up&(talent.elemental_blast.enabled&maelstrom<75)|maelstrom<50))
 # Spread Flame Shock to multiple targets only if talents were selected that benefit from it.
 actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&refreshable&!buff.surge_of_power.up&(talent.deeply_rooted_elements.enabled|talent.ascendance.enabled|talent.primordial_wave.enabled|talent.searing_flames.enabled|talent.magma_chamber.enabled),cycle_targets=1

--- a/profiles/Tier30/T30_Shaman_Elemental.simc
+++ b/profiles/Tier30/T30_Shaman_Elemental.simc
@@ -135,7 +135,7 @@ actions.single_target+=/totemic_recall,if=cooldown.liquid_magma_totem.remains>45
 actions.single_target+=/liquid_magma_totem
 # Use Primordial Wave as much as possible without wasting buffs.
 actions.single_target+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=!buff.primordial_wave.up&!buff.splintered_elements.up
-actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies=1&refreshable&!buff.surge_of_power.up
+actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies=1&refreshable&!buff.surge_of_power.up&(!buff.master_of_the_elements.up|(buff.master_of_the_elements.up&!buff.stormkeeper.up&(talent.elemental_blast.enabled&maelstrom<75)|maelstrom<50))
 # Spread Flame Shock to multiple targets only if talents were selected that benefit from it.
 actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies>1&(spell_targets.chain_lightning>1|spell_targets.lava_beam>1)&refreshable&!buff.surge_of_power.up&(talent.deeply_rooted_elements.enabled|talent.ascendance.enabled|talent.primordial_wave.enabled|talent.searing_flames.enabled|talent.magma_chamber.enabled),cycle_targets=1
 # {EB/Swelling/SoP Lighting build} Start SK window if you have enough maelstrom to: EB > SoP SK_LB > LvB > EB.


### PR DESCRIPTION
We noticed that the sim is occasionally wasting Master of the Elements on Flame Shock when it could otherwise buff a Stormkeepered Lightning Bolt or Spender. I confirmed that this is a ~300 dps gain via Raidbots with @Bloodmallet's help.

Current APL 
https://www.raidbots.com/simbot/report/xi3TXtVNuLTAExWr1rHQNW

Updated APL
https://www.raidbots.com/simbot/report/gT9JMaKBFP1eys1wLdAW4U