### PR TITLE
[Havoc] Remove Fel Barrage talent data workaround

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -7525,10 +7525,8 @@ void demon_hunter_t::init_spells()
   talent.havoc.soulscar            = find_talent_spell( talent_tree::SPECIALIZATION, "Soulscar" );
   talent.havoc.chaotic_disposition = find_talent_spell( talent_tree::SPECIALIZATION, "Chaotic Disposition" );
 
-  talent.havoc.essence_break = find_talent_spell( talent_tree::SPECIALIZATION, "Essence Break" );
-  // The Fel Barrage talent info isn't correct in spell data, for now we pass in the talent entry ID
-  // TODO 10.2 : Change back to stringy form when this is fixed :)
-  talent.havoc.fel_barrage         = find_talent_spell( 117742 );
+  talent.havoc.essence_break       = find_talent_spell( talent_tree::SPECIALIZATION, "Essence Break" );
+  talent.havoc.fel_barrage         = find_talent_spell( talent_tree::SPECIALIZATION, "Fel Barrage" );
   talent.havoc.shattered_destiny   = find_talent_spell( talent_tree::SPECIALIZATION, "Shattered Destiny" );
   talent.havoc.any_means_necessary = find_talent_spell( talent_tree::SPECIALIZATION, "Any Means Necessary" );
   talent.havoc.a_fire_inside       = find_talent_spell( talent_tree::SPECIALIZATION, "A Fire Inside" );


### PR DESCRIPTION
Fel Barrage talent data has been fixed and can once again be found without passing in the id