### PR TITLE
[sim] Do not prevent the default actor from performing its actions.

### DIFF
--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2804,7 +2804,6 @@ void sim_t::init()
     if ( main_target_str.empty() && target_list.empty() )
     {
       target = module_t::enemy()->create_player( this, "Dungeon" );
-      // target->initial.sleeping = target->base.sleeping = target->current.sleeping = true;
     }
     else
     {

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2330,11 +2330,11 @@ void sim_t::init_fight_style()
     case FIGHT_STYLE_PATCHWERK:
       raid_events_str.clear();
       break;
-    
+
     case FIGHT_STYLE_CASTING_PATCHWERK:
       raid_events_str += "/casting,cooldown=500,duration=500";
       break;
-    
+
     case FIGHT_STYLE_HECTIC_ADD_CLEAVE:
     {
       // Phase 1 - Adds and move into position to fight adds
@@ -2356,7 +2356,7 @@ void sim_t::init_fight_style()
                                       first2, cooldown2 );
     }
     break;
-    
+
     case FIGHT_STYLE_DUNGEON_SLICE:
       desired_targets = 1;
       max_time = timespan_t::from_seconds( 360.0 );
@@ -2369,7 +2369,7 @@ void sim_t::init_fight_style()
         "/adds,name=SmallAdd,count=5,count_range=1,first=140,cooldown=45,duration=18,duration_stddev=2"
         "/adds,name=BigAdd,count=2,count_range=1,first=160,cooldown=50,duration=30,duration_stddev=2";
       break;
-    
+
     case FIGHT_STYLE_DUNGEON_ROUTE:
       // To be used in conjunction with "pull" raid events for a simulated dungeon run.
       desired_targets = 1;
@@ -2377,7 +2377,7 @@ void sim_t::init_fight_style()
       // Bloodlust is handled by an option on each pull raid event.
       overrides.bloodlust = 0;
       break;
-    
+
     case FIGHT_STYLE_CLEAVE_ADD:
     {
       auto first_and_duration = static_cast<unsigned>( max_time.total_seconds() * 0.05 );
@@ -2388,16 +2388,16 @@ void sim_t::init_fight_style()
                                       first_and_duration, cooldown, first_and_duration, last );
     }
     break;
-    
+
     case FIGHT_STYLE_LIGHT_MOVEMENT:
       raid_events_str += "/movement,players_only=1,cooldown=40,cooldown_stddev=10,distance=15,distance_min=10,distance_max=20,first=15";
       break;
-    
+
     case FIGHT_STYLE_HEAVY_MOVEMENT:
       raid_events_str += "/movement,players_only=1,cooldown=20,cooldown_stddev=15,distance=25,distance_min=20,distance_max=30,first=15";
       raid_events_str += "/movement,players_only=1,cooldown=45,cooldown_stddev=15,distance=45,distance_min=40,distance_max=50,first=30";
       break;
-    
+
     case FIGHT_STYLE_BEASTLORD:
     {
       deprecated = true;
@@ -2420,7 +2420,7 @@ void sim_t::init_fight_style()
                                       beast_last );
     }
     break;
-    
+
     case FIGHT_STYLE_HELTER_SKELTER:
       deprecated = true;
       raid_events_str += "/casting,cooldown=30,duration=3,first=15";
@@ -2428,7 +2428,7 @@ void sim_t::init_fight_style()
       raid_events_str += "/stun,cooldown=60,duration=2";
       raid_events_str += "/invulnerable,cooldown=120,duration=3";
       break;
-    
+
     case FIGHT_STYLE_ULTRAXION:
       deprecated = true;
       max_time = timespan_t::from_seconds( 366.0 );
@@ -2445,7 +2445,7 @@ void sim_t::init_fight_style()
       raid_events_str += "/damage,first=240.0,period=2.0,last=299.5,amount=44855,type=shadow";
       raid_events_str += "/damage,first=300.0,period=1.0,amount=44855,type=shadow";
       break;
-    
+
     default:
       fight_style = FIGHT_STYLE_PATCHWERK;
       break;
@@ -2804,7 +2804,7 @@ void sim_t::init()
     if ( main_target_str.empty() && target_list.empty() )
     {
       target = module_t::enemy()->create_player( this, "Dungeon" );
-      target->initial.sleeping = target->base.sleeping = target->current.sleeping = true;
+      // target->initial.sleeping = target->base.sleeping = target->current.sleeping = true;
     }
     else
     {


### PR DESCRIPTION
Commit 4be94135517 caused Fluffy Pillow to no longer be the default actor used in all sims and the new default actor for DungeonSlice and DungeonRoute Dungeon is forced to sleep immediately upon initialization.

This causes tanks to not take damage in DungeonSlice sims, which makes the fight style perform poorly.

Given that DungeonRoute sims can have damage dealt to the actor configured, this may not be an appropriate change for DungeonRoute.

An alternative approach would be to provide all sims with an actor that deals damage to all tank-roled players that are active by default, with a global sim option to disable this behaviour.