### PR TITLE
[Player] Change Sample Sequence Timings for Queue'd Spells

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -6746,7 +6746,10 @@ action_t* player_t::execute_action()
 
       if ( !is_enemy() )
       {
-        sequence_add( action, action->target, sim->current_time() );
+        if ( action->queue_event )
+          sequence_add( action, action->target, action->queue_event->occurs() );
+        else
+          sequence_add( action, action->target, sim->current_time() );
       }
     }
   }


### PR DESCRIPTION
Currently Queue'd Spells do not get added at the right time to the sample sequence so they report incorrectly, this is a slight work around to that which produces correct timestamps for my test.

Are there any immediate apparent issues with this that I hadn't considered?