### PR TITLE
[Rogue/Outlaw] PTR - Add Feather Foot to Sprint buff

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -9808,7 +9808,8 @@ void rogue_t::create_buffs()
   buffs.sprint = make_buff( this, "sprint", spell.sprint )
     ->set_cooldown( timespan_t::zero() )
     ->set_default_value_from_effect_type( A_MOD_INCREASE_SPEED )
-    ->add_invalidate( CACHE_RUN_SPEED );
+    ->add_invalidate( CACHE_RUN_SPEED )
+    ->apply_affecting_aura( talent.rogue.featherfoot );
 
   buffs.slice_and_dice = new buffs::slice_and_dice_t( this );
   buffs.stealth = new buffs::stealth_t( this );


### PR DESCRIPTION
Added `talent.rogue.featherfoot` to `buffs.sprint` to properly increase Sprint duration if talent is taken (for PTR build). Purpose of change is to see sprint buff uptime if used on CD for PTR build

Based on discussion in [discord](https://discord.com/channels/244067101478879234/244072792948080641/1158477874605596802)