### PR TITLE
[Action] refactor costs to handle flat modifiers & percent multipliers

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -1074,7 +1074,8 @@ bool action_t::verify_actor_weapon() const
 double action_t::base_cost() const
 {
   resource_e cr = current_resource();
-  double c      = base_costs[ cr ];
+  double c = base_costs[ cr ].base;
+
   if ( secondary_costs[ cr ] != 0 )
   {
     c += secondary_costs[ cr ];

--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -321,14 +321,58 @@ public:
   /// Default full duration of dot.
   timespan_t dot_duration;
 
-  // Maximum number of DoT stacks.
+  /// Maximum number of DoT stacks.
   int dot_max_stack;
 
+  struct base_cost_t
+  {
+    double base = 0.0;
+    double flat_add = 0.0;
+    double pct_mul = 1.0;
+
+    base_cost_t() = default;
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    base_cost_t( T c ) : base( c ) {}
+
+    double cost() const
+    { return ( base + flat_add ) * pct_mul; }
+
+    operator double() const
+    { return cost(); }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    base_cost_t& operator=( T c )
+    { base = c; flat_add = 0.0; pct_mul = 1.0; return *this; }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    base_cost_t& operator+=( T flat )
+    { flat_add += flat; return *this; }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    base_cost_t& operator-=( T flat )
+    { flat_add -= flat; return *this; }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    base_cost_t& operator*=( T pct )
+    { pct_mul *= pct; return *this; }
+
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
+    base_cost_t& operator/=( T pct )
+    { pct_mul /= pct; return *this; }
+
+    friend void sc_format_to( const base_cost_t& c, fmt::format_context::iterator out )
+    { fmt::format_to( out, "{}", c.cost() ); }
+  };
+
   /// Cost of using the ability.
-  std::array< double, RESOURCE_MAX > base_costs, secondary_costs;
+  std::array<base_cost_t, RESOURCE_MAX> base_costs;
+  
+  /// Maximum amount of additional resource that can be expended.
+  std::array<double, RESOURCE_MAX> secondary_costs;
 
   /// Cost of using ability per periodic effect tick.
-  std::array< double, RESOURCE_MAX > base_costs_per_tick;
+  std::array<double, RESOURCE_MAX> base_costs_per_tick;
 
   /// Minimum base direct damage
   double base_dd_min;
@@ -691,8 +735,9 @@ public:
 
   virtual double cost() const;
 
-  virtual double cost_flat_modifier() const
-  { return 0.0; }
+  virtual double cost_flat_modifier() const;
+
+  virtual double cost_pct_multiplier() const;
 
   virtual double base_cost() const;
 

--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -324,6 +324,10 @@ public:
   /// Maximum number of DoT stacks.
   int dot_max_stack;
 
+  /// Container to hold base cost and all permanent/passive modifiers. We need to hold these separate because flat
+  /// modifiers, including those from dynamic sources, are calculated before percent multipliers. The final cost is
+  /// properly reconstituted in action_t::cost(). Also includes operator overloads for ease of use/compatibility with
+  /// operations to double type previously used to store base cost.
   struct base_cost_t
   {
     double base = 0.0;

--- a/engine/action/parse_effects.hpp
+++ b/engine/action/parse_effects.hpp
@@ -296,14 +296,14 @@ public:
       effect_modifiers[ i ].first = spell->effectN( i + 1 ).base_value();
   }
 
-  double cost() const override
-  {
-    return std::max( 0.0, ( BASE::cost() * get_effects_value( cost_effects, false, false ) ) );
-  }
-
   double cost_flat_modifier() const override
   {
     return BASE::cost_flat_modifier() + get_effects_value( flat_cost_effects, true, false );
+  }
+
+  double cost_pct_multiplier() const override
+  {
+    return BASE::cost_pct_multiplier() * get_effects_value( cost_effects, false, false );
   }
 
   double composite_ta_multiplier( const action_state_t* s ) const override

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -720,16 +720,11 @@ namespace monk
         return pm;
       }
 
-      double cost() const override
+      double cost_pct_multiplier() const override
       {
-        double c = ab::cost();
-
-        if ( c == 0 )
-          return c;
+        double c = ab::cost_pct_multiplier();
 
         c *= 1.0 + cost_reduction();
-        if ( c < 0 )
-          c = 0;
 
         return c;
       }
@@ -5657,9 +5652,9 @@ namespace monk
           return am;
         }
 
-        double cost() const override
+        double cost_pct_multiplier() const override
         {
-          double c = monk_heal_t::cost();
+          double c = monk_heal_t::cost_pct_multiplier();
 
           if ( p()->buff.thunder_focus_tea->check() )
             c *= 1 + p()->talent.mistweaver.thunder_focus_tea->effectN( 2 ).percent();  // saved as -100

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -1244,9 +1244,9 @@ struct word_of_glory_t : public holy_power_consumer_t<paladin_heal_t>
     return am;
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = holy_power_consumer_t::cost();
+    double c = holy_power_consumer_t::cost_pct_multiplier();
 
     if ( p()->buffs.shining_light_free->check() )
       c *= 1.0 + p()->buffs.shining_light_free->data().effectN( 1 ).percent();

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -1321,7 +1321,12 @@ struct holy_power_consumer_t : public Base
       return 0.0;
     }
 
-    double c = ab::cost();
+    return ab::cost();
+  }
+
+  double cost_flat_modifier() const override
+  {
+    double c = ab::cost_flat_modifier();
 
     if ( ab::p()->talents.vanguard_of_justice->ok() &&
          this->data().affected_by( ab::p()->talents.vanguard_of_justice->effectN( 1 ) ) )
@@ -1329,7 +1334,7 @@ struct holy_power_consumer_t : public Base
       c += ab::p()->talents.vanguard_of_justice->effectN( 1 ).base_value();
     }
 
-    return std::max( c, 0.0 );
+    return c;
   }
 
   void impact( action_state_t* s ) override
@@ -1354,7 +1359,10 @@ struct holy_power_consumer_t : public Base
     if ( ab::background && is_divine_storm )
       return;
 
-    bool isFreeSLDPSpender = p->buffs.divine_purpose->up() || ( is_wog && p->buffs.shining_light_free->up() ) || (is_divine_storm && p->buffs.empyrean_power->up());
+    bool isFreeSLDPSpender = p->buffs.divine_purpose->up() ||
+                           ( is_wog && p->buffs.shining_light_free->up() ) ||
+                           ( is_divine_storm && p->buffs.empyrean_power->up() ) ||
+                           ( ( is_wog || is_sotr ) && p->buffs.bastion_of_light->up() );
 
     int num_hopo_spent = holy_power_consumer_t::cost();
     // Free spenders seem to count as 3 Holy Power, regardless the cost

--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -854,9 +854,9 @@ struct shield_of_the_righteous_t : public holy_power_consumer_t<paladin_melee_at
     return am;
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = holy_power_consumer_t::cost();
+    double c = holy_power_consumer_t::cost_pct_multiplier();
 
     if ( p()->buffs.bastion_of_light->check() )
       c *= 1.0 + p()->buffs.bastion_of_light->data().effectN( 1 ).percent();

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -6636,7 +6636,7 @@ struct howling_blast_t final : public death_knight_spell_t
     // If Pillar of Frost is up, Rime procs still increases its value
     if ( p() -> buffs.pillar_of_frost -> up() && p() -> buffs.rime -> up() )
     {
-      p() -> buffs.pillar_of_frost_bonus -> trigger( as<int>( base_costs[ RESOURCE_RUNE ] ) );
+      p() -> buffs.pillar_of_frost_bonus -> trigger( static_cast<int>( base_costs[ RESOURCE_RUNE ] ) );
     }
 
     if ( p() -> buffs.pillar_of_frost -> up() && p() -> talent.frost.obliteration.ok() )
@@ -6927,18 +6927,6 @@ struct obliterate_t final : public death_knight_melee_attack_t
     {
       p()->consume_killing_machine( p()->procs.killing_machine_oblit, total_delay );
     }
-  }
-
-  double cost() const override
-  {
-    double c = death_knight_melee_attack_t::cost();
-
-    if ( c < 0 )
-    {
-      c = 0;
-    }
-
-    return c;
   }
 
   // Allow on-cast procs

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -1605,8 +1605,6 @@ public:
     parse_effects( p()->buff.gathering_starstuff );
     parse_effects( p()->buff.incarnation_moonkin, p()->talent.elunes_guidance );
     parse_effects( p()->buff.owlkin_frenzy );
-    // TODO: remove when action_t::apply_affecting_aura order of operations for cost modifiers is established
-    parse_effects( p()->talent.rattle_the_stars );
     parse_effects( p()->buff.starweavers_warp );
     parse_effects( p()->buff.starweavers_weft );
     parse_effects( p()->buff.touch_the_cosmos );
@@ -2142,7 +2140,7 @@ public:
 
   void consume_resource() override
   {
-    double eff_cost = base_cost();
+    double eff_cost = base_costs[ RESOURCE_ENERGY ].base;
 
     base_t::consume_resource();
 
@@ -3662,7 +3660,7 @@ struct ferocious_bite_t : public cat_finisher_t
     // Incarn does affect the additional energy consumption.
     double _max_used = max_excess_energy * ( 1.0 + p()->buff.incarnation_cat->check_value() );
 
-    excess_energy = std::min( _max_used, ( p()->resources.current[ RESOURCE_ENERGY ] - cat_finisher_t::cost() ) );
+    excess_energy = std::min( _max_used, ( p()->resources.current[ RESOURCE_ENERGY ] - cost() ) );
     
     cat_finisher_t::execute();
   }
@@ -5792,7 +5790,7 @@ public:
       p_buff->trigger();
 
     // pulsar accumulate based on the cost before any talents and effects
-    p_buff->current_value += data().cost( POWER_ASTRAL_POWER );
+    p_buff->current_value += base_costs[ RESOURCE_ASTRAL_POWER ].base;
 
     if ( p_buff->check_value() >= p_cap )
     {
@@ -12962,8 +12960,7 @@ void druid_t::apply_affecting_auras( action_t& action )
   action.apply_affecting_aura( talent.radiant_moonlight );
   action.apply_affecting_aura( talent.twin_moons );
   action.apply_affecting_aura( talent.wild_surges );
-  // TODO: uncomment when action_t::apply_affecting_aura order of operations for cost modifiers is established
-  // action.apply_affecting_aura( talent.rattle_the_stars );
+  action.apply_affecting_aura( talent.rattle_the_stars );
   action.apply_affecting_aura( sets->set( DRUID_BALANCE, T30, B2 ) );
   
   // Feral 

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -2140,7 +2140,7 @@ public:
 
   void consume_resource() override
   {
-    double eff_cost = base_costs[ RESOURCE_ENERGY ].base;
+    double eff_cost = base_cost();
 
     base_t::consume_resource();
 
@@ -5790,7 +5790,7 @@ public:
       p_buff->trigger();
 
     // pulsar accumulate based on the cost before any talents and effects
-    p_buff->current_value += base_costs[ RESOURCE_ASTRAL_POWER ].base;
+    p_buff->current_value += base_cost();
 
     if ( p_buff->check_value() >= p_cap )
     {

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -1055,16 +1055,16 @@ public:
     ab::execute();
 
     if ( triggers_calling_the_shots )
-      p() -> trigger_calling_the_shots( this, ab::cost() );
+      p() -> trigger_calling_the_shots( this, this->cost() );
 
     if ( affected_by.t29_sv_4pc_cost )
       p() -> buffs.bestial_barrage -> expire();
     
     if ( triggers_t30_sv_4p )
-      p() -> trigger_t30_sv_4p( this, ab::cost() );
+      p() -> trigger_t30_sv_4p( this, this->cost() );
 
     if ( triggers_rapid_reload )
-      p() -> trigger_rapid_reload( this, ab::cost() );
+      p() -> trigger_rapid_reload( this, this->cost() );
   }
 
   void impact( action_state_t* s ) override
@@ -2381,9 +2381,9 @@ struct basic_attack_t : public hunter_main_pet_attack_t
     return am;
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = hunter_main_pet_attack_t::cost();
+    double c = hunter_main_pet_attack_t::cost_pct_multiplier();
 
     if ( use_wild_hunt() )
       c *= wild_hunt.cost_pct;
@@ -3080,11 +3080,6 @@ struct kill_shot_t : hunter_ranged_attack_t
     return hunter_ranged_attack_t::n_targets();
   }
 
-  double cost() const override
-  {
-    return hunter_ranged_attack_t::cost();
-  }
-
   bool target_ready( player_t* candidate_target ) override
   {
     return hunter_ranged_attack_t::target_ready( candidate_target ) &&
@@ -3154,9 +3149,9 @@ struct arcane_shot_t: public hunter_ranged_attack_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = hunter_ranged_attack_t::cost();
+    double c = hunter_ranged_attack_t::cost_pct_multiplier();
 
     if ( p() -> buffs.eagletalons_true_focus -> check() )
       c *= 1 + p() -> talents.eagletalons_true_focus -> effectN( 3 ).percent();
@@ -3983,9 +3978,9 @@ struct chimaera_shot_t: public hunter_ranged_attack_t
 
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = hunter_ranged_attack_t::cost();
+    double c = hunter_ranged_attack_t::cost_pct_multiplier();
 
     if ( p() -> buffs.eagletalons_true_focus -> check() )
       c *= 1 + p() -> talents.eagletalons_true_focus -> effectN( 3 ).percent();
@@ -4114,7 +4109,12 @@ struct aimed_shot_t : public hunter_ranged_attack_t
     if ( casting ? lock_and_loaded : p() -> buffs.lock_and_load -> check() )
       return 0;
 
-    double c = hunter_ranged_attack_t::cost();
+    return hunter_ranged_attack_t::cost();
+  }
+
+  double cost_pct_multiplier() const override
+  {
+    double c = hunter_ranged_attack_t::cost_pct_multiplier();
 
     if ( p() -> buffs.eagletalons_true_focus -> check() )
       c *= 1 + p() -> talents.eagletalons_true_focus -> effectN( 1 ).percent();
@@ -4465,9 +4465,9 @@ struct multishot_mm_t: public hunter_ranged_attack_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = hunter_ranged_attack_t::cost();
+    double c = hunter_ranged_attack_t::cost_pct_multiplier();
 
     if ( p() -> buffs.eagletalons_true_focus -> check() )
       c *= 1 + p() -> talents.eagletalons_true_focus -> effectN( 3 ).percent();
@@ -5535,9 +5535,9 @@ struct kill_command_t: public hunter_spell_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = hunter_spell_t::cost();
+    double c = hunter_spell_t::cost_pct_multiplier();
 
     c *= 1 + p() -> buffs.flamewakers_cobra_sting -> check_value();
     c *= 1 + p() -> buffs.cobra_sting -> check_value();

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -1055,16 +1055,16 @@ public:
     ab::execute();
 
     if ( triggers_calling_the_shots )
-      p() -> trigger_calling_the_shots( this, this->cost() );
+      p() -> trigger_calling_the_shots( this, this -> cost() );
 
     if ( affected_by.t29_sv_4pc_cost )
       p() -> buffs.bestial_barrage -> expire();
     
     if ( triggers_t30_sv_4p )
-      p() -> trigger_t30_sv_4p( this, this->cost() );
+      p() -> trigger_t30_sv_4p( this, this -> cost() );
 
     if ( triggers_rapid_reload )
-      p() -> trigger_rapid_reload( this, this->cost() );
+      p() -> trigger_rapid_reload( this, this -> cost() );
   }
 
   void impact( action_state_t* s ) override

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -1836,14 +1836,14 @@ struct arcane_mage_spell_t : public mage_spell_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = mage_spell_t::cost();
+    double c = mage_spell_t::cost_pct_multiplier();
 
     for ( auto cr : cost_reductions )
       c *= 1.0 + cr->check_value();
 
-    return std::max( c, 0.0 );
+    return c;
   }
 
   double arcane_charge_multiplier( bool arcane_barrage = false ) const
@@ -2775,9 +2775,9 @@ struct arcane_blast_t final : public arcane_mage_spell_t
     return std::max( arcane_mage_spell_t::travel_time(), 6_ms );
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = arcane_mage_spell_t::cost();
+    double c = arcane_mage_spell_t::cost_pct_multiplier();
 
     c *= 1.0 + p()->buffs.arcane_charge->check() * p()->buffs.arcane_charge->data().effectN( 5 ).percent();
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -2363,12 +2363,9 @@ public:
   virtual double composite_poison_flat_modifier( const action_state_t* ) const
   { return 0.0; }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = ab::cost();
-
-    if ( c <= 0 )
-      return 0;
+    double c = ab::cost_pct_multiplier();
 
     if ( p()->talent.subtlety.shadow_focus->ok() && p()->stealthed( STEALTH_BASIC | STEALTH_SHADOW_DANCE ) )
     {
@@ -2384,9 +2381,6 @@ public:
     {
       c *= 1.0 + p()->buffs.goremaws_bite->check_value();
     }
-
-    if ( c <= 0 )
-      c = 0;
 
     return c;
   }
@@ -4735,9 +4729,9 @@ struct pistol_shot_t : public rogue_attack_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = rogue_attack_t::cost();
+    double c = rogue_attack_t::cost_pct_multiplier();
 
     if ( p()->buffs.opportunity->check() )
     {

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1647,11 +1647,10 @@ public:
     return c;
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = ab::cost();
+    double c = ab::cost_pct_multiplier();
 
-    // set cost to zero after cost additions and reductions are applied to prevent negative cost values
     if ( affected_by_ns_cost && p()->buff.natures_swiftness->check() && !ab::background && ab::current_resource() != RESOURCE_MAELSTROM )
     {
       c *= 1.0 + p()->talent.natures_swiftness->effectN( 1 ).percent();

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -1076,13 +1076,16 @@ public:
 
   virtual double tactician_cost() const
   {
+    double base = ab::base_costs[ ab::current_resource() ].base;
+
     if ( ab::sim->log )
     {
       ab::sim->out_debug.printf(
           "Rage used to calculate tactician chance from ability %s: %4.4f, actual rage used: %4.4f", ab::name(),
-          ab::cost(), base_t::cost() );
+          base, this->cost() );
     }
-    return ab::cost();
+
+    return base;
   }
 
   int n_targets() const override
@@ -2904,11 +2907,6 @@ struct cleave_t : public warrior_attack_t
     reduced_aoe_targets = 5.0;
   }
 
-  double cost() const override
-  {
-    return warrior_attack_t::cost();
-  }
-
   double action_multiplier() const override
   {
     double am = warrior_attack_t::action_multiplier();
@@ -3621,15 +3619,24 @@ struct fury_execute_parent_t : public warrior_attack_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = warrior_attack_t::cost();
-    c        = std::min( max_rage, std::max( p()->resources.current[ RESOURCE_RAGE ], c ) );
+    auto c = warrior_attack_t::cost_pct_multiplier();
 
     if ( p()->talents.fury.improved_execute->ok() )
     {
       c *= 1.0 + p()->talents.fury.improved_execute->effectN( 1 ).percent();
     }
+
+    return c;
+  }
+
+  double cost() const override
+  {
+    double c = warrior_attack_t::cost();
+
+    c = std::min( max_rage, std::max( p()->resources.current[ RESOURCE_RAGE ], c ) );
+
     return c;
   }
 
@@ -4904,9 +4911,9 @@ struct revenge_t : public warrior_attack_t
       }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double cost = warrior_attack_t::cost();
+    double cost = warrior_attack_t::cost_pct_multiplier();
     cost *= 1.0 + p()->buff.revenge->check_value();
     //cost *= 1.0 + p()->buff.vengeance_revenge->check_value();
     return cost;
@@ -6496,15 +6503,6 @@ struct ignore_pain_t : public warrior_spell_t
 
     base_dd_max = base_dd_min = 0;
     resource_current = RESOURCE_RAGE;
-  }
-
-  double cost() const override
-  {
-    double c = warrior_spell_t::cost();
-
-    //c *= 1.0 + p() -> buff.vengeance_ignore_pain -> value();
-
-    return c;
   }
 
   void execute() override

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -1076,7 +1076,7 @@ public:
 
   virtual double tactician_cost() const
   {
-    double base = ab::base_costs[ ab::current_resource() ].base;
+    double base = ab::base_cost();
 
     if ( ab::sim->log )
     {

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -903,12 +903,6 @@ public:
     spell_t::reset();
   }
 
-  double cost() const override
-  {
-    double c = spell_t::cost();
-    return c;
-  }
-
   void consume_resource() override
   {
     spell_t::consume_resource();

--- a/engine/class_modules/warlock/sc_warlock_affliction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_affliction.cpp
@@ -343,9 +343,9 @@ struct malefic_rapture_t : public affliction_spell_t
     add_child( impact_action );
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = affliction_spell_t::cost();
+    double c = affliction_spell_t::cost_pct_multiplier();
 
     if ( p()->buffs.tormented_crescendo->check() )
     {

--- a/engine/class_modules/warlock/sc_warlock_demonology.cpp
+++ b/engine/class_modules/warlock/sc_warlock_demonology.cpp
@@ -473,9 +473,9 @@ struct call_dreadstalkers_t : public demonology_spell_t
     may_crit = false;
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = demonology_spell_t::cost();
+    double c = demonology_spell_t::cost_pct_multiplier();
 
     if ( p()->buffs.demonic_calling->check() )
     {
@@ -521,10 +521,10 @@ struct call_dreadstalkers_t : public demonology_spell_t
     {  // benefit tracking
 
       //Despite having no cost when Demonic Calling is up, this spell will still proc effects based on shard spending (last checked 2022-10-04)
-      double base_cost = demonology_spell_t::cost();
+      double base_shards = base_cost();
 
       if ( p()->talents.grand_warlocks_design->ok() && !p()->min_version_check( VERSION_10_2_0 ) )
-        p()->cooldowns.demonic_tyrant->adjust( -base_cost * p()->talents.grand_warlocks_design->effectN( 2 ).time_value(), false );
+        p()->cooldowns.demonic_tyrant->adjust( -base_shards * p()->talents.grand_warlocks_design->effectN( 2 ).time_value(), false );
 
       if ( p()->buffs.nether_portal->up() )
       {
@@ -546,7 +546,7 @@ struct call_dreadstalkers_t : public demonology_spell_t
 
       if ( p()->talents.soul_conduit->ok() )
       {
-        make_event<sc_event_t>( *p()->sim, p(), as<int>( base_cost ) );
+        make_event<sc_event_t>( *p()->sim, p(), as<int>( base_shards ) );
       }
 
       p()->buffs.demonic_calling->decrement();

--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -26,7 +26,7 @@ public:
     warlock_spell_t::consume_resource();
 
     int shards_used = as<int>( cost() );
-    int base_cost = as<int>( destruction_spell_t::cost() ); // Power Overwhelming is ignoring any cost changes
+    int base_shards = as<int>( base_cost() ); // Power Overwhelming is ignoring any cost changes
 
     // Do cost changes reduce number of draws appropriately? This may be difficult to check
     if ( resource_current == RESOURCE_SOUL_SHARD && p()->buffs.rain_of_chaos->check() && shards_used > 0 )
@@ -49,15 +49,15 @@ public:
         make_event( sim, 1_ms, [ this, overflow ] { p()->buffs.impending_ruin->trigger( overflow ); } );
     }
 
-    if ( p()->talents.power_overwhelming->ok() && resource_current == RESOURCE_SOUL_SHARD && base_cost > 0 )
+    if ( p()->talents.power_overwhelming->ok() && resource_current == RESOURCE_SOUL_SHARD && base_shards > 0 )
     {
-      p()->buffs.power_overwhelming->trigger( base_cost );
+      p()->buffs.power_overwhelming->trigger( base_shards );
     }
 
     // 2022-10-17: Spell data is missing the % chance!
     // Need to test further, but chance appears independent of shard cost
     // Also procs even if the cast is free due to other effects
-    if ( resource_current == RESOURCE_SOUL_SHARD && base_cost > 0 && p()->sets->has_set_bonus( WARLOCK_DESTRUCTION, T29, B2 ) && rng().roll( 0.2 ) )
+    if ( resource_current == RESOURCE_SOUL_SHARD && base_shards > 0 && p()->sets->has_set_bonus( WARLOCK_DESTRUCTION, T29, B2 ) && rng().roll( 0.2 ) )
     {
       p()->buffs.chaos_maelstrom->trigger();
       p()->procs.chaos_maelstrom->occur();
@@ -718,9 +718,9 @@ struct chaos_bolt_t : public destruction_spell_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = destruction_spell_t::cost();
+    double c = destruction_spell_t::cost_pct_multiplier();
 
     if ( p()->buffs.ritual_of_ruin->check() )
       c *= 1.0 + p()->talents.ritual_of_ruin_buff->effectN( 2 ).percent();
@@ -962,9 +962,9 @@ struct rain_of_fire_t : public destruction_spell_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = destruction_spell_t::cost();
+    double c = destruction_spell_t::cost_pct_multiplier();
 
     if ( p()->buffs.ritual_of_ruin->check() )
       c *= 1.0 + p()->talents.ritual_of_ruin_buff->effectN( 5 ).percent();

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1311,9 +1311,9 @@ struct fel_firebolt_t : public warlock_pet_spell_t
     }
   }
 
-  double cost() const override
+  double cost_pct_multiplier() const override
   {
-    double c = warlock_pet_spell_t::cost();
+    double c = warlock_pet_spell_t::cost_pct_multiplier();
 
     if ( p()->o()->warlock_base.fel_firebolt_2->ok() )
       c *= 1.0 + p()->o()->warlock_base.fel_firebolt_2->effectN( 1 ).percent();

--- a/engine/report/report_html_player.cpp
+++ b/engine/report/report_html_player.cpp
@@ -1070,9 +1070,9 @@ void print_html_action_info( report::sc_html_stream& os, unsigned stats_mask, co
                   "<ul>\n" );
       fmt::print( os, "<li><span class=\"label\">resource:</span>{}</li>\n",
                   util::resource_type_string( a->current_resource() ) );
-      fmt::print( os, "<li><span class=\"label\">base_cost:</span>{:.1f}</li>\n",
+      fmt::print( os, "<li><span class=\"label\">base_cost:</span>{}</li>\n",
                   a->base_costs[ a->current_resource() ] );
-      fmt::print( os, "<li><span class=\"label\">secondary_cost:</span>{:.1f}</li>\n",
+      fmt::print( os, "<li><span class=\"label\">secondary_cost:</span>{}</li>\n",
                   a->secondary_costs[ a->current_resource() ] );
       fmt::print( os, "<li><span class=\"label\">energize_type:</span>{}</li>\n", a->energize_type );
       fmt::print( os, "<li><span class=\"label\">energize_resource:</span>{}</li>\n", a->energize_resource );


### PR DESCRIPTION
Flat cost modifiers appear to be applied before percentage multiplier to spell costs, regardless of whether the effects are applied via a permanent or temporary aura.

As cost modification can happen at various places depending on the class module code, we need to keep all three values separate to properly calculate the final cost.

A base_cost_t object is used for action_t::base_costs[] with appropriate operator overloads to provide compatibility with existing code.