### PR TITLE
[Warlock] Dreadstalker travel and melee modeling improvements

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -503,10 +503,14 @@ struct call_dreadstalkers_t : public demonology_spell_t
 
     unsigned count = as<unsigned>( p()->talents.call_dreadstalkers->effectN( 1 ).base_value() );
 
-    auto dogs = p()->warlock_pet_list.dreadstalkers.spawn( p()->talents.call_dreadstalkers_2->duration(), count );
-
     // Set a randomized offset on first melee attacks after travel time. Make sure it's the same value for each dog so they're synced
     timespan_t delay = rng().range( 0_s, 1_s );
+
+    timespan_t dur_adjust = duration_adjustment( delay );
+
+    auto dogs = p()->warlock_pet_list.dreadstalkers.spawn( p()->talents.call_dreadstalkers_2->duration() + dur_adjust, count );
+
+
     for ( auto d : dogs )
     {
       if ( d->is_active() )
@@ -560,6 +564,14 @@ struct call_dreadstalkers_t : public demonology_spell_t
 
       p()->buffs.dread_calling->expire();
     }
+  }
+
+  timespan_t duration_adjustment( timespan_t delay )
+  {
+    // Despawn events appear to be offset from the melee attack check in a correlated manner
+    // Starting with this function which mimics despawns on the "off-beats" compared to the 1s heartbeat for the melee attack
+    // This may require updating if better understanding is found for the behavior, such as a fudge from Blizzard related to player distance
+    return ( delay + 500_ms ) % 1_s;
   }
 };
 

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -505,6 +505,14 @@ struct call_dreadstalkers_t : public demonology_spell_t
 
     auto dogs = p()->warlock_pet_list.dreadstalkers.spawn( p()->talents.call_dreadstalkers_2->duration(), count );
 
+    // Set a randomized offset on first melee attacks after travel time. Make sure it's the same value for each dog so they're synced
+    timespan_t delay = rng().range( 0_s, 1_s );
+    for ( auto d : dogs )
+    {
+      if ( d->is_active() )
+        d->server_action_delay = delay;
+    }
+
     if ( p()->buffs.demonic_calling->up() )
     {  // benefit tracking
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -204,7 +204,7 @@ void warlock_pet_t::init_special_effects()
 void warlock_pet_t::schedule_ready( timespan_t delta_time, bool waiting )
 {
   dot_t* d;
-  if ( melee_attack && !melee_attack->execute_event && 
+  if ( melee_attack && !melee_attack->execute_event &&
        ( melee_on_summon || !debug_cast<pets::warlock_pet_melee_t*>( melee_attack )->first ) &&
        !( special_action && ( d = special_action->get_dot() ) && d->is_ticking() ) )
   {
@@ -1576,9 +1576,9 @@ struct dreadstalker_leap_t : warlock_pet_t::travel_t
     warlock_pet_t::travel_t::execute();
 
     // There is an observed delay of up to 1 second before a melee attack begins again for pets after a movement action like the leap (possibly server tick?)
-    make_event( sim, timespan_t::from_seconds( rng().range( 1.0 ) ), [ this ]{ 
-      debug_cast<warlock_pet_t*>( player )->melee_attack->reset(); 
-      debug_cast<warlock_pet_t*>( player )->melee_attack->execute(); 
+    make_event( sim, timespan_t::from_seconds( rng().range( 1.0 ) ), [ this ]{
+      debug_cast<warlock_pet_t*>( player )->melee_attack->reset();
+      debug_cast<warlock_pet_t*>( player )->melee_attack->execute();
     } );
   }
 };

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1607,7 +1607,7 @@ void dreadstalker_t::arise()
 
   if ( position() <= 1.0 )
   {
-    melee_attack->reset(); // Within this range, Dreadstalkers will not do a leap, so they immediately start using auto attacks
+    melee_on_summon = true; // Within this range, Dreadstalkers will not do a leap, so they immediately start using auto attacks
   }
 }
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1481,6 +1481,7 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "drea
   owner_coeff.health = 0.4;
 
   melee_on_summon = false; // Dreadstalkers leap from the player location to target, which has a non-negligible travel time
+  server_action_delay = 0_ms; // Will be set when spawning Dreadstalkers to ensure pets are synced on delay
 }
 
 struct dreadbite_t : public warlock_pet_melee_attack_t
@@ -1576,7 +1577,7 @@ struct dreadstalker_leap_t : warlock_pet_t::travel_t
     warlock_pet_t::travel_t::execute();
 
     // There is an observed delay of up to 1 second before a melee attack begins again for pets after a movement action like the leap (possibly server tick?)
-    make_event( sim, timespan_t::from_seconds( rng().range( 1.0 ) ), [ this ]{
+    make_event( sim, debug_cast<dreadstalker_t*>( player )->server_action_delay, [ this ]{
       debug_cast<warlock_pet_t*>( player )->melee_attack->reset();
       debug_cast<warlock_pet_t*>( player )->melee_attack->execute();
     } );

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -204,7 +204,8 @@ void warlock_pet_t::init_special_effects()
 void warlock_pet_t::schedule_ready( timespan_t delta_time, bool waiting )
 {
   dot_t* d;
-  if ( melee_attack && !melee_attack->execute_event &&
+  if ( melee_attack && !melee_attack->execute_event && 
+       ( melee_on_summon || !debug_cast<pets::warlock_pet_melee_t*>( melee_attack )->first ) &&
        !( special_action && ( d = special_action->get_dot() ) && d->is_ticking() ) )
   {
     melee_attack->schedule_execute();
@@ -281,7 +282,7 @@ double warlock_pet_t::composite_melee_speed() const
 
 void warlock_pet_t::arise()
 {
-  if ( melee_attack )
+  if ( melee_attack && melee_on_summon )
     melee_attack->reset();
 
   pet_t::arise();
@@ -1468,7 +1469,7 @@ double wild_imp_pet_t::composite_player_multiplier( school_e school ) const
 
 dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "dreadstalker", PET_DREADSTALKER, true )
 {
-  action_list_str = "travel/dreadbite";
+  action_list_str = "leap/dreadbite";
   resource_regeneration  = regen_type::DISABLED;
 
   // 2023-09-20: Coefficient updated
@@ -1478,6 +1479,8 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "drea
     owner_coeff.ap_from_sp = 0.55;
 
   owner_coeff.health = 0.4;
+
+  melee_on_summon = false; // Dreadstalkers leap from the player location to target, which has a non-negligible travel time
 }
 
 struct dreadbite_t : public warlock_pet_melee_attack_t
@@ -1554,6 +1557,32 @@ struct dreadstalker_melee_t : warlock_pet_melee_t
   }
 };
 
+struct dreadstalker_leap_t : warlock_pet_t::travel_t
+{
+  dreadstalker_leap_t( dreadstalker_t* p ) : warlock_pet_t::travel_t( p, "leap" )
+  {
+    speed = 30.0; // Note: this is an approximation - leap may have some variation with distance. This could be updated with a function in the future by overriding execute_time()
+  }
+
+  void schedule_execute( action_state_t* s ) override
+  {
+    debug_cast<warlock_pet_t*>( player )->melee_attack->cancel();
+
+    warlock_pet_t::travel_t::schedule_execute( s );
+  }
+
+  void execute() override
+  {
+    warlock_pet_t::travel_t::execute();
+
+    // There is an observed delay of up to 1 second before a melee attack begins again for pets after a movement action like the leap (possibly server tick?)
+    make_event( sim, timespan_t::from_seconds( rng().range( 1.0 ) ), [ this ]{ 
+      debug_cast<warlock_pet_t*>( player )->melee_attack->reset(); 
+      debug_cast<warlock_pet_t*>( player )->melee_attack->execute(); 
+    } );
+  }
+};
+
 void dreadstalker_t::init_base_stats()
 {
   warlock_pet_t::init_base_stats();
@@ -1574,6 +1603,11 @@ void dreadstalker_t::arise()
   }
 
   dreadbite_executes = 1;
+
+  if ( position() <= 1.0 )
+  {
+    melee_attack->reset(); // Within this range, Dreadstalkers will not do a leap, so they immediately start using auto attacks
+  }
 }
 
 void dreadstalker_t::demise()
@@ -1608,6 +1642,8 @@ action_t* dreadstalker_t::create_action( util::string_view name, util::string_vi
 {
   if ( name == "dreadbite" )
     return new dreadbite_t( this );
+  if ( name == "leap" )
+    return new dreadstalker_leap_t( this );
 
   return warlock_pet_t::create_action( name, options_str );
 }

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -442,6 +442,7 @@ private:
 struct dreadstalker_t : public warlock_pet_t
 {
   int dreadbite_executes;
+  timespan_t server_action_delay;
 
   dreadstalker_t( warlock_t* );
   void init_base_stats() override;

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -54,6 +54,7 @@ struct warlock_pet_t : public pet_t
   } buffs;
 
   bool is_main_pet          = false;
+  bool melee_on_summon = true; // Set this to false for a pet to prevent t=0 melees. You MUST schedule a new auto attack manually elsewhere in the implementation if this is disabled
 
   warlock_pet_t( warlock_t*, util::string_view, pet_e, bool = false );
   void init_base_stats() override;
@@ -101,7 +102,10 @@ struct warlock_pet_t : public pet_t
     double speed;
     double melee_pos;
 
-    travel_t( player_t* player ) : action_t( ACTION_OTHER, "travel", player )
+    travel_t( warlock_pet_t* player ) : travel_t( player, "travel" )
+    {  }
+
+    travel_t( warlock_pet_t* player, util::string_view action_name ) : action_t( ACTION_OTHER, action_name, player )
     {
       trigger_gcd = 0_ms;
       speed = 33.0;


### PR DESCRIPTION
Work done to better overhaul the behavior related to travel and melees that was originally documented in #8683 . These module core features unfortunately conflict with that PR, but should be more modifiable moving forward, so they will supersede the code changes there.

Some considerations, such as a distance-based fudge factor from Blizzard, are not included in this set of changes. It would be worth a new PR focused on narrow updates to the functions here in the future.