### PR TITLE
[Hunter] Set Deathblow to be a non-activated spell

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -7016,7 +7016,8 @@ void hunter_t::create_buffs()
             cooldowns.kill_shot -> reset( true );
             buffs.razor_fragments -> trigger();
           }
-        } );
+        } )
+      -> set_activated( false );
 
   buffs.razor_fragments =
     make_buff( this, "razor_fragments", find_spell( 388998 ) )


### PR DESCRIPTION
This is done to ensure that there is a built-in delay before the actor can react to the buff and cast Kill Shot immediately after finishing a Aimed Shot cast. 