### PR TITLE
[core] enable_all_item_effects

### DIFF
--- a/engine/action/dbc_proc_callback.cpp
+++ b/engine/action/dbc_proc_callback.cpp
@@ -169,7 +169,8 @@ void dbc_proc_callback_t::trigger( action_t* a, action_state_t* state )
 
 dbc_proc_callback_t::dbc_proc_callback_t( const item_t& i, const special_effect_t& e )
   : action_callback_t( e.player ),
-    item( i.parent_slot != SLOT_INVALID ? i : e.player->items[SLOT_MAIN_HAND] ),
+    // item( i.parent_slot != SLOT_INVALID ? i : e.player->items[SLOT_MAIN_HAND] ),
+    item( i ),
     effect( e ),
     cooldown( nullptr ),
     target_specific_cooldown( nullptr ),
@@ -191,7 +192,8 @@ dbc_proc_callback_t::dbc_proc_callback_t( const item_t& i, const special_effect_
 
 dbc_proc_callback_t::dbc_proc_callback_t( const item_t* i, const special_effect_t& e )
   : action_callback_t( e.player ),
-    item( i ? *i : e.player->items[SLOT_MAIN_HAND] ),
+    // item( i ? *i : e.player->items[SLOT_MAIN_HAND] ),
+    item( *i ),
     effect( e ),
     cooldown( nullptr ),
     target_specific_cooldown( nullptr ),
@@ -272,13 +274,17 @@ void dbc_proc_callback_t::initialize()
   // in which case the proc does not trigger a buff.
   proc_buff = effect.create_buff();
 
-  if ( effect.weapon_proc )
+  if ( effect.weapon_proc && effect.item )
   {
-    if ( effect.player->sim->enable_all_item_effects )
-      weapon = effect.player->items[SLOT_MAIN_HAND].weapon();
-    else if ( effect.item )
-      weapon = effect.item->weapon();
+    weapon = effect.item->weapon();
   }
+  // if ( effect.weapon_proc )
+  // {
+  //   if ( effect.player->sim->enable_all_item_effects )
+  //     weapon = effect.player->items[SLOT_MAIN_HAND].weapon();
+  //   else if ( effect.item )
+  //     weapon = effect.item->weapon();
+  // }
 
   if ( proc_buff && effect.expire_on_max_stack != -1 )
   {

--- a/engine/action/dbc_proc_callback.cpp
+++ b/engine/action/dbc_proc_callback.cpp
@@ -168,8 +168,8 @@ void dbc_proc_callback_t::trigger( action_t* a, action_state_t* state )
 }
 
 dbc_proc_callback_t::dbc_proc_callback_t( const item_t& i, const special_effect_t& e )
-  : action_callback_t( i.player ),
-    item( i ),
+  : action_callback_t( e.player ),
+    item( i.parent_slot != SLOT_INVALID ? i : e.player->items[SLOT_MAIN_HAND] ),
     effect( e ),
     cooldown( nullptr ),
     target_specific_cooldown( nullptr ),
@@ -190,8 +190,8 @@ dbc_proc_callback_t::dbc_proc_callback_t( const item_t& i, const special_effect_
 }
 
 dbc_proc_callback_t::dbc_proc_callback_t( const item_t* i, const special_effect_t& e )
-  : action_callback_t( i->player ),
-    item( *i ),
+  : action_callback_t( e.player ),
+    item( i ? *i : e.player->items[SLOT_MAIN_HAND] ),
     effect( e ),
     cooldown( nullptr ),
     target_specific_cooldown( nullptr ),
@@ -272,9 +272,12 @@ void dbc_proc_callback_t::initialize()
   // in which case the proc does not trigger a buff.
   proc_buff = effect.create_buff();
 
-  if ( effect.weapon_proc && effect.item )
+  if ( effect.weapon_proc )
   {
-    weapon = effect.item->weapon();
+    if ( effect.player->sim->enable_all_item_effects )
+      weapon = effect.player->items[SLOT_MAIN_HAND].weapon();
+    else if ( effect.item )
+      weapon = effect.item->weapon();
   }
 
   if ( proc_buff && effect.expire_on_max_stack != -1 )

--- a/engine/item/special_effect.cpp
+++ b/engine/item/special_effect.cpp
@@ -83,6 +83,11 @@ special_effect_t::special_effect_t( const item_t* item ) : item( item ), player(
   reset();
 }
 
+special_effect_t::special_effect_t( const item_t& item ) : item( &item ), player( item.player )
+{
+  reset();
+}
+
 void special_effect_t::reset()
 {
   type = SPECIAL_EFFECT_NONE;

--- a/engine/item/special_effect.hpp
+++ b/engine/item/special_effect.hpp
@@ -102,6 +102,7 @@ public:
   { reset(); }
 
   special_effect_t( const item_t* item );
+  special_effect_t( const item_t& item );
 
   // Uses a custom initialization callback or object
   bool is_custom() const

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -2081,6 +2081,9 @@ void player_t::create_special_effects()
 
   sim->print_debug( "Creating special effects for {}.", *this );
 
+  if ( sim->enable_all_item_effects ) {
+    unique_gear::initialize_all_special_effects( this );
+  }
   // Initialize all item-based special effects. This includes any DBC-backed enchants, gems, as well
   // as inherent item effects that use a spell
   for ( auto& item : items )
@@ -11571,8 +11574,8 @@ std::unique_ptr<expr_t> player_t::create_expression( util::string_view expressio
 
       if ( splits[ 1 ] == "rallied_to_victory_ally_estimate" )
       {
-        return make_fn_expr( expression_str, [ this ] { 
-          return dragonflight_opts.rallied_to_victory_ally_estimate; 
+        return make_fn_expr( expression_str, [ this ] {
+          return dragonflight_opts.rallied_to_victory_ally_estimate;
         } );
       }
 

--- a/engine/player/unique_gear.cpp
+++ b/engine/player/unique_gear.cpp
@@ -4775,8 +4775,8 @@ void unique_gear::initialize_all_special_effects(player_t *actor)
   {
     // Blacklist of special effects by spell id for effects that are broken.
     switch (special_effect.spell_id) {
-      case 293512:
-      case 299464:
+      // case 293512:
+      // case 299464:
       case 302916:
         // new
       case 187611:

--- a/engine/player/unique_gear.cpp
+++ b/engine/player/unique_gear.cpp
@@ -4778,6 +4778,13 @@ void unique_gear::initialize_all_special_effects(player_t *actor)
       case 293512:
       case 299464:
       case 302916:
+        // new
+      case 187611:
+      case 187613:
+      case 187614:
+      case 187615:
+      case 302773:
+      case 426827:
         continue;
     }
     actor->sim->print_debug("enabling all special effects: {}", special_effect.spell_id);

--- a/engine/player/unique_gear.cpp
+++ b/engine/player/unique_gear.cpp
@@ -4773,12 +4773,17 @@ void unique_gear::initialize_all_special_effects(player_t *actor)
 {
   for ( special_effect_db_item_t& special_effect : __special_effect_db )
   {
+    // Blacklist of special effects by spell id for effects that are broken.
+    switch (special_effect.spell_id) {
+      case 293512:
+      case 299464:
+      case 302916:
+        continue;
+    }
     actor->sim->print_debug("enabling all special effects: {}", special_effect.spell_id);
-    special_effect_t* proxy_effect = new special_effect_t( actor );
+    special_effect_t* proxy_effect = new special_effect_t( actor->items[SLOT_MAIN_HAND] );
     unique_gear::initialize_special_effect( *proxy_effect, special_effect.spell_id );
-    if ( !(proxy_effect->type != SPECIAL_EFFECT_NONE) &&
-         !(proxy_effect->proc_flags_ != 0 ))
-      actor->special_effects.push_back( proxy_effect );
+    actor->special_effects.push_back( proxy_effect );
   }
 }
 

--- a/engine/player/unique_gear.hpp
+++ b/engine/player/unique_gear.hpp
@@ -79,6 +79,8 @@ void initialize_special_effect_fallbacks( player_t* actor );
 // Second-phase special effect initializer
 void initialize_special_effect_2( special_effect_t* effect );
 
+void initialize_all_special_effects( player_t* actor );
+
 // Initialize special effects related to various race spells
 void initialize_racial_effects( player_t* );
 

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -4755,9 +4755,7 @@ void items::yellow_punchcard( special_effect_t& effect )
 
   auto punchcard = init_punchcard( effect );
   if ( punchcard.parsed.data.id == 0 )
-  {
     return;
-  }
 
   auto budget = item_database::item_budget( effect.player, punchcard.item_level() );
 
@@ -4794,9 +4792,7 @@ void items::subroutine_overclock( special_effect_t& effect )
 {
   auto punchcard = init_punchcard( effect );
   if ( punchcard.parsed.data.id == 0 )
-  {
     return;
-  }
 
   stat_buff_t* buff = debug_cast<stat_buff_t*>( buff_t::find( effect.player, "subroutine_overclock" ) );
   if ( !buff )
@@ -4815,6 +4811,9 @@ void items::subroutine_overclock( special_effect_t& effect )
 
 void items::subroutine_recalibration( special_effect_t& effect )
 {
+  if ( init_punchcard( effect ).parsed.data.id == 0 )
+    return;
+
   struct recalibration_cb_t : public dbc_proc_callback_t
   {
     unsigned casts, req_casts;
@@ -4911,6 +4910,9 @@ void items::subroutine_recalibration( special_effect_t& effect )
 
 void items::subroutine_optimization( special_effect_t& effect )
 {
+  if ( init_punchcard( effect ).parsed.data.id == 0 )
+    return;
+
   struct subroutine_optimization_buff_t : public buff_t
   {
     std::array<double, STAT_MAX> stats;
@@ -4925,7 +4927,9 @@ void items::subroutine_optimization( special_effect_t& effect )
         minor_stat( STAT_NONE ),
         punchcard( init_punchcard( effect ) ),
         raw_bonus( item_database::apply_combat_rating_multiplier(
-            effect.player, combat_rating_multiplier_type::CR_MULTIPLIER_TRINKET, punchcard.item_level(),
+            effect.player,
+            combat_rating_multiplier_type::CR_MULTIPLIER_TRINKET,
+            punchcard.item_level(),
             effect.driver()->effectN( 2 ).average( &( punchcard ) ) ) )
     {
       // Find the two stats provided by the punchcard.
@@ -5112,6 +5116,9 @@ void items::subroutine_optimization( special_effect_t& effect )
 
 void items::harmonic_dematerializer( special_effect_t& effect )
 {
+  if ( init_punchcard( effect ).parsed.data.id == 0 )
+    return;
+
   struct harmonic_dematerializer_t : public proc_spell_t
   {
     buff_t* buff;

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -4296,7 +4296,7 @@ void items::ashvanes_razor_coral( special_effect_t& effect )
             } );
   }
 
-  // Special secondary tracking buff to track the somewhat odd in-game stacking behavior 
+  // Special secondary tracking buff to track the somewhat odd in-game stacking behavior
   // Currently the in-game system uses the buff "stack" on refreshes, while the Crit value is encoded in the dynamic buff value
   // As SimC uses the stack for tracking the base crit * stack multiplier instead of a dyanmic value, we use this instead
   // Reuse the existing buff spell data, but don't create as stat_buff_t since we don't want it to do anything

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -1512,6 +1512,7 @@ sim_t::sim_t()
     allow_experimental_specializations( false ),
     enable_all_talents( false ),
     enable_all_sets( false ),
+    enable_all_item_effects( false ),
     progressbar_type( 0 ),
     armory_retries( 3 ),
     enemy_death_pct( 0 ),
@@ -2330,11 +2331,11 @@ void sim_t::init_fight_style()
     case FIGHT_STYLE_PATCHWERK:
       raid_events_str.clear();
       break;
-    
+
     case FIGHT_STYLE_CASTING_PATCHWERK:
       raid_events_str += "/casting,cooldown=500,duration=500";
       break;
-    
+
     case FIGHT_STYLE_HECTIC_ADD_CLEAVE:
     {
       // Phase 1 - Adds and move into position to fight adds
@@ -2356,7 +2357,7 @@ void sim_t::init_fight_style()
                                       first2, cooldown2 );
     }
     break;
-    
+
     case FIGHT_STYLE_DUNGEON_SLICE:
       desired_targets = 1;
       max_time = timespan_t::from_seconds( 360.0 );
@@ -2369,7 +2370,7 @@ void sim_t::init_fight_style()
         "/adds,name=SmallAdd,count=5,count_range=1,first=140,cooldown=45,duration=18,duration_stddev=2"
         "/adds,name=BigAdd,count=2,count_range=1,first=160,cooldown=50,duration=30,duration_stddev=2";
       break;
-    
+
     case FIGHT_STYLE_DUNGEON_ROUTE:
       // To be used in conjunction with "pull" raid events for a simulated dungeon run.
       desired_targets = 1;
@@ -2377,7 +2378,7 @@ void sim_t::init_fight_style()
       // Bloodlust is handled by an option on each pull raid event.
       overrides.bloodlust = 0;
       break;
-    
+
     case FIGHT_STYLE_CLEAVE_ADD:
     {
       auto first_and_duration = static_cast<unsigned>( max_time.total_seconds() * 0.05 );
@@ -2388,16 +2389,16 @@ void sim_t::init_fight_style()
                                       first_and_duration, cooldown, first_and_duration, last );
     }
     break;
-    
+
     case FIGHT_STYLE_LIGHT_MOVEMENT:
       raid_events_str += "/movement,players_only=1,cooldown=40,cooldown_stddev=10,distance=15,distance_min=10,distance_max=20,first=15";
       break;
-    
+
     case FIGHT_STYLE_HEAVY_MOVEMENT:
       raid_events_str += "/movement,players_only=1,cooldown=20,cooldown_stddev=15,distance=25,distance_min=20,distance_max=30,first=15";
       raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=15,distance=45,distance_min=40,distance_max=50,first=30";
       break;
-    
+
     case FIGHT_STYLE_BEASTLORD:
     {
       deprecated = true;
@@ -2420,7 +2421,7 @@ void sim_t::init_fight_style()
                                       beast_last );
     }
     break;
-    
+
     case FIGHT_STYLE_HELTER_SKELTER:
       deprecated = true;
       raid_events_str += "/casting,cooldown=30,duration=3,first=15";
@@ -2428,7 +2429,7 @@ void sim_t::init_fight_style()
       raid_events_str += "/stun,cooldown=60,duration=2";
       raid_events_str += "/invulnerable,cooldown=120,duration=3";
       break;
-    
+
     case FIGHT_STYLE_ULTRAXION:
       deprecated = true;
       max_time = timespan_t::from_seconds( 366.0 );
@@ -2445,7 +2446,7 @@ void sim_t::init_fight_style()
       raid_events_str += "/damage,first=240.0,period=2.0,last=299.5,amount=44855,type=shadow";
       raid_events_str += "/damage,first=300.0,period=1.0,amount=44855,type=shadow";
       break;
-    
+
     default:
       fight_style = FIGHT_STYLE_PATCHWERK;
       break;
@@ -3646,6 +3647,7 @@ void sim_t::create_options()
   add_option( opt_bool( "allow_experimental_specializations", allow_experimental_specializations ) );
   add_option( opt_bool( "enable_all_talents", enable_all_talents ) );
   add_option( opt_bool( "enable_all_sets", enable_all_sets ) );
+  add_option( opt_bool( "enable_all_item_effects" , enable_all_item_effects ) );
 
   // Raid buff overrides
   add_option( opt_func( "optimal_raid", parse_optimal_raid ) );

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -148,6 +148,7 @@ struct sim_t : private sc_thread_t
   bool        allow_experimental_specializations;
   bool        enable_all_talents;
   bool        enable_all_sets;
+  bool        enable_all_item_effects;
   int         progressbar_type;
   int         armory_retries;
   std::unordered_map<std::string, std::string> item_slot_overrides;
@@ -629,7 +630,7 @@ struct sim_t : private sc_thread_t
   std::vector<sim_t*> children; // Manual delete!
   int thread_index;
   computer_process::priority_e process_priority;
-  
+
   std::shared_ptr<work_queue_t> work_queue;
 
   // Related Simulations


### PR DESCRIPTION
Work in progress implementation that enables all item effects registered via `register_special_effect`.

Unimplemented:
- Providing some behaviour to limit enabling all item effects to a specific expansion or other subset of effects.

Current issues with some potential solutions:
Many special effects use the pattern `effect.item->player` instead of directly using `effect.player`. This causes segfaults as `effect.item` is uninitialized due to the source item being unknowable and very likely incorrect.
- Provide a default item. Possibly fails if other information is extracted from the item.
- Update all implementations with `effect.player`.

Additionally, effects may depend on `item` through `effect.weapon_proc` being true. None have been discovered at this point.
- Provide a default item. An implementation for providing the mainhand was added, but is not guaranteed to work, as it could be the offhand that causes this to occur.