### PR TITLE
[monk] Refactor create_proc_callback lambda

### DIFF
--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -134,6 +134,16 @@ namespace monk
     // For Debug reporting, used by create_proc_callback in init_special_effects
     std::map< std::string, std::vector< action_t *> > proc_tracking;
 
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               proc_flag PF_OVERRIDE, proc_flag2 PF2_OVERRIDE,
+                               action_t *proc_action_override = nullptr );
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               action_t *proc_action_override = nullptr );
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               proc_flag PF_OVERRIDE, action_t *proc_action_override = nullptr );
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               proc_flag2 PF2_OVERRIDE, action_t *proc_action_override = nullptr );
+
     struct sample_data_t
     {
       sc_timeline_t stagger_effective_damage_timeline;


### PR DESCRIPTION
`dbc_proc_callback_t` requires a fairly complete `special_effect_t` to be passed into it when you construct it. As a result, the `create_proc_callback` lambda existed to help facilitate this and remove a lot of the boilerplate that is required to avoid some nasty side-affects.

Unfortunately, `create_proc_callback` just gathers `proc_flags` from `effect_driver`, and disallows for configuration of `proc_flags2`, nor overriding of `proc_flags`. This caused incorrect behaviour with RF and EK being able to only proc once-per-execute instead of once-per-impact.

To solve this, `create_proc_callback` was factored out into a member of `monk_t` with the following prototypes:
```diff --git a/engine/class_modules/monk/sc_monk.hpp b/engine/class_modules/monk/sc_monk.hpp
index 7b1f818bab..63e79a6ffa 100644
--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -134,6 +134,16 @@ namespace monk
     // For Debug reporting, used by create_proc_callback in init_special_effects
     std::map< std::string, std::vector< action_t *> > proc_tracking;

+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               proc_flag PF_OVERRIDE, proc_flag2 PF2_OVERRIDE,
+                               action_t *proc_action_override = nullptr );
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               action_t *proc_action_override = nullptr );
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               proc_flag PF_OVERRIDE, action_t *proc_action_override = nullptr );
+    void create_proc_callback( const spell_data_t *effect_driver, bool ( *trigger )( monk_t* player, action_state_t *state ),
+                               proc_flag2 PF2_OVERRIDE, action_t *proc_action_override = nullptr );
```

These overloads allow you to use `create_proc_callback` in an identical manner to the behaviour of the original lambda, and if required, override `proc_flag` or `proc_flag2` entries.

I'm not happy with the solution, but given that it is entirely compatible with the current implementation, I'd consider it good enough for the time being.

The one thing that stands out to me as being a bit sketchy, is using `static_cast<proc_flagx>(0)` as a default null-flag. Given that it's a bitfield, it's not a *huge* issue, but it could break due to external changes, and this would definitely not be a long-term solution.

RPPM effects may still be impacted negatively by the previous behaviour, and looking into BB/WW T31 2p behaviour from non-actions (ticks/dots) and overriding `proc_flag2` appropriately.

I threw in a quick and easy for both RF and EK, but both of those are long-overdue for reverification.