### PR TITLE
WW 10.1.7 updates

### DIFF
--- a/profiles/generators/Tier30/T30_Generate_Monk.simc
+++ b/profiles/generators/Tier30/T30_Generate_Monk.simc
@@ -28,25 +28,25 @@ save=T30_Monk_Brewmaster.simc
 monk="T30_Monk_Windwalker"
 spec=windwalker
 level=70
-race=orc
+race=void_elf
 role=dps
-talents=B0QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACikkoFJJAAAAAJSSaASSSSgkSkISIFJJJJplAAAA
+talents=B0QAK5xc05YQdq4E+VOLrE2vpCAAAAAAABRSS0ikEAAAAgEJJFAJJJJBJiERCtikkWSSLBAAAA
 
-head=cover_of_the_vermillion_forge,id=202506,bonus_id=9410/1504/9413,gem_id=192991
-neck=torc_of_passed_time,id=201759,bonus_id=8840/8836/8902/8783/8784/8782/1537,gem_id=192925/192925/192925,crafted_stats=32/40
-shoulders=spines_of_the_vermillion_forge,id=205833,bonus_id=9410/1507
-back=voice_of_the_silent_star,id=204465,bonus_id=9410/1498
-chest=lifebound_chestpiece,id=193399,bonus_id=8840/8836/8902/1537/9379/8960,enchant=waking_stats_3,crafted_stats=32/40
-wrists=ferocious_hyena_hidebinders,id=193793,bonus_id=7977/1669/4786/7935,gem_id=192925,enchant=devotion_of_avoidance_3
-hands=fists_of_the_vermillion_forge,id=202507,bonus_id=9410/1501
-waist=blackbelt_of_the_vermillion_forge,id=202503,bonus_id=9410/1507,gem_id=192925,enchant=shadowed_belt_clasp_3
-legs=pantaloons_of_the_vermillion_forge,id=202505,bonus_id=9410/1501,enchant=lambent_armor_kit_3
-feet=lifebound_boots,id=193398,bonus_id=8840/8836/8902/1537/9379/8960,enchant=watchers_loam_3,crafted_stats=32/40
-finger1=onyx_annulet,id=203460,bonus_id=1491,gem_id=204027/204029/204011,enchant=devotion_of_versatility_3
-finger2=seal_of_diurnas_chosen,id=195480,bonus_id=7981/7935/1498,gem_id=192925,enchant=devotion_of_versatility_3
-trinket1=beacon_to_the_beyond,id=203963,bonus_id=6652/8783/8784/9414/9415/4800/4786/1498
-trinket2=dragonfire_bomb_dispenser,id=202610,bonus_id=9410/1498
-main_hand=djaruun_pillar_of_the_elder_flame,id=202569,bonus_id=9410/1498,enchant=shadowflame_wreathe_3
+head=cover_of_the_vermillion_forge,id=202506,bonus_id=6652/9229/9410/9382/1504/8767/9413,gem_id=192991
+neck=torc_of_passed_time,id=201759,bonus_id=8836/8840/8902/8783/8782/9405/8795/9376/8174/9366,gem_id=192932/192932/192932,crafted_stats=36/32,crafting_quality=5
+shoulders=spines_of_the_vermillion_forge,id=205833,bonus_id=6652/9227/9410/9383/1507/8767
+back=voice_of_the_silent_star,id=204465,bonus_id=9410/9385/1498/8767,enchant=graceful_avoidance_3
+chest=lifebound_chestpiece,id=193399,bonus_id=8836/8840/8902/9405/9376/8797/8960/8795/9366,enchant=waking_stats_3,crafted_stats=32/40,crafting_quality=5
+wrists=needlessly_complex_wristguards,id=198327,bonus_id=8836/8840/8902/9405/9376/8951/8865/9366/9413,gem_id=201409/192932,enchant=devotion_of_avoidance_3,crafted_stats=32,crafting_quality=5
+hands=fists_of_the_vermillion_forge,id=202507,bonus_id=6652/9383/9410/8095/9230/1501
+waist=blackbelt_of_the_vermillion_forge,id=202503,bonus_id=9383/9410/8095/1507/9413,gem_id=192932,enchant=shadowed_belt_clasp_3
+legs=pantaloons_of_the_vermillion_forge,id=202505,bonus_id=6652/9228/9410/9382/1504/8767,enchant=fierce_armor_kit_3
+feet=slimy_expulsion_boots,id=193451,bonus_id=8836/8840/8902/8960/9405/9376/9366,enchant=watchers_loam_3,crafting_quality=5
+finger1=tormentors_siphoning_signet,id=204466,bonus_id=6652/9410/9382/1501/8767/9413,gem_id=192932,enchant=devotion_of_versatility_3
+finger2=seal_of_diurnas_chosen,id=195480,bonus_id=7981/1498/8767/8780,gem_id=192932,enchant=devotion_of_versatility_3
+trinket1=neltharions_call_to_dominance,id=204202,bonus_id=6652/9410/9385/1498/8767
+trinket2=dragonfire_bomb_dispenser,id=202610,bonus_id=9410/9382/1498/8767
+main_hand=djaruun_pillar_of_the_elder_flame,id=202569,bonus_id=6652/9410/9383/8159/1498/8767,enchant=shadowflame_wreathe_3
 
 save=T30_Monk_Windwalker.simc
 


### PR DESCRIPTION
Updated WW (Serenity) talent string for WoW 10.1.7 talentstring changes. Race updated to void_elf because that's BIS. Gear upgraded to remove annulet and equip Call to Dominance, and minor socket changes. Changes tested here: https://www.raidbots.com/simbot/report/q2NiVoott4fkLpuSf5XPDT/simc