### PR TITLE
[damage_buff_t] Allow overriding the base scaling quantity in addition to per-stack scaling

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -3839,12 +3839,13 @@ buff_t* damage_buff_t::apply_affecting_effect( const spelleffect_data_t& effect 
 
 damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, double multiplier )
 {
-  return set_buff_mod( mod, spell_data_t::nil(), 0, multiplier );
+  return set_buff_mod( mod, spell_data_t::nil(), 0, multiplier, 1.0 );
 }
 
-damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, const spell_data_t* s, size_t effect_idx, double multiplier )
+damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
 {
   assert( mod.s_data == nullptr && mod.effect_idx == 0 );
+  mod.initial_multiplier = initial_multiplier;
 
   if( multiplier != 0.0 )
     mod.multiplier = 1.0 + multiplier;
@@ -3863,26 +3864,26 @@ damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, const s
 damage_buff_t* damage_buff_t::set_direct_mod( double multiplier )
 { return set_direct_mod( spell_data_t::nil(), 0, multiplier ); }
 
-damage_buff_t* damage_buff_t::set_direct_mod( const spell_data_t* s, size_t effect_idx, double multiplier )
-{ return set_buff_mod( direct_mod, s, effect_idx, multiplier ); }
+damage_buff_t* damage_buff_t::set_direct_mod( const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
+{ return set_buff_mod( direct_mod, s, effect_idx, multiplier, initial_multiplier ); }
 
 damage_buff_t* damage_buff_t::set_periodic_mod( double multiplier )
 { return set_periodic_mod( spell_data_t::nil(), 0, multiplier ); }
 
-damage_buff_t* damage_buff_t::set_periodic_mod( const spell_data_t* s, size_t effect_idx, double multiplier )
-{ return set_buff_mod( periodic_mod, s, effect_idx, multiplier ); }
+damage_buff_t* damage_buff_t::set_periodic_mod( const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
+{ return set_buff_mod( periodic_mod, s, effect_idx, multiplier, initial_multiplier ); }
 
 damage_buff_t* damage_buff_t::set_auto_attack_mod( double multiplier )
 { return set_auto_attack_mod( spell_data_t::nil(), 0, multiplier ); }
 
-damage_buff_t* damage_buff_t::set_auto_attack_mod( const spell_data_t* s, size_t effect_idx, double multiplier )
-{ return set_buff_mod( auto_attack_mod, s, effect_idx, multiplier ); }
+damage_buff_t* damage_buff_t::set_auto_attack_mod( const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
+{ return set_buff_mod( auto_attack_mod, s, effect_idx, multiplier, initial_multiplier ); }
 
 damage_buff_t* damage_buff_t::set_crit_chance_mod( double multiplier )
 { return set_crit_chance_mod( spell_data_t::nil(), 0, multiplier ); }
 
 damage_buff_t* damage_buff_t::set_crit_chance_mod( const spell_data_t* s, size_t effect_idx, double multiplier )
-{ return set_buff_mod( crit_chance_mod, s, effect_idx, multiplier ); }
+{ return set_buff_mod( crit_chance_mod, s, effect_idx, multiplier, 1.0 ); }
 
 bool damage_buff_t::is_affecting( const spell_data_t* s )
 {

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -535,6 +535,7 @@ struct damage_buff_t : public buff_t
     const spell_data_t* s_data = nullptr;
     size_t effect_idx = 0;
     double multiplier = 1.0;
+    double initial_multiplier = 1.0;
     std::vector<int> labels;
   };
 
@@ -573,11 +574,11 @@ struct damage_buff_t : public buff_t
   };
 
   damage_buff_t* set_direct_mod( double );
-  damage_buff_t* set_direct_mod( const spell_data_t*, size_t, double = 0.0 );
+  damage_buff_t* set_direct_mod( const spell_data_t*, size_t, double = 0.0, double = 1.0 );
   damage_buff_t* set_periodic_mod( double );
-  damage_buff_t* set_periodic_mod( const spell_data_t*, size_t, double = 0.0 );
+  damage_buff_t* set_periodic_mod( const spell_data_t*, size_t, double = 0.0, double = 1.0 );
   damage_buff_t* set_auto_attack_mod( double );
-  damage_buff_t* set_auto_attack_mod( const spell_data_t*, size_t, double = 0.0 );
+  damage_buff_t* set_auto_attack_mod( const spell_data_t*, size_t, double = 0.0, double = 1.0 );
   damage_buff_t* set_crit_chance_mod( double );
   damage_buff_t* set_crit_chance_mod( const spell_data_t*, size_t, double = 0.0 );
 
@@ -595,7 +596,7 @@ struct damage_buff_t : public buff_t
 
   // Get current direct damage buff multiplier value multiplied by current stacks + benefit tracking.
   double stack_value_direct()
-  { return 1.0 + current_stack * ( value_direct() - 1.0 ); }
+  { return !current_stack ? 1.0 : direct_mod.initial_multiplier + current_stack * ( value_direct() - 1.0 ); }
 
   // Get current direct damage buff multiplier value + NO benefit tracking.
   double check_value_direct() const
@@ -603,7 +604,7 @@ struct damage_buff_t : public buff_t
 
   // Get current direct damage buff multiplier value multiplied by current stacks + NO benefit tracking.
   double check_stack_value_direct() const
-  { return 1.0 + current_stack * ( check_value_direct() - 1.0 ); }
+  { return !current_stack ? 1.0 : direct_mod.initial_multiplier + current_stack * ( check_value_direct() - 1.0 ); }
 
   // Get current periodic damage buff multiplier value + benefit tracking.
   double value_periodic()
@@ -614,7 +615,7 @@ struct damage_buff_t : public buff_t
 
   // Get current periodic damage buff multiplier value multiplied by current stacks + benefit tracking.
   double stack_value_periodic()
-  { return 1.0 + current_stack * ( value_periodic() - 1.0 ); }
+  { return !current_stack ? 1.0 : periodic_mod.initial_multiplier + current_stack * ( value_periodic() - 1.0 ); }
 
   // Get current periodic damage buff multiplier value + NO benefit tracking.
   double check_value_periodic() const
@@ -622,7 +623,7 @@ struct damage_buff_t : public buff_t
 
   // Get current periodic damage buff multiplier value multiplied by current stacks + NO benefit tracking.
   double check_stack_value_periodic() const
-  { return 1.0 + current_stack * ( check_value_periodic() - 1.0 ); }
+  { return !current_stack ? 1.0 : periodic_mod.initial_multiplier + current_stack * ( check_value_periodic() - 1.0 ); }
 
   // Get current AA damage buff multiplier value + benefit tracking.
   double value_auto_attack()
@@ -633,7 +634,7 @@ struct damage_buff_t : public buff_t
 
   // Get current AA damage buff multiplier value multiplied by current stacks + benefit tracking.
   double stack_value_auto_attack()
-  { return 1.0 + current_stack * ( value_auto_attack() - 1.0 ); }
+  { return !current_stack ? 1.0 : auto_attack_mod.initial_multiplier + current_stack * ( value_auto_attack() - 1.0 ); }
 
   // Get current AA damage buff multiplier value + NO benefit tracking.
   double check_value_auto_attack() const
@@ -641,7 +642,7 @@ struct damage_buff_t : public buff_t
 
   // Get current AA damage buff multiplier value multiplied by current stacks + NO benefit tracking.
   double check_stack_value_auto_attack() const
-  { return 1.0 + current_stack * ( check_value_auto_attack() - 1.0 ); }
+  { return !current_stack ? 1.0 : auto_attack_mod.initial_multiplier + current_stack * ( check_value_auto_attack() - 1.0 ); }
 
   // Get current additive crit chance buff value + benefit tracking.
   double value_crit_chance()
@@ -664,7 +665,7 @@ struct damage_buff_t : public buff_t
 
 protected:
   damage_buff_t* set_buff_mod( damage_buff_modifier_t&, double );
-  damage_buff_t* set_buff_mod( damage_buff_modifier_t&, const spell_data_t*, size_t, double );
+  damage_buff_t* set_buff_mod( damage_buff_modifier_t&, const spell_data_t*, size_t, double, double );
 };
 
 /**


### PR DESCRIPTION
This way buffs where the first stack provides a greater benefit than following stacks, like the Fatebound Coin (Heads) buff for rogue, can be appropriately represented (with some data overrides).