### PR TITLE
[Havoc] Use Deck of Cards RNG for A Fire Inside

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -367,7 +367,7 @@ public:
       player_talent_t fel_barrage;  // Old implementation
       player_talent_t shattered_destiny;
       player_talent_t any_means_necessary;
-      player_talent_t a_fire_inside;  // NYI
+      player_talent_t a_fire_inside;
 
     } havoc;
 
@@ -709,7 +709,8 @@ public:
   // Shuffled proc objects
   struct shuffled_rngs_t
   {
-  } shuffled_rngs;
+    shuffled_rng_t* a_fire_inside;
+  } shuffled_rng;
 
   // Special
   struct actives_t
@@ -3437,11 +3438,8 @@ struct immolation_aura_t : public demon_hunter_spell_t
     }
   };
 
-  double afi_chance;
-
   immolation_aura_t( demon_hunter_t* p, util::string_view options_str )
-    : demon_hunter_spell_t( "immolation_aura", p, p->spell.immolation_aura, options_str ),
-      afi_chance( p->talent.havoc.a_fire_inside->effectN( 3 ).percent() )
+    : demon_hunter_spell_t( "immolation_aura", p, p->spell.immolation_aura, options_str )
   {
     may_miss     = false;
     dot_duration = timespan_t::zero();
@@ -3499,7 +3497,7 @@ struct immolation_aura_t : public demon_hunter_spell_t
     p()->buff.immolation_aura->trigger();
     demon_hunter_spell_t::execute();
 
-    if ( p()->talent.havoc.a_fire_inside->ok() && rng().roll( afi_chance ) )
+    if ( p()->talent.havoc.a_fire_inside->ok() && p()->shuffled_rng.a_fire_inside->trigger() )
       cooldown->reset( true, 1 );
   }
 };
@@ -7341,6 +7339,11 @@ void demon_hunter_t::init_rng()
   {
     rppm.felblade         = get_rppm( "felblade", spell.felblade_reset_havoc );
     rppm.demonic_appetite = get_rppm( "demonic_appetite", spec.demonic_appetite );
+
+    // 2023-11-02 There is no spell data for this.
+    // The RNG was described as "marbles in a bag" with "3 wins out of 10 total" by Realz in Fel Hammer Discord.
+    // https://discord.com/channels/213770335735119873/449080055893590017/1169492209121378365
+    shuffled_rng.a_fire_inside = get_shuffled_rng( "a_fire_inside", 3, 10 );
   }
   else  // DEMON_HUNTER_VENGEANCE
   {


### PR DESCRIPTION
We've been informed in The Fel Hammer Discord that AFI uses a 3 in 10 deck of cards for its RNG.

[Discord link to dev comment](https://discord.com/channels/213770335735119873/449080055893590017/1169492209121378365) / [Screenshot](https://i.imgur.com/93iq83H.png)