### PR TITLE
[Monk] Execute Bountiful Brew action on proc

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -4748,6 +4748,7 @@ namespace monk
         bountiful_brew_t( monk_t &p )
           : monk_spell_t( "bountiful_brew", &p, p.talent.brewmaster.bountiful_brew )
         {
+          background = true;
           harmful = false;
           cooldown->duration = timespan_t::zero();
           aoe = -1;
@@ -8289,6 +8290,8 @@ namespace monk
           if ( proc_action_override != nullptr )
             break;
         }
+      } else {
+        effect->execute_action = proc_action_override;
       }
 
       if ( proc_action_override != nullptr )
@@ -8413,7 +8416,7 @@ namespace monk
         p->active_actions.bountiful_brew->set_target( state->target );
 
         return true;
-      } );
+      }, active_actions.bountiful_brew );
     }
 
     // ======================================


### PR DESCRIPTION
`create_proc_callback` searches for an effect that matches the spell ID of an existing action. Bountiful Brew's effect has no spell ID, which results in it never being executed.

We can provide the action as an override, but we additionally need to set it to the effect's `execute_action`.

Bountiful Brew was previously not set as `background = true`, but I'm not sure why. Executing the proc'd action without this results in an error.