### PR TITLE
Add include guards to parse_buff_effects.hpp

### DIFF
--- a/engine/action/parse_buff_effects.hpp
+++ b/engine/action/parse_buff_effects.hpp
@@ -3,6 +3,8 @@
 // Send questions to natehieter@gmail.com
 // ==========================================================================
 
+#pragma once
+
 #include "action/action.hpp"
 #include "buff/buff.hpp"
 #include "player/player.hpp"


### PR DESCRIPTION
I am unsure if any negative implications exist to this change.

Enables importing parse_buff_effects into a class module implementation and header.