### PR TITLE
[Player] cleanup player_t buffs

### DIFF
--- a/engine/action/spell.cpp
+++ b/engine/action/spell.cpp
@@ -31,8 +31,7 @@ spell_base_t::spell_base_t( action_e at,
                             util::string_view token,
                             player_t* p,
                             const spell_data_t* s ) :
-  action_t( at, token, p, s ),
-  procs_courageous_primal_diamond( true )
+  action_t( at, token, p, s )
 {
   min_gcd = p -> min_gcd;
   gcd_type = gcd_haste_type::SPELL_SPEED; // Hasten spell GCDs by default
@@ -232,14 +231,6 @@ result_amount_type spell_t::report_amount_type( const action_state_t* state ) co
   }
 
   return result_type;
-}
-
-void spell_t::init()
-{
-  spell_base_t::init();
-
-  if ( harmful )
-    procs_courageous_primal_diamond = false;
 }
 
 double spell_t::composite_hit() const

--- a/engine/action/spell.hpp
+++ b/engine/action/spell.hpp
@@ -18,7 +18,6 @@ public:
   result_amount_type amount_type( const action_state_t* /* state */, bool /* periodic */ = false ) const override;
   result_amount_type report_amount_type( const action_state_t* /* state */ ) const override;
   double miss_chance( double hit, player_t* t ) const override;
-  void   init() override;
   double composite_hit() const override;
   double composite_versatility(const action_state_t* state) const override;
   double composite_target_multiplier(player_t* target) const override;

--- a/engine/action/spell_base.hpp
+++ b/engine/action/spell_base.hpp
@@ -10,9 +10,6 @@
 
 struct spell_base_t : public action_t
 {
-  // special item flags
-  bool procs_courageous_primal_diamond;
-
   spell_base_t( action_e at, util::string_view token, player_t* p);
   spell_base_t( action_e at, util::string_view token, player_t* p, const spell_data_t* s );
 

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -3450,7 +3450,7 @@ absorb_buff_t* absorb_buff_t::set_cumulative( bool c )
 
 bool movement_buff_t::trigger( int stacks, double value, double chance, timespan_t duration )
 {
-  if ( player->buffs.norgannons_sagacity_stacks )
+  if ( player->buffs.norgannons_sagacity_stacks && player->buffs.norgannons_sagacity )
   {
     auto sagacity = player->buffs.norgannons_sagacity_stacks->check();
 

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -6834,7 +6834,7 @@ namespace monk
         {
           range::for_each( p.close_to_heart_aura->target_list(), [ this ] ( player_t *target )
         {
-          target->buffs.close_to_heart_leech_aura->trigger( 1, ( leech_increase ), 1, timespan_t::from_seconds( 10 ) );
+          target->buffs.close_to_heart_aura->trigger( 1, ( leech_increase ), 1, timespan_t::from_seconds( 10 ) );
         } );
         } );
         set_trigger_spell( p.talent.general.close_to_heart );
@@ -6859,7 +6859,7 @@ namespace monk
         {
           range::for_each( p.generous_pour_aura->target_list(), [ this ] ( player_t *target )
         {
-          target->buffs.generous_pour_avoidance_aura->trigger( 1, ( avoidance_increase ), 1, timespan_t::from_seconds( 10 ) );
+          target->buffs.generous_pour_aura->trigger( 1, ( avoidance_increase ), 1, timespan_t::from_seconds( 10 ) );
         } );
         } );
         set_trigger_spell( p.talent.general.generous_pour );
@@ -9545,8 +9545,7 @@ namespace monk
       }
       else
       {
-        buffs.close_to_heart_leech_aura->trigger( 1, buffs.close_to_heart_leech_aura->data().effectN( 1 ).percent(), 1,
-          timespan_t::zero() );
+        buffs.close_to_heart_aura->trigger( 1, buffs.close_to_heart_aura->data().effectN( 1 ).percent(), 1, 0_ms );
       }
     }
 
@@ -9558,8 +9557,7 @@ namespace monk
       }
       else
       {
-        buffs.generous_pour_avoidance_aura->trigger( 1, buffs.generous_pour_avoidance_aura->data().effectN( 1 ).percent(), 1,
-          timespan_t::zero() );
+        buffs.generous_pour_aura->trigger( 1, buffs.generous_pour_aura->data().effectN( 1 ).percent(), 1, 0_ms );
       }
     }
 
@@ -10563,10 +10561,10 @@ namespace monk
 
     void init( player_t *p ) const override
     {
-      p->buffs.close_to_heart_leech_aura =
-        make_buff( p, "close_to_heart_leech_aura", p->find_spell( 389684 ) )->add_invalidate( CACHE_LEECH );
-      p->buffs.close_to_heart_leech_aura =
-        make_buff( p, "generous_pour_avoidance_aura", p->find_spell( 389685 ) )->add_invalidate( CACHE_AVOIDANCE );
+      // TODO: healing received bonus NYI
+      p->buffs.close_to_heart_aura = make_buff( p, "close_to_heart_aura", p->find_spell( 389684 ) );
+      // TODO: grants A_MOD_DAMAGE_AVOIDANCE, not avoidance rating. NYI.
+      p->buffs.generous_pour_aura =  make_buff( p, "generous_pour_aura", p->find_spell( 389685 ) );
       p->buffs.windwalking_movement_aura =
         make_buff( p, "windwalking_movement_aura", p->find_spell( 365080 ) )->add_invalidate( CACHE_RUN_SPEED );
     }

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -2647,6 +2647,8 @@ struct priest_module_t final : public module_t
   }
   void init( player_t* p ) const override
   {
+    p->buffs.body_and_soul    = make_buff( p, "body_and_soul", p->find_spell( 65081 ) );
+    p->buffs.angelic_feather  = make_buff( p, "angelic_feather", p->find_spell( 121557 ) );
     p->buffs.guardian_spirit  = make_buff( p, "guardian_spirit",
                                           p->find_spell( 47788 ) );  // Let the ability handle the CD
     p->buffs.pain_suppression = make_buff( p, "pain_suppression",

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -1567,7 +1567,7 @@ public:
               ceil( ab::last_resource_cost * p()->azerite_spells.memory_of_lucid_dreams->effectN( 1 ).percent() );
           p()->resource_gain( cr, amount, p()->gain.memory_of_lucid_dreams );
 
-          if ( p()->azerite.memory_of_lucid_dreams.rank() >= 3 )
+          if ( p()->buffs.lucid_dreams && p()->azerite.memory_of_lucid_dreams.rank() >= 3 )
           {
           p()->buffs.lucid_dreams->trigger();
           }
@@ -10213,7 +10213,7 @@ double warrior_t::resource_gain( resource_e r, double a, gain_t* g, action_t* ac
       a *= 1.0 + spell.recklessness_buff->effectN( 4 ).percent();
   }
   // Memory of Lucid Dreams
-  if ( buffs.memory_of_lucid_dreams->up() )
+  if ( buffs.memory_of_lucid_dreams && buffs.memory_of_lucid_dreams->up() )
   {
     a *= 1.0 + buffs.memory_of_lucid_dreams->data().effectN( 1 ).percent();
   }

--- a/engine/player/azerite_data.hpp
+++ b/engine/player/azerite_data.hpp
@@ -388,6 +388,7 @@ void condensed_life_force( special_effect_t& effect );
 void conflict_and_strife( special_effect_t& effect );
 void purification_protocol( special_effect_t& effect );
 void ripple_in_space( special_effect_t& effect );
+void lucid_dreams( special_effect_t& effect );
 void the_unbound_force( special_effect_t& effect );
 void worldvein_resonance( special_effect_t& effect );
 void strive_for_perfection( special_effect_t& effect );

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -1176,8 +1176,6 @@ player_t::player_t( sim_t* s, player_e t, util::string_view n, race_e r )
     karazhan_trinkets_paired( false ),
     item_cooldown( new cooldown_t("item_cd", *this) ),
     default_item_group_cooldown( 20_s ),
-    warlords_unseeing_eye( 0.0 ),
-    warlords_unseeing_eye_stats(),
     auto_attack_modifier( 0.0 ),
     auto_attack_base_modifier( 0.0 ),
     auto_attack_multiplier( 1.0 ),

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -2965,7 +2965,6 @@ void player_t::init_gains()
   gains.vampiric_embrace   = get_gain( "vampiric_embrace" );
   gains.leech              = get_gain( "leech" );
   gains.embrace_of_bwonsamdi = get_gain( "embrace_of_bwonsamdi" );
-  gains.urh_restoration    = get_gain( "urh_restoration" );
 }
 
 void player_t::init_procs()

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -1173,7 +1173,6 @@ player_t::player_t( sim_t* s, player_e t, util::string_view n, race_e r )
     sets( ( !is_pet() && !is_enemy() ) ? new set_bonus_t( this ) : nullptr ),
     meta_gem( META_GEM_NONE ),
     matching_gear( false ),
-    karazhan_trinkets_paired( false ),
     item_cooldown( new cooldown_t("item_cd", *this) ),
     default_item_group_cooldown( 20_s ),
     auto_attack_modifier( 0.0 ),
@@ -12485,7 +12484,6 @@ void player_t::create_options()
   add_option( opt_timespan( "reaction_time_offset", reaction_offset ) );
   add_option( opt_timespan( "reaction_time_max", reaction_max ) );
   add_option( opt_bool( "stat_cache", cache.active ) );
-  add_option( opt_bool( "karazhan_trinkets_paired", karazhan_trinkets_paired ) );
   add_option( opt_timespan( "default_item_group_cooldown", default_item_group_cooldown, 0_ms, timespan_t::max() ) );
   add_option( opt_func( "override.precombat_state",
     [ this ] ( sim_t*, util::string_view, util::string_view value ) {

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -3810,122 +3810,43 @@ void player_t::create_buffs()
   if ( !is_enemy() && type != HEALING_ENEMY )
   {
     // Racials
-    buffs.berserking = make_buff( this, "berserking", find_spell( 26297 ) )->add_invalidate( CACHE_HASTE );
-    buffs.stoneform  = make_buff( this, "stoneform", find_spell( 65116 ) );
-    buffs.blood_fury = make_buff<stat_buff_t>( this, "blood_fury", find_racial_spell( "Blood Fury" ) )
+    buffs.berserking = make_buff_fallback( race == RACE_TROLL, this, "berserking", find_spell( 26297 ) )
+                           ->add_invalidate( CACHE_HASTE );
+
+    buffs.stoneform = make_buff_fallback( race == RACE_DWARF, this, "stoneform", find_spell( 65116 ) );
+
+    buffs.blood_fury = make_buff_fallback<stat_buff_t>( race == RACE_ORC, this, "blood_fury", find_racial_spell( "Blood Fury" ) )
                            ->add_invalidate( CACHE_SPELL_POWER )
                            ->add_invalidate( CACHE_ATTACK_POWER );
-    buffs.fortitude  = make_buff( this, "fortitude", find_spell( 137593 ) )->set_activated( false );
-    buffs.shadowmeld = make_buff( this, "shadowmeld", find_spell( 58984 ) )->set_cooldown( timespan_t::zero() );
 
-    buffs.ancestral_call[ 0 ] = make_buff<stat_buff_t>( this, "rictus_of_the_laughing_skull", find_spell( 274739 ) );
-    buffs.ancestral_call[ 1 ] = make_buff<stat_buff_t>( this, "zeal_of_the_burning_blade", find_spell( 274740 ) );
-    buffs.ancestral_call[ 2 ] = make_buff<stat_buff_t>( this, "ferocity_of_the_frostwolf", find_spell( 274741 ) );
-    buffs.ancestral_call[ 3 ] = make_buff<stat_buff_t>( this, "might_of_the_blackrock", find_spell( 274742 ) );
+    buffs.shadowmeld = make_buff_fallback( race == RACE_NIGHT_ELF, this, "shadowmeld", find_spell( 58984 ) )
+                           ->set_cooldown( 0_ms );
 
-    buffs.fireblood = make_buff<stat_buff_t>( this, "fireblood", find_spell( 265226 ) )
-                        ->add_stat( convert_hybrid_stat( STAT_STR_AGI_INT ),
-                          util::round( find_spell( 265226 ) -> effectN( 1 ).average( this, level() ) ) * 3 );
+    buffs.ancestral_call[ 0 ] = make_buff_fallback<stat_buff_t>( race == RACE_MAGHAR_ORC, this,
+                                                                 "rictus_of_the_laughing_skull", find_spell( 274739 ) );
+    buffs.ancestral_call[ 1 ] = make_buff_fallback<stat_buff_t>( race == RACE_MAGHAR_ORC, this,
+                                                                 "zeal_of_the_burning_blade", find_spell( 274740 ) );
+    buffs.ancestral_call[ 2 ] = make_buff_fallback<stat_buff_t>( race == RACE_MAGHAR_ORC, this,
+                                                                 "ferocity_of_the_frostwolf", find_spell( 274741 ) );
+    buffs.ancestral_call[ 3 ] = make_buff_fallback<stat_buff_t>( race == RACE_MAGHAR_ORC, this,
+                                                                 "might_of_the_blackrock", find_spell( 274742 ) );
 
-    buffs.archmages_greater_incandescence_agi =
-        make_buff( this, "archmages_greater_incandescence_agi", find_spell( 177172 ) )
-            ->add_invalidate( CACHE_AGILITY );
-    buffs.archmages_greater_incandescence_str =
-        make_buff( this, "archmages_greater_incandescence_str", find_spell( 177175 ) )
-            ->add_invalidate( CACHE_STRENGTH );
-    buffs.archmages_greater_incandescence_int =
-        make_buff( this, "archmages_greater_incandescence_int", find_spell( 177176 ) )
-            ->add_invalidate( CACHE_INTELLECT );
+    if ( race == RACE_DARK_IRON_DWARF )
+    {
+      buffs.fireblood =
+          make_buff<stat_buff_t>( this, "fireblood", find_spell( 265226 ) )
+              ->add_stat( convert_hybrid_stat( STAT_STR_AGI_INT ),
+                          util::round( find_spell( 265226 )->effectN( 1 ).average( this, level() ) ) * 3 );
+    }
+    else
+      buffs.fireblood = buff_t::make_fallback( this, "fireblood", this );
 
-    buffs.archmages_incandescence_agi =
-        make_buff( this, "archmages_incandescence_agi", find_spell( 177161 ) )->add_invalidate( CACHE_AGILITY );
-    buffs.archmages_incandescence_str =
-        make_buff( this, "archmages_incandescence_str", find_spell( 177160 ) )->add_invalidate( CACHE_STRENGTH );
-    buffs.archmages_incandescence_int =
-        make_buff( this, "archmages_incandescence_int", find_spell( 177159 ) )->add_invalidate( CACHE_INTELLECT );
-
-    // Legendary meta haste buff
-    buffs.tempus_repit = make_buff( this, "tempus_repit", find_spell( 137590 ) )
-        ->add_invalidate( CACHE_SPELL_SPEED )->set_activated( false );
-
-    buffs.darkflight = make_buff( this, "darkflight", find_racial_spell( "darkflight" ) );
-
-    buffs.nitro_boosts = make_buff( this, "nitro_boosts", find_spell( 54861 ) );
-
-    buffs.amplification = make_buff( this, "amplification", find_spell( 146051 ) )
-                              ->add_invalidate( CACHE_MASTERY )
-                              ->add_invalidate( CACHE_HASTE )
-                              ->add_invalidate( CACHE_VERSATILITY )
-                              ->set_chance( 0 );
-    buffs.amplification_2 = make_buff( this, "amplification_2", find_spell( 146051 ) )
-                                ->add_invalidate( CACHE_MASTERY )
-                                ->add_invalidate( CACHE_HASTE )
-                                ->add_invalidate( CACHE_VERSATILITY )
-                                ->set_chance( 0 );
-
-    buffs.temptation = make_buff( this, "temptation", find_spell( 234143 ) )
-                           ->set_cooldown( timespan_t::zero() )
-                           ->set_chance( 1 )
-                           ->set_default_value( 0.1 );  // Not in spelldata
-
-    buffs.courageous_primal_diamond_lucidity = make_buff( this, "lucidity", find_spell( 137288 ) );
-
-    buffs.body_and_soul = make_buff( this, "body_and_soul", find_spell( 64129 ) )
-                              ->set_max_stack( 1 )
-                              ->set_duration( timespan_t::from_seconds( 4.0 ) );
-
-    buffs.angelic_feather = make_buff( this, "angelic_feather", find_spell( 121557 ) )
-                                ->set_max_stack( 1 )
-                                ->set_duration( timespan_t::from_seconds( 6.0 ) );
-
-    buffs.close_to_heart_leech_aura = make_buff( this, "close_to_heart", find_spell( 389684 ) )
-                                        ->add_invalidate( CACHE_LEECH );
-    buffs.generous_pour_avoidance_aura = make_buff( this, "generous pour", find_spell( 389685 ) )
-                                            ->add_invalidate( CACHE_AVOIDANCE );
-    buffs.windwalking_movement_aura = make_buff( this, "windwalking", find_spell( 365080 ) )
-                                        ->add_invalidate( CACHE_RUN_SPEED );
+    buffs.darkflight = make_buff_fallback( race == RACE_WORGEN, this, "darkflight", find_racial_spell( "darkflight" ) );
 
     buffs.movement = new movement_buff_t( this );
 
     if ( !is_pet() )
     {
-      buffs.memory_of_lucid_dreams = make_buff<stat_buff_t>( this, "memory_of_lucid_dreams",
-        find_spell( 298357 ) );
-
-      auto memory_of_lucid_dreams = find_azerite_essence( "Memory of Lucid Dreams" );
-      buffs.lucid_dreams = make_buff<stat_buff_t>( this, "lucid_dreams", find_spell( 298343 ) );
-      buffs.lucid_dreams->add_stat( STAT_VERSATILITY_RATING,
-        memory_of_lucid_dreams.spell_ref( 3U, essence_spell::UPGRADE, essence_type::MINOR ).effectN( 1 ).average(
-          memory_of_lucid_dreams.item() ) );
-      buffs.lucid_dreams->set_quiet( memory_of_lucid_dreams.rank() < 3 );
-
-      buffs.reckless_force = make_buff( this, "reckless_force", find_spell( 302932 ) )
-        ->add_invalidate(CACHE_CRIT_CHANCE)
-        ->set_default_value( find_spell( 302932 )->effectN( 1 ).percent() );
-
-      buffs.reckless_force_counter = make_buff( this, "reckless_force_counter", find_spell( 302917 ) );
-
-      auto worldvein_resonance = find_azerite_essence( "Worldvein Resonance" );
-      buffs.lifeblood = make_buff<stat_buff_t>( this, "lifeblood", find_spell( 295137 ) );
-      buffs.lifeblood->add_stat( convert_hybrid_stat( STAT_STR_AGI_INT ),
-        worldvein_resonance.spell( 1, essence_type::MINOR )->effectN( 5 ).average( worldvein_resonance.item() ) );
-
-      buffs.seething_rage_essence = make_buff( this, "seething_rage_essence", find_spell( 297126 ) )
-        ->set_default_value( find_spell( 297126 )->effectN( 1 ).percent() );
-
-      buffs.guardian_of_azeroth = make_buff( this, "guardian_of_azeroth", find_spell( 295855 ) )
-        ->set_default_value( find_spell( 295855 )->effectN( 1 ).percent() )
-        ->add_invalidate( CACHE_HASTE );
-
-      auto ripple_in_space = find_azerite_essence( "Ripple in Space" );
-      buffs.reality_shift = make_buff<stat_buff_t>( this, "reality_shift", find_spell( 302916 ) );
-      buffs.reality_shift->add_stat( convert_hybrid_stat( STAT_STR_AGI_INT ),
-        ripple_in_space.spell_ref(1U, essence_type::MINOR).effectN( 2 ).average(
-          ripple_in_space.item() ) );
-      buffs.reality_shift->set_duration( find_spell( 302952 )->duration()
-        + timespan_t::from_seconds( ripple_in_space.spell_ref( 2U, essence_spell::UPGRADE, essence_type::MINOR ).effectN( 1 ).base_value() / 1000 ) );
-      buffs.reality_shift->set_cooldown( find_spell( 302953 )->duration() );
-
       buffs.windfury_totem = make_buff<buff_t>( this, "windfury_totem", find_spell( 327942 ) )
         ->set_duration( sim->max_time * 3 )
         ->set_chance( as<double>( sim->overrides.windfury_totem ) );
@@ -3939,10 +3860,6 @@ void player_t::create_buffs()
         ->set_default_value_from_effect( 1 )
         ->set_cooldown( 0_ms )
         ->add_invalidate( CACHE_HASTE );
-
-      // Runecarves
-      buffs.norgannons_sagacity_stacks = make_buff( this, "norgannons_sagacity_stacks", find_spell( 339443 ) );
-      buffs.norgannons_sagacity = make_buff( this, "norgannons_sagacity", find_spell( 339445 ) );
 
       // External trinkets
       if ( external_buffs.soleahs_secret_technique )
@@ -4176,17 +4093,8 @@ double player_t::composite_melee_haste() const
     if ( buffs.bloodlust->check() )
       h *= 1.0 / ( 1.0 + buffs.bloodlust->check_stack_value() );
 
-    if ( buffs.mongoose_mh && buffs.mongoose_mh->check() )
-      h *= 1.0 / ( 1.0 + 30 / current.rating.attack_haste );
-
-    if ( buffs.mongoose_oh && buffs.mongoose_oh->check() )
-      h *= 1.0 / ( 1.0 + 30 / current.rating.attack_haste );
-
     if ( buffs.berserking->check() )
       h *= 1.0 / ( 1.0 + buffs.berserking->data().effectN( 1 ).percent() );
-
-    if ( buffs.guardian_of_azeroth->check() )
-      h *= 1.0 / ( 1.0 + buffs.guardian_of_azeroth->check_stack_value() );
 
     h *= 1.0 / ( 1.0 + racials.nimble_fingers->effectN( 1 ).percent() );
     h *= 1.0 / ( 1.0 + racials.time_is_money->effectN( 1 ).percent() );
@@ -4330,14 +4238,8 @@ double player_t::composite_melee_crit_chance() const
   for ( auto b : buffs.stat_pct_buffs[ STAT_PCT_BUFF_CRIT ] )
     ac += b->check_stack_value();
 
-  // The Unbound Force crit bonus from 20 stack proc
-  if (buffs.reckless_force)
-    ac += buffs.reckless_force->check_value();
-
   ac += racials.viciousness->effectN( 1 ).percent();
   ac += racials.arcane_acuity->effectN( 1 ).percent();
-  if ( buffs.embrace_of_paku )
-    ac += buffs.embrace_of_paku->check_value();
 
   if ( timeofday == DAY_TIME )
     ac += racials.touch_of_elune->effectN( 1 ).percent();
@@ -4553,9 +4455,6 @@ double player_t::composite_spell_haste() const
     if ( buffs.berserking->check() )
       h *= 1.0 / ( 1.0 + buffs.berserking->data().effectN( 1 ).percent() );
 
-    if ( buffs.guardian_of_azeroth->check() )
-      h *= 1.0 / ( 1.0 + buffs.guardian_of_azeroth->check_stack_value() );
-
     h *= 1.0 / ( 1.0 + racials.nimble_fingers->effectN( 1 ).percent() );
     h *= 1.0 / ( 1.0 + racials.time_is_money->effectN( 1 ).percent() );
 
@@ -4578,9 +4477,9 @@ double player_t::composite_spell_speed() const
 
   if ( !is_pet() && !is_enemy() && type != HEALING_ENEMY )
   {
-    if ( buffs.tempus_repit->check() )
+    if ( buffs.tempus_repit &&  buffs.tempus_repit->check() )
     {
-      speed *= 1.0 / ( 1.0 + buffs.tempus_repit->data().effectN( 1 ).percent() );
+      speed *= 1.0 / ( 1.0 + buffs.tempus_repit->check_stack_value() );
     }
 
     if ( buffs.nefarious_pact )
@@ -4629,14 +4528,8 @@ double player_t::composite_spell_crit_chance() const
   for ( auto b : buffs.stat_pct_buffs[ STAT_PCT_BUFF_CRIT ] )
     sc += b->check_stack_value();
 
-  // reckless force (The Unbound Force) crit bonus from 20 stack proc
-  if (buffs.reckless_force)
-    sc += buffs.reckless_force->check_value();
-
   sc += racials.viciousness->effectN( 1 ).percent();
   sc += racials.arcane_acuity->effectN( 1 ).percent();
-  if ( buffs.embrace_of_paku )
-    sc += buffs.embrace_of_paku->check_value();
 
   if ( timeofday == DAY_TIME )
   {
@@ -4689,9 +4582,6 @@ double player_t::composite_damage_versatility() const
   if ( !is_pet() && !is_enemy() && type != HEALING_ENEMY )
   {
     cdv += sim->auras.mark_of_the_wild->check_value();
-
-    if ( buffs.legendary_tank_buff )
-      cdv += buffs.legendary_tank_buff->check_value();
   }
 
   if ( buffs.dmf_well_fed )
@@ -4714,9 +4604,6 @@ double player_t::composite_heal_versatility() const
   if ( !is_pet() && !is_enemy() && type != HEALING_ENEMY )
   {
     chv += sim->auras.mark_of_the_wild->check_value();
-
-    if ( buffs.legendary_tank_buff )
-      chv += buffs.legendary_tank_buff->check_value();
   }
 
   if ( buffs.dmf_well_fed )
@@ -4739,9 +4626,6 @@ double player_t::composite_mitigation_versatility() const
   if ( !is_pet() && !is_enemy() && type != HEALING_ENEMY )
   {
     cmv += sim->auras.mark_of_the_wild->check_value() / 2;
-
-    if ( buffs.legendary_tank_buff )
-      cmv += buffs.legendary_tank_buff->check_value() / 2;
   }
 
   if ( buffs.dmf_well_fed )
@@ -4994,7 +4878,7 @@ double player_t::temporary_movement_modifier() const
 
   if ( !is_enemy() && type != HEALING_ENEMY )
   {
-    if ( buffs.stampeding_roar )
+    if ( buffs.stampeding_roar && buffs.stampeding_roar->check() )
       temporary = std::max( buffs.stampeding_roar->check_value(), temporary );
   }
 
@@ -5003,16 +4887,16 @@ double player_t::temporary_movement_modifier() const
     if ( buffs.darkflight->check() )
       temporary = std::max( buffs.darkflight->data().effectN( 1 ).percent(), temporary );
 
-    if ( buffs.nitro_boosts->check() )
+    if ( buffs.nitro_boosts && buffs.nitro_boosts->check() )
       temporary = std::max( buffs.nitro_boosts->data().effectN( 1 ).percent(), temporary );
 
-    if ( buffs.body_and_soul->check() )
+    if ( buffs.body_and_soul && buffs.body_and_soul->check() )
       temporary = std::max( buffs.body_and_soul->data().effectN( 1 ).percent(), temporary );
 
-    if ( buffs.angelic_feather->check() )
+    if ( buffs.angelic_feather && buffs.angelic_feather->check() )
       temporary = std::max( buffs.angelic_feather->data().effectN( 1 ).percent(), temporary );
 
-    if ( buffs.windwalking_movement_aura->check() )
+    if ( buffs.windwalking_movement_aura && buffs.windwalking_movement_aura->check() )
       temporary = std::max( buffs.windwalking_movement_aura->data().effectN( 1 ).percent(), temporary );
 
     if ( buffs.normalization_increase && buffs.normalization_increase->check() )
@@ -5087,24 +4971,12 @@ double player_t::composite_attribute_multiplier( attribute_e attr ) const
   {
     case ATTR_STRENGTH:
       pct_type = STAT_PCT_BUFF_STRENGTH;
-      if ( buffs.archmages_greater_incandescence_str->check() )
-        m *= 1.0 + buffs.archmages_greater_incandescence_str->data().effectN( 1 ).percent();
-      if ( buffs.archmages_incandescence_str->check() )
-        m *= 1.0 + buffs.archmages_incandescence_str->data().effectN( 1 ).percent();
       break;
     case ATTR_AGILITY:
       pct_type = STAT_PCT_BUFF_AGILITY;
-      if ( buffs.archmages_greater_incandescence_agi->check() )
-        m *= 1.0 + buffs.archmages_greater_incandescence_agi->data().effectN( 1 ).percent();
-      if ( buffs.archmages_incandescence_agi->check() )
-        m *= 1.0 + buffs.archmages_incandescence_agi->data().effectN( 1 ).percent();
       break;
     case ATTR_INTELLECT:
       pct_type = STAT_PCT_BUFF_INTELLECT;
-      if ( buffs.archmages_greater_incandescence_int->check() )
-        m *= 1.0 + buffs.archmages_greater_incandescence_int->data().effectN( 1 ).percent();
-      if ( buffs.archmages_incandescence_int->check() )
-        m *= 1.0 + buffs.archmages_incandescence_int->data().effectN( 1 ).percent();
       if ( sim->auras.arcane_intellect->check() )
         m *= 1.0 + sim->auras.arcane_intellect->current_value;
       break;
@@ -5498,21 +5370,6 @@ void player_t::combat_begin()
   for ( size_t i = 0, end = collected_data.combat_start_resource.size(); i < end; ++i )
   {
     collected_data.combat_start_resource[ i ].add( resources.current[ i ] );
-  }
-
-  if ( buffs.cooldown_reduction )
-    buffs.cooldown_reduction->trigger();
-
-  if ( buffs.amplification )
-    buffs.amplification->trigger();
-
-  if ( buffs.amplification_2 )
-    buffs.amplification_2->trigger();
-
-  if ( buffs.tyrants_decree_driver )
-  {  // Assume actor has stacked the buff to max stack precombat.
-    buffs.tyrants_decree_driver->trigger();
-    buffs.tyrants_immortality->trigger( buffs.tyrants_immortality->max_stack() );
   }
 
   auto add_timed_buff_triggers = [ this ] ( const std::vector<timespan_t>& times, buff_t* buff, timespan_t duration = timespan_t::min() )
@@ -7805,14 +7662,11 @@ void player_t::target_mitigation( school_e school, result_amount_type dmg_type, 
   if ( buffs.pain_suppression && buffs.pain_suppression->up() )
     s->result_amount *= 1.0 + buffs.pain_suppression->data().effectN( 1 ).percent();
 
-  if ( buffs.naarus_discipline && buffs.naarus_discipline->check() )
-    s->result_amount *= 1.0 + buffs.naarus_discipline->stack_value();
-
   if ( buffs.stoneform && buffs.stoneform->up() )
     s->result_amount *= 1.0 + buffs.stoneform->data().effectN( 1 ).percent();
 
   if ( buffs.fortitude && buffs.fortitude->up() )
-    s->result_amount *= 1.0 + buffs.fortitude->data().effectN( 1 ).percent();
+    s->result_amount *= 1.0 + buffs.fortitude->check_value();
 
   if ( buffs.elemental_chaos_earth && buffs.elemental_chaos_earth->check() )
     s->result_amount *= 1.0 + buffs.elemental_chaos_earth->check_value();

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -389,11 +389,6 @@ struct player_t : public actor_t
   bool karazhan_trinkets_paired;
   std::unique_ptr<cooldown_t> item_cooldown;
   timespan_t default_item_group_cooldown;
-  cooldown_t* legendary_tank_cloak_cd; // non-Null if item available
-
-  // Warlord's Unseeing Eye (6.2 Trinket)
-  double warlords_unseeing_eye;
-  stats_t* warlords_unseeing_eye_stats;
 
   // Misc Multipliers
   // auto attack modifier and multiplier (for Jeweled Signet of Melandrus and similar effects)
@@ -597,14 +592,12 @@ struct player_t : public actor_t
   struct gains_t
   {
     gain_t* arcane_torrent;
-    gain_t* endurance_of_niuzao;
     std::array<gain_t*, RESOURCE_MAX> resource_regen;
     gain_t* health;
     gain_t* mana_potion;
     gain_t* restore_mana;
     gain_t* touch_of_the_grave;
     gain_t* vampiric_embrace;
-    gain_t* warlords_unseeing_eye;
     gain_t* embrace_of_bwonsamdi;
     gain_t* urh_restoration;
 

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -599,7 +599,6 @@ struct player_t : public actor_t
     gain_t* touch_of_the_grave;
     gain_t* vampiric_embrace;
     gain_t* embrace_of_bwonsamdi;
-    gain_t* urh_restoration;
 
     gain_t* leech;
   } gains;

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -431,58 +431,38 @@ struct player_t : public actor_t
     buff_t* exhaustion;
     buff_t* guardian_spirit;
     buff_t* blessing_of_sacrifice;
-    buff_t* mongoose_mh;
-    buff_t* mongoose_oh;
     buff_t* nitro_boosts;
     buff_t* pain_suppression;
     buff_t* movement;
     buff_t* stampeding_roar;
     buff_t* shadowmeld;
-    buff_t* close_to_heart_leech_aura;
-    buff_t* generous_pour_avoidance_aura;
+    buff_t* close_to_heart_aura;
+    buff_t* generous_pour_aura;
     buff_t* windwalking_movement_aura;
     buff_t* stoneform;
     buff_t* stunned;
     std::array<buff_t*, 4> ancestral_call;
     buff_t* fireblood;
-    buff_t* embrace_of_paku;
     buff_t* symbol_of_hope; // Priest spell
 
     buff_t* berserking;
     buff_t* bloodlust;
     buff_t* windfury_totem;
 
-    buff_t* cooldown_reduction;
-    buff_t* amplification;
-    buff_t* amplification_2;
-
     // Legendary meta stuff
     buff_t* courageous_primal_diamond_lucidity;
     buff_t* tempus_repit;
     buff_t* fortitude;
 
-    buff_t* archmages_greater_incandescence_str;
-    buff_t* archmages_greater_incandescence_agi;
-    buff_t* archmages_greater_incandescence_int;
-    buff_t* archmages_incandescence_str;
-    buff_t* archmages_incandescence_agi;
-    buff_t* archmages_incandescence_int;
     buff_t* legendary_aoe_ring; // Legendary ring buff.
-    buff_t* legendary_tank_buff;
 
     // 7.0 trinket proxy buffs
     buff_t* incensed;
     buff_t* taste_of_mana; // Gnawed Thumb Ring buff
 
     // 7.1
-    buff_t* temptation; // Ring that goes on a 5 minute cd if you use it too much.
     buff_t* nefarious_pact; // Whispers in the dark good buff
     buff_t* devils_due; // Whispers in the dark bad buff
-
-    // 6.2 trinket proxy buffs
-    buff_t* naarus_discipline; // Priest-Discipline Boss 13 T18 trinket
-    buff_t* tyrants_immortality; // Tyrant's Decree trinket proc
-    buff_t* tyrants_decree_driver; // Tyrant's Decree trinket driver
 
     buff_t* demon_damage_buff; // 6.2.3 Heirloom trinket demon damage buff
 
@@ -502,25 +482,15 @@ struct player_t : public actor_t
     // Azerite power
     buff_t* normalization_increase;
 
-    // Uldir
-    buff_t* reorigination_array;
-
     /// 8.2 Azerite Essences
-    stat_buff_t* memory_of_lucid_dreams;
-    stat_buff_t* lucid_dreams; // Versatility Buff from Rank 3
-    buff_t* reckless_force; // The Unbound Force minor - crit chance
-    buff_t* reckless_force_counter; // The Unbound Force minor - max 20 stack counter
-    stat_buff_t* lifeblood; // Worldvein Resonance - grant primary stat per shard, max 4
+    buff_t* memory_of_lucid_dreams;
+    buff_t* lucid_dreams; // Versatility Buff from Rank 3
     buff_t* seething_rage_essence; // Blood of the Enemy major - 25% crit dam
-    stat_buff_t* reality_shift; // Ripple in Space minor - primary stat on moving 25yds
-    buff_t* guardian_of_azeroth; // Condensed Life-Force major - R3 stacking haste on pet cast
 
     // 8.2 misc
     buff_t* damage_to_aberrations; // Benthic belt special effect
     buff_t* fathom_hunter; // Follower themed Benthic boots special effect
     buff_t* delirious_frenzy; // Dream's End 1H STR axe attack speed buff
-    buff_t* bioelectric_charge; // Diver's Folly 1H AGI axe buff to store damage
-    buff_t* razor_coral; // Ashvane's Razor Coral trinket crit rating buff
 
     // 9.0 class buffs
     buff_t* focus_magic; // Mage talent

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -386,7 +386,6 @@ struct player_t : public actor_t
   std::unique_ptr<set_bonus_t> sets;
   meta_gem_e meta_gem;
   bool matching_gear;
-  bool karazhan_trinkets_paired;
   std::unique_ptr<cooldown_t> item_cooldown;
   timespan_t default_item_group_cooldown;
 

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -405,6 +405,9 @@ void item::arans_relaxing_ruby( special_effect_t& effect )
 
 void item::ring_of_collapsing_futures( special_effect_t& effect )
 {
+  if ( create_fallback_buffs( effect, { "temptation" } ) )
+    return;
+
   struct collapse_t: public proc_spell_t {
     collapse_t( const special_effect_t& effect ):
       proc_spell_t( "collapse", effect.player,
@@ -458,7 +461,12 @@ void item::ring_of_collapsing_futures( special_effect_t& effect )
     }
   };
 
-  effect.custom_buff = effect.player -> buffs.temptation;
+  auto lockout = make_buff( effect.player, "temptation", effect.player->find_spell( 234143 ) )
+    ->set_cooldown( 0_ms )
+    ->set_chance( 1 )
+    ->set_default_value( 0.1 );  // Not in spelldata
+
+  effect.custom_buff = lockout;
   effect.execute_action = new apply_debuff_t( effect );
   effect.buff_disabled = true; // Buff application is handled inside apply_debuff_t, and this will prevent use_item
                                // from putting the item on cooldown but not using the action.
@@ -5981,7 +5989,7 @@ void unique_gear::register_special_effects_legion()
 
   /* Legion 7.1 Dungeon */
   register_special_effect( 230257, item::arans_relaxing_ruby            );
-  register_special_effect( 234142, item::ring_of_collapsing_futures     );
+  register_special_effect( 234142, item::ring_of_collapsing_futures, true );
   register_special_effect( 230222, item::mrrgrias_favor                 );
   register_special_effect( 231952, item::toe_knees_promise              );
   register_special_effect( 230236, item::deteriorated_construct_core    );

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -946,9 +946,8 @@ struct thunder_ritual_impact_t : public proc_spell_t
     callbacks = false;
     pair_icd = effect.player -> get_cooldown( "paired_trinket_icd" );
     pair_icd -> duration = timespan_t::from_seconds( 60.0 );
-    if ( player -> karazhan_trinkets_paired )
+    if ( unique_gear::find_special_effect( player, 231952 ) )
     {
-
       pair_multiplied = true;
     }
     base_dd_min = base_dd_max = data().effectN( 1 ).average( effect.item ) * chest_multiplier;
@@ -2354,7 +2353,7 @@ struct flame_gale_pulse_t : proc_spell_t
     callbacks = false;
     school = SCHOOL_FIRE;
     aoe = -1;
-    if ( player -> karazhan_trinkets_paired )
+    if ( unique_gear::find_special_effect( player, 230222 ) )
       paired_multiplier += 0.3;
     base_dd_min = base_dd_max = data().effectN( 1 ).average( effect.item ) * paired_multiplier * chest_multiplier;
   }

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -5008,9 +5008,17 @@ void maw_rattle( special_effect_t& /* effect */ )
 void norgannons_sagacity( special_effect_t& effect )
 {
   effect.proc_flags2_ |= PF2_CAST | PF2_CAST_DAMAGE | PF2_CAST_HEAL;
-  effect.custom_buff = effect.player->buffs.norgannons_sagacity_stacks;
 
-  new dbc_proc_callback_t( effect.player, effect );
+  auto p = effect.player;
+  if ( !p->buffs.norgannons_sagacity_stacks )
+  {
+    p->buffs.norgannons_sagacity_stacks = make_buff( p, "norgannons_sagacity_stacks", p->find_spell( 339443 ) );
+    p->buffs.norgannons_sagacity = make_buff( p, "norgannons_sagacity", p->find_spell( 339445 ) );
+  }
+
+  effect.custom_buff = p->buffs.norgannons_sagacity_stacks;
+
+  new dbc_proc_callback_t( p, effect );
 }
 
 void sephuzs_proclamation( special_effect_t& effect )


### PR DESCRIPTION
* use fallback for berserking racial
* use fallback for stoneform racial
* use fallback for blood fury racial
* use fallback for shadowmeld racial
* use fallback for ancestral call racial
* use fallback for fireblood racial
* use fallback for darkflight racial
* convert embrace of paku to stat_pct_buff
* remove duplicate close_to_heart_aura definition
* remove duplicate generous_pour_aura definition
* move body_and_soul definition to priest_module_t
* move angelic_feather definition to priest_module_t
* move norgannons_sagacity definition to unique_gear_shadowlands
* move lucid_dreams definition to azerite_data
* convert guardian_of_azeroth to stat_pct_buff
* move seething_rage definition to azerite_data
* move reality_shift to azerite_data
* convert reckless_force to stat_pct_buff
* move lifeblood to azerite_data
* move diver's folly damage storage buff to unique_gear_bfa
* move razor coral buff to unique_gear_bfa
* remove unused reorigination buff
* move ring of collapsing futures lockout to unique_gear_legion
* move 6.2 trinket proxy buff definitions to unique_gear
* convert WOD legendary tank ring buff to stat_pct_buff
* convert WOD pre-legendary ring buffs to stat_pct_buff
* remove spell_t::procs_courageous_primal_diamond
* move MOP legendary meta gem definitions to unique_gear
* remove unused readiness MOP buff
* remove unused amplification MOP buff
* remove unused mongoose_oh and moongoose_mh