### PR TITLE
[Warlock] 30 yards default

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -1740,7 +1740,7 @@ void warlock_t::init_procs()
 void warlock_t::init_base_stats()
 {
   if ( base.distance < 1.0 )
-    base.distance = 40.0;
+    base.distance = 30.0;
 
   player_t::init_base_stats();
 


### PR DESCRIPTION
Changed default distance to target from 40 to 30 yards.

Need to change the wiki too : https://github.com/simulationcraft/simc/wiki/Characters#optional