### PR TITLE
[Hunter] change BM 4pc to better model currently bugged behavior

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -3821,12 +3821,15 @@ struct multishot_bm_t: public hunter_ranged_attack_t
 
       if ( p() -> tier_set.t31_bm_4pc.ok() ) {
 
-        if ( p() -> bugs ){
-          if (!( p() -> pets.dire_beast.active_pets().empty)){
-            p() -> pets.dire_beast.active_pets().last() -> buffs.beast_cleave -> trigger();
+        if ( p() -> bugs )
+        {
+          if (!( p() -> pets.dire_beast.active_pets().empty()))
+          {
+            p() -> pets.dire_beast.active_pets().back() -> buffs.beast_cleave -> trigger();
           }
         }
-        else {
+        else
+        {
           for ( auto pet : p() -> pets.dire_beast.active_pets() )
             pet -> buffs.beast_cleave -> trigger();
         }
@@ -5540,12 +5543,15 @@ struct kill_command_t: public hunter_spell_t
 
     if ( p() -> tier_set.t31_bm_4pc.ok() )
 
-      if ( p() -> bugs ){
-        if (!( p() -> pets.dire_beast.active_pets().empty)){
-          p() -> pets.dire_beast.active_pets().last() -> active.kill_command -> execute_on_target( target );
+      if ( p() -> bugs )
+      {
+        if (!( p() -> pets.dire_beast.active_pets().empty()))
+        {
+          p() -> pets.dire_beast.active_pets().back() -> active.kill_command -> execute_on_target( target );
         }
       }
-      else {
+      else
+      {
         for ( auto pet : p() -> pets.dire_beast.active_pets() )
           pet -> active.kill_command -> execute_on_target( target );
       }

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -3821,6 +3821,7 @@ struct multishot_bm_t: public hunter_ranged_attack_t
 
       if ( p() -> tier_set.t31_bm_4pc.ok() ) {
 
+        // see https://github.com/SimCMinMax/WoW-BugTracker/issues/1135
         if ( p() -> bugs )
         {
           if (!( p() -> pets.dire_beast.active_pets().empty()))
@@ -5542,7 +5543,8 @@ struct kill_command_t: public hunter_spell_t
       pet -> active.kill_command -> execute_on_target( target );
 
     if ( p() -> tier_set.t31_bm_4pc.ok() )
-
+    {
+      // see https://github.com/SimCMinMax/WoW-BugTracker/issues/1135
       if ( p() -> bugs )
       {
         if (!( p() -> pets.dire_beast.active_pets().empty()))
@@ -5555,6 +5557,7 @@ struct kill_command_t: public hunter_spell_t
         for ( auto pet : p() -> pets.dire_beast.active_pets() )
           pet -> active.kill_command -> execute_on_target( target );
       }
+    }
     p() -> buffs.tip_of_the_spear -> trigger();
 
     if ( reset.chance != 0 )

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -3820,8 +3820,10 @@ struct multishot_bm_t: public hunter_ranged_attack_t
         pet -> buffs.beast_cleave -> trigger();
 
       if ( p() -> tier_set.t31_bm_4pc.ok() ) {
-        for ( auto pet : p() -> pets.dire_beast.active_pets() )
+        for ( auto pet : p() -> pets.dire_beast.active_pets() ){
           pet -> buffs.beast_cleave -> trigger();
+          break;
+        }
       }
     }
 
@@ -5531,9 +5533,10 @@ struct kill_command_t: public hunter_spell_t
       pet -> active.kill_command -> execute_on_target( target );
 
     if ( p() -> tier_set.t31_bm_4pc.ok() )
-      for ( auto pet : p() -> pets.dire_beast.active_pets() )
+      for ( auto pet : p() -> pets.dire_beast.active_pets() ){
         pet -> active.kill_command -> execute_on_target( target );
-
+        break;
+      }
     p() -> buffs.tip_of_the_spear -> trigger();
 
     if ( reset.chance != 0 )

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -3820,9 +3820,15 @@ struct multishot_bm_t: public hunter_ranged_attack_t
         pet -> buffs.beast_cleave -> trigger();
 
       if ( p() -> tier_set.t31_bm_4pc.ok() ) {
-        for ( auto pet : p() -> pets.dire_beast.active_pets() ){
-          pet -> buffs.beast_cleave -> trigger();
-          break;
+
+        if ( p() -> bugs ){
+          if (!( p() -> pets.dire_beast.active_pets().empty)){
+            p() -> pets.dire_beast.active_pets().last() -> buffs.beast_cleave -> trigger();
+          }
+        }
+        else {
+          for ( auto pet : p() -> pets.dire_beast.active_pets() )
+            pet -> buffs.beast_cleave -> trigger();
         }
       }
     }
@@ -5533,9 +5539,15 @@ struct kill_command_t: public hunter_spell_t
       pet -> active.kill_command -> execute_on_target( target );
 
     if ( p() -> tier_set.t31_bm_4pc.ok() )
-      for ( auto pet : p() -> pets.dire_beast.active_pets() ){
-        pet -> active.kill_command -> execute_on_target( target );
-        break;
+
+      if ( p() -> bugs ){
+        if (!( p() -> pets.dire_beast.active_pets().empty)){
+          p() -> pets.dire_beast.active_pets().last() -> active.kill_command -> execute_on_target( target );
+        }
+      }
+      else {
+        for ( auto pet : p() -> pets.dire_beast.active_pets() )
+          pet -> active.kill_command -> execute_on_target( target );
       }
     p() -> buffs.tip_of_the_spear -> trigger();
 

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -1004,7 +1004,7 @@ public:
     if ( triggers_calling_the_shots )
       ab::sim -> print_debug( "{} action {} set to proc Calling the Shots", ab::player -> name(), ab::name() );
 
-    if ( p() -> tier_set.t30_sv_4pc.ok() ) 
+    if ( p() -> tier_set.t30_sv_4pc.ok() )
     {
       if ( triggers_t30_sv_4p.is_none() )
       {
@@ -1013,7 +1013,7 @@ public:
     }
     else
     {
-      triggers_t30_sv_4p = false; 
+      triggers_t30_sv_4p = false;
     }
 
     if ( triggers_t30_sv_4p )
@@ -3819,20 +3819,11 @@ struct multishot_bm_t: public hunter_ranged_attack_t
       for ( auto pet : pets::active<pets::hunter_pet_t>( p() -> pets.main, p() -> pets.animal_companion ) )
         pet -> buffs.beast_cleave -> trigger();
 
-      if ( p() -> tier_set.t31_bm_4pc.ok() ) {
-
-        // see https://github.com/SimCMinMax/WoW-BugTracker/issues/1135
-        if ( p() -> bugs )
+      if ( p() -> tier_set.t31_bm_4pc.ok() )
+      {
+        if (!( p() -> pets.dire_beast.active_pets().empty()))
         {
-          if (!( p() -> pets.dire_beast.active_pets().empty()))
-          {
             p() -> pets.dire_beast.active_pets().back() -> buffs.beast_cleave -> trigger();
-          }
-        }
-        else
-        {
-          for ( auto pet : p() -> pets.dire_beast.active_pets() )
-            pet -> buffs.beast_cleave -> trigger();
         }
       }
     }
@@ -5544,18 +5535,9 @@ struct kill_command_t: public hunter_spell_t
 
     if ( p() -> tier_set.t31_bm_4pc.ok() )
     {
-      // see https://github.com/SimCMinMax/WoW-BugTracker/issues/1135
-      if ( p() -> bugs )
+      if (!( p() -> pets.dire_beast.active_pets().empty()))
       {
-        if (!( p() -> pets.dire_beast.active_pets().empty()))
-        {
-          p() -> pets.dire_beast.active_pets().back() -> active.kill_command -> execute_on_target( target );
-        }
-      }
-      else
-      {
-        for ( auto pet : p() -> pets.dire_beast.active_pets() )
-          pet -> active.kill_command -> execute_on_target( target );
+        p() -> pets.dire_beast.active_pets().back() -> active.kill_command -> execute_on_target( target );
       }
     }
     p() -> buffs.tip_of_the_spear -> trigger();


### PR DESCRIPTION
this should model behavior described in https://github.com/SimCMinMax/WoW-BugTracker/issues/1135

I'm not 100% sure if active_pets() returns the earliest pet or latest pet first, so might need to tweak this