### PR TITLE
[raid_events] Option Deprecation

### DIFF
--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -1498,7 +1498,7 @@ void enemy_t::add_tank_heal_raid_event( tank_dummy_e tank_dummy )
   //                                           NONE, WEAK, DUNGEON, RAID,  HEROIC, MYTHIC
   std::array<int, numTankDummies> heal_value = { 0, 12000, 24000, 36000, 48000, 60000 };
   size_t tank_dummy_index                    = static_cast<size_t>( tank_dummy );
-  std::string heal_raid_event = fmt::format( "heal,name=tank_heal,amount={},period=0.5,duration=0,player_if=role.tank",
+  std::string heal_raid_event = fmt::format( "heal,name=tank_heal,amount={},cooldown=0.5,duration=0,player_if=role.tank",
                                              heal_value[ tank_dummy_index ] );
   sim->raid_events_str += "/" + heal_raid_event;
   std::string::size_type cut_pt = heal_raid_event.find_first_of( ',' );

--- a/engine/sim/raid_event.hpp
+++ b/engine/sim/raid_event.hpp
@@ -83,11 +83,11 @@ public:
   {
     return distance_max;
   }
-  double min_distance()
+  double max_distance()
   {
     return distance_min;
   }
-  double max_distance()
+  double min_distance()
   {
     return distance_max;
   }

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2437,14 +2437,14 @@ void sim_t::init_fight_style()
       vary_combat_length = 0.0;
       raid_events_str += "/flying,first=0,duration=500,cooldown=500";
       raid_events_str += "/position_switch,first=0,duration=500,cooldown=500";
-      raid_events_str += "/stun,duration=1.0,first=45.0,period=45.0";
-      raid_events_str += "/stun,duration=1.0,first=57.0,period=57.0";
-      raid_events_str += "/damage,first=6.0,period=6.0,last=59.5,amount=44000,type=shadow";
-      raid_events_str += "/damage,first=60.0,period=5.0,last=119.5,amount=44855,type=shadow";
-      raid_events_str += "/damage,first=120.0,period=4.0,last=179.5,amount=44855,type=shadow";
-      raid_events_str += "/damage,first=180.0,period=3.0,last=239.5,amount=44855,type=shadow";
-      raid_events_str += "/damage,first=240.0,period=2.0,last=299.5,amount=44855,type=shadow";
-      raid_events_str += "/damage,first=300.0,period=1.0,amount=44855,type=shadow";
+      raid_events_str += "/stun,duration=1.0,first=45.0,cooldown=45.0";
+      raid_events_str += "/stun,duration=1.0,first=57.0,cooldown=57.0";
+      raid_events_str += "/damage,first=6.0,cooldown=6.0,last=59.5,amount=44000,type=shadow";
+      raid_events_str += "/damage,first=60.0,cooldown=5.0,last=119.5,amount=44855,type=shadow";
+      raid_events_str += "/damage,first=120.0,cooldown=4.0,last=179.5,amount=44855,type=shadow";
+      raid_events_str += "/damage,first=180.0,cooldown=3.0,last=239.5,amount=44855,type=shadow";
+      raid_events_str += "/damage,first=240.0,cooldown=2.0,last=299.5,amount=44855,type=shadow";
+      raid_events_str += "/damage,first=300.0,cooldown=1.0,amount=44855,type=shadow";
       break;
 
     default:


### PR DESCRIPTION
Deprecates or deduplicates the following options:
* `raid_event_t::period` -> Deprecated in favor of `raid_event_t::cooldown`.
* `movement_event_t::distance_min`, `movement_event_t::distance_max` -> Removed, already provided by `raid_event_t`.
* `adds_event_t::spawn_radius_min`, `adds_event_t::spawn_radius_max` -> Deprecated in favor of `raid_event_t::distance_min`, `raid_event_t::distance_max`, as they are named more similarly to the option name and already exist.

Small piece of my ongoing work in `raid_event`. Currently focusing on taking a look through all of the options and make the APL interface more consistent between each raid event, as they have a lot of shared options.