### PR TITLE
[Issue][#7378] added check for raid_event type and raid_event cooldown

### DIFF
--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -2124,7 +2124,10 @@ void raid_event_t::init( sim_t* sim )
     try
     {
       auto raid_event = create( sim, name, options );
-
+      if ( raid_event->type == "pull" && raid_event->cooldown <= timespan_t::zero() )
+      {
+        throw std::invalid_argument( "raid_event type is pull and max_time is set to 0" );
+      }
       if ( raid_event->cooldown <= timespan_t::zero() )
       {
         throw std::invalid_argument( "Cooldown not set or negative." );


### PR DESCRIPTION
checks if raid_event type is pull and raid_event cooldown is less than 0