### PR TITLE
dbc_extract3: Add MapChallengeMode, MythicPlusSeasonTrackedMap and rename DisplaySeason.api_season

### DIFF
--- a/dbc_extract3/formats/10.1.7.51237.json
+++ b/dbc_extract3/formats/10.1.7.51237.json
@@ -346,7 +346,7 @@
     "fields": [
       { "data_type": "S", "field": "desc" },
       { "data_type": "i", "field": "id" },
-      { "data_type": "i", "field": "unk_1" },
+      { "data_type": "i", "field": "api_season" },
       { "data_type": "i", "field": "expansion_season" },
       { "data_type": "i", "field": "id_expansion" },
       { "data_type": "i", "field": "unk_2" }
@@ -974,6 +974,17 @@
       { "data_type": "I", "field": "flags", "elements": 2 }
     ]
   },
+  "MapChallengeMode": {
+    "fields": [
+      { "data_type": "S", "field": "name" },
+      { "data_type": "i", "field": "id" },
+      { "data_type": "i", "field": "id_map", "ref": "Map" },
+      { "data_type": "B", "field": "flags" },
+      { "data_type": "I", "field": "expansion_level" },
+      { "data_type": "I", "field": "unk_1" },
+      { "data_type": "H", "field": "criteria_count", "elements": 3 }
+    ]
+  },
   "MapDifficulty": {
     "parent": "Map",
     "fields": [
@@ -1046,6 +1057,12 @@
       { "data_type": "i", "field": "milestone_season" },
       { "data_type": "i", "field": "id_expansion" },
       { "data_type": "i", "field": "heroic_lfg_dungeon_min_gear" }
+    ]
+  },
+  "MythicPlusSeasonTrackedMap": {
+    "parent": "DisplaySeason",
+    "fields": [
+      { "data_type": "i", "field": "id_map_challenge_mode", "ref": "MapChallengeMode" }
     ]
   },
   "MythicPlusSeasonRewardLevels": {

--- a/dbc_extract3/formats/10.2.0.51790.json
+++ b/dbc_extract3/formats/10.2.0.51790.json
@@ -346,7 +346,7 @@
     "fields": [
       { "data_type": "S", "field": "desc" },
       { "data_type": "i", "field": "id" },
-      { "data_type": "i", "field": "unk_1" },
+      { "data_type": "i", "field": "api_season" },
       { "data_type": "i", "field": "expansion_season" },
       { "data_type": "i", "field": "id_expansion" },
       { "data_type": "i", "field": "unk_2" }
@@ -974,6 +974,17 @@
       { "data_type": "i", "field": "flags", "elements": 3 }
     ]
   },
+  "MapChallengeMode": {
+    "fields": [
+      { "data_type": "S", "field": "name" },
+      { "data_type": "i", "field": "id" },
+      { "data_type": "i", "field": "id_map", "ref": "Map" },
+      { "data_type": "B", "field": "flags" },
+      { "data_type": "I", "field": "expansion_level" },
+      { "data_type": "I", "field": "unk_1" },
+      { "data_type": "H", "field": "criteria_count", "elements": 3 }
+    ]
+  },
   "MapDifficulty": {
     "parent": "Map",
     "fields": [
@@ -1046,6 +1057,12 @@
       { "data_type": "i", "field": "milestone_season" },
       { "data_type": "i", "field": "id_expansion" },
       { "data_type": "i", "field": "heroic_lfg_dungeon_min_gear" }
+    ]
+  },
+  "MythicPlusSeasonTrackedMap": {
+    "parent": "DisplaySeason",
+    "fields": [
+      { "data_type": "i", "field": "id_map_challenge_mode", "ref": "MapChallengeMode" }
     ]
   },
   "MythicPlusSeasonRewardLevels": {


### PR DESCRIPTION
* Add `MapChallengeMode` based on [WoWDBDefs' definition][0]. `criteria_count` is based on their naming, this looks like the time limits (in seconds) for +1/+2/+3 chesting.
* Add `MythicPlusSeasonTrackedMap` based on [WoWDBDefs' definition][2]
* Rename `DisplaySeason.unk_1` to `.api_season`. This appears to match the season IDs in the [Mythic Keystone Season REST API][1]. [WoWDBDefs][3] also calls that field `Season`, and notes it matches [the Lua API (`milestoneSeasonID`)][4].

API example:

```json
{
  "_links": {
    "self": {
      "href": "https://us.api.blizzard.com/data/wow/mythic-keystone/season/10?namespace=dynamic-us"
    }
  },
  "id": 10,
  "start_timestamp": 1683644400000,
  "periods": [ /* ... */ ],
  "season_name": "Mythic+ Dungeons (Dragonflight Season 2)"
}
```

DisplaySeason dump example:

```csv
desc,id,api_season,expansion_season,id_expansion,unk_2
...
"Defeat %d Aberrus, the Shadowed Crucible |4Boss:Bosses",21,10,2,9,2
```

CSV exports of all those new definitions seem sensible.

These additions and relations are enough to be able to:
* get a list of Mythic+ seasons and correlate that with the REST API (via `api_season`)
* get a list of all Mythic+ (challenge mode) dungeons, including the megadungeon splits of Tazavesh and Mechagon (via `MapChallengeMode`)
* get a list of all linkages between Mythic+ seasons and their constituent dungeons (via `MythicPlusSeasonTrackedMap`)

[0]: https://github.com/wowdev/WoWDBDefs/blob/bf4a75fbb382b6ddd3ddbbb6be547532b73f6e7e/definitions/MapChallengeMode.dbd#L111-L133
[1]: https://develop.battle.net/documentation/world-of-warcraft/game-data-apis
[2]: https://github.com/wowdev/WoWDBDefs/blob/bf4a75fbb382b6ddd3ddbbb6be547532b73f6e7e/definitions/MythicPlusSeasonTrackedMap.dbd#L13-L31
[3]: https://github.com/wowdev/WoWDBDefs/blob/bf4a75fbb382b6ddd3ddbbb6be547532b73f6e7e/definitions/DisplaySeason.dbd
[4]: https://warcraft.wiki.gg/wiki/API_C_MythicPlus.GetCurrentSeasonValues