### PR TITLE
[Warlock] Update Affliciton ST APL

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -62,7 +62,7 @@ void affliction( player_t* p )
   default_->add_action( "call_action_list,name=aoe,if=active_enemies>3" );
   default_->add_action( "call_action_list,name=ogcd" );
   default_->add_action( "call_action_list,name=items" );
-  default_->add_action( "malefic_rapture,if=talent.dread_touch&talent.malefic_affliction&debuff.dread_touch.remains<2&buff.malefic_affliction.stack=3" );
+  default_->add_action( "malefic_rapture,if=talent.dread_touch&debuff.dread_touch.remains<2&debuff.dread_touch.up" );
   default_->add_action( "unstable_affliction,if=remains<5" );
   default_->add_action( "agony,if=remains<5" );
   default_->add_action( "corruption,if=remains<5" );


### PR DESCRIPTION
The line that was keeping dread touch up depended on a talent that no longer exists, resulting in loss of dread touch uptime. Sim before change -> https://www.raidbots.com/simbot/report/cokJg4ZrsFrBSFDB5H6j2o Sim after change -> https://www.raidbots.com/simbot/report/eBdEvxepSMR7drFUgHtZ1e