### PR TITLE
[Frost DK] Refactor Chill Streak

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -2665,7 +2665,7 @@ void buff_t::expire( timespan_t delay )
 
   if ( expire_callback )
   {
-    expire_callback( this, remaining_duration, expiration_stacks );
+    expire_callback( this, expiration_stacks, remaining_duration );
   }
 
   expire_override( expiration_stacks, remaining_duration );  // virtual expire call

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1370,6 +1370,16 @@ buff_t* buff_t::set_stack_change_callback( const buff_stack_change_callback_t& c
   return this;
 }
 
+buff_t* buff_t::set_expire_callback( const buff_expire_callback_t& cb )
+{
+  if (!is_fallback)
+  {
+    expire_callback = cb;
+  }
+
+  return this;
+}
+
 buff_t* buff_t::set_reverse_stack_count( int count )
 {
   reverse_stack_reduction = count;
@@ -2666,6 +2676,11 @@ void buff_t::expire( timespan_t delay )
   if ( stack_change_callback )
   {
     stack_change_callback( this, old_stack, current_stack );
+  }
+
+  if ( expire_callback )
+  {
+    expire_callback( this, remaining_duration, expiration_stacks );
   }
 
   if ( player )

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -2663,6 +2663,11 @@ void buff_t::expire( timespan_t delay )
     expire_count++;
   }
 
+  if ( expire_callback )
+  {
+    expire_callback( this, remaining_duration, expiration_stacks );
+  }
+
   expire_override( expiration_stacks, remaining_duration );  // virtual expire call
 
   current_value = 0;
@@ -2676,11 +2681,6 @@ void buff_t::expire( timespan_t delay )
   if ( stack_change_callback )
   {
     stack_change_callback( this, old_stack, current_stack );
-  }
-
-  if ( expire_callback )
-  {
-    expire_callback( this, remaining_duration, expiration_stacks );
   }
 
   if ( player )

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -50,6 +50,7 @@ using buff_tick_callback_t = std::function<void(buff_t* buff, int current_tick, 
 using buff_tick_time_callback_t = std::function<timespan_t(const buff_t*, unsigned)>;
 using buff_refresh_duration_callback_t = std::function<timespan_t(const buff_t*, timespan_t)>;
 using buff_stack_change_callback_t = std::function<void(buff_t*, int old_stack, int new_stack)>;
+using buff_expire_callback_t = std::function<void( buff_t* buff, timespan_t duration, int stacks )>;
 
 // Buffs ====================================================================
 
@@ -113,6 +114,7 @@ public:
   buff_refresh_duration_callback_t refresh_duration_callback;
   buff_stack_behavior stack_behavior;
   buff_stack_change_callback_t stack_change_callback;
+  buff_expire_callback_t expire_callback;
   bool allow_precombat;
 
   // Ticking buff values
@@ -395,6 +397,7 @@ public:
   buff_t* set_rppm( rppm_scale_e scale = RPPM_NONE, double freq = -1, double mod = -1);
   buff_t* set_trigger_spell( const spell_data_t* s );
   buff_t* set_stack_change_callback( const buff_stack_change_callback_t& cb );
+  buff_t* set_expire_callback( const buff_expire_callback_t& cb );
   buff_t* set_reverse_stack_count( int count );
   buff_t* set_stack_behavior( buff_stack_behavior b );
   buff_t* set_allow_precombat( bool b );

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -50,7 +50,7 @@ using buff_tick_callback_t = std::function<void(buff_t* buff, int current_tick, 
 using buff_tick_time_callback_t = std::function<timespan_t(const buff_t*, unsigned)>;
 using buff_refresh_duration_callback_t = std::function<timespan_t(const buff_t*, timespan_t)>;
 using buff_stack_change_callback_t = std::function<void(buff_t*, int old_stack, int new_stack)>;
-using buff_expire_callback_t = std::function<void( buff_t* buff, timespan_t duration, int stacks )>;
+using buff_expire_callback_t = std::function<void( buff_t* buff, int stacks, timespan_t duration )>;
 
 // Buffs ====================================================================
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -155,10 +155,6 @@ namespace runeforge {
   void unending_thirst( special_effect_t& ); // Effect only procs on killing blows, NYI
 }
 
-namespace debuffs {
-  struct chill_streak_debuff_t;
-}
-
 enum runeforge_apocalypse { DEATH, FAMINE, PESTILENCE, WAR, MAX };
 
 // ==========================================================================

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4915,7 +4915,7 @@ struct chill_streak_debuff_t final : public buff_t
   chill_streak_debuff_t( death_knight_td_t& td, player_t* t, death_knight_t* p ) :
     buff_t( td, "chill_streak_debuff", p -> spell.chill_streak_damage ),
     damage( get_action<chill_streak_damage_t>( "chill_streak_damage", p ) ), 
-    player( p ), tar( t )
+    player( p ), tar( t ), hit_count( 0 )
   {
     max_hits = as<int>( p->talent.frost.chill_streak->effectN( 1 ).base_value() );
     if ( p->sets->has_set_bonus( DEATH_KNIGHT_FROST, T31, B4 ) )

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -1475,7 +1475,7 @@ inline death_knight_td_t::death_knight_td_t( player_t* target, death_knight_t* p
   debuff.lingering_chill = make_buff( *this, "lingering_chill", p -> spell.lingering_chill )
                             -> set_default_value( p -> spell.lingering_chill -> effectN( 1 ).percent() );
 
-  debuff.chill_streak = new chill_streak_debuff_t( target, p );
+  debuff.chill_streak = new chill_streak_debuff_t( *this, target, p );
 
   // Unholy
   debuff.festering_wound  = make_buff( *this, "festering_wound", p -> spell.festering_wound_debuff )
@@ -4907,8 +4907,8 @@ struct chill_streak_debuff_t final : public buff_t
 {
   int hit_count;
 
-  chill_streak_debuff_t( player_t* t, death_knight_t* p ) :
-    buff_t( t, "chill_streak_debuff", p -> spell.chill_streak_damage ),
+  chill_streak_debuff_t( death_knight_td_t& td, player_t* t, death_knight_t* p ) :
+    buff_t( td, "chill_streak_debuff", p -> spell.chill_streak_damage ),
     damage( get_action<chill_streak_damage_t>( "chill_streak_damage", p ) ), 
     player( p ), tar( t )
   {

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4874,13 +4874,6 @@ struct chill_streak_damage_t final : public death_knight_spell_t
     }
   }
 
-  void execute() override
-  {
-    // Setting a variable min travel time to more accurately emulate in game variance
-    min_travel_time = rng().gauss( 0.5, 0.2 );
-    death_knight_spell_t::execute();
-  }
-
   void impact( action_state_t* state ) override
   {
     if ( state -> target -> is_player() )

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -1479,8 +1479,10 @@ inline death_knight_td_t::death_knight_td_t( player_t* target, death_knight_t* p
                             -> set_default_value( p -> spell.lingering_chill -> effectN( 1 ).percent() );
 
   debuff.chill_streak = make_buff( *this, "chill_streak", p->spell.chill_streak_damage )
-                            -> set_expire_callback( [ target, p ]( buff_t*, timespan_t d, int s ) 
+                            -> set_quiet( true )
+                            -> set_expire_callback( [ target, p ]( buff_t*, timespan_t d, int ) 
                             {
+                              // Chill streak doesnt bounce if the target dies before the debuff expires
                               if( d == timespan_t::zero() )
                               {
                                 p -> chill_streak_bounce( target );
@@ -9064,7 +9066,6 @@ void death_knight_t::chill_streak_bounce( player_t* t )
     }
   };
 
-  const death_knight_td_t* td = get_target_data( t );
   make_event<cs_bounce_t>( *sim, this, t );
 }
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4874,6 +4874,13 @@ struct chill_streak_damage_t final : public death_knight_spell_t
     }
   }
 
+  void execute() override
+  {
+    // Setting a variable min travel time to more accurately emulate in game variance
+    min_travel_time = rng().gauss( 0.4, 0.2 );
+    death_knight_spell_t::execute();
+  }
+
   void impact( action_state_t* state ) override
   {
     if ( state -> target -> is_player() )


### PR DESCRIPTION
More accurately emulates in game behavior with a 0.3s debuff period that triggers the next "bounce" event. If an enemy dies with it on them, it will not bounce again. Or, if an enemy dies before it hits them, same result. 