### PR TITLE
[Warlock] Fixed Demonic Inspiration talent to only affect the main pet

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -253,7 +253,7 @@ double warlock_pet_t::composite_spell_haste() const
 {
   double m = pet_t::composite_spell_haste();
 
-  if ( o()->talents.demonic_inspiration->ok() )
+  if ( is_main_pet &&  o()->talents.demonic_inspiration->ok() )
     m *= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
 
   return m;
@@ -263,7 +263,7 @@ double warlock_pet_t::composite_spell_speed() const
 {
   double m = pet_t::composite_spell_speed();
 
-  if ( o()->talents.demonic_inspiration->ok() )
+  if ( is_main_pet &&  o()->talents.demonic_inspiration->ok() )
       m /= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
 
   return m;
@@ -273,7 +273,7 @@ double warlock_pet_t::composite_melee_speed() const
 {
   double m = pet_t::composite_melee_speed();
 
-  if ( o()->talents.demonic_inspiration->ok() )
+  if ( is_main_pet && o()->talents.demonic_inspiration->ok() )
     m /= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
 
   return m;


### PR DESCRIPTION
[Demonic Inspiration](https://www.wowhead.com/spell=386858/demonic-inspiration?spellModifier=137044) talent increases the attack speed of the main pet by 5%, and only the main pet.

Simc is increasing the attack speed of all pets by default with this talent, and only some pets (Grimoire: Felguard and Pit Lord) have the ``composite_melee_speed`` function overloaded so they are not affected.

The changes simply add a ``is_main_pet`` check in the default ``warlock_pet_t::composite_spell_haste``, ``warlock_pet_t::composite_spell_speed``, ``warlock_pet_t::composite_melee_speed`` functions. This boolean is already present in the ``warlock_pet_t`` class, so it's a straightforward change.