### PR TITLE
[Warrior] Multitarget debuff application fixes for CS, EP, and SS

### DIFF
--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -2476,7 +2476,7 @@ struct mortal_strike_unhinged_t : public warrior_attack_t
 
     warrior_td_t* td = this->td( execute_state->target );
     td->debuffs_exploiter->expire();
-    td->debuffs_executioners_precision->expire();
+    //td->debuffs_executioners_precision->expire();
   }
 
   void impact( action_state_t* s ) override
@@ -2501,6 +2501,10 @@ struct mortal_strike_unhinged_t : public warrior_attack_t
     if ( p()->talents.arms.fatality->ok() && p()->rppm.fatal_mark->trigger() && target->health_percentage() > 30 )
     {  // does this eat RPPM when switching from low -> high health target?
       td( s->target )->debuffs_fatal_mark->trigger();
+    }
+    if ( td( s->target )->debuffs_executioners_precision->up() )
+    {
+      td( s->target )->debuffs_executioners_precision->expire();
     }
     if ( p()->tier_set.t29_arms_4pc->ok() && s->result == RESULT_CRIT )
     {
@@ -2633,7 +2637,7 @@ struct mortal_strike_t : public warrior_attack_t
 
     warrior_td_t* td = this->td( execute_state->target );
     td->debuffs_exploiter->expire();
-    td->debuffs_executioners_precision->expire();
+    //td->debuffs_executioners_precision->expire();
   }
 
   void impact( action_state_t* s ) override
@@ -2658,6 +2662,10 @@ struct mortal_strike_t : public warrior_attack_t
     if ( p()->talents.arms.fatality->ok() && p()->rppm.fatal_mark->trigger() && target->health_percentage() > 30 )
     { // does this eat RPPM when switching from low -> high health target?
       td( s->target )->debuffs_fatal_mark->trigger();
+    }
+    if ( td( s->target )->debuffs_executioners_precision->up() )
+    {
+      td( s->target )->debuffs_executioners_precision->expire();
     }
     if ( p()->tier_set.t29_arms_4pc->ok() && s->result == RESULT_CRIT )
     {
@@ -3588,6 +3596,16 @@ struct colossus_smash_t : public warrior_attack_t
     return b;
   }
 
+  void impact( action_state_t* s ) override
+  {
+    warrior_attack_t::impact( s );
+
+    if ( result_is_hit( s->result ) )
+    {
+      td( s->target )->debuffs_colossus_smash->trigger();
+    }
+  }
+
   void execute() override
   {
     warrior_attack_t::execute();
@@ -3599,7 +3617,7 @@ struct colossus_smash_t : public warrior_attack_t
 
     if ( result_is_hit( execute_state->result ) )
     {
-      td( execute_state->target )->debuffs_colossus_smash->trigger();
+      //td( execute_state->target )->debuffs_colossus_smash->trigger();
       p()->buff.test_of_might_tracker->trigger();
 
       if ( p()->talents.arms.in_for_the_kill->ok() )
@@ -4028,6 +4046,11 @@ struct execute_damage_t : public warrior_attack_t
         residual_action::trigger( finishing_wound, state->target, amount );
       }
     }
+
+    if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( state->result ) ) )
+    {
+      td( state->target )->debuffs_executioners_precision->trigger();
+    }
   }
 };
 
@@ -4125,10 +4148,10 @@ struct execute_arms_t : public warrior_attack_t
       }
       p()->buff.sudden_death->expire();
     }
-    if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
-    {
-      td( execute_state->target )->debuffs_executioners_precision->trigger();
-    }
+    //if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
+    //{
+    //  td( execute_state->target )->debuffs_executioners_precision->trigger();
+    //}
     if ( p()->legendary.exploiter.ok() && !p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
     {
       td( execute_state->target )->debuffs_exploiter->trigger();
@@ -5052,9 +5075,9 @@ struct skullsplitter_t : public warrior_attack_t
   {
     warrior_attack_t::impact( s );
 
-    warrior_td_t* td = p()->get_target_data( target );
     if ( !p() -> dbc -> ptr )
     {
+      warrior_td_t* td = p()->get_target_data( target );
       trigger_tide_of_blood( td->dots_deep_wounds );
 
       if ( p()->talents.arms.tide_of_blood->ok() )
@@ -5064,7 +5087,13 @@ struct skullsplitter_t : public warrior_attack_t
     }
     else
     {
-      td->debuffs_skullsplitter->trigger();
+      //warrior_td_t* cur_target = p()->get_target_data( target );
+      //warrior_td_t* impact_target = td( s->target );
+      //td->debuffs_skullsplitter->trigger();
+      if ( result_is_hit( s->result ) )
+      {
+        td( s->target )->debuffs_skullsplitter->trigger();
+      }
     }
   }
 };
@@ -7032,10 +7061,10 @@ struct condemn_arms_t : public warrior_attack_t
     {
       p()->buff.sudden_death->expire();
     }
-    if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
-    {
-      td( execute_state->target )->debuffs_executioners_precision->trigger();
-    }
+    //if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
+    //{
+    //  td( execute_state->target )->debuffs_executioners_precision->trigger();
+    //}
     if ( p()->legendary.exploiter.ok() && !p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
     {
       td( execute_state->target )->debuffs_exploiter->trigger();
@@ -9362,17 +9391,15 @@ warrior_td_t::warrior_td_t( player_t* target, warrior_t& p ) : actor_target_data
                               if ( old_ == 0 )
                               {
                                 auto coeff = 1.0 / ( 1.0 + buff_ -> default_value );
-                                if ( dots_deep_wounds -> is_ticking() )
-                                  dots_deep_wounds -> adjust( coeff );
-                                if ( p.talents.arms.tide_of_blood -> ok() && dots_rend -> is_ticking() )
+                                dots_deep_wounds -> adjust( coeff );
+                                if ( p.talents.arms.tide_of_blood -> ok() )
                                   dots_rend -> adjust( coeff );
                               }
                               else if ( new_ == 0 )
                               {
                                 auto coeff = 1.0 + buff_ -> default_value;
-                                if ( dots_deep_wounds -> is_ticking() )
-                                  dots_deep_wounds -> adjust( coeff );
-                                if ( p.talents.arms.tide_of_blood -> ok() && dots_rend -> is_ticking() )
+                                dots_deep_wounds -> adjust( coeff );
+                                if ( p.talents.arms.tide_of_blood -> ok() )
                                   dots_rend -> adjust( coeff );
                               }
                             } );

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -2476,7 +2476,6 @@ struct mortal_strike_unhinged_t : public warrior_attack_t
 
     warrior_td_t* td = this->td( execute_state->target );
     td->debuffs_exploiter->expire();
-    //td->debuffs_executioners_precision->expire();
   }
 
   void impact( action_state_t* s ) override
@@ -2637,7 +2636,6 @@ struct mortal_strike_t : public warrior_attack_t
 
     warrior_td_t* td = this->td( execute_state->target );
     td->debuffs_exploiter->expire();
-    //td->debuffs_executioners_precision->expire();
   }
 
   void impact( action_state_t* s ) override
@@ -4148,10 +4146,6 @@ struct execute_arms_t : public warrior_attack_t
       }
       p()->buff.sudden_death->expire();
     }
-    //if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
-    //{
-    //  td( execute_state->target )->debuffs_executioners_precision->trigger();
-    //}
     if ( p()->legendary.exploiter.ok() && !p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
     {
       td( execute_state->target )->debuffs_exploiter->trigger();
@@ -5087,9 +5081,6 @@ struct skullsplitter_t : public warrior_attack_t
     }
     else
     {
-      //warrior_td_t* cur_target = p()->get_target_data( target );
-      //warrior_td_t* impact_target = td( s->target );
-      //td->debuffs_skullsplitter->trigger();
       if ( result_is_hit( s->result ) )
       {
         td( s->target )->debuffs_skullsplitter->trigger();
@@ -7061,10 +7052,6 @@ struct condemn_arms_t : public warrior_attack_t
     {
       p()->buff.sudden_death->expire();
     }
-    //if ( p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
-    //{
-    //  td( execute_state->target )->debuffs_executioners_precision->trigger();
-    //}
     if ( p()->legendary.exploiter.ok() && !p()->talents.arms.executioners_precision->ok() && ( result_is_hit( execute_state->result ) ) )
     {
       td( execute_state->target )->debuffs_exploiter->trigger();


### PR DESCRIPTION
Current sim behavior is not correctly applying certain debuffs from single target abilities in multi-target scenarios when Sweeping Strikes is up, referenced in https://github.com/simulationcraft/simc/issues/8256.

The issue is that these debuffs are triggered in function overrides of `execute()` using `execute_state->target` to specify the target on which to apply the debuff. But this points to the primary target of the player rather than the target hit by the attack. I've moved the associated `trigger()` and `expire()` calls into function overrides for `impact()`, which seems to have fixed the issue. Note there are other debuffs I haven't touched that are almost certainly bugged as well (Exploiter, for example, but this is an outdated ability).

I also made some cosmetic changes to the new Skullsplitter debuff behavior, removing redundant calls to `is_ticking()` before calling `adjust()`, since `adjust()` already checks if the associated DoT is ticking.