### PR TITLE
[player] Add hybrid mainstat types to stat_gain, stat_loss, and cache_from_stat.

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -7081,6 +7081,10 @@ void player_t::stat_gain( stat_e stat, double amount, gain_t* gain, action_t* ac
     case STAT_STRENGTH:
     case STAT_AGILITY:
     case STAT_INTELLECT:
+    case STAT_AGI_INT:
+    case STAT_STR_AGI:
+    case STAT_STR_INT:
+    case STAT_STR_AGI_INT:
     case STAT_SPIRIT:
     case STAT_SPELL_POWER:
     case STAT_ATTACK_POWER:
@@ -7220,6 +7224,10 @@ void player_t::stat_loss( stat_e stat, double amount, gain_t* gain, action_t* ac
     case STAT_STRENGTH:
     case STAT_AGILITY:
     case STAT_INTELLECT:
+    case STAT_AGI_INT:
+    case STAT_STR_AGI:
+    case STAT_STR_INT:
+    case STAT_STR_AGI_INT:
     case STAT_SPIRIT:
     case STAT_SPELL_POWER:
     case STAT_ATTACK_POWER:

--- a/engine/sc_enums.hpp
+++ b/engine/sc_enums.hpp
@@ -1071,6 +1071,7 @@ enum cache_e
   CACHE_AGI_INT,
   CACHE_STR_AGI,
   CACHE_STR_INT,
+  CACHE_STR_AGI_INT,
   CACHE_SPELL_POWER,
   CACHE_ATTACK_POWER,
   CACHE_TOTAL_MELEE_ATTACK_POWER,
@@ -1138,6 +1139,7 @@ check( SPIRIT );
 check( AGI_INT );
 check( STR_AGI );
 check( STR_INT );
+check( STR_AGI_INT );
 #undef check
 
 inline cache_e cache_from_stat( stat_e st )
@@ -1149,6 +1151,10 @@ inline cache_e cache_from_stat( stat_e st )
       case STAT_STAMINA:
       case STAT_INTELLECT:
       case STAT_SPIRIT:
+      case STAT_AGI_INT:
+      case STAT_STR_AGI:
+      case STAT_STR_INT:
+      case STAT_STR_AGI_INT:
         return static_cast<cache_e>( st );
       case STAT_SPELL_POWER:
         return CACHE_SPELL_POWER;


### PR DESCRIPTION
These four stats were missing from several asserts and were not possible to cast from stat to cache as well.

There may be other missing stats, but those are the only ones that have come up in my testing so far.