### PR TITLE
dbc_extract3: Swap TradeSkillCategory fields id_parent_trade_skill_category and id_skill_line

### DIFF
--- a/dbc_extract3/formats/10.1.7.51237.json
+++ b/dbc_extract3/formats/10.1.7.51237.json
@@ -1699,8 +1699,8 @@
     "fields": [
       { "data_type": "S", "field": "name" },
       { "data_type": "S", "field": "horde_name" },
-      { "data_type": "h", "field": "id_skill_line" },
-      { "data_type": "h", "field": "id_parent_trade_skill_category" },
+      { "data_type": "h", "field": "id_parent_trade_skill_category", "ref": "TradeSkillCategory" },
+      { "data_type": "h", "field": "id_skill_line", "ref": "SkillLine" },
       { "data_type": "h", "field": "order" },
       { "data_type": "b", "field": "flags" }
     ]

--- a/dbc_extract3/formats/10.2.0.51790.json
+++ b/dbc_extract3/formats/10.2.0.51790.json
@@ -1699,8 +1699,8 @@
     "fields": [
       { "data_type": "S", "field": "name" },
       { "data_type": "S", "field": "horde_name" },
-      { "data_type": "h", "field": "id_skill_line" },
-      { "data_type": "h", "field": "id_parent_trade_skill_category" },
+      { "data_type": "h", "field": "id_parent_trade_skill_category", "ref": "TradeSkillCategory" },
+      { "data_type": "h", "field": "id_skill_line", "ref": "SkillLine" },
       { "data_type": "h", "field": "order" },
       { "data_type": "b", "field": "flags" }
     ]


### PR DESCRIPTION
Swap `TradeSkillCategory` fields `id_parent_trade_skill_category` and `id_skill_line`.

**After** swapping fields, the relations _now_ correct:

```csv
$ head -n1 trade_skill_category.txt; grep 1570 trade_skill_category.txt
id,name,horde_name,id_parent_trade_skill_category,id_skill_line,order,flags
1570,"Dragon Isles Alchemy - Header","",0,171,910,0
1582,"Dragon Isles Recipes","",1570,2823,910,1
```

`171` and `2823` are SkillLineIDs: https://warcraft.wiki.gg/wiki/TradeSkillLineID

```
$ head -n1 skill_line.txt; grep -m1 ,171, skill_line.txt; grep -m1 ,2823, skill_line.txt
name,alternate_verb,description,horde_display_name,neutral_display_name,id,category,id_spell_icon_file,can_link,id_parent_skill_line,parent_tier_index,flags,id_spell_book_spell,unk_1,unk_2
"Alchemy","Refill","Higher alchemy skill allows you to learn higher level alchemy recipes.  Alchemy recipes can be found on trainers around the world as well as from quests and monsters.","","",171,11,4620669,1,0,0,4224,2259,0,0
"Dragon Isles Alchemy","","","","",2823,11,4620669,0,171,13,0,0,962,0
```

I've checked this against 10.1.7.51237 (live) and 10.2.0.51790 (PTR).

I *haven't* updated any old builds' definitions as I don't have the files downloaded to check them. If I'm reading [WoWDBDefs for this structure][0] correctly, this ordering has been in place since around 8.0.1.26287, so they're probably wrong too.

But I only really care about the current stuff. 😅 

[0]: https://github.com/wowdev/WoWDBDefs/blob/aebfb2f37e7af54febd408a8e13c16d72730369e/definitions/TradeSkillCategory.dbd#L123-L140