### PR TITLE
[APL] Removes duplicate conditional within Thunderous Roar APL

### DIFF
--- a/engine/class_modules/apl/apl_warrior.cpp
+++ b/engine/class_modules/apl/apl_warrior.cpp
@@ -235,7 +235,7 @@ void arms( player_t* p )
   single_target->add_action( "colossus_smash" );
   single_target->add_action( "skullsplitter,if=!talent.test_of_might&dot.deep_wounds.remains&(debuff.colossus_smash.up|cooldown.colossus_smash.remains>3)" );
   single_target->add_action( "skullsplitter,if=talent.test_of_might&dot.deep_wounds.remains" );
-  single_target->add_action( "thunderous_roar,if=buff.test_of_might.up|debuff.colossus_smash.up|debuff.colossus_smash.up|cooldown.colossus_smash.remains<3|buff.avatar.up" );
+  single_target->add_action( "thunderous_roar,if=buff.test_of_might.up|debuff.colossus_smash.up|cooldown.colossus_smash.remains<3|buff.avatar.up" );
   single_target->add_action( "whirlwind,if=talent.storm_of_swords&talent.test_of_might&rage.pct>80&debuff.colossus_smash.up" );
   single_target->add_action( "thunder_clap,if=dot.rend.remains<=gcd&!talent.tide_of_blood" );
   single_target->add_action( "bladestorm,if=talent.hurricane&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)|talent.unhinged&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)" );

--- a/profiles/Tier31/T31_Warrior_Arms.simc
+++ b/profiles/Tier31/T31_Warrior_Arms.simc
@@ -119,7 +119,7 @@ actions.single_target+=/warbreaker
 actions.single_target+=/colossus_smash
 actions.single_target+=/skullsplitter,if=!talent.test_of_might&dot.deep_wounds.remains&(debuff.colossus_smash.up|cooldown.colossus_smash.remains>3)
 actions.single_target+=/skullsplitter,if=talent.test_of_might&dot.deep_wounds.remains
-actions.single_target+=/thunderous_roar,if=buff.test_of_might.up|debuff.colossus_smash.up|debuff.colossus_smash.up|cooldown.colossus_smash.remains<3|buff.avatar.up
+actions.single_target+=/thunderous_roar,if=buff.test_of_might.up|debuff.colossus_smash.up|cooldown.colossus_smash.remains<3|buff.avatar.up
 actions.single_target+=/whirlwind,if=talent.storm_of_swords&talent.test_of_might&rage.pct>80&debuff.colossus_smash.up
 actions.single_target+=/thunder_clap,if=dot.rend.remains<=gcd&!talent.tide_of_blood
 actions.single_target+=/bladestorm,if=talent.hurricane&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)|talent.unhinged&(buff.test_of_might.up|!talent.test_of_might&debuff.colossus_smash.up)


### PR DESCRIPTION
**Summary:**
This change removes a duplicate "debuff.colossus_smash.up" which was present within the Thunderous Roar entry for Arm's single target APL. 
- Before: `|debuff.colossus_smash.up|debuff.colossus_smash.up|`
- After: `|debuff.colossus_smash.up|`

**Impact:**
This should have no perceivable change to performance of the spec, and solely exists to clean up an extraneous entry.