### PR TITLE
[Hunter] Prioritise Rapid Fire a bit more if you won't cap Aimed Shot charges

### DIFF
--- a/engine/class_modules/apl/apl_hunter.cpp
+++ b/engine/class_modules/apl/apl_hunter.cpp
@@ -180,7 +180,7 @@ void marksmanship( player_t* p )
   st->add_action( "stampede" );
   st->add_action( "death_chakram" );
   st->add_action( "wailing_arrow,if=active_enemies>1" );
-  st->add_action( "rapid_fire,if=talent.surging_shots" );
+  st->add_action( "rapid_fire,if=talent.surging_shots|action.aimed_shot.full_recharge_time>gcd+cast_time" );
   st->add_action( "kill_shot" );
   st->add_action( "trueshot,if=variable.trueshot_ready" );
   st->add_action( "multishot,if=buff.salvo.up&!talent.volley", "Trigger Salvo if Volley isn't being used to trigger it." );

--- a/engine/class_modules/apl/apl_hunter.cpp
+++ b/engine/class_modules/apl/apl_hunter.cpp
@@ -180,7 +180,7 @@ void marksmanship( player_t* p )
   st->add_action( "stampede" );
   st->add_action( "death_chakram" );
   st->add_action( "wailing_arrow,if=active_enemies>1" );
-  st->add_action( "rapid_fire,if=talent.surging_shots|action.aimed_shot.full_recharge_time>gcd+cast_time" );
+  st->add_action( "rapid_fire,if=talent.surging_shots|action.aimed_shot.full_recharge_time>action.aimed_shot.cast_time+cast_time" );
   st->add_action( "kill_shot" );
   st->add_action( "trueshot,if=variable.trueshot_ready" );
   st->add_action( "multishot,if=buff.salvo.up&!talent.volley", "Trigger Salvo if Volley isn't being used to trigger it." );

--- a/engine/class_modules/apl/hunter/mm.txt
+++ b/engine/class_modules/apl/hunter/mm.txt
@@ -40,7 +40,7 @@ actions.st+=/explosive_shot
 actions.st+=/stampede
 actions.st+=/death_chakram
 actions.st+=/wailing_arrow,if=active_enemies>1
-actions.st+=/rapid_fire,if=talent.surging_shots
+actions.st+=/rapid_fire,if=talent.surging_shots|action.aimed_shot.full_recharge_time>gcd+cast_time
 actions.st+=/kill_shot
 actions.st+=/trueshot,if=variable.trueshot_ready
 # Trigger Salvo if Volley isn't being used to trigger it.

--- a/engine/class_modules/apl/hunter/mm.txt
+++ b/engine/class_modules/apl/hunter/mm.txt
@@ -40,7 +40,7 @@ actions.st+=/explosive_shot
 actions.st+=/stampede
 actions.st+=/death_chakram
 actions.st+=/wailing_arrow,if=active_enemies>1
-actions.st+=/rapid_fire,if=talent.surging_shots|action.aimed_shot.full_recharge_time>gcd+cast_time
+actions.st+=/rapid_fire,if=talent.surging_shots|action.aimed_shot.full_recharge_time>action.aimed_shot.cast_time+cast_time
 actions.st+=/kill_shot
 actions.st+=/trueshot,if=variable.trueshot_ready
 # Trigger Salvo if Volley isn't being used to trigger it.


### PR DESCRIPTION
It's a gain to Prioritise Rapid Fire over Aimed Shot if you won't cap Aimed Shot charges. Seems to be slightly gear dependent as it's bigger for my personal sim.

Personal Sim: https://www.raidbots.com/simbot/report/ksyP6FjBeBzPkYZRdFreVw
T30 MM Sim (Using new best talents): https://www.raidbots.com/simbot/report/jvZcjUkYAy4bTC4U74GqKW