### PR TITLE
[Outlaw] Add DF4 profile and some APL updates

### DIFF
--- a/engine/class_modules/apl/rogue/outlaw.simc
+++ b/engine/class_modules/apl/rogue/outlaw.simc
@@ -33,6 +33,8 @@ actions+=/variable,name=ambush_condition,value=(talent.hidden_opportunity|combo_
 actions+=/variable,name=finish_condition,value=effective_combo_points>=cp_max_spend-1-(stealthed.all&talent.crackshot)
 # With multiple targets, this variable is checked to decide whether some CDs should be synced with Blade Flurry
 actions+=/variable,name=blade_flurry_sync,value=spell_targets.blade_flurry<2&raid_event.adds.in>20|buff.blade_flurry.remains>gcd
+# Force Roll the Bones to be refreshed when needed if 0 targets are active, as the RTB action in the sublist is not checked
+actions+=/roll_the_bones,if=rtb_buffs.max_remains<=2&spell_targets.blade_flurry=0&raid_event.adds.in<20
 actions+=/call_action_list,name=cds
 # High priority stealth list, will fall through if no conditions are met
 actions+=/call_action_list,name=stealth,if=stealthed.all
@@ -74,6 +76,9 @@ actions.cds+=/keep_it_rolling,if=!variable.rtb_reroll&rtb_buffs>=3+set_bonus.tie
 actions.cds+=/ghostly_strike,if=effective_combo_points<cp_max_spend
 # Use Sepsis to trigger Crackshot or if the target will survive its DoT
 actions.cds+=/sepsis,if=talent.crackshot&cooldown.between_the_eyes.ready&variable.finish_condition&!stealthed.all|!talent.crackshot&target.time_to_die>11&buff.between_the_eyes.up|fight_remains<11
+# Manic Grieftorch and Beacon to the Beyond should not be used during stealth and have higher priority than stealth cooldowns
+actions.cds+=/use_item,name=manic_grieftorch,if=!stealthed.all&buff.between_the_eyes.up|fight_remains<=5
+actions.cds+=/use_item,name=beacon_to_the_beyond,if=!stealthed.all&buff.between_the_eyes.up|fight_remains<=5
 # Crackshot builds use stealth cooldowns if Between the Eyes is ready
 actions.cds+=/call_action_list,name=stealth_cds,if=!stealthed.all&(!talent.crackshot|cooldown.between_the_eyes.ready)
 actions.cds+=/thistle_tea,if=!buff.thistle_tea.up&(energy.base_deficit>=100|fight_remains<charges*6)
@@ -85,10 +90,8 @@ actions.cds+=/berserking
 actions.cds+=/fireblood
 actions.cds+=/ancestral_call
 # Default conditions for usable items.
-actions.cds+=/use_item,name=manic_grieftorch,use_off_gcd=1,if=gcd.remains<=action.sinister_strike.gcd%2&(!stealthed.all&buff.between_the_eyes.up|fight_remains<=5)
 # Use Bomb Dispenser on cooldown, but hold if 2nd trinket is nearly off cooldown, unless at max charges or sim duration ends soon
 actions.cds+=/use_item,name=dragonfire_bomb_dispenser,use_off_gcd=1,if=gcd.remains<=action.sinister_strike.gcd%2&((!trinket.1.is.dragonfire_bomb_dispenser&trinket.1.cooldown.remains>10|trinket.2.cooldown.remains>10)|cooldown.dragonfire_bomb_dispenser.charges>2|fight_remains<20|!trinket.2.has_cooldown|!trinket.1.has_cooldown)
-actions.cds+=/use_item,name=beacon_to_the_beyond,use_off_gcd=1,if=gcd.remains<=action.sinister_strike.gcd%2&(!stealthed.all&buff.between_the_eyes.up|fight_remains<=5)
 actions.cds+=/use_item,name=stormeaters_boon,if=spell_targets.blade_flurry>desired_targets|raid_event.adds.in>60|fight_remains<10
 actions.cds+=/use_item,name=windscar_whetstone,if=spell_targets.blade_flurry>desired_targets|raid_event.adds.in>60|fight_remains<7
 actions.cds+=/use_items,slots=trinket1,if=buff.between_the_eyes.up|trinket.1.has_stat.any_dps|fight_remains<=20
@@ -97,8 +100,8 @@ actions.cds+=/use_items,slots=trinket2,if=buff.between_the_eyes.up|trinket.2.has
 # Finishers
 # Use Between the Eyes to keep the crit buff up, but on cooldown if Improved/Greenskins/T30, and avoid overriding Greenskins
 actions.finish=between_the_eyes,if=!talent.crackshot&(buff.between_the_eyes.remains<4|talent.improved_between_the_eyes|talent.greenskins_wickers|set_bonus.tier30_4pc)&!buff.greenskins_wickers.up
-# Crackshot builds use Between the Eyes outside of Stealth if Vanish or Dance will not come off cooldown within the next cast
-actions.finish+=/between_the_eyes,if=talent.crackshot&cooldown.vanish.remains>45&cooldown.shadow_dance.remains>12
+# Crackshot builds use Between the Eyes outside of Stealth if we will not enter a Stealth window before the next cast
+actions.finish+=/between_the_eyes,if=talent.crackshot&cooldown.vanish.remains>45&cooldown.shadow_dance.remains>12&(raid_event.adds.remains>8|raid_event.adds.in<raid_event.adds.remains|!raid_event.adds.up)
 actions.finish+=/slice_and_dice,if=buff.slice_and_dice.remains<fight_remains&refreshable
 actions.finish+=/killing_spree,if=debuff.ghostly_strike.up|!talent.ghostly_strike
 actions.finish+=/cold_blood

--- a/profiles/generators/DF4/DF4_Generate_Rogue.simc
+++ b/profiles/generators/DF4/DF4_Generate_Rogue.simc
@@ -40,8 +40,8 @@ back=voice_of_the_silent_star,id=204465,bonus_id=10359/1495
 chest=lurking_specters_brigandine,id=217206,bonus_id=10359/1488,enchant=waking_stats_3
 wrists=lifebound_bindings,id=193419,bonus_id=8780/8797/8960/10249/10359/9405,gem_id=192932,crafted_stats=32/40
 hands=lurking_specters_handgrips,id=217207,bonus_id=10359/1488
-waist=troggskin_waistband,id=193668,bonus_id=1808,ilevel=528,gem_id=192932,enchant_id=6904
-legs=annoras_punctured_leggings,id=193811,ilevel=528,enchant_id=6830
+waist=troggskin_waistband,id=193668,bonus_id=1808,ilevel=528,gem_id=192932
+legs=annoras_punctured_leggings,id=193811,ilevel=528,enchant=fierce_armor_kit_3
 feet=toxic_thorn_footwraps,id=193452,bonus_id=8960/8840/8836/8902/10249/10359/9405,crafted_stats=32/40
 finger1=seal_of_diurnas_chosen,id=195480,bonus_id=1808/10359/1488,gem_id=192932,enchant=devotion_of_versatility_3
 finger2=tormentors_siphoning_signet,id=204466,bonus_id=1808/10359/1488,gem_id=192932,enchant=devotion_of_versatility_3

--- a/profiles/generators/DF4/DF4_Generate_Rogue.simc
+++ b/profiles/generators/DF4/DF4_Generate_Rogue.simc
@@ -25,32 +25,32 @@
 
 # save=DF4_Rogue_Assassination.simc
 
-# rogue="DF4_Rogue_Outlaw"
-# spec=outlaw
-# level=70
-# race=tauren
-# role=attack
-# position=back
-# talents=BQQAAAAAAAAAAAAAAAAAAAAAAAAEkkEJCSSIJCSkkmkEtkIlkAAAAAAAaJJkERhcgSaBAAAQSCA
+rogue="DF4_Rogue_Outlaw"
+spec=outlaw
+level=70
+race=tauren
+role=attack
+position=back
+talents=BQQAAAAAAAAAAAAAAAAAAAAAAAAEkkEJCSSIJCSkkmkEtkIlkAAAAAAAaJJkERhcgSaBAAAQSCA
 
-# head=lucid_shadewalkers_deathmask,id=207236,bonus_id=1808/7187/1520,enchant=incandescent_essence,gem_id=192991
-# neck=ouroboreal_necklet,id=210214,bonus_id=8782/7187/1520,gem_id=192932/192932/192932
-# shoulder=lucid_shadewalkers_bladed_spaulders,id=207234,bonus_id=7187/1520
-# back=inflammable_drapeleaf,id=207160,bonus_id=7187/1520
-# chest=lucid_shadewalkers_cuirass,id=207239,bonus_id=7187/1520,enchant=waking_stats_3
-# wrist=lifebound_bindings,id=193419,bonus_id=8780/8797/8960/9500/9405,gem_id=192932,crafted_stats=32/40
-# hands=flamewakers_grips,id=207130,bonus_id=7187/1520
-# waist=belt_of_gleaming_determination,id=158306,bonus_id=1808,gem_id=192932,ilevel=489
-# legs=lucid_shadewalkers_chausses,id=207235,bonus_id=7187/1520,enchant=fierce_armor_kit_3
-# feet=toxic_thorn_footwraps,id=193452,bonus_id=9500/9405
-# finger1=thornwoven_band,id=162548,bonus_id=1808,enchant=devotion_of_versatility_3,gem_id=192932,ilevel=489
-# finger2=signet_of_the_last_elder,id=207162,bonus_id=1808/7187/1520,enchant=devotion_of_critical_strike_3,gem_id=192932
-# trinket1=cataclysmic_signet_brand,id=207166,bonus_id=7187/1520
-# trinket2=mydas_talisman,id=158319,ilevel=489
-# main_hand=thorncaller_claw,id=207784,bonus_id=7187/1520,enchant=sophic_devotion_3
-# off_hand=nick_of_time,id=207996,bonus_id=9526,enchant=wafting_devotion_3,ilevel=489
+head=lurking_specters_visage,id=217208,bonus_id=1808/10359/1488,gem_id=192982,enchant=incandescent_essence
+neck=ouroboreal_necklet,id=210214,bonus_id=8782/10359/1488,gem_id=192932/192932/192932
+shoulders=lurking_specters_shoulderblades,id=217210,bonus_id=10359/1488
+back=voice_of_the_silent_star,id=204465,bonus_id=10359/1495
+chest=lurking_specters_brigandine,id=217206,bonus_id=10359/1488,enchant=waking_stats_3
+wrists=lifebound_bindings,id=193419,bonus_id=8780/8797/8960/10249/10359/9405,gem_id=192932,crafted_stats=32/40
+hands=lurking_specters_handgrips,id=217207,bonus_id=10359/1488
+waist=troggskin_waistband,id=193668,bonus_id=1808,ilevel=528,gem_id=192932,enchant_id=6904
+legs=annoras_punctured_leggings,id=193811,ilevel=528,enchant_id=6830
+feet=toxic_thorn_footwraps,id=193452,bonus_id=8960/8840/8836/8902/10249/10359/9405,crafted_stats=32/40
+finger1=seal_of_diurnas_chosen,id=195480,bonus_id=1808/10359/1488,gem_id=192932,enchant=devotion_of_versatility_3
+finger2=tormentors_siphoning_signet,id=204466,bonus_id=1808/10359/1488,gem_id=192932,enchant=devotion_of_versatility_3
+trinket1=cataclysmic_signet_brand,id=207166,bonus_id=10359/1488
+trinket2=manic_grieftorch,id=194308,bonus_id=10359/1488
+main_hand=forgestorm,id=193785,bonus_id=10359/1488,enchant=wafting_devotion_3
+off_hand=thorncaller_claw,id=207784,bonus_id=10359/1488,enchant=wafting_devotion_3
 
-# save=DF4_Rogue_Outlaw.simc
+save=DF4_Rogue_Outlaw.simc
 
 # rogue=DF4_Rogue_Subtlety
 # level=70


### PR DESCRIPTION
- Add Roll the Bones action in default action list to be used when 0 targets are active
- Manic Grieftorch and Beacon to the Beyond can't be used between globals anymore, and should be higher priority than stealth cooldowns
- Add out-of-stealth Between the Eyes logic to better handle situations where it's not supposed to be casted if the actor will recast stealth soon in Dungeonslice/Dungeonroute