### PR TITLE
[Gear] add options for balefire branch stack loss

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12774,6 +12774,10 @@ void player_t::create_options()
   add_option( opt_float( "dragonflight.string_of_delicacies_min_allies", dragonflight_opts.string_of_delicacies_min_allies, 0.0, 4 ) );
   add_option( opt_float( "dragonflight.string_of_delicacies_multi_actor_skip_chance",
                          dragonflight_opts.string_of_delicacies_multi_actor_skip_chance, 0.0, 1 ) );
+  add_option( opt_string( "dragonflight.balefire_branch_loss_rng_type", dragonflight_opts.balefire_branch_loss_rng_type ) );
+  add_option( opt_float( "dragonflight.balefire_branch_loss_rppm", dragonflight_opts.balefire_branch_loss_rppm, 0.0, std::numeric_limits<double>::max() ) );
+  add_option( opt_float( "dragonflight.balefire_branch_loss_percent", dragonflight_opts.balefire_branch_loss_rppm, 0.0, 1.0 ) );
+  add_option( opt_int( "dragonflight.balefire_branch_loss_stacks", dragonflight_opts.balefire_branch_loss_stacks, 0, 20 ) );
 
   // Obsolete options
 

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -772,6 +772,14 @@ struct player_t : public actor_t
     double string_of_delicacies_min_allies = 0;
     // String of Delicacies skip chance for multi actor sims. Makes it skip a buff to lower the power and simulate loosing some to healers.
     double string_of_delicacies_multi_actor_skip_chance = 0.2;
+    // Which random method to use to determine Balefire Branch stack loss from damage. Accepts "rppm" or "percent"
+    std::string balefire_branch_loss_rng_type = "rppm";
+    // Set RPPM when "rppm" method is selected
+    double balefire_branch_loss_rppm = 1;
+    // Set percent change when "percent" method is selected
+    double balefire_branch_loss_percent = 0.1;
+    // How many stacks to lose
+    int balefire_branch_loss_stacks = 2;
   } dragonflight_opts;
 
 private:


### PR DESCRIPTION
All player-scoped options, prepended with "dragonflight."

    // Which random method to use to determine Balefire Branch stack loss from damage. Accepts "rppm" or "percent"
    std::string balefire_branch_loss_rng_type = "rppm";
    // Set RPPM when "rppm" method is selected
    double balefire_branch_loss_rppm = 1;
    // Set percent change when "percent" method is selected
    double balefire_branch_loss_percent = 0.1;
    // How many stacks to lose
    int balefire_branch_loss_stacks = 2;