### PR TITLE
[Afflction] T31 Tier Set

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -583,6 +583,9 @@ struct soul_rot_t : public warlock_spell_t
   {
     parse_options( options_str );
     aoe = 1 + as<int>( p->talents.soul_rot->effectN( 3 ).base_value() );
+
+    if ( p->sets->has_set_bonus( WARLOCK_AFFLICTION, T31, B2 ) )
+      apply_affecting_aura( p->sets->set( WARLOCK_AFFLICTION, T31, B2 ) );
   }
 
   soul_rot_t( warlock_t* p, util::string_view opt, bool soul_swap ) : soul_rot_t( p, opt )
@@ -598,6 +601,9 @@ struct soul_rot_t : public warlock_spell_t
     warlock_spell_t::execute();
 
     p()->buffs.soul_rot->trigger();
+
+    if ( p()->sets->has_set_bonus( WARLOCK_AFFLICTION, T31, B4 ) )
+      p()->buffs.soulstealer->trigger();
   }
 
   void impact( action_state_t* s ) override
@@ -2286,7 +2292,6 @@ void warlock_t::apply_affecting_auras( action_t& action )
   action.apply_affecting_aura( talents.dark_virtuosity );
   action.apply_affecting_aura( talents.kindled_malice );
   action.apply_affecting_aura( talents.xavius_gambit ); // TOCHECK: Should this just go in Unstable Affliction struct for clarity?
-
 }
 
 struct warlock_module_t : public module_t

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1506,7 +1506,8 @@ void warlock_t::create_buffs()
   create_buffs_affliction();
 
   buffs.soul_rot = make_buff(this, "soul_rot", talents.soul_rot)
-                       ->set_cooldown( 0_ms );
+                       ->set_cooldown( 0_ms )
+                       ->set_duration( talents.soul_rot->duration() + sets->set( WARLOCK_AFFLICTION, T31, B2 )->effectN( 2 ).time_value() );
 
   buffs.wrath_of_consumption = make_buff( this, "wrath_of_consumption", talents.wrath_of_consumption_buff )
                                ->set_default_value( talents.wrath_of_consumption->effectN( 2 ).percent() );

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -492,6 +492,7 @@ public:
     const spell_data_t* cruel_inspiration; // T29 2pc procs haste buff
     const spell_data_t* cruel_epiphany; // T29 4pc also procs stacks of this buff when 2pc procs, increases Malefic Rapture/Seed of Corruption damage
     const spell_data_t* infirmity; // T30 4pc applies this debuff when using Vile Taint/Phantom Singularity
+    const spell_data_t* soulstealer; // T31 4pc buff from casting Soulrot
 
     // Demonology
     const spell_data_t* blazing_meteor; // T29 4pc procs buff which makes next Hand of Gul'dan instant + increased damage
@@ -544,6 +545,7 @@ public:
     propagate_const<buff_t*> dark_harvest_crit; // ...but split into two in simc for better handling
     propagate_const<buff_t*> cruel_inspiration; // T29 2pc
     propagate_const<buff_t*> cruel_epiphany; // T29 4pc
+    propagate_const<buff_t*> soulstealer;  // T31 4pc buff
 
     // Demonology Buffs
     propagate_const<buff_t*> demonic_power; // Buff from Summon Demonic Tyrant (increased demon damage + duration)

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -937,8 +937,9 @@ void warlock_t::create_buffs_affliction()
   buffs.cruel_epiphany = make_buff( this, "cruel_epiphany", tier.cruel_epiphany )
                              ->set_default_value_from_effect( 1 );
 
-  buffs.soulstealer = make_buff( this, "soulstealer", tier.soulstealer )->set_default_value_from_effect( 1 );
-  buffs.soulstealer->set_initial_stack( buffs.soulstealer->max_stack() );
+  buffs.soulstealer = make_buff( this, "soulstealer", tier.soulstealer )
+                          ->set_default_value_from_effect( 1 )
+                          ->set_reverse( true );
 }
 
 void warlock_t::init_spells_affliction()

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -246,8 +246,11 @@ struct malefic_rapture_t : public affliction_spell_t
 {
   struct malefic_rapture_damage_t : public affliction_spell_t
   {
+    timespan_t t31_soulstealer_extend;
+
     malefic_rapture_damage_t( warlock_t* p )
-      : affliction_spell_t( "Malefic Rapture (hit)", p, p->talents.malefic_rapture_dmg )
+      : affliction_spell_t( "Malefic Rapture (hit)", p, p->talents.malefic_rapture_dmg ),
+        t31_soulstealer_extend( p->sets->set( WARLOCK_AFFLICTION, T31, B4 )->effectN( 1 ).time_value() )
     {
       background = dual = true;
       spell_power_mod.direct = p->talents.malefic_rapture->effectN( 1 ).sp_coeff();
@@ -264,6 +267,8 @@ struct malefic_rapture_t : public affliction_spell_t
 
       if ( p()->talents.focused_malignancy->ok() && td( s->target )->dots_unstable_affliction->is_ticking() )
         m *= 1.0 + p()->talents.focused_malignancy->effectN( 1 ).percent();
+      
+      m *= 1.0 + p()->buffs.soulstealer->check_value();
 
       return m;
     }
@@ -279,6 +284,30 @@ struct malefic_rapture_t : public affliction_spell_t
         if ( target_data->dots_unstable_affliction->is_ticking() )
           target_data->debuffs_dread_touch->trigger();
       }
+
+      if ( p()->buffs.soulstealer->check() )
+      {
+        if ( target_data->dots_agony->is_ticking() )
+          target_data->dots_agony->adjust_duration( t31_soulstealer_extend );
+
+        if ( target_data->dots_corruption->is_ticking() )
+          target_data->dots_corruption->adjust_duration( t31_soulstealer_extend );
+
+        if ( target_data->dots_siphon_life->is_ticking() )
+          target_data->dots_siphon_life->adjust_duration( t31_soulstealer_extend );
+
+        if ( target_data->dots_unstable_affliction->is_ticking() )
+          target_data->dots_unstable_affliction->adjust_duration( t31_soulstealer_extend );
+
+        if ( target_data->debuffs_haunt->up() )
+          target_data->debuffs_haunt->extend_duration( p(), t31_soulstealer_extend );
+
+        if ( target_data->dots_vile_taint->is_ticking() )
+          target_data->dots_vile_taint->adjust_duration( t31_soulstealer_extend );
+
+        if ( target_data->dots_phantom_singularity->is_ticking() )
+          target_data->dots_phantom_singularity->adjust_duration( t31_soulstealer_extend );
+      }
     }
 
     void execute() override
@@ -292,6 +321,8 @@ struct malefic_rapture_t : public affliction_spell_t
       }
 
       affliction_spell_t::execute();
+
+      p()->buffs.soulstealer->decrement();
     }
   };
 
@@ -906,6 +937,9 @@ void warlock_t::create_buffs_affliction()
 
   buffs.cruel_epiphany = make_buff( this, "cruel_epiphany", tier.cruel_epiphany )
                              ->set_default_value_from_effect( 1 );
+
+  buffs.soulstealer = make_buff( this, "soulstealer", tier.soulstealer )->set_default_value_from_effect( 1 );
+  buffs.soulstealer->set_initial_stack( buffs.soulstealer->max_stack() );
 }
 
 void warlock_t::init_spells_affliction()
@@ -1013,6 +1047,9 @@ void warlock_t::init_spells_affliction()
 
   // T30 (Aberrus, the Shadowed Crucible)
   tier.infirmity = find_spell( 409765 );
+
+  // T31 (Amirdrassil, the Dream's Hope)
+  tier.soulstealer = sets->set( WARLOCK_AFFLICTION, T31, B4 )->effectN( 2 ).trigger();
 }
 
 void warlock_t::create_soul_swap_actions()

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -369,7 +369,7 @@ struct malefic_rapture_t : public affliction_spell_t
 
     p()->buffs.tormented_crescendo->decrement();
     p()->buffs.cruel_epiphany->decrement();
-    p()->buffs.soulstealer->decrement();
+    p()->buffs.soulstealer->decrement(); // 2023-09-11: On PTR spell-queuing with an instant MR can cause this to decrement without giving the extensions. NOT CURRENTLY IMPLEMENTED
   }
 
   size_t available_targets( std::vector<player_t*>& tl ) const override
@@ -1049,7 +1049,7 @@ void warlock_t::init_spells_affliction()
   tier.infirmity = find_spell( 409765 );
 
   // T31 (Amirdrassil, the Dream's Hope)
-  tier.soulstealer = sets->set( WARLOCK_AFFLICTION, T31, B4 )->effectN( 2 ).trigger();
+  tier.soulstealer = sets->set( WARLOCK_AFFLICTION, T31, B4 )->effectN( 2 ).trigger(); // Should be ID 423765
 }
 
 void warlock_t::create_soul_swap_actions()

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -321,8 +321,6 @@ struct malefic_rapture_t : public affliction_spell_t
       }
 
       affliction_spell_t::execute();
-
-      p()->buffs.soulstealer->decrement();
     }
   };
 
@@ -371,6 +369,7 @@ struct malefic_rapture_t : public affliction_spell_t
 
     p()->buffs.tormented_crescendo->decrement();
     p()->buffs.cruel_epiphany->decrement();
+    p()->buffs.soulstealer->decrement();
   }
 
   size_t available_targets( std::vector<player_t*>& tl ) const override


### PR DESCRIPTION
Implement the Affliction T31 Set
The T31 2pc is well formed spell data wise, so an apply affecting is enough. Since it only affects soul rot so I put it in the soulrot struct this time.
The T31 4pc is also well formed for the damage amp but it's a buff. With no support for parse_affecting_buffs in the warlock module and no need with one as simple as this it is manually implemented.
T31 4pc extension manually done on impact where it can check every single dot that MR impacts, thankfully MR will impact every target that has a DOT so this functions as an efficient loop through all targets with the dots.
Tested that it expires correctly on the last stack in sims so the implementation here fully works as if there were no bugs in game.