### PR TITLE
[Action] implement lockable state flags

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -2549,6 +2549,10 @@ void action_t::init()
   if ( quiet )
     stats->quiet = true;
 
+  // lock existing constructor state flags before parsing
+  snapshot_flags.toggle_lock( true );
+  update_flags.toggle_lock( true );
+
   if ( rolling_periodic )
   {
     // Rolling Periodic refresh behavior overrides other behaviors.
@@ -2621,6 +2625,10 @@ void action_t::init()
   {
     update_flags &= ~STATE_HASTE;
   }
+
+  // release state flag locks
+  snapshot_flags.toggle_lock( false );
+  update_flags.toggle_lock( false );
 
   // Figure out BfA attack power mode based on information assigned to the action object. Note that
   // this only defines the ap type, the ability may not necessarily use attack power at all, however

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2323,7 +2323,7 @@ struct frost_mage_spell_t : public mage_spell_t
   bool track_shatter;
   shatter_source_t* shatter_source;
 
-  unsigned impact_flags;
+  state_flags_t impact_flags;
 
   frost_mage_spell_t( std::string_view n, mage_t* p, const spell_data_t* s = spell_data_t::nil() ) :
     mage_spell_t( n, p, s ),

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -5490,7 +5490,7 @@ struct fire_nova_t : public shaman_spell_t
  */
 struct lava_burst_t : public shaman_spell_t
 {
-  unsigned impact_flags;
+  state_flags_t impact_flags;
   bool wlr_buffed_impact;
   bool ps_buffed_impact;
 


### PR DESCRIPTION
State flags are added/removed via spell attribute parsing during action_t::init(). This means that anything set during construction can be overriden, and as such users must remember to explictly override init() and make changes there.

This allows state flags to be 'locked' in place during spell attribute parsing in action_t::init() such that any flag set/unset during action construction will not be changed. Any changes to state flags made while unlocked will always be applied.