### PR TITLE
[Outlaw] More PTR APL updates

### DIFF
--- a/engine/class_modules/apl/rogue/outlaw_ptr.simc
+++ b/engine/class_modules/apl/rogue/outlaw_ptr.simc
@@ -6,8 +6,8 @@ actions.precombat+=/food
 # Snapshot raid buffed stats before combat begins and pre-potting is done.
 actions.precombat+=/snapshot_stats
 actions.precombat+=/blade_flurry,precombat_seconds=3,if=talent.underhanded_upper_hand
-actions.precombat+=/adrenaline_rush,precombat_seconds=2,if=talent.improved_adrenaline_rush
 actions.precombat+=/roll_the_bones,precombat_seconds=2
+actions.precombat+=/adrenaline_rush,precombat_seconds=1,if=talent.improved_adrenaline_rush
 actions.precombat+=/slice_and_dice,precombat_seconds=1
 actions.precombat+=/stealth
 
@@ -20,12 +20,12 @@ actions+=/kick
 actions+=/variable,name=rtb_reroll,value=rtb_buffs.will_lose=(rtb_buffs.will_lose.buried_treasure+rtb_buffs.will_lose.grand_melee&spell_targets.blade_flurry<2&raid_event.adds.in>10)
 # Crackshot builds without T31 should reroll for TB (or BS without HO) if we won't lose over 1 buff
 actions+=/variable,name=rtb_reroll,if=talent.crackshot&talent.hidden_opportunity&!set_bonus.tier31_4pc,value=(!rtb_buffs.will_lose.true_bearing&talent.hidden_opportunity|!rtb_buffs.will_lose.broadside&!talent.hidden_opportunity)&rtb_buffs.will_lose<=1
-# Crackshot builds with T31 should attempt to get or preserve TB (or BS without HO) if we won't lose over 2 buffs
-actions+=/variable,name=rtb_reroll,if=talent.crackshot&set_bonus.tier31_4pc,value=buff.true_bearing.up&rtb_buffs.total=1|(buff.true_bearing.remains<=3&talent.hidden_opportunity|buff.broadside.remains<=3&!talent.hidden_opportunity)&rtb_buffs.will_lose<=2
+# Crackshot builds with T31 should attempt to get or preserve TB (or BS without HO) if we won't lose over 2 buffs (3 with Loaded Dice)
+actions+=/variable,name=rtb_reroll,if=talent.crackshot&set_bonus.tier31_4pc,value=buff.true_bearing.up&rtb_buffs.total=1|(buff.true_bearing.remains<=3&talent.hidden_opportunity|buff.broadside.remains<=3&!talent.hidden_opportunity)&rtb_buffs.will_lose<=2+buff.loaded_dice.up
 # With HO and no Crackshot, reroll for SnC or any 2 buffs excluding GM in single target
 actions+=/variable,name=rtb_reroll,if=!talent.crackshot&talent.hidden_opportunity,value=!rtb_buffs.will_lose.skull_and_crossbones&(rtb_buffs.will_lose<2+rtb_buffs.will_lose.grand_melee&spell_targets.blade_flurry<2&raid_event.adds.in>10)
-# Additional reroll conditions in the event all active buffs will not be rolled away
-actions+=/variable,name=rtb_reroll,if=!talent.hidden_opportunity,value=variable.rtb_reroll|(rtb_buffs.normal=0&rtb_buffs.longer>=1)&!(buff.broadside.up&buff.true_bearing.up&buff.skull_and_crossbones.up)&!(buff.broadside.remains>39|buff.true_bearing.remains>39|buff.ruthless_precision.remains>39|buff.skull_and_crossbones.remains>39)
+# Additional reroll rules if all active buffs will not be rolled away and we don't already have BS+TB+SnC
+actions+=/variable,name=rtb_reroll,value=variable.rtb_reroll|rtb_buffs.normal=0&rtb_buffs.longer>=1&!(buff.broadside.up&buff.true_bearing.up&buff.skull_and_crossbones.up)&rtb_buffs.max_remains<=39
 # Avoid rerolls when we will not have time remaining on the fight or add wave to recoup the opportunity cost of the global
 actions+=/variable,name=rtb_reroll,op=reset,if=!(raid_event.adds.remains>12|raid_event.adds.up&(raid_event.adds.in-raid_event.adds.remains)<6|target.time_to_die>12)|fight_remains<12
 actions+=/variable,name=ambush_condition,value=(talent.hidden_opportunity|combo_points.deficit>=2+talent.improved_ambush+buff.broadside.up)&energy>=50
@@ -61,15 +61,15 @@ actions.build+=/pistol_shot,if=!talent.fan_the_hammer&buff.opportunity.up&(energ
 actions.build+=/sinister_strike
 
 # Cooldowns
-actions.cds=adrenaline_rush,if=!buff.adrenaline_rush.up&(!talent.improved_adrenaline_rush|combo_points<=2)
+# Use ADR without clipping itself and when under 2cp if Improved, but Crackshot builds can clip it in stealth
+actions.cds=adrenaline_rush,if=(!buff.adrenaline_rush.up|stealthed.all&talent.crackshot&talent.improved_adrenaline_rush)&(combo_points<=2|!talent.improved_adrenaline_rush)
 # Maintain Blade Flurry on 2+ targets, and on single target with Underhanded, or on cooldown at 5+ targets with Deft Maneuvers
 actions.cds+=/blade_flurry,if=(spell_targets>=2-talent.underhanded_upper_hand&!stealthed.rogue)&buff.blade_flurry.remains<gcd|talent.deft_maneuvers&spell_targets>=5&!variable.finish_condition
-# Use RTB with no buffs, or to reroll, or just before normal buffs expire with T31
-actions.cds+=/roll_the_bones,if=rtb_buffs=0|variable.rtb_reroll|buff.roll_the_bones.remains<=2&set_bonus.tier31_4pc
-# Use KIR with at least 4 buffs
-actions.cds+=/keep_it_rolling,if=!variable.rtb_reroll&rtb_buffs>=4&(buff.shadow_dance.down|rtb_buffs>=6)
-# Sync Ghostly Strike with Killing Spree, otherwise use on cooldown
-actions.cds+=/ghostly_strike,if=talent.killing_spree&cooldown.killing_spree.ready|!talent.killing_spree|fight_remains<13
+# Use RTB with no buffs, or to reroll, or just before buffs expire with T31
+actions.cds+=/roll_the_bones,if=rtb_buffs=0|variable.rtb_reroll|rtb_buffs.max_remains<=2&set_bonus.tier31_4pc
+# Use KIR with at least 3 buffs (4 with T31)
+actions.cds+=/keep_it_rolling,if=!variable.rtb_reroll&rtb_buffs>=3+set_bonus.tier31_4pc&(buff.shadow_dance.down|rtb_buffs>=6)
+actions.cds+=/ghostly_strike
 # Use Blade Rush at ~50% energy, and more regularly with increasing target count
 actions.cds+=/blade_rush,if=variable.blade_flurry_sync&(energy.base_time_to_max>4-spell_targets%3)&!stealthed.all
 actions.cds+=/call_action_list,name=stealth_cds,if=!stealthed.all
@@ -90,12 +90,12 @@ actions.cds+=/use_items,slots=trinket1,if=buff.between_the_eyes.up|trinket.1.has
 actions.cds+=/use_items,slots=trinket2,if=buff.between_the_eyes.up|trinket.2.has_stat.any_dps|fight_remains<=20
 
 # Finishers
-# Use BtE to keep the crit buff up, but on cooldown if Improved or for Greenskins, and avoid overriding Greenskins
-actions.finish=between_the_eyes,if=!talent.crackshot&(buff.between_the_eyes.remains<4|talent.greenskins_wickers&!buff.greenskins_wickers.up|!talent.greenskins_wickers&talent.improved_between_the_eyes|!talent.greenskins_wickers&set_bonus.tier30_4pc)
+# Use BtE to keep the crit buff up, but on cooldown if Improved/Greenskins/T30, and avoid overriding Greenskins
+actions.finish=between_the_eyes,if=!talent.crackshot&(buff.between_the_eyes.remains<4|talent.improved_between_the_eyes|talent.greenskins_wickers|set_bonus.tier30_4pc)&!buff.greenskins_wickers.up
 # Crackshot builds use BtE outside of Stealth if Vanish or Dance will not come off cooldown within the next cast
 actions.finish+=/between_the_eyes,if=talent.crackshot&(cooldown.vanish.remains>45&cooldown.shadow_dance.remains>15)
 actions.finish+=/slice_and_dice,if=buff.slice_and_dice.remains<fight_remains&refreshable
-actions.finish+=/killing_spree
+actions.finish+=/killing_spree,if=debuff.ghostly_strike.up|!talent.ghostly_strike
 actions.finish+=/cold_blood
 actions.finish+=/dispatch
 


### PR DESCRIPTION
- Use RTB before ADR in precombat
- Add Loaded Dice to T31 Crackshot reroll variable
- Update 39s additional reroll rule to use the new rtb_buffs.max_remains
- Crackshot builds can refresh ADR when it's already active in stealth for the combo points
- Update RTB rule that clips buffs with 2s remaining to use rtb_buffs.max_remains
- Use KIR at 3 buffs without T31
- Clean up non-Crackshot BTE syntax
- Decouple Ghostly Strike casts from Killing Spree cooldown