### PR TITLE
[Druid] Set adaptive swarm target count for Dungeonslice/DungeonRoute sims

### DIFF
--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -10682,10 +10682,10 @@ void druid_t::init()
 
   if ( sim->fight_style == FIGHT_STYLE_DUNGEON_SLICE || sim->fight_style == FIGHT_STYLE_DUNGEON_ROUTE )
   {
-    if ( options.adaptive_swarm_melee_targets == 9 )
-      options.adaptive_swarm_melee_targets = 3;
-    if ( options.adaptive_swarm_ranged_targets == 14 )
-      options.adaptive_swarm_ranged_targets = 1;
+    if ( options.adaptive_swarm_melee_targets == 7 )
+      options.adaptive_swarm_melee_targets = 2;
+    if ( options.adaptive_swarm_ranged_targets == 12 )
+      options.adaptive_swarm_ranged_targets = 2;
   }
 }
 


### PR DESCRIPTION
Prior to this commit, dungeon sims were still doing 7/12 targets due to the changed lines not matching default settings. This has been fixed and the dungeon sims now do 2/2 targets.