### PR TITLE
Change to BM AoE APL

### DIFF
--- a/engine/class_modules/apl/apl_hunter.cpp
+++ b/engine/class_modules/apl/apl_hunter.cpp
@@ -80,7 +80,7 @@ void beast_mastery( player_t* p )
   cleave->add_action( "barbed_shot,target_if=min:dot.barbed_shot.remains,if=pet.main.buff.frenzy.up&pet.main.buff.frenzy.remains<=gcd+0.25|talent.scent_of_blood&cooldown.bestial_wrath.remains<12+gcd|full_recharge_time<gcd&cooldown.bestial_wrath.remains" );
   cleave->add_action( "multishot,if=gcd-pet.main.buff.beast_cleave.remains>0.25" );
   cleave->add_action( "bestial_wrath" );
-  cleave->add_action( "kill_command,if=full_recharge_time<gcd&talent.alpha_predator&talent.kill_cleave" );
+  cleave->add_action( "kill_command,if=talent.kill_cleave" );
   cleave->add_action( "call_of_the_wild" );
   cleave->add_action( "explosive_shot" );
   cleave->add_action( "stampede,if=buff.bestial_wrath.up|target.time_to_die<15" );

--- a/engine/class_modules/apl/hunter/bm.txt
+++ b/engine/class_modules/apl/hunter/bm.txt
@@ -26,7 +26,7 @@ actions.cleave=/barbed_shot,target_if=max:debuff.latent_poison.stack,if=debuff.l
 actions.cleave+=/barbed_shot,target_if=min:dot.barbed_shot.remains,if=pet.main.buff.frenzy.up&pet.main.buff.frenzy.remains<=gcd+0.25|talent.scent_of_blood&cooldown.bestial_wrath.remains<12+gcd|full_recharge_time<gcd&cooldown.bestial_wrath.remains
 actions.cleave+=/multishot,if=gcd-pet.main.buff.beast_cleave.remains>0.25
 actions.cleave+=/bestial_wrath
-actions.cleave+=/kill_command,if=full_recharge_time<gcd&talent.alpha_predator&talent.kill_cleave
+actions.cleave+=/kill_command,if=talent.kill_cleave
 actions.cleave+=/call_of_the_wild
 actions.cleave+=/explosive_shot
 actions.cleave+=/stampede,if=buff.bestial_wrath.up|target.time_to_die<15


### PR DESCRIPTION
Hi all

First time doing a pull request, so sorry if I did it wrong.
Found its a DPS gain to send KC on CD as high prio and not only when it reaches 2 charges on the cleave APL (aka change the kill command line in cleave from **actions.cleave+=/kill_command,if=full_recharge_time<gcd&talent.alpha_predator** to just **actions.cleave+=/kill_command** ).

I did a few scenarios with here. 
https://www.raidbots.com/simbot/report/vbGrJTAh3PcRHbkrB4KZir 5T sim. Was a gain on anything from 2-5 I tested.
https://www.raidbots.com/simbot/report/meg9m9C53owkPuSNWWA5Dt - MDT sim

Also verfied it was a dps gain with the default BM profile and some sample picks of other chars and I could not get it to not be worth the change.
Let me know if there is any issues !