### PR TITLE
[DH] Remove Sigil of Flame damage bug

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3018,19 +3018,6 @@ struct sigil_of_flame_damage_t : public demon_hunter_sigil_t
     }
   }
 
-  double action_ta_multiplier() const override
-  {
-    double am = demon_hunter_sigil_t::action_ta_multiplier();
-
-    // 2023-05-01 -- Sigil of Flame's DoT currently deals twice the intended damage.
-    //               There are currently two Apply Aura: Periodic Damage effects in the spell data
-    //               (Effects #2 and #3) which could potentially be the reason for this.
-    if ( p()->bugs )
-      am *= 2.0;
-
-    return am;
-  }
-
   void impact( action_state_t* s ) override
   {
     demon_hunter_sigil_t::impact( s );


### PR DESCRIPTION
Sigil of flame's AP coefficient has been doubled in spell data but the actual damage in game has remained the same. The bug has effectively been fixed.