### PR TITLE
Allow callbacks to be triggered from pet actions

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -1797,22 +1797,15 @@ void action_t::execute()
     {
       // "On spell cast", only performed for foreground actions
       if ( ( pt2 = execute_state->cast_proc_type2() ) != PROC2_INVALID )
-      {
-        action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, execute_state );
-      }
+        player->trigger_callbacks( pt, pt2, this, execute_state );
 
       // "On an execute result"
       if ( ( pt2 = execute_state->execute_proc_type2() ) != PROC2_INVALID )
-      {
-        action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, execute_state );
-      }
+        player->trigger_callbacks( pt, pt2, this, execute_state );
 
       // "On interrupt cast result"
       if ( ( pt2 = execute_state->interrupt_proc_type2() ) != PROC2_INVALID )
-      {
-        if ( execute_state->target->debuffs.casting->check() )
-          action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, execute_state );
-      }
+        player->trigger_callbacks( pt, pt2, this, execute_state );
     }
 
     // Special handling for "Cast Successful" procs
@@ -1823,22 +1816,15 @@ void action_t::execute()
 
       // "On spell cast", only performed for foreground actions
       if ( ( pt2 = execute_state->cast_proc_type2() ) != PROC2_INVALID )
-      {
-        action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, execute_state );
-      }
+        player->trigger_callbacks( pt, pt2, this, execute_state );
 
       // "On an execute result"
       if ( ( pt2 = execute_state->execute_proc_type2() ) != PROC2_INVALID )
-      {
-        action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, execute_state );
-      }
+        player->trigger_callbacks( pt, pt2, this, execute_state );
 
       // "On interrupt cast result"
       if ( ( pt2 = execute_state->interrupt_proc_type2() ) != PROC2_INVALID )
-      {
-        if ( execute_state->target->debuffs.casting->check() )
-          action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, execute_state );
-      }
+        player->trigger_callbacks( pt, pt2, this, execute_state );
     }
   }
 

--- a/engine/action/action_callback.cpp
+++ b/engine/action/action_callback.cpp
@@ -7,35 +7,36 @@
 #include "action.hpp"
 #include "player/player.hpp"
 
-action_callback_t::action_callback_t( player_t* l, bool ap, bool asp ) :
-  listener( l ), active( true ), allow_self_procs( asp ), allow_procs( ap )
+action_callback_t::action_callback_t( player_t* l, bool ap, bool asp )
+  : listener( l ), active( true ), allow_self_procs( asp ), allow_procs( ap ), allow_pet_procs( false )
 {
   assert( l );
   if ( range::find( l->callbacks.all_callbacks, this ) == l->callbacks.all_callbacks.end() )
     l->callbacks.all_callbacks.push_back( this );
 }
 
-void action_callback_t::trigger(const std::vector<action_callback_t*>& v, action_t* a, action_state_t* state )
+void action_callback_t::trigger( const std::vector<action_callback_t*>& v, action_t* a, action_state_t* state )
 {
-  if (a && !a->player->in_combat) return;
+  if ( a && !a->player->in_combat )
+    return;
 
   std::size_t size = v.size();
-  for (std::size_t i = 0; i < size; i++)
+  for ( std::size_t i = 0; i < size; i++ )
   {
-    action_callback_t* cb = v[i];
-    if (cb->active)
+    action_callback_t* cb = v[ i ];
+    if ( cb->active )
     {
-      if (!cb->allow_procs && a && a->proc) return;
-      cb->trigger(a, state);
+      if ( !cb->allow_procs && a && a->proc )
+        return;
+
+      cb->trigger( a, state );
     }
   }
 }
 
-void action_callback_t::reset(const std::vector<action_callback_t*>& v)
+void action_callback_t::reset( const std::vector<action_callback_t*>& v )
 {
   std::size_t size = v.size();
-  for (std::size_t i = 0; i < size; i++)
-  {
-    v[i]->reset();
-  }
+  for ( std::size_t i = 0; i < size; i++ )
+    v[ i ]->reset();
 }

--- a/engine/action/action_callback.hpp
+++ b/engine/action/action_callback.hpp
@@ -20,6 +20,7 @@ struct action_callback_t : private noncopyable
   bool active;
   bool allow_self_procs;
   bool allow_procs;
+  bool allow_pet_procs;
 
   action_callback_t(player_t* l, bool ap = false, bool asp = false);
   virtual ~action_callback_t() = default;

--- a/engine/action/heal.cpp
+++ b/engine/action/heal.cpp
@@ -231,9 +231,7 @@ void heal_t::assess_damage( result_amount_type heal_type, action_state_t* s )
     proc_types pt = s->proc_type();
     proc_types2 pt2 = s->impact_proc_type2();
     if ( pt != PROC1_INVALID && pt2 != PROC2_INVALID )
-    {
-      action_callback_t::trigger( player->callbacks.procs[ pt ][ pt2 ], this, s );
-    }
+      player->trigger_callbacks( pt, pt2, this, s );
   }
 
   if ( record_healing )

--- a/engine/player/effect_callbacks.cpp
+++ b/engine/player/effect_callbacks.cpp
@@ -22,6 +22,14 @@ void add_callback( std::vector<action_callback_t*>& callbacks, action_callback_t
 
 }  // namespace
 
+void effect_callbacks_t::add_callback( proc_types type, proc_types2 type2, action_callback_t* cb )
+{
+  ::add_callback( procs[ type ][ type2 ], cb );
+
+  if ( cb->allow_pet_procs )
+    ::add_callback( pet_procs[ type ][ type2 ], cb );
+}
+
 void effect_callbacks_t::add_proc_callback( proc_types type, uint64_t flags, action_callback_t* cb )
 {
   std::string s;
@@ -41,25 +49,24 @@ void effect_callbacks_t::add_proc_callback( proc_types type, uint64_t flags, act
          ( type == PROC1_PERIODIC || type == PROC1_PERIODIC_TAKEN || type == PROC1_PERIODIC_HEAL ||
            type == PROC1_PERIODIC_HEAL_TAKEN || type == PROC1_NONE_HEAL || type == PROC1_MAGIC_HEAL ) )
     {
-      add_callback( procs[ type ][ PROC2_HIT ], cb );
+      add_callback( type, PROC2_HIT, cb );
       if ( cb->listener->sim->debug )
         s.append( util::proc_type_string( type ) ).append( util::proc_type2_string( PROC2_HIT ) ).append( " " );
 
-      add_callback( procs[ type ][ PROC2_CRIT ], cb );
+      add_callback( type, PROC2_CRIT, cb );
       if ( cb->listener->sim->debug )
         s.append( util::proc_type_string( type ) ).append( util::proc_type2_string( PROC2_CRIT ) ).append( " " );
     }
     // Do normal registration based on the existence of the flag
     else
     {
-      add_callback( procs[ type ][ pt ], cb );
+      add_callback( type, pt, cb );
       if ( cb->listener->sim->debug )
         s.append( util::proc_type_string( type ) ).append( util::proc_type2_string( pt ) ).append( " " );
     }
   }
 
-  if ( sim->debug )
-    sim->out_debug.print( "{}", s );
+  sim->print_debug( "{}{}", s, cb->allow_pet_procs ? "(+pet) " : "" );
 }
 
 effect_callbacks_t::~effect_callbacks_t()

--- a/engine/player/effect_callbacks.hpp
+++ b/engine/player/effect_callbacks.hpp
@@ -35,6 +35,7 @@ struct effect_callbacks_t
   using proc_array_t = std::array<proc_on_array_t, PROC1_TYPE_MAX>;
 
   proc_array_t procs;
+  proc_array_t pet_procs;  // callbacks that can proc from pets
 
   effect_callbacks_t( sim_t* sim ) : sim( sim ) {}
 
@@ -81,5 +82,6 @@ private:
   /// A vector of (driver-id, callback-execute-function) tuples
   std::vector<callback_execute_entry_t> execute_fn;
 
+  void add_callback( proc_types type, proc_types2 type2, action_callback_t* cb );
   void add_proc_callback( proc_types type, uint64_t flags, action_callback_t* cb );
 };

--- a/engine/player/pet.cpp
+++ b/engine/player/pet.cpp
@@ -344,6 +344,13 @@ void pet_t::assess_damage( school_e       school,
   return base_t::assess_damage( school, type, s );
 }
 
+void pet_t::trigger_callbacks( proc_types type, proc_types2 type2, action_t* action, action_state_t* state )
+{
+  player_t::trigger_callbacks( type, type2, action, state );
+
+  action_callback_t::trigger( owner->callbacks.pet_procs[ type ][ type2 ], action, state );
+}
+
 void pet_t::init_finished()
 {
   player_t::init_finished();

--- a/engine/player/pet.hpp
+++ b/engine/player/pet.hpp
@@ -50,6 +50,7 @@ public:
   void init_finished() override;
   void reset() override;
   void assess_damage( school_e, result_amount_type, action_state_t* s ) override;
+  void trigger_callbacks( proc_types, proc_types2, action_t*, action_state_t* ) override;
 
   virtual void summon( timespan_t duration = timespan_t::zero() );
   virtual void dismiss( bool expired = false );

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -3511,7 +3511,7 @@ void player_t::init_assessors()
     proc_types pt   = state->proc_type();
     proc_types2 pt2 = state->impact_proc_type2();
     if ( pt != PROC1_INVALID && pt2 != PROC2_INVALID )
-      action_callback_t::trigger( callbacks.procs[ pt ][ pt2 ], state->action, state );
+      trigger_callbacks( pt, pt2, state->action, state );
 
     return assessor::CONTINUE;
   } );
@@ -7705,7 +7705,7 @@ void player_t::do_damage( action_state_t* incoming_state )
     // On damage/heal in. Proc flags are arranged as such that the "incoming"
     // version of the primary proc flag is always follows the outgoing version.
     if ( pt != PROC1_INVALID && pt2 != PROC2_INVALID )
-      action_callback_t::trigger( callbacks.procs[ pt + 1 ][ pt2 ], incoming_state->action, incoming_state );
+      trigger_callbacks( static_cast<proc_types>( pt + 1 ), pt2, incoming_state->action, incoming_state );
   }
 
   // Check if target is dying
@@ -7849,6 +7849,11 @@ void player_t::assess_heal( school_e, result_amount_type, action_state_t* s )
 
   // store iteration heal taken
   iteration_heal_taken += s->result_amount;
+}
+
+void player_t::trigger_callbacks( proc_types type, proc_types2 type2, action_t* action, action_state_t* state )
+{
+  action_callback_t::trigger( callbacks.procs[ type ][ type2 ], action, state );
 }
 
 void player_t::summon_pet( util::string_view pet_name, const timespan_t duration )

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -1182,6 +1182,7 @@ public:
   virtual void assess_damage_imminent( school_e, result_amount_type, action_state_t* );
   virtual void do_damage( action_state_t* );
   virtual void assess_heal( school_e, result_amount_type, action_state_t* );
+  virtual void trigger_callbacks( proc_types, proc_types2, action_t*, action_state_t* );
 
   virtual bool taunt( player_t* /* source */ ) { return false; }
 


### PR DESCRIPTION
setting `action_callback_t::allow_pet_procs` to `true` will allow pet actions/damage to trigger the callback when it is registered to the owner