### PR TITLE
[CI] Regenerate profiles automatically on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
+            generate_profiles_ci.sh
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-clang-build:
@@ -139,6 +140,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
+            generate_profiles_ci.sh
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-run:
@@ -182,6 +184,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
+            generate_profiles_ci.sh
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
       - name: Run
@@ -226,6 +229,7 @@ jobs:
             ${{ runner.workspace }}/b/ninja/simc
             profiles
             tests
+            generate_profiles_ci.sh
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
       - name: Install Python dependencies
@@ -239,6 +243,47 @@ jobs:
           SIMC_THREADS: 2
           SIMC_ITERATIONS: 2
         run: ${{ github.workspace }}/tests/run.py ${{ matrix.spec }} -tests trinket baseline --max-profiles-to-use 1 --enable-all-talents --enable-all-sets
+  
+  simc-profiles:
+    name: profiles
+    runs-on: ${{ matrix.os }}
+    needs: [ ubuntu-clang-build ]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cppVersion: [17]
+        compiler: [clang++-15]        
+        include:
+          - compiler: clang++-15
+            os: ubuntu-22.04
+    
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ runner.workspace }}/b/ninja/simc
+            profiles
+            tests
+            generate_profiles_ci.sh
+          key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+
+      - name: Run
+        env:
+          UBSAN_OPTIONS: print_stacktrace=1
+          SIMC_CLI_PATH: ${{ runner.workspace }}/b/ninja/simc
+          SIMC_PROFILE_DIR: ${{ github.workspace }}/profiles/${{ matrix.tier }}
+          SIMC_THREADS: 2
+          SIMC_ITERATIONS: 2
+        run: ${{ github.workspace }}/generate_profiles_ci.sh
+
+      - name: Commit Profiles
+        uses: EndBug/add-and-commit@v9.1.4
+        with:
+          message: 'Regenerate profiles'
+          default_author: github_actions
+          fetch: false
+          add: '*.simc'
 
   build-osx:
     name: macos-latest
@@ -268,6 +313,9 @@ jobs:
        
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
 
        # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
@@ -276,6 +324,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1       
         with:
           arch: ${{ matrix.arch }}
+
 
       - name: Generate project files
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
             profiles
             tests
             generate_profiles_ci.sh
+            .git
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-clang-build:
@@ -141,6 +142,7 @@ jobs:
             profiles
             tests
             generate_profiles_ci.sh
+            .git
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
   ubuntu-run:
@@ -185,6 +187,7 @@ jobs:
             profiles
             tests
             generate_profiles_ci.sh
+            .git
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
       - name: Run
@@ -230,6 +233,7 @@ jobs:
             profiles
             tests
             generate_profiles_ci.sh
+            .git
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
 
       - name: Install Python dependencies
@@ -248,6 +252,7 @@ jobs:
     name: profiles
     runs-on: ${{ matrix.os }}
     needs: [ ubuntu-clang-build ]
+    if: ${{ github.event_name == 'push' }}
 
     strategy:
       fail-fast: false
@@ -266,7 +271,10 @@ jobs:
             profiles
             tests
             generate_profiles_ci.sh
+            .git
           key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+
+      - uses: actions/checkout@v4
 
       - name: Run
         env:
@@ -275,7 +283,8 @@ jobs:
           SIMC_PROFILE_DIR: ${{ github.workspace }}/profiles/${{ matrix.tier }}
           SIMC_THREADS: 2
           SIMC_ITERATIONS: 2
-        run: ${{ github.workspace }}/generate_profiles_ci.sh
+        run: | 
+          ${{ github.workspace }}/generate_profiles_ci.sh
 
       - name: Commit Profiles
         uses: EndBug/add-and-commit@v9.1.4
@@ -313,10 +322,7 @@ jobs:
        
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-
+      
        # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,7 @@ jobs:
         run: ${{ github.workspace }}/tests/run.py ${{ matrix.spec }} -tests trinket baseline --max-profiles-to-use 1 --enable-all-talents --enable-all-sets
   
   simc-profiles:
-    name: profiles
+    name: Regenerate profiles
     runs-on: ${{ matrix.os }}
     needs: [ ubuntu-clang-build ]
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,7 +322,7 @@ jobs:
        
     steps:
       - uses: actions/checkout@v3
-      
+
        # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
       
@@ -330,7 +330,6 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1       
         with:
           arch: ${{ matrix.arch }}
-
 
       - name: Generate project files
         run: |

--- a/generate_profiles_ci.sh
+++ b/generate_profiles_ci.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -e
+
+if [ ! -d "profiles" ]; then
+  echo 'You must run this script with simc root as current working directory.'
+  exit 0
+fi
+cd 'profiles'
+PROFDIR='PreRaids'
+echo "---$PROFDIR---"
+if [ -d $PROFDIR ]; then
+  cd $PROFDIR/
+  ${SIMC_CLI_PATH} "../generators/$PROFDIR/PR_Generate.simc"
+  cd ../
+else
+  echo 'Skipped PreRaids, directory not found.'
+fi
+for tier in 29 30 31
+do
+  PROFDIR="Tier$tier"
+  echo "---$PROFDIR---"
+  if [ ! -d $PROFDIR ]; then
+    echo "Skipped $PROFDIR, directory not found."
+    continue
+  fi
+  cd $PROFDIR/
+  ${SIMC_CLI_PATH} '../generators/Tier'$tier'/T'$tier'_Generate.simc'
+  cd ../
+done
+echo 'done'


### PR DESCRIPTION
Adds automatic profile regen to our CI steps. Forgetting to run profile generation after changing a gear piece or apl line is a common mistake, but it can be quickly done without manual intervention. This is set up to only run on push. The [docs](https://github.com/marketplace/actions/add-commit#working-with-prs) for the commit action indicate that it can run into issues when running on PR workflows due to write access issues.

The actions logs for a test run can be found [here](https://github.com/Khazakdk/simc/actions/runs/7990849959) and the commit generated can be found [here](https://github.com/Khazakdk/simc/commit/2bd34749e9afea58de192e0330df9df92952b81b).

Changes
- New script that uses an env variable to run the simc cli instead of relying on a hardcoded path
- Add new script and git folder to cache to avoid doing another full repo checkout. When checkout runs for the new step, it only needs to establish the ref to be used later on the commit action. [Log here](https://github.com/Khazakdk/simc/actions/runs/7990849959/job/21820687213)
- Create new CI step to run the script and commit the changes, with the commit done as the actions user

