### PR TITLE
[Warlock] Improve dreadstalkers behavior

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -123,6 +123,7 @@ public:
   int incinerate_last_target_count; // For use with T30 Destruction tier set
   double shadow_invocation_proc_chance; // 2023-09-10: Annoyingly, at this time there is no listed proc chance in data for Shadow Invocation
   double doom_brand_accumulator;
+  timespan_t dreadstalker_first_attack_delay_rng; // Used to set the same rng delay for the first melee auto-attack of the last pair of summoned dreadstalkers
   std::vector<event_t*> wild_imp_spawns; // Used for tracking incoming imps from HoG
 
   unsigned active_pets;

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -98,6 +98,7 @@ struct warlock_pet_t : public pet_t
   // "Executes" for a length of time it would take to travel from current distance to 1.0 at 33 yds/sec
   struct travel_t : public action_t
   {
+    static constexpr double default_melee_pos = 1.0;
     double speed;
     double melee_pos;
 
@@ -105,7 +106,7 @@ struct warlock_pet_t : public pet_t
     {
       trigger_gcd = 0_ms;
       speed = 33.0;
-      melee_pos = 1.0;
+      melee_pos = default_melee_pos;
     }
 
     void execute() override
@@ -438,6 +439,9 @@ private:
 struct dreadstalker_t : public warlock_pet_t
 {
   int dreadbite_executes;
+  timespan_t first_attack_delay;
+  double initial_travel_speed;
+  double initial_distance;
 
   dreadstalker_t( warlock_t* );
   void init_base_stats() override;


### PR DESCRIPTION
The simc behavior of the [Dreadstalkers](https://www.wowhead.com/spell=104316/call-dreadstalkers) is not completely faithful to the in-game behavior. The main differences could be categorized into the nexts:
- Distance should affect dreadstalkers, since when they are summoned they charge towards the target, which will take longer depending on the distance. Currently in simc dreadstalkers start attacking immediately after being summoned.
- Regardless of this travel time, the first hit of the dreadstalkers has a certain random delay (although this does not apply if they are summoned at melee) that must be added to the travel time. This is not currently being implemented in simc.
- Although the duration of the dreadstalkers is supposedly 12 seconds, the actual duration in-game is extended a bit randomly, and this is not being taken into account in simc. This random extension time is directly related to the delay of the first melee attack delay mentioned above in a not-very-intuitive way. The reason for this relation is unknown, although it is supposed to be related to how the WoW server processes and updates events.

In addition to these differences, until recently in simc the [Demonic Inspiration](https://www.wowhead.com/spell=386858/demonic-inspiration) talent was also incorrectly applied to dreadstalkers (which should only affect the main pet), increasing its attack speed by 5%. This was already corrected several weeks ago in [this other PR](https://github.com/simulationcraft/simc/pull/8656).

All of these factors affect the number of melee attacks dreadstalkers do in each summon, which is quite relevant for simulations in ST and even in AoE due to [Dreadlash](https://www.wowhead.com/spell=264078/dreadlash), [Carnivorous Stalkers](https://www.wowhead.com/spell=386194/carnivorous-stalkers), and [The Houndmaster's Stratagem](https://www.wowhead.com/spell=267170/the-houndmasters-stratagem) talents.

With this PR, multiple changes are made to the dreadstalkers, adding travel time, the random delay of the first melee attack, and the random extra duration, so they behave similarly to how they do in-game. Although in-game at a distance of 5yd the dreadstalkers still charge, since this is the minimum distance value that the user can set (at least for the warlock) in simc, then for distance values less than or equal to 5yd it will be considered that dreadstalkers are summoned at melee range.