### PR TITLE
Add <stdio.h> to concurrency.cpp to fix cmake perror

### DIFF
--- a/engine/util/concurrency.cpp
+++ b/engine/util/concurrency.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <stdio.h>
 
 #if defined( SC_WINDOWS )
 #define NOMINMAX


### PR DESCRIPTION
Hello,

Please let me know if anything is missing. I've tried to go over the contribution guidelines and I believe I should have everything covered.

It appears that the header `<stdio.h>` is required to properly compile with `cmake` when using the function `perror` like in `concurrency.cpp`. This may be due to an update in `cmake` as this file doesn't appear to have been changed in about 2 years and the package was building fine up until about a week or two ago.

See the link below for more info:

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/perror-wperror?view=msvc-170#requirements

I normally build `simc` via the Arch User Repository for simplicity. The relevant link to the listing on the AUR and the specified PKGBUILD is listed below.

AUR: https://aur.archlinux.org/packages/simulationcraft-git
PKGBUILD: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=simulationcraft-git

I was able to fork the repo and add my change to the PKGBUILD where I added `<stdio.h>` to `concurrency.cpp` and the package was able to be built successfully.

OS: Arch Linux
Kernel: 6.3.1-zen2-1-zen
CMake Version: 3.26.3-1

Please let me know if you need any additional information, or if I have done any part of this process incorrectly.

Thank you,
-Halornek