### PR TITLE
[Warlock] Dreadstalkers leap and melee attacks fixes and improvements

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1577,9 +1577,8 @@ struct dreadstalker_leap_t : warlock_pet_t::travel_t
 
   bool ready() override
   {
-    // Dreadstalkers will not do a leap if are summoned too close to the target. In addition, the leap can only occur once.
-    // We assume the pet does not ever need to be anywhere except the main raid target
-    return ( (!debug_cast<dreadstalker_t*>( player )->melee_on_summon) && (debug_cast<dreadstalker_t*>( player )->leap_executes > 0) && (player->current.distance > melee_pos) );
+    // Dreadstalkers will not do a leap if are summoned too close to the target. In addition, the leap can only occur once. 
+    return ( (!debug_cast<dreadstalker_t*>( player )->melee_on_summon) && (debug_cast<dreadstalker_t*>( player )->leap_executes > 0) && (warlock_pet_t::travel_t::ready()) );
   }
 
   void execute() override

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -442,6 +442,7 @@ private:
 struct dreadstalker_t : public warlock_pet_t
 {
   int dreadbite_executes;
+  int leap_executes;
   timespan_t server_action_delay;
 
   dreadstalker_t( warlock_t* );


### PR DESCRIPTION
Some modifications as continuation of [#8683](https://github.com/simulationcraft/simc/pull/8683) and [#8698](https://github.com/simulationcraft/simc/pull/8698).

It is intended to correct some errors of [#8698](https://github.com/simulationcraft/simc/pull/8698) PR:
- ``position()`` function is used incorrectly to try to get the distance, but that function returns the position relative to the enemy (front, back, ranged_front, ranged_back), not the distance range.
- The distance check to establish the ``melee_on_summon`` flag must be done at the beginning of ``dreadstalker_t::arise()`` (before the ``warlock_pet_t::arise()`` call), not at the end.
- The melee auto in ``dreadstalker_leap_t`` should only be cancelled/scheduled if the ``melee_on_summon`` flag is ``false``, since otherwise melee auto-attacks are performed normally just after summon, not after the leap.

Additionally, the following change has been added to this PR:
- Now at distance <= 5yd the dreadstalker summon is considered at melee range (the melee auto-attacks starts immediately), instead of 1yd. The 5yd was selected because is the minimum that the user can establish in simc, and is usually considered melee range in simc.
