### PR TITLE
[Gear] Dragonfire Bomb Dispenser uses generic aoe target scaling

### DIFF
--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -910,7 +910,7 @@ void dragonfire_bomb_dispenser( special_effect_t& effect )
   auto coeff_data = effect.player->find_spell( 408667 );
 
   // AoE Explosion
-  auto explode = create_proc_action<generic_aoe_proc_t>( "dragonfire_bomb_aoe", effect, "dragonfire_bomb_aoe", 408694 );
+  auto explode = create_proc_action<generic_aoe_proc_t>( "dragonfire_bomb_aoe", effect, "dragonfire_bomb_aoe", 408694, true );
   explode->name_str_reporting = "AOE";
   explode->base_dd_min = explode->base_dd_max = coeff_data->effectN( 2 ).average( effect.item );
   effect.player->register_on_kill_callback( [ p = effect.player, explode ]( player_t* t ) {


### PR DESCRIPTION
Example log (filtered by Bomb Dispenser's on-death damage instances): https://www.warcraftlogs.com/reports/6ZM8aLQnfx4wh1NB#fight=28&type=damage-done&source=6&ability=408694&view=events

00:53.194 -- Bomb crits 1 target for 138183
06:34.464 -- Bomb hits 4 targets, would have been 50091 * 4 if they all crit, which is a 45% increase over 138183
22:09.243 -- Bomb hits 5 targets, would have been 44219 * 5 if they all crit, which is a 60% increase over 138183
13:29.920 -- Bomb hits 9 targets, would have been 27244 * 9 if they all crit, which is a ~77% increase over 138183 (had small versatility buff from Molten Overflow)
