### PR TITLE
[Warlock] Inferno target scaling is missing in DF (#8766)

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_destruction.cpp
+++ b/engine/class_modules/warlock/sc_warlock_destruction.cpp
@@ -914,7 +914,9 @@ struct rain_of_fire_t : public destruction_spell_t
 
       if ( p()->talents.inferno->ok() && result_is_hit( s->result ) )
       {
-        if ( rng().roll( p()->talents.inferno->effectN( 1 ).percent() * ( 5.0 / std::max(5u, s->n_targets ) ) ) )
+        auto target_scaling = p()->bugs ? 1.0 : ( 5.0 / std::max( 5u, s->n_targets ) );
+
+        if ( rng().roll( p()->talents.inferno->effectN( 1 ).percent() * target_scaling ) )
         {
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.inferno );
         }


### PR DESCRIPTION
(cherry picked from commit a99849036a3c9e34dec40ed6ee8ecfa0eed7395d)