### PR TITLE
[cmake] EVENT_QUEUE_DEBUG Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(SC_NO_NETWORKING "Disable all networking related stuff." OFF)
 # Install everything into a flat folder structure by default for packaging on windows
 option(SC_USE_FLAT_INSTALL "Install files into a flat folder structure" ${WIN32})
 
-option(EVENT_QUEUE_DEBUG "Enable Event Queue Debug Info" OFF)
+option(SC_EVENT_QUEUE_DEBUG "Enable Event Queue Debug Info" OFF)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Projects Settings   
+# Projects Settings
 cmake_minimum_required (VERSION 3.10...3.22)
 
 # Set OSX minimum version parity with Qt project
@@ -15,6 +15,8 @@ option(SC_NO_NETWORKING "Disable all networking related stuff." OFF)
 
 # Install everything into a flat folder structure by default for packaging on windows
 option(SC_USE_FLAT_INSTALL "Install files into a flat folder structure" ${WIN32})
+
+option(EVENT_QUEUE_DEBUG "Enable Event Queue Debug Info" OFF)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
@@ -82,7 +84,7 @@ install(TARGETS simc DESTINATION ${SIMC_INSTALL_BIN})
 
 install(DIRECTORY profiles/ DESTINATION ${SIMC_INSTALL_SHARED}/profiles
     FILES_MATCHING PATTERN "*.simc" )
-install(FILES 
+install(FILES
   README.md
   CONTRIBUTING.md
   COPYING

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -41,9 +41,13 @@ if(NOT SC_NO_NETWORKING)
     endif()
 endif()
 
+if(SC_EVENT_QUEUE_DEBUG)
+    target_compile_definitions(engine PUBLIC EVENT_QUEUE_DEBUG)
+endif()
+
 target_compile_definitions(engine PRIVATE "SC_GIT_REV=\"${GIT_COMMIT_HASH}\"" "SC_GIT_BRANCH=\"${GIT_BRANCH}\"")
 
-add_custom_target(file_toucher 
+add_custom_target(file_toucher
         COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${CMAKE_CURRENT_SOURCE_DIR}/util/git_info.cpp)
 
 add_dependencies(engine file_toucher)


### PR DESCRIPTION
 Allow for the EVENT_QUEUE_DEBUG option to be enabled in cmake more easily when using Cmake to build.