### PR TITLE
[Warlock] Pass raw tyrant CD to builds which do not take GFG

### DIFF
--- a/profiles/Tier31/T31_Warlock_Demonology.simc
+++ b/profiles/Tier31/T31_Warlock_Demonology.simc
@@ -130,7 +130,7 @@ actions.tyrant+=/shadow_bolt
 
 actions.variables=variable,name=tyrant_timings,op=set,value=120+time,if=((buff.nether_portal.up&buff.nether_portal.remains<3&talent.nether_portal)|fight_remains<20|pet.demonic_tyrant.active&fight_remains<100|fight_remains<25|(pet.demonic_tyrant.active|!talent.summon_demonic_tyrant&buff.dreadstalkers.up))&variable.tyrant_sync<=0
 actions.variables+=/variable,name=tyrant_sync,value=(variable.tyrant_timings-time)
-actions.variables+=/variable,name=tyrant_cd,op=setif,value=variable.tyrant_sync,value_else=cooldown.summon_demonic_tyrant.remains,condition=((((fight_remains+time)%%120<=85&(fight_remains+time)%%120>=25)|time>=210))&variable.tyrant_sync>0&!talent.grand_warlocks_design
+actions.variables+=/variable,name=tyrant_cd,op=setif,value=variable.tyrant_sync,value_else=cooldown.summon_demonic_tyrant.remains,condition=((((fight_remains+time)%%120<=85&(fight_remains+time)%%120>=25)|time>=210))&variable.tyrant_sync>0&!talent.grand_warlocks_design&talent.grimoire_felguard
 actions.variables+=/variable,name=pet_expire,op=set,value=(buff.dreadstalkers.remains>?buff.vilefiend.remains)-gcd*0.5,if=buff.vilefiend.up&buff.dreadstalkers.up
 actions.variables+=/variable,name=pet_expire,op=set,value=(buff.dreadstalkers.remains>?buff.grimoire_felguard.remains)-gcd*0.5,if=!talent.summon_vilefiend&talent.grimoire_felguard&buff.dreadstalkers.up
 actions.variables+=/variable,name=pet_expire,op=set,value=(buff.dreadstalkers.remains)-gcd*0.5,if=!talent.summon_vilefiend&(!talent.grimoire_felguard|!set_bonus.tier30_2pc)&buff.dreadstalkers.up


### PR DESCRIPTION
Raidbots example: https://www.raidbots.com/simbot/report/e8wW9Giw8J7B9cgxHUbZuS

Minor adjustment, pass raw Tyrant cooldown instead of synced Tyrant timings to builds that are not running GFG. On average about 2-3% gain for non-GFG builds, should have no effect on GFG build behavior.