### PR TITLE
Add health% timeline to JSON and HTML output

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -6796,6 +6796,8 @@ void player_t::collect_resource_timeline_information()
     elem.timeline.add( sim->current_time(), resources.current[ elem.type ] );
   }
 
+  collected_data.health_pct.add( sim->current_time(), health_percentage() );
+
   for ( auto& elem : collected_data.stat_timelines )
   {
     auto value = get_stat_value(elem.type);
@@ -13390,6 +13392,7 @@ player_collected_data_t::player_collected_data_t( const player_t* player ) :
   max_spike_amount( player->name_str + " Max Spike Value", tank_container_type( player, 2 ) ),
   target_metric( player->name_str + " Target Metric", generic_container_type( player, 1 ) ),
   resource_timelines(),
+  health_pct(),
   combat_start_resource(
     ( !player->is_enemy() && ( !player->is_pet() || player->sim->report_pets_separately ) ) ? RESOURCE_MAX : 0 ),
   combat_end_resource(
@@ -13499,6 +13502,8 @@ void player_collected_data_t::merge( const player_t& other_player )
     }
   }
 
+  health_pct.merge( other.health_pct );
+
   for ( size_t i = 0, end = combat_start_resource.size(); i < end; ++i )
   {
     combat_start_resource[ i ].merge( other.combat_start_resource[ i ] );
@@ -13551,6 +13556,7 @@ void player_collected_data_t::analyze( const player_t& p )
     timeline_dmg_taken.adjust( *p.sim );
     timeline_healing_taken.adjust( *p.sim );
 
+    health_pct.adjust( *p.sim );
     range::for_each( resource_timelines, [&p]( resource_timeline_t& tl ) { tl.timeline.adjust( *p.sim ); } );
     range::for_each( stat_timelines, [&p]( stat_timeline_t& tl ) { tl.timeline.adjust( *p.sim ); } );
 
@@ -13565,6 +13571,7 @@ void player_collected_data_t::analyze( const player_t& p )
     timeline_dmg_taken.adjust( fight_length );
     timeline_healing_taken.adjust( fight_length );
 
+    health_pct.adjust( fight_length );
     range::for_each( resource_timelines, [this]( resource_timeline_t& tl ) { tl.timeline.adjust( fight_length ); } );
     range::for_each( stat_timelines, [this]( stat_timeline_t& tl ) { tl.timeline.adjust( fight_length ); } );
 

--- a/engine/player/player_collected_data.hpp
+++ b/engine/player/player_collected_data.hpp
@@ -68,6 +68,9 @@ struct player_collected_data_t
   };
   // Druid requires 4 resource timelines health/mana/energy/rage
   std::vector<resource_timeline_t> resource_timelines;
+  // For some actors (typically enemies), health and health percentage
+  // timelines might not match. Track health percentage separately.
+  sc_timeline_t health_pct;
 
   std::vector<simple_sample_data_t> combat_start_resource;
   std::vector<simple_sample_data_with_min_max_t> combat_end_resource;

--- a/engine/report/json/report_json.cpp
+++ b/engine/report/json/report_json.cpp
@@ -636,6 +636,7 @@ void collected_data_to_json( JsonOutput root, const ::report::json::report_confi
       if ( it != cd.resource_timelines.end() )
       {
         root[ "resource_timelines" ][ util::resource_type_string( r ) ] = it -> timeline;
+        if ( r == RESOURCE_HEALTH ) root[ "resource_timelines" ][ "health_pct" ] = cd.health_pct;
       }
     } );
 

--- a/engine/report/report_html_player.cpp
+++ b/engine/report/report_html_player.cpp
@@ -3181,6 +3181,16 @@ void print_html_player_resources( report::sc_html_stream& os, const player_t& p 
 
     os << ts.to_target_div();
     p.sim->add_chart_data( ts );
+
+    if ( p.is_enemy() && timeline.type == RESOURCE_HEALTH )
+    {
+      highchart::time_series_t pct_ts( highchart::build_id( p, "resource_health_pct" ), *p.sim );
+      chart::generate_actor_timeline( pct_ts, p, "health_pct", color::resource_color( RESOURCE_HEALTH ), p.collected_data.health_pct );
+      pct_ts.set_mean( p.collected_data.health_pct.mean() );
+
+      os << pct_ts.to_target_div();
+      p.sim->add_chart_data( pct_ts );
+    }
   }
 
   if ( p.primary_role() == ROLE_TANK && !p.is_enemy() )  // Experimental, restrict to tanks for now


### PR DESCRIPTION
The enemy health graph tends to confuse people when simc runs with `fixed_time=1`. Instead of removing/hiding it, make the information about what's happening to health% explicit.