### PR TITLE
[Warlock] Add precombat timer for Power Siphon

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -174,7 +174,7 @@ void demonology( player_t* p )
   precombat->add_action( "variable,name=next_tyrant,op=set,value=14+talent.grimoire_felguard+talent.summon_vilefiend" );
   precombat->add_action( "variable,name=shadow_timings,default=0,op=reset" );
   precombat->add_action( "variable,name=shadow_timings,op=set,value=0,if=cooldown.invoke_power_infusion_0.duration!=120" );
-  precombat->add_action( "power_siphon" );
+  precombat->add_action( "power_siphon,precombat_seconds=10" );
   precombat->add_action( "demonbolt,if=!buff.power_siphon.up" );
   precombat->add_action( "shadow_bolt" );
 

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1160,6 +1160,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   cooldowns.soul_fire = get_cooldown( "soul_fire" );
   cooldowns.felstorm_icd = get_cooldown( "felstorm_icd" );
   cooldowns.grimoire_felguard = get_cooldown( "grimoire_felguard" );
+  cooldowns.power_siphon = get_cooldown( "power_siphon" );
 
   resource_regeneration = regen_type::DYNAMIC;
   regen_caches[ CACHE_HASTE ] = true;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -510,6 +510,7 @@ public:
     propagate_const<cooldown_t*> soul_fire;
     propagate_const<cooldown_t*> felstorm_icd; // Shared between Felstorm, Demonic Strength, and Guillotine
     propagate_const<cooldown_t*> grimoire_felguard;
+    propagate_const<cooldown_t*> power_siphon;
   } cooldowns;
 
   // Buffs

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -694,9 +694,13 @@ struct bilescourge_bombers_t : public demonology_spell_t
 
 struct power_siphon_t : public demonology_spell_t
 {
+  timespan_t precombat_seconds;
+
   power_siphon_t( warlock_t* p, util::string_view options_str )
-    : demonology_spell_t( "Power Siphon", p, p->talents.power_siphon )
+    : demonology_spell_t( "Power Siphon", p, p->talents.power_siphon ), 
+      precombat_seconds(0_s)
   {
+    add_option( opt_timespan( "precombat_seconds", precombat_seconds ) );
     parse_options( options_str );
     harmful = false;
     ignore_false_positive = true;
@@ -725,6 +729,8 @@ struct power_siphon_t : public demonology_spell_t
     {
       p()->buffs.power_siphon->trigger( 2, p()->talents.power_siphon_buff->duration() );
       p()->buffs.demonic_core->trigger( 2, p()->warlock_base.demonic_core_buff->duration() );
+      p()->cooldowns.power_siphon->adjust( -precombat_seconds, false );
+      p()->buffs.demonic_core->extend_duration( p(), - precombat_seconds );
       return;
     }
 

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -730,7 +730,7 @@ struct power_siphon_t : public demonology_spell_t
       p()->buffs.power_siphon->trigger( 2, p()->talents.power_siphon_buff->duration() );
       p()->buffs.demonic_core->trigger( 2, p()->warlock_base.demonic_core_buff->duration() );
       p()->cooldowns.power_siphon->adjust( -precombat_seconds, false );
-      p()->buffs.demonic_core->extend_duration( p(), - precombat_seconds );
+      p()->buffs.demonic_core->extend_duration( p(), -precombat_seconds );
       return;
     }
 


### PR DESCRIPTION
Adding precombat timer for Power Siphon in the same style as some rogue abilities currently have.
The current sim uses Power Siphon at 0s, but in reality we use it at -10s (this has implications mainly for our Fel Covenant build, but is still relevant to all other Power Siphon builds).

This isn't perfect because I am not adjusting the Inner Demons imp spawn cycle at all, but is better than what we currently use.