### PR TITLE
Add wowhead ptr-2 item data source

### DIFF
--- a/engine/dbc/sc_item_data.cpp
+++ b/engine/dbc/sc_item_data.cpp
@@ -599,6 +599,7 @@ bool item_database::initialize_item_sources( item_t& item, std::vector<std::stri
       if ( ! util::str_compare_ci( split, "local" ) &&
            ! util::str_compare_ci( split, "wowhead" ) &&
            ! util::str_compare_ci( split, "ptrhead" ) &&
+           ! util::str_compare_ci( split, "ptr2head" ) &&
            ! util::str_compare_ci( split, "bcpapi" ) )
       {
         continue;

--- a/engine/interfaces/wowhead.cpp
+++ b/engine/interfaces/wowhead.cpp
@@ -28,6 +28,7 @@ std::string source_str( wowhead::wowhead_e source )
   switch ( source )
   {
     case wowhead::PTR:  return "ptr";
+    case wowhead::PTR2:  return "ptr-2";
 #if SC_BETA
     case wowhead::BETA: return SC_BETA_STR;
 #endif
@@ -40,6 +41,7 @@ std::string source_desc_str( wowhead::wowhead_e source )
   switch ( source )
   {
     case wowhead::PTR:  return "PTR";
+    case wowhead::PTR2:  return "PTR2";
 #if SC_BETA
     case wowhead::BETA: return "Beta";
 #endif

--- a/engine/interfaces/wowhead.hpp
+++ b/engine/interfaces/wowhead.hpp
@@ -16,6 +16,7 @@ enum wowhead_e
 {
   LIVE,
   PTR,
+  PTR2,
   BETA
 };
 

--- a/engine/item/item.cpp
+++ b/engine/item/item.cpp
@@ -2146,6 +2146,8 @@ bool item_t::download_item( item_t& item )
         success = wowhead::download_item( item, wowhead::LIVE, cache::ONLY );
       else if ( sources[ i ] == "ptrhead" )
         success = wowhead::download_item( item, wowhead::PTR, cache::ONLY );
+      else if ( sources[ i ] == "ptr2head" )
+        success = wowhead::download_item( item, wowhead::PTR2, cache::ONLY );
 #if SC_BETA
       else if ( sources[ i ] == SC_BETA_STR "head" )
         success = wowhead::download_item( item, wowhead::BETA, cache::ONLY );
@@ -2164,6 +2166,8 @@ bool item_t::download_item( item_t& item )
         success = wowhead::download_item( item, wowhead::LIVE, cache::items() );
       else if ( sources[ i ] == "ptrhead" )
         success = wowhead::download_item( item, wowhead::PTR, cache::items() );
+      else if ( sources[ i ] == "ptr2head" )
+        success = wowhead::download_item( item, wowhead::PTR2, cache::items() );
 #if SC_BETA
       else if ( sources[ i ] == SC_BETA_STR "head" )
         success = wowhead::download_item( item, wowhead::BETA, cache::items() );

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -793,7 +793,7 @@ bool parse_spell_query( sim_t*             sim,
 // and the complete set of valid data source names.
 const char* const default_item_db_sources[] =
 {
-  "local", "bcpapi", "wowhead", "ptrhead"
+  "local", "bcpapi", "wowhead", "ptrhead", "ptr2head"
 #if SC_BETA
   , SC_BETA_STR "head"
 #endif

--- a/qt/sc_OptionsTab.cpp
+++ b/qt/sc_OptionsTab.cpp
@@ -236,6 +236,8 @@ SC_OptionsTab::SC_OptionsTab( SC_MainWindow* parent ) : QTabWidget( parent ), ma
 #if SC_USE_PTR
   itemSourceOptions.emplace_back( tr( "Wowhead.com (PTR)" ), "ptrhead",
                                   tr( "Remote Wowhead.com PTR item data source" ) );
+  itemSourceOptions.emplace_back( tr( "Wowhead.com (PTR2)" ), "ptr2head",
+                                  tr( "Remote Wowhead.com PTR2 item data source" ) );
 #endif
 #if SC_BETA
   itemSourceOptions.emplace_back( tr( "Wowhead.com (Beta)" ), SC_BETA_STR "head",


### PR DESCRIPTION
Since the `(Beta)` wowhead isn't in use this time around, and instead we have the `ptr-2` instance of wowhead for 10.2.