### PR TITLE
[rng] Add additional timespan_t gauss_* methods and remove uses of clamp on randomly generated values.

### DIFF
--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -986,18 +986,12 @@ struct pause_action_t : public action_t
 
   timespan_t execute_time() const override
   {
-    timespan_t duration = sim->rng().gauss( base_execute_time, duration_stddev );
-
-    duration = clamp( duration, duration_min, duration_max );
-
-    return duration;
+    return sim->rng().gauss_ab( base_execute_time, duration_stddev, duration_min, duration_max );
   }
 
   void update_ready( timespan_t /* cd_duration */ ) override
   {
-    timespan_t cd = sim->rng().gauss( cooldown->duration, cooldown_stddev );
-
-    cd = clamp( cd, cooldown_min, cooldown_max );
+    timespan_t cd = sim->rng().gauss_ab( cooldown->duration, cooldown_stddev, cooldown_min, cooldown_max );
 
     action_t::update_ready( cd );
   }

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -3160,8 +3160,8 @@ struct arcane_missiles_t final : public arcane_mage_spell_t
     if ( p()->bugs && tick_remains > 0_ms )
     {
       timespan_t mean_delay = p()->options.arcane_missiles_chain_delay;
-      timespan_t delay = rng().gauss( mean_delay, mean_delay * p()->options.arcane_missiles_chain_relstddev );
-      timespan_t chain_remains = tick_remains - clamp( delay, 0_ms, tick_remains - 1_ms );
+      timespan_t delay = rng().gauss_b( mean_delay, mean_delay * p()->options.arcane_missiles_chain_relstddev, tick_remains - 1_ms );
+      timespan_t chain_remains = tick_remains - delay;
       // If tick_remains == 0_ms, this would subtract 1 from ticks.
       // This is not implemented in simc, but this actually appears
       // to happen in game, which can result in missing ticks if

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -3160,7 +3160,7 @@ struct arcane_missiles_t final : public arcane_mage_spell_t
     if ( p()->bugs && tick_remains > 0_ms )
     {
       timespan_t mean_delay = p()->options.arcane_missiles_chain_delay;
-      timespan_t delay = rng().gauss_b( mean_delay, mean_delay * p()->options.arcane_missiles_chain_relstddev, tick_remains - 1_ms );
+      timespan_t delay = rng().gauss_ab( mean_delay, mean_delay * p()->options.arcane_missiles_chain_relstddev, 0_ms, tick_remains - 1_ms );
       timespan_t chain_remains = tick_remains - delay;
       // If tick_remains == 0_ms, this would subtract 1 from ticks.
       // This is not implemented in simc, but this actually appears

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -1351,7 +1351,7 @@ void darkmoon_deck_watcher( special_effect_t& effect )
       shield->trigger( dur );
 
       // TODO: placeholder value put at 2s before depletion. change to reasonable value.
-      auto deplete = rng().gauss_b( sim->dragonflight_opts.darkmoon_deck_watcher_deplete, 1_s, dur );
+      auto deplete = rng().gauss_ab( sim->dragonflight_opts.darkmoon_deck_watcher_deplete, 1_s, 0_s, dur );
 
       make_event( *sim, deplete, [ this ]() { shield->expire(); } );
     }

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -1351,8 +1351,7 @@ void darkmoon_deck_watcher( special_effect_t& effect )
       shield->trigger( dur );
 
       // TODO: placeholder value put at 2s before depletion. change to reasonable value.
-      auto deplete = rng().gauss( sim->dragonflight_opts.darkmoon_deck_watcher_deplete, 1_s );
-      clamp( deplete, 0_ms, dur );
+      auto deplete = rng().gauss_b( sim->dragonflight_opts.darkmoon_deck_watcher_deplete, 1_s, dur );
 
       make_event( *sim, deplete, [ this ]() { shield->expire(); } );
     }

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -1487,9 +1487,9 @@ void anima_field_emitter( special_effect_t& effect )
       timespan_t buff_duration = max_duration;
       if ( listener->sim->shadowlands_opts.anima_field_emitter_mean != std::numeric_limits<double>::max() )
       {
-        buff_duration = timespan_t::from_seconds( listener->sim->rng().gauss_b( listener->sim->shadowlands_opts.anima_field_emitter_mean,
+        buff_duration = timespan_t::from_seconds( listener->sim->rng().gauss_ab( listener->sim->shadowlands_opts.anima_field_emitter_mean,
                                                                                   listener->sim->shadowlands_opts.anima_field_emitter_stddev,
-                                                                                  max_duration.total_seconds() ) );
+                                                                                 0.0, max_duration.total_seconds() ) );
       }
 
       if ( buff_duration > timespan_t::zero() )

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -1487,9 +1487,9 @@ void anima_field_emitter( special_effect_t& effect )
       timespan_t buff_duration = max_duration;
       if ( listener->sim->shadowlands_opts.anima_field_emitter_mean != std::numeric_limits<double>::max() )
       {
-        double new_duration = rng().gauss( listener->sim->shadowlands_opts.anima_field_emitter_mean,
-            listener->sim->shadowlands_opts.anima_field_emitter_stddev );
-        buff_duration = timespan_t::from_seconds( clamp( new_duration, 0.0, max_duration.total_seconds() ) );
+        buff_duration = timespan_t::from_seconds( listener->sim->rng().gauss_b( listener->sim->shadowlands_opts.anima_field_emitter_mean,
+                                                                                  listener->sim->shadowlands_opts.anima_field_emitter_stddev,
+                                                                                  max_duration.total_seconds() ) );
       }
 
       if ( buff_duration > timespan_t::zero() )

--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -2040,6 +2040,7 @@ void raid_event_t::reset()
   event_t::cancel( duration_event );
   event_t::cancel( start_event );
   event_t::cancel( end_event );
+
   affected_players.clear();
 }
 

--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -1697,9 +1697,7 @@ timespan_t raid_event_t::cooldown_time()
   }
   else
   {
-    time = sim->rng().gauss( cooldown, cooldown_stddev );
-
-    time = clamp( time, cooldown_min, cooldown_max );
+    time = sim->rng().gauss_ab( cooldown, cooldown_stddev, cooldown_min, cooldown_max );
   }
 
   return time;
@@ -1707,11 +1705,7 @@ timespan_t raid_event_t::cooldown_time()
 
 timespan_t raid_event_t::duration_time()
 {
-  timespan_t time = sim->rng().gauss( duration, duration_stddev );
-
-  time = clamp( time, duration_min, duration_max );
-
-  return time;
+  return sim->rng().gauss_ab( duration, duration_stddev, duration_min, duration_max );
 }
 
 timespan_t raid_event_t::next_time() const

--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -1653,6 +1653,7 @@ raid_event_t::raid_event_t( sim_t* s, util::string_view type )
     affected_role( ROLE_NONE ),
     player_if_expr_str(),
     saved_duration( timespan_t::zero() ),
+    saved_cooldown( timespan_t::zero() ),
     player_expressions(),
     is_up( false ),
     activation_status( activation_status_e::not_yet_activated ),
@@ -2017,6 +2018,7 @@ void raid_event_t::schedule()
 
       if ( raid_event->activation_status == activation_status_e::activated )
       {
+        raid_event->saved_cooldown = ct;
         raid_event->cooldown_event = make_event<cooldown_event_t>( sim(), sim(), raid_event, ct );
       }
       else
@@ -2381,10 +2383,10 @@ double raid_event_t::evaluate_raid_event_expression( sim_t* s, util::string_view
   }
 
   if ( filter == "duration" )
-    return e->duration_time().total_seconds();
+    return e->saved_duration.total_seconds() != 0.0 ? e->saved_duration.total_seconds() : e->duration.total_seconds();
 
   if ( filter == "cooldown" )
-    return e->cooldown_time().total_seconds();
+    return e->saved_cooldown.total_seconds() != 0.0 ? e->saved_cooldown.total_seconds() : e->cooldown.total_seconds();
 
   if ( filter == "distance" )
     return e->distance_max;

--- a/engine/sim/raid_event.hpp
+++ b/engine/sim/raid_event.hpp
@@ -59,6 +59,7 @@ public:
   std::string player_if_expr_str;
 
   timespan_t saved_duration;
+  timespan_t saved_cooldown;
   std::vector<player_t*> affected_players;
   std::unordered_map<size_t, std::unique_ptr<expr_t>> player_expressions;
   std::vector<std::unique_ptr<option_t>> options;

--- a/engine/util/rng.hpp
+++ b/engine/util/rng.hpp
@@ -323,7 +323,8 @@ template <typename Engine>
 timespan_t basic_rng_t<Engine>::gauss( timespan_t mean, timespan_t stddev )
 {
   return timespan_t::from_native( gauss_a( static_cast<double>( timespan_t::to_native( mean ) ),
-                                           static_cast<double>( timespan_t::to_native( stddev ) ), 0.0 ) );
+                                           static_cast<double>( timespan_t::to_native( stddev ) ),
+                                           0.0 ) );
 }
 
 template <typename Engine>
@@ -346,9 +347,10 @@ timespan_t basic_rng_t<Engine>::gauss_a( timespan_t mean, timespan_t stddev, tim
 template <typename Engine>
 timespan_t basic_rng_t<Engine>::gauss_b( timespan_t mean, timespan_t stddev, timespan_t max )
 {
-  return timespan_t::from_native( gauss_b( static_cast<double>( timespan_t::to_native( mean ) ),
-                                           static_cast<double>( timespan_t::to_native( stddev ) ),
-                                           static_cast<double>( timespan_t::to_native( max ) ) ) );
+  return timespan_t::from_native( gauss_ab( static_cast<double>( timespan_t::to_native( mean ) ),
+                                            static_cast<double>( timespan_t::to_native( stddev ) ),
+                                            0.0,
+                                            static_cast<double>( timespan_t::to_native( max ) ) ) );
 }
 
 template <typename Engine>

--- a/engine/util/rng.hpp
+++ b/engine/util/rng.hpp
@@ -270,10 +270,13 @@ template <typename Engine>
 double basic_rng_t<Engine>::gauss_ab( double mean, double stddev, double min, double max )
 {
   assert( stddev >= 0.0 && "Stddev must be non-negative." );
-  assert( min < max && "Minimum must be less than maximum." );
+  assert( min <= max && "Minimum must be less than or equal to maximum." );
   assert( mean >= min && mean <= max && "Mean must be contained within the interval [min, max]" );
 
   if ( stddev == 0.0 )
+    return mean;
+
+  if ( min == max )
     return mean;
 
   double min_cdf      = stdnormal_cdf( ( min - mean ) / stddev );

--- a/engine/util/rng.hpp
+++ b/engine/util/rng.hpp
@@ -279,7 +279,7 @@ double basic_rng_t<Engine>::gauss_ab( double mean, double stddev, double min, do
   }
 
   if ( min == max )
-    return mean;
+    return min;
 
   double min_cdf      = stdnormal_cdf( ( min - mean ) / stddev );
   double max_cdf      = stdnormal_cdf( ( max - mean ) / stddev );

--- a/engine/util/rng.hpp
+++ b/engine/util/rng.hpp
@@ -271,10 +271,12 @@ double basic_rng_t<Engine>::gauss_ab( double mean, double stddev, double min, do
 {
   assert( stddev >= 0.0 && "Stddev must be non-negative." );
   assert( min <= max && "Minimum must be less than or equal to maximum." );
-  assert( mean >= min && mean <= max && "Mean must be contained within the interval [min, max]" );
 
   if ( stddev == 0.0 )
+  {
+    assert( mean >= min && mean <= max && "Mean must be contained within the interval [min, max]" );
     return mean;
+  }
 
   if ( min == max )
     return mean;

--- a/engine/util/rng.hpp
+++ b/engine/util/rng.hpp
@@ -117,6 +117,9 @@ public:
 
   /// Timespan Gaussian Distribution
   timespan_t gauss( timespan_t mean, timespan_t stddev );
+  timespan_t gauss_ab( timespan_t mean, timespan_t stddev, timespan_t min, timespan_t max );
+  timespan_t gauss_a( timespan_t mean, timespan_t stddev, timespan_t min );
+  timespan_t gauss_b( timespan_t mean, timespan_t stddev, timespan_t max );
 
   /// Timespan Exponential Distribution
   timespan_t exponential( timespan_t nu );
@@ -321,6 +324,31 @@ timespan_t basic_rng_t<Engine>::gauss( timespan_t mean, timespan_t stddev )
 {
   return timespan_t::from_native( gauss_a( static_cast<double>( timespan_t::to_native( mean ) ),
                                            static_cast<double>( timespan_t::to_native( stddev ) ), 0.0 ) );
+}
+
+template <typename Engine>
+timespan_t basic_rng_t<Engine>::gauss_ab( timespan_t mean, timespan_t stddev, timespan_t min, timespan_t max )
+{
+  return timespan_t::from_native( gauss_ab( static_cast<double>( timespan_t::to_native( mean ) ),
+                                            static_cast<double>( timespan_t::to_native( stddev ) ),
+                                            static_cast<double>( timespan_t::to_native( min ) ),
+                                            static_cast<double>( timespan_t::to_native( max ) ) ) );
+}
+
+template <typename Engine>
+timespan_t basic_rng_t<Engine>::gauss_a( timespan_t mean, timespan_t stddev, timespan_t min )
+{
+  return timespan_t::from_native( gauss_a( static_cast<double>( timespan_t::to_native( mean ) ),
+                                           static_cast<double>( timespan_t::to_native( stddev ) ),
+                                           static_cast<double>( timespan_t::to_native( min ) ) ) );
+}
+
+template <typename Engine>
+timespan_t basic_rng_t<Engine>::gauss_b( timespan_t mean, timespan_t stddev, timespan_t max )
+{
+  return timespan_t::from_native( gauss_b( static_cast<double>( timespan_t::to_native( mean ) ),
+                                           static_cast<double>( timespan_t::to_native( stddev ) ),
+                                           static_cast<double>( timespan_t::to_native( max ) ) ) );
 }
 
 template <typename Engine>


### PR DESCRIPTION
[rng]
* Explicitly provide timespan_t gauss_a, gauss_b and gauss_ab.

[other]
* Remove uses of clamp on randomly generated values.

The only class module this touches is Mage. I'm confident this accurately reproduces the intent behind the previous implementation, but would appreciate an extra pair of eyes there.