### PR TITLE
Fixed talents for 10.1.5: Update T30_Generate_Evoker.simc

### DIFF
--- a/profiles/generators/Tier30/T30_Generate_Evoker.simc
+++ b/profiles/generators/Tier30/T30_Generate_Evoker.simc
@@ -4,7 +4,7 @@ level=70
 race=dracthyr
 role=spell
 position=back
-talents=BsbBAAAAAAAAAAAAAAAAAAAAAAkAAAAAAApkWkIHQCCJJJlkENINkIRSIhkEJSkkEB
+talents=BsbBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJSCSaSQABikIRSItoFJJhcgkWCIRSLSikEIQA
 
 dragonflight.ominous_chromatic_essence_dragonflight=azure
 dragonflight.ominous_chromatic_essence_allies=obsidian/emerald/bronze/azure/ruby


### PR DESCRIPTION
Fixed talents for 10.1.5, talents are not working after patch. This is highest ST.