### PR TITLE
[Gear] Refactor & Fix Issue with Thorncaller Claw

### DIFF
--- a/engine/player/actor_target_data.hpp
+++ b/engine/player/actor_target_data.hpp
@@ -76,7 +76,6 @@ struct actor_target_data_t : public actor_pair_t, private noncopyable
     buff_t* embed_blade; // Bandolier of Twisted Blades
     buff_t* web_of_dreams; // Dreambinder, Loom of the Great Cycle ST Root
     buff_t* dream_shackles; // Dreambinder, Loom of the Great Cycle AoE Slow
-    buff_t* thorn_spirit; // Thorncaller Claw
   } debuff;
 
   struct atd_dot_t

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -7683,23 +7683,7 @@ void dreambinder_loom_of_the_great_cycle( special_effect_t& effect )
 // 424965 Thorn Spirit DoT
 // 425177 Thorn Burst ICD + Proc Flags
 // 425181 Thorn Burst Damage
-// TODO: Implement on-death effect
 void thorncaller_claw( special_effect_t& effect ) {
-  struct thorn_spirit_t : public generic_proc_t
-  {
-    thorn_spirit_t( const special_effect_t& effect )
-      : generic_proc_t( effect, "thorn_spirit", effect.player->find_spell( 424965 ) )
-    {
-      base_td = effect.driver()->effectN( 2 ).average( effect.item );
-    }
-
-    void impact( action_state_t* s ) override
-    {
-      generic_proc_t::impact( s );
-      player->get_target_data( s->target )->debuff.thorn_spirit->trigger();
-    }
-  };
-
   // 2023-10-13: Split damage has generic AOE scaling, confirmed via testing
   auto thorn_burst_damage = create_proc_action<generic_aoe_proc_t>( "thorn_burst", effect, "thorn_burst", effect.player->find_spell( 425181 ), true );
   thorn_burst_damage->base_dd_min = thorn_burst_damage->base_dd_max = effect.driver()->effectN( 3 ).average( effect.item );
@@ -7715,22 +7699,22 @@ void thorncaller_claw( special_effect_t& effect ) {
   auto thorn_burst_proc = new dbc_proc_callback_t( effect.player, *thorn_burst );
   thorn_burst_proc->initialize();
   thorn_burst_proc->activate();
+  
+  auto thorn_spirit = create_proc_action<generic_proc_t>( "thorn_spirit", effect, "thorn_spirit", effect.player->find_spell( 424965 ) );
+  thorn_spirit->base_td = effect.driver()->effectN( 2 ).average( effect.item );
+  thorn_spirit->add_child( thorn_burst_damage );
 
   effect.player->callbacks.register_callback_trigger_function(
-      425177, dbc_proc_callback_t::trigger_fn_type::CONDITION,
-      [ effect ]( const dbc_proc_callback_t*, action_t*, action_state_t* s ) {
-        auto td = effect.player->get_target_data( s->target )->debuff.thorn_spirit;
-        return td->check();
+      thorn_burst->spell_id, dbc_proc_callback_t::trigger_fn_type::CONDITION,
+      [ thorn_spirit ]( const dbc_proc_callback_t*, action_t*, action_state_t* s ) {
+        return thorn_spirit->get_dot( s->target )->is_ticking();
       } );
-
-  auto thorn_spirit = create_proc_action<thorn_spirit_t>( "thorn_spirit", effect );
-  thorn_spirit->add_child( thorn_burst_damage );
 
   // 2023-10-14: When Thorn Spirit spreads to a new target on demise it is applied with full duration.
   // Can spread to a target with an existing Thorn Spirit even if other targets are in range, refreshes normally.
   range::for_each( effect.player->sim->actor_list, [ effect, thorn_spirit ]( player_t* target ) {
     target->register_on_demise_callback( effect.player, [ effect, thorn_spirit ]( player_t* t ) {
-      if ( effect.player->get_target_data( t )->debuff.thorn_spirit->check() )
+      if ( thorn_spirit->get_dot( t )->is_ticking() )
       {
         thorn_spirit->target_cache.is_valid = false;
         std::vector<player_t*> targets      = thorn_spirit->target_list();
@@ -7750,21 +7734,6 @@ void thorncaller_claw( special_effect_t& effect ) {
 
   new dbc_proc_callback_t( effect.player, effect );
 }
-
-struct thorn_spirit_initializer_t : public item_targetdata_initializer_t
-{
-  thorn_spirit_initializer_t() : item_targetdata_initializer_t( 424406, 424965 )
-  {
-  }
-
-  void operator()( actor_target_data_t* td ) const override
-  {
-    bool active = init( td->source );
-
-    td->debuff.thorn_spirit = make_buff_fallback( active, *td, "thorn_spirit", debuffs[ td->source ] );
-    td->debuff.thorn_spirit->reset();
-  }
-};
 
 // Armor
 void assembly_guardians_ring( special_effect_t& effect )
@@ -9967,7 +9936,6 @@ void register_target_data_initializers( sim_t& sim )
   sim.register_target_data_initializer( items::embed_blade_initializer_t() );
   sim.register_target_data_initializer( items::web_of_dreams_initializer_t() );
   sim.register_target_data_initializer( items::dream_shackles_initializer_t() );
-  sim.register_target_data_initializer( items::thorn_spirit_initializer_t() );
 }
 
 void register_hotfixes()


### PR DESCRIPTION
Thorncaller claw's dummy debuff's refresh behaviour did not match the dot's refresh behaviour because it did not have a tick period/behaviour set. This caused thorn burst to not proc toward the end of thorn spirit if the dot was refreshed. Similarly, the dot would not spread to a new target on death if it had been refreshed.

My solution is to just remove the dummy debuff and use the dot's is_ticking() for the thorn burst proc and on_demise checks.