### PR TITLE
[Warrior] Remove redundant APL  entry

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -9145,7 +9145,6 @@ void warrior_t::apl_prot()
   generic -> add_action( "shield_slam" );
   generic -> add_action( "thunder_clap,if=dot.rend.remains<=1&buff.violent_outburst.down" );
   generic -> add_action( "execute,if=buff.sudden_death.up&talent.sudden_death.enabled" );
-  generic -> add_action( "execute,if=spell_targets.revenge=1&(talent.massacre.enabled|talent.juggernaut.enabled)&rage>=50" );
   generic -> add_action( "execute,if=spell_targets.revenge=1&rage>=50" );
   generic -> add_action( "thunder_clap,if=(spell_targets.thunder_clap>1|cooldown.shield_slam.remains&!buff.violent_outburst.up)" );
   generic -> add_action( "revenge,if=(rage>=60&target.health.pct>20|buff.revenge.up&target.health.pct<=20&rage<=18&cooldown.shield_slam.remains|buff.revenge.up&target.health.pct>20)|(rage>=60&target.health.pct>35|buff.revenge.up&target.health.pct<=35&rage<=18&cooldown.shield_slam.remains|buff.revenge.up&target.health.pct>35)&talent.massacre.enabled" );


### PR DESCRIPTION
The following line catches this one either way.

How is warrior's APL generated? Does the cpp generate the simc, or the other way around? It looks like the simc generates the cpp here <https://github.com/simulationcraft/simc/tree/dragonflight/engine/class_modules/apl>, but not for warrior.