### PR TITLE
[Warlock] Add Expression to Track Expiring IGB

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -2092,6 +2092,22 @@ std::unique_ptr<expr_t> warlock_t::create_pet_expression( util::string_view name
       } );
     } );
   }
+  else if ( name_str == "last_cast_igb_imps" )
+  {
+    return make_fn_expr( "last_cast_igb_imps", [ this ]() {
+      return warlock_pet_list.wild_imps.n_active_pets( []( const pets::demonology::wild_imp_pet_t* pet ) {
+        return pet->resources.current[ RESOURCE_ENERGY ] < 32 && pet->buffs.imp_gang_boss->check();
+      } );
+    } );
+  }
+  else if ( name_str == "two_cast_igb_imps" )
+  {
+    return make_fn_expr( "two_cast_igb_imps", [ this ]() {
+      return warlock_pet_list.wild_imps.n_active_pets( []( const pets::demonology::wild_imp_pet_t* pet ) {
+        return pet->resources.current[ RESOURCE_ENERGY ] < 48 && pet->buffs.imp_gang_boss->check();
+      } );
+    } );
+  }
   else if ( name_str == "igb_ratio" )
   {
     return make_fn_expr( "igb_ratio", [ this ]() {
@@ -2147,6 +2163,14 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
     return create_pet_expression( name_str );
   }
   else if ( name_str == "two_cast_imps" )
+  {
+    return create_pet_expression( name_str );
+  }
+  else if ( name_str == "last_cast_igb_imps" )
+  {
+    return create_pet_expression( name_str );
+  }
+  else if ( name_str == "two_cast_igb_imps" )
   {
     return create_pet_expression( name_str );
   }


### PR DESCRIPTION
Expose number of expiring Imp Gang Bosses to APL.
Lets you check how many IGB are on last cast or second to last cast.

This is needed to be able to do APL work (reasonably fast, local sims are too slow for demonology sadly) to check if caring about IGB expiry provides a significant damage gain towards Implosion ST for 10.1.5.