### PR TITLE
[Warlock] Fix occasional 6th Drain Soul tick

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -466,10 +466,12 @@ struct drain_soul_t : public affliction_spell_t
 
   timespan_t composite_dot_duration( const action_state_t* s ) const override
   {
-    timespan_t dur = dot_duration * ( ( base_tick_time * s->haste ) / base_tick_time );
-
+    double modifier = 1.0;
+    
     if ( p()->buffs.nightfall->check() )
-      dur *= 1.0 + p()->talents.nightfall_buff->effectN( 4 ).percent();
+      modifier += p()->talents.nightfall_buff->effectN( 4 ).percent();
+
+    timespan_t dur = dot_duration * (( s->haste * modifier * base_tick_time ) / base_tick_time );
 
     return dur;
   }


### PR DESCRIPTION
Re-ordered multiplication, hopefully preserves some precision before multiplying into timespans.

Appears to resolve the issue of occasional 6-tick DS and is reflected in logs and haste scaling plots matching expectations.