### PR TITLE
Make Surv APL use Fury of the Eagle in ST when Djaruun is not equipped

### DIFF
--- a/engine/class_modules/apl/apl_hunter.cpp
+++ b/engine/class_modules/apl/apl_hunter.cpp
@@ -321,7 +321,7 @@ void survival( player_t* p )
   st->add_action( "wildfire_bomb,if=raid_event.adds.in>cooldown.wildfire_bomb.full_recharge_time-(cooldown.wildfire_bomb.full_recharge_time%3.5)&set_bonus.tier30_4pc&(!dot.wildfire_bomb.ticking&debuff.shredded_armor.stack>0&focus+cast_regen<focus.max|active_enemies>1)" );
   st->add_action( "mongoose_bite,target_if=max:debuff.latent_poison.stack,if=buff.mongoose_fury.up" );
   st->add_action( "explosive_shot,if=talent.ranger&(!raid_event.adds.exists|raid_event.adds.in>28)" );
-  st->add_action( "fury_of_the_eagle,if=cooldown.elder_flame_408821.remains>40&target.health.pct<65&talent.ruthless_marauder&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.in>40)" );
+  st->add_action( "fury_of_the_eagle,if=(!equipped.djaruun_pillar_of_the_elder_flame|cooldown.elder_flame_408821.remains>40)&target.health.pct<65&talent.ruthless_marauder&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.in>40)" );
   st->add_action( "mongoose_bite,target_if=max:debuff.latent_poison.stack,if=focus+action.kill_command.cast_regen>focus.max-10|set_bonus.tier30_4pc" );
   st->add_action( "raptor_strike,target_if=max:debuff.latent_poison.stack" );
   st->add_action( "steel_trap" );

--- a/engine/class_modules/apl/hunter/sv.txt
+++ b/engine/class_modules/apl/hunter/sv.txt
@@ -85,7 +85,7 @@ actions.st+="/mongoose_bite,if=dot.shrapnel_bomb.ticking"
 actions.st+="/wildfire_bomb,if=raid_event.adds.in>cooldown.wildfire_bomb.full_recharge_time-(cooldown.wildfire_bomb.full_recharge_time%3.5)&set_bonus.tier30_4pc&(!dot.wildfire_bomb.ticking&debuff.shredded_armor.stack>0&focus+cast_regen<focus.max|active_enemies>1)"
 actions.st+="/mongoose_bite,target_if=max:debuff.latent_poison.stack,if=buff.mongoose_fury.up
 actions.st+="/explosive_shot,if=talent.ranger&(!raid_event.adds.exists|raid_event.adds.in>28)
-actions.st+="/fury_of_the_eagle,if=cooldown.elder_flame_408821.remains>40&target.health.pct<65&talent.ruthless_marauder&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.in>40)
+actions.st+="/fury_of_the_eagle,if=(!equipped.djaruun_pillar_of_the_elder_flame|cooldown.elder_flame_408821.remains>40)&target.health.pct<65&talent.ruthless_marauder&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.in>40)
 actions.st+="/mongoose_bite,target_if=max:debuff.latent_poison.stack,if=focus+action.kill_command.cast_regen>focus.max-10|set_bonus.tier30_4pc
 actions.st+="/raptor_strike,target_if=max:debuff.latent_poison.stack"
 actions.st+="/steel_trap"


### PR DESCRIPTION
The current Survival APL does not use Fury of the Eagle in single target if Djaruun is not equipped since the expression cooldown.elder_flame_408821.remains>40 always evaluates to false. This PR attempts to fix that by adding a conditional for when Djaruun is not equipped to allow the APL to use FotE in single target scenarios.

https://www.raidbots.com/simbot/report/jtA8cT2sV8AYJany9hKCKS Comparing the APL change on the T30 profile (adjusted talents and equipped crafted weapon in place of Djaruun)