### PR TITLE
[Player] On combat callbacks for entering/leaving dungeon combat

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -1685,13 +1685,8 @@ void action_t::execute()
   num_targets_hit              = 0;
   interrupt_immediate_occurred = false;
 
-  if ( harmful )
-  {
-    if ( !player->in_combat && sim->debug )
-      sim->print_debug( "{} enters combat.", *player );
-
-    player->in_combat = true;
-  }
+  if ( harmful && !player->in_combat )
+    player->enter_combat();
 
   // Handle tick_action initial state snapshotting, primarily for handling STATE_MUL_PERSISTENT
   if ( tick_action )

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -8385,6 +8385,8 @@ struct shadowmeld_t : public racial_spell_t
 
     // Shadowmeld stops autoattacks
     player->cancel_auto_attacks();
+
+    player->leave_combat();
   }
 };
 

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -6563,7 +6563,7 @@ void player_t::enter_combat()
 
   in_combat = true;
 
-  sim->print_debug( "{} enters combat.", *this );
+  sim->print_log( "{} enters combat.", *this );
 
   for ( size_t i = 0; i < callbacks_on_combat_state.size(); ++i )
     callbacks_on_combat_state[ i ]( this, in_combat );
@@ -6576,7 +6576,7 @@ void player_t::leave_combat()
 
   in_combat = false;
 
-  sim->print_debug( "{} leaves combat.", *this );
+  sim->print_log( "{} leaves combat.", *this );
 
   for ( size_t i = 0; i < callbacks_on_combat_state.size(); ++i )
     callbacks_on_combat_state[ i ]( this, in_combat );

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -294,6 +294,7 @@ struct player_t : public actor_t
   std::vector<std::pair<player_t*, std::function<void( player_t* )>>> callbacks_on_demise;
   std::vector<std::pair<player_t*, std::function<void( void )>>> callbacks_on_arise;
   std::vector<std::function<void( player_t* )>> callbacks_on_kill;
+  std::vector<std::function<void( player_t*, bool )>> callbacks_on_combat_state;
 
   // Action Priority List
   auto_dispose< std::vector<action_t*> > action_list;
@@ -1147,9 +1148,12 @@ public:
   virtual void schedule_cwc_ready( timespan_t delta_time = timespan_t::min() );
   virtual void arise();
   virtual void demise();
+  virtual void enter_combat();
+  virtual void leave_combat();
   virtual timespan_t available() const;
   virtual action_t* select_action( const action_priority_list_t&, execute_type type = execute_type::FOREGROUND, const action_t* context = nullptr );
   virtual action_t* execute_action();
+
 
   virtual void   regen( timespan_t periodicity = timespan_t::from_seconds( 0.25 ) );
   virtual double resource_gain( resource_e resource_type, double amount, gain_t* source = nullptr,
@@ -1346,6 +1350,7 @@ public:
   void register_on_demise_callback( player_t* source, std::function<void( player_t* )> fn );
   void register_on_arise_callback( player_t* source, std::function<void( void )> fn );
   void register_on_kill_callback( std::function<void( player_t* )> fn );
+  void register_on_combat_state_callback( std::function<void( player_t*, bool )> fn );
 
   void update_off_gcd_ready();
   void update_cast_while_casting_ready();

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -576,9 +576,6 @@ struct player_t : public actor_t
     buff_t* heavens_nemesis; // Neltharax, Enemy of the Sky
 
     // 10.1 buffs
-    buff_t* anvil_strike_combat;
-    buff_t* anvil_strike_no_combat;
-
   } buffs;
 
   struct debuffs_t

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -5713,16 +5713,6 @@ void roiling_shadowflame( special_effect_t& e )
       }
     }
 
-    void activate() override
-    {
-      generic_proc_t::activate();
-
-      // Stacking buff is removed when dropping combat in dungeon-style fight types
-      sim->target_non_sleeping_list.register_callback( [ this ]( player_t* ) {
-        if ( sim->target_non_sleeping_list.empty() )
-          buff->expire();
-      } );
-    }
   };
 
   auto new_driver_id = 412547;  // Rppm data moved out of the main driver into this spell
@@ -5736,6 +5726,11 @@ void roiling_shadowflame( special_effect_t& e )
   e.execute_action = damage;
 
   new dbc_proc_callback_t( e.player, e );
+
+  e.player->register_on_combat_state_callback( [ stack_buff ]( player_t*, bool c ) {
+    if ( !c )
+      stack_buff->expire();
+  } );
 }
 
 // Stacking debuff: 407087

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -4154,18 +4154,22 @@ void neltharions_call_to_dominance( special_effect_t& effect )
 // Warrior - Shield Slam, Mortal Strike, Raging Blow, Annihilator
 void elementium_pocket_anvil( special_effect_t& e )
 {
-  e.player->buffs.anvil_strike_combat =
+  auto anvil_strike_combat =
       create_buff<buff_t>( e.player, "anvil_strike_combat", e.player->find_spell( 408578 ) )
           ->set_cooldown( 0_ms )
           ->set_default_value( e.player->find_spell( 401303 )->effectN( 3 ).percent() );
 
-  e.player->buffs.anvil_strike_no_combat =
+  auto anvil_strike_no_combat =
       create_buff<buff_t>( e.player, "anvil_strike_no_combat", e.player->find_spell( 408533 ) )
           ->set_default_value( e.player->find_spell( 401303 )->effectN( 3 ).percent() );
 
   struct elementium_pocket_anvil_use_t : public generic_proc_t
   {
-    elementium_pocket_anvil_use_t( const special_effect_t& e ) : generic_proc_t( e, "anvil_strike", e.driver() )
+    buff_t* combat_buff;
+    buff_t* no_combat_buff;
+
+    elementium_pocket_anvil_use_t( const special_effect_t& e, buff_t* combat, buff_t* no_combat )
+      : generic_proc_t( e, "anvil_strike", e.driver() ), combat_buff( combat ), no_combat_buff( no_combat )
     {
       aoe         = -1;
       base_dd_min = base_dd_max = e.player->find_spell( 401303 )->effectN( 2 ).average( e.item );
@@ -4176,44 +4180,35 @@ void elementium_pocket_anvil( special_effect_t& e )
     void execute() override
     {
       generic_proc_t::execute();
-      if ( sim->target_non_sleeping_list.size() > 0 )
-      {
-        player->buffs.anvil_strike_combat->trigger();
-      }
-      if ( sim->target_non_sleeping_list.size() == 0 )
-      {
-        player->buffs.anvil_strike_no_combat->trigger();
-      }
+
+      if ( player->in_combat )
+        combat_buff->trigger();
+      else
+        no_combat_buff->trigger();
     }
   };
 
   struct elementium_pocket_anvil_equip_t : public generic_proc_t
   {
-    action_t* use;
+    buff_t* combat_buff;
+    buff_t* no_combat_buff;
 
-    elementium_pocket_anvil_equip_t( const special_effect_t& e )
+    elementium_pocket_anvil_equip_t( const special_effect_t& e, buff_t* combat, buff_t* no_combat )
       : generic_proc_t( e, "echoed_flare", e.player->find_spell( 401324 ) ),
-        use( create_proc_action<elementium_pocket_anvil_use_t>( "anvil_strike", e ) )
+        combat_buff( combat ),
+        no_combat_buff( no_combat )
     {
       // 27-4-2023, Probably a bug? Damage value on tooltip multiplied by 0.6x. Tooltip matches in game test result.
       // Retest later to ensure this is still the behavior experienced.
       base_dd_min = base_dd_max = e.player->find_spell( 401303 )->effectN( 1 ).average( e.item ) * 0.6;
-      add_child( use );
     }
 
     double composite_da_multiplier( const action_state_t* state ) const override
     {
       double m = generic_proc_t::composite_da_multiplier( state );
 
-      if ( player->buffs.anvil_strike_combat->check() )
-      {
-        m *= 1.0 + player->buffs.anvil_strike_combat->check_stack_value();
-      }
-
-      if ( player->buffs.anvil_strike_no_combat->check() )
-      {
-        m *= 1.0 + player->buffs.anvil_strike_no_combat->check_stack_value();
-      }
+      m *= 1.0 + combat_buff->check_stack_value();
+      m *= 1.0 + no_combat_buff->check_stack_value();
 
       return m;
     }
@@ -4309,25 +4304,9 @@ void elementium_pocket_anvil( special_effect_t& e )
 
   auto equip            = new special_effect_t( e.player );
   equip->spell_id       = driver_id;
-  equip->execute_action = create_proc_action<elementium_pocket_anvil_equip_t>( "echoed_flare", e );
+  equip->execute_action = create_proc_action<elementium_pocket_anvil_equip_t>( "echoed_flare", e, anvil_strike_combat,
+                                                                               anvil_strike_no_combat );
   equip->type           = SPECIAL_EFFECT_EQUIP;
-  equip->activation_cb  = [ p = e.player ]() {
-    p->sim->target_non_sleeping_list.register_callback( [ p ]( player_t* ) {
-      auto enemies = p->sim->target_non_sleeping_list.size();
-      auto combat = p->buffs.anvil_strike_combat->check();
-      auto no_combat = p->buffs.anvil_strike_no_combat->check();
-      if ( enemies && no_combat )
-      {
-        p->buffs.anvil_strike_combat->trigger( no_combat );
-        p->buffs.anvil_strike_no_combat->expire();
-      }
-      else if ( !enemies && combat )
-      {
-        p->buffs.anvil_strike_no_combat->trigger( combat );
-        p->buffs.anvil_strike_combat->expire();
-      }
-    } );
-  };
   e.player->special_effects.push_back( equip );
 
   equip->player->callbacks.register_callback_trigger_function(
@@ -4338,7 +4317,28 @@ void elementium_pocket_anvil( special_effect_t& e )
 
   new dbc_proc_callback_t( e.player, *equip );
 
-  e.execute_action = create_proc_action<elementium_pocket_anvil_use_t>( "anvil_strike", e );
+  e.execute_action = create_proc_action<elementium_pocket_anvil_use_t>( "anvil_strike", e, anvil_strike_combat,
+                                                                        anvil_strike_no_combat );
+  equip->execute_action->add_child( e.execute_action );
+
+  e.player->register_on_combat_state_callback( [ anvil_strike_combat, anvil_strike_no_combat ]( player_t*, bool c ) {
+    if ( c )
+    {
+      if ( auto stack = anvil_strike_no_combat->check() )
+      {
+        anvil_strike_combat->trigger( stack );
+        anvil_strike_no_combat->expire();
+      }
+    }
+    else
+    {
+      if ( auto stack = anvil_strike_combat->check() )
+      {
+        anvil_strike_no_combat->trigger( stack );
+        anvil_strike_combat->expire();
+      }
+    }
+  } );
 }
 
 // Ominous Chromatic Essence

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -3596,17 +3596,6 @@ void desperate_invokers_codex( special_effect_t& effect )
       make_event( *sim, [ this ]() { item_cd->adjust( -timespan_t::from_seconds( buff->check_stack_value() ) ); } );
       spell_cd->adjust( -timespan_t::from_seconds( buff->check_stack_value() ) );
     }
-
-    void activate() override
-    {
-      generic_proc_t::activate();
-
-      // Stacking Buff is removed when dropping combat in dungeon-style fight types
-      sim->target_non_sleeping_list.register_callback( [ this ]( player_t* ) {
-        if ( sim->target_non_sleeping_list.empty() )
-          buff->expire();
-      } );
-    }
   };
 
   effect.execute_action = create_proc_action<desperate_invocation_t>( "Desperate Invocation", effect, hatred );
@@ -3616,6 +3605,11 @@ void desperate_invokers_codex( special_effect_t& effect )
       effect.player->get_cooldown( effect.cooldown_name() )->adjust( -timespan_t::from_seconds( b->check_value() ) );
       effect.player->get_cooldown( effect.name() )->adjust( -timespan_t::from_seconds( b->check_value() ) );
     }
+  } );
+
+  effect.player->register_on_combat_state_callback( [ hatred ]( player_t*, bool c ) {
+    if ( !c )
+      hatred->expire();
   } );
 }
 

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -650,6 +650,11 @@ void dragonfire_bomb_dispenser( special_effect_t& effect )
     restock_driver->proc_flags2_ = PF2_CRIT;
 
     new dbc_proc_callback_t( effect.player, *restock_driver );
+
+    effect.player->register_on_combat_state_callback( [ skilled_restock ]( player_t*, bool c ) {
+      if ( !c )
+        skilled_restock->expire();
+    } );
   }
 
   // AoE Explosion

--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -281,6 +281,7 @@ struct adds_event_t final : public raid_event_t
     double x_offset      = 0;
     double y_offset      = 0;
     bool offset_computed = false;
+    auto existing        = sim->target_non_sleeping_list.size();
 
     // Keep track of each add duration so after summons (and dismissals) are done, we can adjust the saved_duration of
     // the add event to match the add with the longest lifetime.
@@ -334,6 +335,13 @@ struct adds_event_t final : public raid_event_t
     }
 
     regenerate_cache();
+
+    // trigger enter combat state callbacks if no adds were existing
+    if ( sim->fight_style == fight_style_e::FIGHT_STYLE_DUNGEON_SLICE && !existing )
+    {
+      for ( auto p : affected_players )
+        p->enter_combat();
+    }
   }
 
   void _finish() override
@@ -345,6 +353,13 @@ struct adds_event_t final : public raid_event_t
     for ( size_t i = 0; i < adds_to_remove; i++ )
     {
       adds[ i ]->dismiss();
+    }
+
+    // trigger leave combat state callbacks if no adds are remaining
+    if ( sim->fight_style == fight_style_e::FIGHT_STYLE_DUNGEON_SLICE && !sim->target_non_sleeping_list.size() )
+    {
+      for ( auto p : affected_players )
+        p->leave_combat();
     }
   }
 };
@@ -592,6 +607,13 @@ struct pull_event_t final : raid_event_t
 
     event_t::cancel( redistribute_event );
 
+    // trigger leave combat state callbacks if no adds are remaining
+    if ( !sim->target_non_sleeping_list.size() )
+    {
+      for ( auto p : affected_players )
+        p->leave_combat();
+    }
+
     // find the next pull and spawn it
     if ( auto next = next_pull() )
     {
@@ -678,6 +700,7 @@ struct pull_event_t final : raid_event_t
     
     spawned = true;
     spawn_time = sim->current_time();
+    auto existing = sim->target_non_sleeping_list.size();
 
     if ( bloodlust )
     {
@@ -730,6 +753,13 @@ struct pull_event_t final : raid_event_t
                     pull, adds.size(), total_health, delay.total_seconds() );
 
     regenerate_cache();
+
+    // trigger enter combat state callbacks if no adds were existing
+    if ( !existing )
+    {
+      for ( auto p : affected_players )
+        p->enter_combat();
+    }
   }
 
   void reset() override

--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -281,7 +281,6 @@ struct adds_event_t final : public raid_event_t
     double x_offset      = 0;
     double y_offset      = 0;
     bool offset_computed = false;
-    auto existing        = sim->target_non_sleeping_list.size();
 
     // Keep track of each add duration so after summons (and dismissals) are done, we can adjust the saved_duration of
     // the add event to match the add with the longest lifetime.
@@ -335,13 +334,6 @@ struct adds_event_t final : public raid_event_t
     }
 
     regenerate_cache();
-
-    // trigger enter combat state callbacks if no adds were existing
-    if ( sim->fight_style == fight_style_e::FIGHT_STYLE_DUNGEON_SLICE && !existing )
-    {
-      for ( auto p : affected_players )
-        p->enter_combat();
-    }
   }
 
   void _finish() override
@@ -700,7 +692,6 @@ struct pull_event_t final : raid_event_t
     
     spawned = true;
     spawn_time = sim->current_time();
-    auto existing = sim->target_non_sleeping_list.size();
 
     if ( bloodlust )
     {
@@ -753,13 +744,6 @@ struct pull_event_t final : raid_event_t
                     pull, adds.size(), total_health, delay.total_seconds() );
 
     regenerate_cache();
-
-    // trigger enter combat state callbacks if no adds were existing
-    if ( !existing )
-    {
-      for ( auto p : affected_players )
-        p->enter_combat();
-    }
   }
 
   void reset() override


### PR DESCRIPTION
* add `player_t::enter_combat()` virtual function to trigger when entering combat via a harmful action
* add `player_t::leave_combat()` virtual function to trigger when "leaving" combat due to:
  * no valid targets after a `/pull` raid event is finished, or
  * no valid targets when a `/adds` raid event is finished and the fight style is DungeonSlice
* add `player_t::register_on_combat_state_callback()` to add to callbacks triggered when entering or leaving combat via the above methods. Argument is a functor that take parameters `player_t*` (which points to the players) and `bool` (which is the `player_t::in_combat` value) and returns `void`.
```
player->register_on_combat_state_callback( []( player_t* p, bool in_combat ) {
  if ( in_combat )
    p->buff.killing_stuff->trigger();
  else
    p->buff.eating_food->trigger();
};
```
