### PR TITLE
[Mage] Frost APL support for Spoils of Neltharus

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -500,6 +500,7 @@ void frost( player_t* p )
   aoe->add_action( "call_action_list,name=movement" );
 
   cds->add_action( "time_warp,if=buff.exhaustion.up&buff.bloodlust.down" );
+  cds->add_action( "use_item,name=spoils_of_neltharus,if=buff.spoils_of_neltharus_mastery.up|buff.spoils_of_neltharus_haste.up&buff.bloodlust.down&buff.temporal_warp.down&time>0|buff.spoils_of_neltharus_vers.up&(buff.bloodlust.up|buff.temporal_warp.up)" );
   cds->add_action( "potion,if=prev_off_gcd.icy_veins|fight_remains<60" );
   cds->add_action( "flurry,if=time=0&active_enemies<=2" );
   cds->add_action( "icy_veins,if=buff.rune_of_power.down&(buff.icy_veins.down|talent.rune_of_power&(remaining_winters_chill=2|active_enemies>=3&talent.ice_caller))" );


### PR DESCRIPTION
The trinket Spoils of Neltharus gives, on use, a stat buff based on a passive buff you always have. If not played around, the trinket effectively gives a random stat. Considering how low of an impact crit has above 33.3% for frost, and haste doesn't reduce gcd above 100%, Frost mages gain a lot by playing around it. The trinket gives about 15% of a stat, so crit will almost always be bad, as most mages have at least 18% crit. With Bloodlust + Icy Veins, having 100% haste is also very easy.

From my testings, I found that using it with mastery only isn't a good idea, as it delays the trinket too much on average, so using it with the two bests stats is the optimal (3 stats loses more from the stats being worse than it gains from using the trinket more).
As haste is bad during lust, the stats are mastery+vers in BL and mastery+haste without BL.

[https://www.raidbots.com/simbot/report/s1pzGAPUKwnLe5NtUEzLN1](https://www.raidbots.com/simbot/report/s1pzGAPUKwnLe5NtUEzLN1)

When BL is used on pull, the very first action of the fight at time=0 sees bloodlust as being down, so we need a time>0 check on the haste condition:

[https://www.raidbots.com/simbot/report/nKToYAaKyKVANUfXeWc3YH](https://www.raidbots.com/simbot/report/nKToYAaKyKVANUfXeWc3YH)

Also, the `use_item` line should be at the top of action.cd, to be used before flurry on pull, otherwise the `spoils_of_neltharus_initial_type` option is wasted:

[without option](https://www.raidbots.com/simbot/report/6kaNVybKKUAMdguj16hTwV)
[with option](https://www.raidbots.com/simbot/report/pry45vYXiidoiDPwfVdVSm)
