### PR TITLE
[Parse] remove target_data template requirement

### DIFF
--- a/engine/action/parse_effects.cpp
+++ b/engine/action/parse_effects.cpp
@@ -21,42 +21,43 @@ void player_effect_t::print_parsed_line( report::sc_html_stream& os, const sim_t
                                          std::function<std::string( uint32_t )> note_fn,
                                          std::function<std::string( double )> val_str_fn ) const
 {
-std::vector<std::string> notes;
+  std::vector<std::string> notes;
 
-if ( !use_stacks )
+  if ( !use_stacks )
     notes.emplace_back( "No-stacks" );
 
-if ( mastery )
+  if ( mastery )
     notes.emplace_back( "Mastery" );
 
-if ( func )
+  if ( func )
     notes.emplace_back( "Conditional" );
 
-if ( !buff && !func )
+  if ( !buff && !func )
     notes.emplace_back( "Passive" );
 
-if ( note_fn )
+  if ( note_fn )
     notes.emplace_back( note_fn( opt_enum ) );
 
-range::for_each( notes, []( auto& s ) { s[ 0 ] = std::toupper( s[ 0 ] ); } );
+  range::for_each( notes, []( auto& s ) { s[ 0 ] = std::toupper( s[ 0 ] ); } );
 
-std::string val_str = val_str_fn ? val_str_fn( value )
-                      : mastery  ? fmt::format( "{:.5f}", value * 100 )
-                                 : fmt::format( "{:.1f}%", value * 100 );
+  std::string val_str = val_str_fn ? val_str_fn( value )
+                        : mastery  ? fmt::format( "{:.5f}", value * 100 )
+                                   : fmt::format( "{:.1f}%", value * 100 );
 
-os.format(
-  "<td class=\"left\">{}</td>"
-  "<td class=\"right\">{}</td>"
-  "<td class=\"right\">{}</td>"
-  "<td class=\"right\">{}</td>"
-  "<td>{}</td>"
-  "<td>{}</td>""</tr>\n",
-  decorate ? report_decorators::decorated_spell_data( sim, eff->spell() ) : eff->spell()->name_cstr(),
-  eff->spell()->id(),
-  eff->index() + 1,
-  val_str,
-  value_type_name( type ),
-  util::string_join( notes ) );
+  os.format(
+    "<td class=\"left\">{}</td>"
+    "<td class=\"right\">{}</td>"
+    "<td class=\"right\">{}</td>"
+    "<td class=\"right\">{}</td>"
+    "<td>{}</td>"
+    "<td>{}</td>"
+    "</tr>\n",
+    decorate ? report_decorators::decorated_spell_data( sim, eff->spell() ) : eff->spell()->name_cstr(),
+    eff->spell()->id(),
+    eff->index() + 1,
+    val_str,
+    value_type_name( type ),
+    util::string_join( notes ) );
 }
 
 void target_effect_t::print_parsed_line( report::sc_html_stream& os, const sim_t& sim, bool decorate,
@@ -348,13 +349,13 @@ void modified_spell_data_t::parse_effect( pack_t<modify_effect_t>& tmp, const sp
     case P_EFFECT_3: idx = 2; break;
     case P_EFFECT_4: idx = 3; break;
     case P_EFFECT_5: idx = 4; break;
-    default: return;
+    default:         return;
   }
 
   if ( !_spell.affected_by_all( eff ) )
     return;
 
-  auto &effN = effects[ idx ];
+  auto& effN = effects[ idx ];
 
   // dupes are not allowed
   if ( range::contains( effN.permanent, &eff ) || range::contains( effN.conditional, &eff, &modify_effect_t::eff ) )

--- a/engine/action/parse_effects.cpp
+++ b/engine/action/parse_effects.cpp
@@ -461,7 +461,7 @@ void parse_effects_t::parse_effect( pack_t<U>& tmp, const spell_data_t* s_data, 
   else
     val = eff.base_value();
 
-  if constexpr ( std::is_same_v<U, player_effect_t> )
+  if constexpr ( is_detected_v<detect_buff, U> && is_detected_v<detect_type, U> )
   {
     if ( tmp.data.buff && tmp.data.type == USE_DEFAULT )
       val = tmp.data.buff->default_value * 100;
@@ -493,7 +493,7 @@ void parse_effects_t::parse_effect( pack_t<U>& tmp, const spell_data_t* s_data, 
   bool flat = false;
   std::vector<U>* vec;
 
-  if constexpr ( std::is_same_v<U, player_effect_t> )
+  if constexpr ( is_detected_v<detect_buff, U> )
     vec = get_effect_vector( eff, tmp.data, val_mul, type_str, flat, force );
   else
     vec = get_target_effect_vector( eff, tmp.data, val_mul, type_str, flat, force );
@@ -501,7 +501,7 @@ void parse_effects_t::parse_effect( pack_t<U>& tmp, const spell_data_t* s_data, 
   if ( !vec )
     return;
 
-  if constexpr ( std::is_same_v<U, player_effect_t> )
+  if constexpr ( is_detected_v<detect_type, U> )
   {
     if ( !val && tmp.data.type == parse_flag_e::USE_DATA )
       return;
@@ -521,7 +521,7 @@ void parse_effects_t::parse_effect( pack_t<U>& tmp, const spell_data_t* s_data, 
   if ( tmp.data.value != 0.0 )
     val_str = val_str + " (overridden)";
 
-  if constexpr ( std::is_same_v<U, player_effect_t> )
+  if constexpr ( is_detected_v<detect_buff, U> && is_detected_v<detect_type, U> )
   {
     if ( tmp.data.buff )
     {

--- a/engine/action/parse_effects.cpp
+++ b/engine/action/parse_effects.cpp
@@ -59,6 +59,39 @@ os.format(
   util::string_join( notes ) );
 }
 
+void target_effect_t::print_parsed_line( report::sc_html_stream& os, const sim_t& sim, bool decorate,
+                                         std::function<std::string( uint32_t )> note_fn,
+                                         std::function<std::string( double )> val_str_fn ) const
+{
+  std::vector<std::string> notes;
+
+  if ( mastery )
+    notes.emplace_back( "Mastery" );
+
+  if ( note_fn )
+    notes.emplace_back( note_fn( opt_enum ) );
+
+  range::for_each( notes, []( auto& s ) { s[ 0 ] = std::toupper( s[ 0 ] ); } );
+
+  std::string val_str = val_str_fn ? val_str_fn( value )
+                        : mastery  ? fmt::format( "{:.5f}", value * 100 )
+                                   : fmt::format( "{:.1f}%", value * 100 );
+
+  os.format(
+    "<td class=\"left\">{}</td>"
+    "<td class=\"right\">{}</td>"
+    "<td class=\"right\">{}</td>"
+    "<td class=\"right\">{}</td>"
+    "<td>{}</td>"
+    "<td>{}</td></tr>\n",
+    decorate ? report_decorators::decorated_spell_data( sim, eff->spell() ) : eff->spell()->name_cstr(),
+    eff->spell()->id(),
+    eff->index() + 1,
+    val_str,
+    "",
+    util::string_join( notes ) );
+}
+
 // adjust value based on effect modifying effects from mod list.
 // currently supports P_EFFECT_1-5 and A_PROC_TRIGGER_SPELL_WITH_VALUE
 // TODO: add support for P_EFFECTS to modify all effects
@@ -413,6 +446,112 @@ void modified_spell_data_t::parsed_effects_html( report::sc_html_stream& os, con
   }
 }
 
+// main effect parsing function with constexpr checks to handle player_effect_t vs target_effect_t
+template <typename U>
+void parse_effects_t::parse_effect( pack_t<U>& tmp, const spell_data_t* s_data, size_t i, bool force )
+{
+  const auto& eff = s_data->effectN( i );
+  bool mastery = s_data->flags( SX_MASTERY_AFFECTS_POINTS );
+  double val = 0.0;
+  double val_mul = 0.01;
+
+  if ( mastery )
+    val = eff.mastery_value();
+  else
+    val = eff.base_value();
+
+  if constexpr ( std::is_same_v<U, player_effect_t> )
+  {
+    if ( tmp.data.buff && tmp.data.type == USE_DEFAULT )
+      val = tmp.data.buff->default_value * 100;
+
+    if ( !is_valid_aura( eff ) )
+      return;
+  }
+  else
+  {
+    if ( !is_valid_target_aura( eff ) )
+      return;
+  }
+
+  if ( tmp.data.value != 0.0 )
+  {
+    val = tmp.data.value;
+    val_mul = 1.0;
+    mastery = false;
+  }
+  else
+  {
+    apply_affecting_mods( tmp, val, mastery, s_data, i );
+
+    if ( mastery )
+      val_mul = 1.0;
+  }
+
+  std::string type_str;
+  bool flat = false;
+  std::vector<U>* vec;
+
+  if constexpr ( std::is_same_v<U, player_effect_t> )
+    vec = get_effect_vector( eff, tmp.data, val_mul, type_str, flat, force );
+  else
+    vec = get_target_effect_vector( eff, tmp.data, val_mul, type_str, flat, force );
+
+  if ( !vec )
+    return;
+
+  if constexpr ( std::is_same_v<U, player_effect_t> )
+  {
+    if ( !val && tmp.data.type == parse_flag_e::USE_DATA )
+      return;
+  }
+  else
+  {
+    if ( !val )
+      return;
+  }
+
+  val *= val_mul;
+
+  std::string val_str = mastery ? fmt::format( "{:.5f}*mastery", val * 100 )
+                        : flat  ? fmt::format( "{}", val )
+                                : fmt::format( "{:.1f}%", val * ( 1 / val_mul ) );
+
+  if ( tmp.data.value != 0.0 )
+    val_str = val_str + " (overridden)";
+
+  if constexpr ( std::is_same_v<U, player_effect_t> )
+  {
+    if ( tmp.data.buff )
+    {
+      if ( tmp.data.type == parse_flag_e::USE_CURRENT )
+        val_str = flat ? "current value" : "current value percent";
+      else if ( tmp.data.type == parse_flag_e::USE_DEFAULT )
+        val_str = val_str + " (default value)";
+    }
+
+    debug_message( tmp.data, type_str, val_str, mastery, s_data, i );
+  }
+  else
+  {
+    target_debug_message( type_str, val_str, s_data, i );
+  }
+
+  tmp.data.value = val;
+  tmp.data.mastery = mastery;
+  tmp.data.eff = &eff;
+  vec->push_back( tmp.data );
+
+  if ( tmp.copy )
+    tmp.copy->push_back( tmp.data );
+}
+
+// explicit template instantiation
+template void parse_effects_t::parse_effect<player_effect_t>( pack_t<player_effect_t>&, const spell_data_t*, size_t,
+                                                              bool );
+template void parse_effects_t::parse_effect<target_effect_t>( pack_t<target_effect_t>&, const spell_data_t*, size_t,
+                                                              bool );
+
 double parse_effects_t::get_effect_value( const player_effect_t& i, bool benefit ) const
 {
   if ( i.func && !i.func() )
@@ -437,4 +576,589 @@ double parse_effects_t::get_effect_value( const player_effect_t& i, bool benefit
     eff_val *= _player->cache.mastery();
 
   return eff_val;
+}
+
+double parse_effects_t::get_target_effect_value( const target_effect_t& i, actor_target_data_t* td ) const
+{
+  if ( auto check = i.func( td ) )
+  {
+    auto eff_val = i.value * check;
+
+    if ( i.mastery )
+      eff_val *= _player->cache.mastery();
+
+    return eff_val;
+  }
+
+  return 0.0;
+}
+
+double parse_player_effects_t::composite_melee_auto_attack_speed() const
+{
+  auto ms = player_t::composite_melee_auto_attack_speed();
+
+  for ( const auto& i : auto_attack_speed_effects )
+    ms *= 1.0 / ( 1.0 + get_effect_value( i ) );
+
+  return ms;
+}
+
+double parse_player_effects_t::composite_attribute_multiplier( attribute_e attr ) const
+{
+  auto am = player_t::composite_attribute_multiplier( attr );
+
+  assert( attr != ATTRIBUTE_NONE && "ATTRIBUTE_NONE will be out of index" );
+
+  for ( const auto& i : attribute_multiplier_effects )
+    if ( i.opt_enum & ( 1 << ( attr - 1 ) ) )
+      am *= 1.0 + get_effect_value( i );
+
+  return am;
+}
+
+double parse_player_effects_t::composite_damage_versatility() const
+{
+  auto v = player_t::composite_damage_versatility();
+
+  for ( const auto& i : versatility_effects )
+    v += get_effect_value( i );
+
+  return v;
+}
+
+double parse_player_effects_t::composite_heal_versatility() const
+{
+  auto v = player_t::composite_heal_versatility();
+
+  for ( const auto& i : versatility_effects )
+    v += get_effect_value( i );
+
+  return v;
+}
+
+double parse_player_effects_t::composite_mitigation_versatility() const
+{
+  auto v = player_t::composite_mitigation_versatility();
+
+  for ( const auto& i : versatility_effects )
+    v += get_effect_value( i ) * 0.5;
+
+  return v;
+}
+
+double parse_player_effects_t::composite_player_multiplier( school_e school ) const
+{
+  auto m = player_t::composite_player_multiplier( school );
+
+  for ( const auto& i : player_multiplier_effects )
+    if ( i.opt_enum & dbc::get_school_mask( school ) )
+      m *= 1.0 + get_effect_value( i, true );
+
+  return m;
+}
+
+double parse_player_effects_t::composite_player_pet_damage_multiplier( const action_state_t* s, bool guardian ) const
+{
+  auto dm = player_t::composite_player_pet_damage_multiplier( s, guardian );
+
+  for ( const auto& i : pet_multiplier_effects )
+    if ( static_cast<bool>( i.opt_enum ) == guardian )
+      dm *= 1.0 + get_effect_value( i, true );
+
+  return dm;
+}
+
+double parse_player_effects_t::composite_attack_power_multiplier() const
+{
+  auto apm = player_t::composite_attack_power_multiplier();
+
+  for ( const auto& i : attack_power_multiplier_effects )
+    apm *= 1.0 + get_effect_value( i );
+
+  return apm;
+}
+
+double parse_player_effects_t::composite_melee_crit_chance() const
+{
+  auto mcc = player_t::composite_melee_crit_chance();
+
+  for ( const auto& i : crit_chance_effects )
+    mcc += get_effect_value( i );
+
+  return mcc;
+}
+
+double parse_player_effects_t::composite_spell_crit_chance() const
+{
+  auto scc = player_t::composite_spell_crit_chance();
+
+  for ( const auto& i : crit_chance_effects )
+    scc += get_effect_value( i );
+
+  return scc;
+}
+
+double parse_player_effects_t::composite_leech() const
+{
+  auto leech = player_t::composite_leech();
+
+  for ( const auto& i : leech_effects )
+    leech += get_effect_value( i );
+
+  return leech;
+}
+
+double parse_player_effects_t::composite_melee_expertise( const weapon_t* ) const
+{
+  auto me = player_t::composite_melee_expertise( nullptr );
+
+  for ( const auto& i : expertise_effects )
+    me += get_effect_value( i );
+
+  return me;
+}
+
+double parse_player_effects_t::composite_crit_avoidance() const
+{
+  auto ca = player_t::composite_crit_avoidance();
+
+  for ( const auto& i : crit_avoidance_effects )
+    ca += get_effect_value( i );
+
+  return ca;
+}
+
+double parse_player_effects_t::composite_parry() const
+{
+  auto parry = player_t::composite_parry();
+
+  for ( const auto& i : parry_effects )
+    parry += get_effect_value( i );
+
+  return parry;
+}
+
+double parse_player_effects_t::composite_armor_multiplier() const
+{
+  auto am = player_t::composite_armor_multiplier();
+
+  for ( const auto& i : armor_multiplier_effects )
+    am *= 1.0 + get_effect_value( i );
+
+  return am;
+}
+
+double parse_player_effects_t::composite_melee_haste() const
+{
+  auto mh = player_t::composite_melee_haste();
+
+  for ( const auto& i : haste_effects )
+    mh *= 1.0 / ( 1.0 + get_effect_value( i ) );
+
+  return mh;
+}
+
+double parse_player_effects_t::composite_spell_haste() const
+{
+  auto sh = player_t::composite_spell_haste();
+
+  for ( const auto& i : haste_effects )
+    sh *= 1.0 / ( 1.0 + get_effect_value( i ) );
+
+  return sh;
+}
+
+double parse_player_effects_t::composite_mastery() const
+{
+  auto m = player_t::composite_mastery();
+
+  for ( const auto& i : mastery_effects )
+    m += get_effect_value( i );
+
+  return m;
+}
+
+double parse_player_effects_t::composite_parry_rating() const
+{
+  auto pr = player_t::composite_parry_rating();
+
+  for ( const auto& i : parry_rating_from_crit_effects )
+    pr += player_t::composite_melee_crit_rating() * get_effect_value( i );
+
+  return pr;
+}
+
+double parse_player_effects_t::composite_dodge() const
+{
+  auto dodge = player_t::composite_dodge();
+
+  for ( const auto& i : dodge_effects )
+    dodge += get_effect_value( i );
+
+  return dodge;
+}
+
+double parse_player_effects_t::matching_gear_multiplier( attribute_e attr ) const
+{
+  double mg = player_t::matching_gear_multiplier( attr );
+
+  assert( attr != ATTRIBUTE_NONE && "ATTRIBUTE_NONE will be out of index" );
+
+  for ( const auto& i : matching_armor_attribute_multiplier_effects )
+    if ( i.opt_enum & ( 1 << ( attr - 1 ) ) )
+      mg += get_effect_value( i );
+
+  return mg;
+}
+
+double parse_player_effects_t::composite_player_target_multiplier( player_t* target, school_e school ) const
+{
+  auto tm = player_t::composite_player_target_multiplier( target, school );
+  auto td = get_target_data( target );
+
+  for ( const auto& i : target_multiplier_effects )
+    if ( i.opt_enum & dbc::get_school_mask( school ) )
+      tm *= 1.0 + get_target_effect_value( i, td );
+
+  return tm;
+}
+
+double parse_player_effects_t::composite_player_target_pet_damage_multiplier( player_t* target, bool guardian ) const
+{
+  auto tm = player_t::composite_player_target_pet_damage_multiplier( target, guardian );
+  auto td = get_target_data( target );
+
+  for ( const auto& i : target_pet_multiplier_effects )
+    if ( static_cast<bool>( i.opt_enum ) == guardian )
+      tm *= 1.0 + get_target_effect_value( i, td );
+
+  return tm;
+}
+
+void parse_player_effects_t::invalidate_cache( cache_e c )
+{
+  player_t::invalidate_cache( c );
+
+  for ( const auto& i : invalidate_with_parent )
+  {
+    if ( c == i.second )
+      player_t::invalidate_cache( i.first );
+  }
+}
+
+bool parse_player_effects_t::is_valid_aura( const spelleffect_data_t& eff ) const
+{
+  switch ( eff.type() )
+  {
+    case E_APPLY_AURA:
+    case E_APPLY_AURA_PET:
+      // TODO: more robust logic around 'party' buffs with radius
+      if ( eff.radius() )
+        return false;
+      break;
+    case E_APPLY_AREA_AURA_PARTY:
+    case E_APPLY_AREA_AURA_PET:
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+std::vector<player_effect_t>* parse_player_effects_t::get_effect_vector( const spelleffect_data_t& eff,
+                                                                         player_effect_t& data, double& val_mul,
+                                                                         std::string& str, bool& /* flat */,
+                                                                         bool /* force */ )
+{
+  auto invalidate = [ &data ]( cache_e c ) {
+    if ( data.buff )
+      data.buff->add_invalidate( c );
+  };
+
+  switch ( eff.subtype() )
+  {
+    case A_MOD_MELEE_AUTO_ATTACK_SPEED:
+    case A_MOD_RANGED_AND_MELEE_AUTO_ATTACK_SPEED:
+      str = "auto attack speed";
+      invalidate( CACHE_AUTO_ATTACK_SPEED );
+      return &auto_attack_speed_effects;
+
+    case A_MOD_TOTAL_STAT_PERCENTAGE:
+      data.opt_enum = eff.misc_value2();
+      {
+        std::vector<std::string> str_list;
+        for ( auto stat : { STAT_STRENGTH, STAT_AGILITY, STAT_STAMINA, STAT_INTELLECT, STAT_SPIRIT } )
+        {
+          if ( data.opt_enum & ( 1 << ( stat - 1 ) ) )
+          {
+            str_list.emplace_back( util::stat_type_string( stat ) );
+            invalidate( cache_from_stat( stat ) );
+          }
+        }
+        str = util::string_join( str_list );
+      }
+
+      if ( eff.spell()->equipped_class() == ITEM_CLASS_ARMOR && eff.spell()->flags( SX_REQUIRES_EQUIPPED_ARMOR_TYPE ) )
+      {
+        auto type_bit = 1U << static_cast<unsigned>( util::matching_armor_type( type ) );
+        if ( eff.spell()->equipped_subclass_mask() == type_bit )
+        {
+          str += "|with matching armor";
+          return &matching_armor_attribute_multiplier_effects;
+        }
+      }
+
+      return &attribute_multiplier_effects;
+
+    case A_MOD_VERSATILITY_PCT:
+      str = "versatility";
+      invalidate( CACHE_VERSATILITY );
+      return &versatility_effects;
+
+    case A_HASTE_ALL:
+      str = "haste";
+      invalidate( CACHE_HASTE );
+      return &haste_effects;
+
+    case A_MOD_MASTERY_PCT:
+      str = "mastery";
+      val_mul = 1.0;
+      invalidate( CACHE_MASTERY );
+      return &mastery_effects;
+
+    case A_MOD_ALL_CRIT_CHANCE:
+      str = "all crit chance";
+      invalidate( CACHE_CRIT_CHANCE );
+      return &crit_chance_effects;
+
+    case A_MOD_DAMAGE_PERCENT_DONE:
+      data.opt_enum = eff.misc_value1();
+      str = data.opt_enum == 0x7f ? "all" : util::school_type_string( dbc::get_school_type( data.opt_enum ) );
+      str += " damage";
+      invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
+      return &player_multiplier_effects;
+
+    case A_MOD_PET_DAMAGE_DONE:
+      data.opt_enum = 0;
+      str = "pet damage";
+      return &pet_multiplier_effects;
+
+    case A_MOD_GUARDIAN_DAMAGE_DONE:
+      data.opt_enum = 1;
+      str = "guardian damage";
+      return &pet_multiplier_effects;
+
+    case A_MOD_ATTACK_POWER_PCT:
+      str = "attack power";
+      invalidate( CACHE_ATTACK_POWER );
+      return &attack_power_multiplier_effects;
+
+    case A_MOD_LEECH_PERCENT:
+      str = "leech";
+      invalidate( CACHE_LEECH );
+      return &leech_effects;
+
+    case A_MOD_EXPERTISE:
+      str = "expertise";
+      invalidate( CACHE_EXP );
+      return &expertise_effects;
+
+    case A_MOD_ATTACKER_MELEE_CRIT_CHANCE:
+      str = "crit avoidance";
+      invalidate( CACHE_CRIT_AVOIDANCE );
+      return &crit_avoidance_effects;
+
+    case A_MOD_PARRY_PERCENT:
+      str = "parry";
+      invalidate( CACHE_PARRY );
+      return &parry_effects;
+
+    case A_MOD_RESISTANCE_PCT:
+    case A_MOD_BASE_RESISTANCE_PCT:
+      str = "armor multiplier";
+      invalidate( CACHE_ARMOR );
+      return &armor_multiplier_effects;
+
+    case A_MOD_PARRY_FROM_CRIT_RATING:
+      str = "parry rating|of crit rating";
+      invalidate_with_parent.emplace_back( CACHE_PARRY, CACHE_CRIT_CHANCE );
+      return &parry_rating_from_crit_effects;
+
+    case A_MOD_DODGE_PERCENT:
+      str = "dodge";
+      invalidate( CACHE_DODGE );
+      return &dodge_effects;
+
+    default:
+      return nullptr;
+  }
+
+  return nullptr;
+}
+
+void parse_player_effects_t::debug_message( const player_effect_t& data, std::string_view type_str,
+                                            std::string_view val_str, bool mastery, const spell_data_t* s_data,
+                                            size_t i )
+{
+  auto splits = util::string_split<std::string_view>( type_str, "|" );
+  auto tok1 = splits[ 0 ];
+  auto tok2 = std::string( val_str );
+
+  if ( splits.size() > 1 )
+    tok2 += fmt::format( " {}", splits[ 1 ] );
+
+  if ( data.buff )
+  {
+    sim->print_debug( "player-effects: {} {} modified by {} {} buff {} ({}#{})", *this, tok1, tok2,
+                      data.use_stacks ? "per stack of" : "with", data.buff->name(), data.buff->data().id(), i );
+  }
+  else if ( mastery && !data.func )
+  {
+    sim->print_debug( "player-effects: {} {} modified by {} from {} ({}#{})", *this, tok1, tok2, s_data->name_cstr(),
+                      s_data->id(), i );
+  }
+  else if ( data.func )
+  {
+    sim->print_debug( "player-effects: {} {} modified by {} with condition from {} ({}#{})", *this, tok1, tok2,
+                      s_data->name_cstr(), s_data->id(), i );
+  }
+  else
+  {
+    sim->print_debug( "player-effects: {} {} modified by {} from {} ({}#{})", *this, tok1, tok2, s_data->name_cstr(),
+                      s_data->id(), i );
+  }
+}
+
+bool parse_player_effects_t::is_valid_target_aura( const spelleffect_data_t& eff ) const
+{
+  if ( eff.type() == E_APPLY_AURA )
+    return true;
+
+  return false;
+}
+
+std::vector<target_effect_t>* parse_player_effects_t::get_target_effect_vector( const spelleffect_data_t& eff,
+                                                                                target_effect_t& data,
+                                                                                double& /* val_mul */, std::string& str,
+                                                                                bool& /* flat */, bool /* force */ )
+{
+  switch ( eff.subtype() )
+  {
+    case A_MOD_DAMAGE_FROM_CASTER:
+      data.opt_enum = eff.misc_value1();
+      str = data.opt_enum == 0x7f ? "all" : util::school_type_string( dbc::get_school_type( data.opt_enum ) );
+      return &target_multiplier_effects;
+
+    case A_MOD_DAMAGE_FROM_CASTER_PET:
+      data.opt_enum = 0;
+      str = "pet";
+      return &target_pet_multiplier_effects;
+
+    case A_MOD_DAMAGE_FROM_CASTER_GUARDIAN:
+      data.opt_enum = 1;
+      str = "guardian";
+      return &target_pet_multiplier_effects;
+
+    default:
+      return nullptr;
+  }
+
+  return nullptr;
+}
+
+void parse_player_effects_t::target_debug_message( std::string_view type_str, std::string_view val_str,
+                                                   const spell_data_t* s_data, size_t i )
+{
+  sim->print_debug( "target-effects: Target {} damage taken modified by {} from {} ({}#{})", type_str, val_str,
+                    s_data->name_cstr(), s_data->id(), i );
+}
+
+void parse_player_effects_t::parsed_effects_html( report::sc_html_stream& os )
+{
+  if ( total_effects_count() )
+  {
+    os << "<h3 class=\"toggle\">Player Effects</h3>"
+       << "<div class=\"toggle-content hide\">"
+       << "<table class=\"sc left even\">\n";
+
+    os << "<thead><tr>"
+       << "<th>Type</th>"
+       << "<th>Spell</th>"
+       << "<th>ID</th>"
+       << "<th>#</th>"
+       << "<th>Value</th>"
+       << "<th>Source</th>"
+       << "<th>Notes</th>"
+       << "</tr></thead>\n";
+
+    auto attr_note = []( uint32_t opt ) {
+      std::vector<std::string> str_list;
+
+      for ( auto stat : { STAT_STRENGTH, STAT_AGILITY, STAT_STAMINA, STAT_INTELLECT, STAT_SPIRIT } )
+        if ( opt & ( 1 << ( stat - 1 ) ) )
+          str_list.emplace_back( util::stat_type_string( stat ) );
+
+      return util::string_join( str_list );
+    };
+
+    auto mult_note = []( uint32_t opt ) {
+      return opt == 0x7f ? "All" : util::school_type_string( dbc::get_school_type( opt ) );
+    };
+
+    auto pet_note = []( uint32_t opt ) {
+      return opt ? "Guardian" : "Pet";
+    };
+
+    auto mastery_val = [ this ]( double v ) {
+      return fmt::format( "{:.1f}%", v * mastery_coefficient() * 100 );
+    };
+
+    print_parsed_type( os, auto_attack_speed_effects, "Auto Attack Speed" );
+    print_parsed_type( os, attribute_multiplier_effects, "Attribute Multiplier", attr_note );
+    print_parsed_type( os, matching_armor_attribute_multiplier_effects, "Matching Armor", attr_note );
+    print_parsed_type( os, versatility_effects, "Versatility" );
+    print_parsed_type( os, player_multiplier_effects, "Player Multiplier", mult_note );
+    print_parsed_type( os, pet_multiplier_effects, "Pet Multiplier", pet_note );
+    print_parsed_type( os, attack_power_multiplier_effects, "Attack Power Multiplier" );
+    print_parsed_type( os, crit_chance_effects, "Crit Chance" );
+    print_parsed_type( os, leech_effects, "Leech" );
+    print_parsed_type( os, expertise_effects, "Expertise" );
+    print_parsed_type( os, crit_avoidance_effects, "Crit Avoidance" );
+    print_parsed_type( os, parry_effects, "Parry" );
+    print_parsed_type( os, armor_multiplier_effects, "Armor Multiplier" );
+    print_parsed_type( os, haste_effects, "Haste" );
+    print_parsed_type( os, mastery_effects, "Mastery", nullptr, mastery_val );
+    print_parsed_type( os, parry_rating_from_crit_effects, "Parry Rating from Crit" );
+    print_parsed_type( os, dodge_effects, "Dodge" );
+    print_parsed_type( os, target_multiplier_effects, "Target Multiplier", mult_note );
+    print_parsed_type( os, target_pet_multiplier_effects, "Target Pet Multiplier", pet_note );
+    print_parsed_custom_type( os );
+
+    os << "</table>\n"
+       << "</div>\n";
+  }
+}
+
+size_t parse_player_effects_t::total_effects_count()
+{
+  return auto_attack_speed_effects.size() +
+         attribute_multiplier_effects.size() +
+         matching_armor_attribute_multiplier_effects.size() +
+         versatility_effects.size() +
+         player_multiplier_effects.size() +
+         pet_multiplier_effects.size() +
+         attack_power_multiplier_effects.size() +
+         crit_chance_effects.size() +
+         leech_effects.size() +
+         expertise_effects.size() +
+         crit_avoidance_effects.size() +
+         parry_effects.size() +
+         armor_multiplier_effects.size() +
+         haste_effects.size() +
+         mastery_effects.size() +
+         parry_rating_from_crit_effects.size() +
+         dodge_effects.size() +
+         target_multiplier_effects.size() +
+         target_pet_multiplier_effects.size();
 }

--- a/engine/action/parse_effects.hpp
+++ b/engine/action/parse_effects.hpp
@@ -61,7 +61,7 @@ struct player_effect_t
   player_effect_t& set_opt_enum( uint32_t e )
   { opt_enum = e; return *this; }
 
-  bool operator==( const player_effect_t&  other )
+  bool operator==( const player_effect_t& other )
   {
     return buff == other.buff && value == other.value && type == other.type && use_stacks == other.use_stacks &&
            mastery == other.mastery && eff == other.eff && opt_enum == other.opt_enum;
@@ -650,7 +650,7 @@ struct parse_player_effects_t : public player_t, public parse_effects_t
                           std::function<std::string( double )> val_str_fn = nullptr )
   {
     auto c = entries.size();
-    if( !c )
+    if ( !c )
       return;
 
     os.format( "<tr><td rowspan=\"{}\" class=\"dark\">{}</td>", c, n );
@@ -915,49 +915,18 @@ public:
     {
       switch ( eff.misc_value1() )
       {
-        case P_GENERIC:
-          str = "direct damage";
-          return &da_multiplier_effects;
-
-        case P_DURATION:
-          str = "duration";
-          return &dot_duration_effects;
-
-        case P_TICK_DAMAGE:
-          str = "tick damage";
-          return &ta_multiplier_effects;
-
-        case P_CAST_TIME:
-          str = "cast time";
-          return &execute_time_effects;
-
-        case P_GCD:
-          str = "gcd";
-          return &gcd_effects;
-
-        case P_TICK_TIME:
-          str = "tick time";
-          return &tick_time_effects;
-
-        case P_COOLDOWN:
-          str = "cooldown";
-          adjust_recharge_multiplier_warning();
-          return &recharge_multiplier_effects;
-
-        case P_RESOURCE_COST:
-          str = "cost percent";
-          return &cost_effects;
-
-        case P_CRIT:
-          str = "crit chance multiplier";
-          return &crit_chance_multiplier_effects;
-
-        case P_CRIT_DAMAGE:
-          str = "crit damage";
-          return &crit_damage_effects;
-
-        default:
-          return nullptr;
+        case P_GENERIC:       str = "direct damage";          return &da_multiplier_effects;
+        case P_DURATION:      str = "duration";               return &dot_duration_effects;
+        case P_TICK_DAMAGE:   str = "tick damage";            return &ta_multiplier_effects;
+        case P_CAST_TIME:     str = "cast time";              return &execute_time_effects;
+        case P_GCD:           str = "gcd";                    return &gcd_effects;
+        case P_TICK_TIME:     str = "tick time";              return &tick_time_effects;
+        case P_RESOURCE_COST: str = "cost percent";           return &cost_effects;
+        case P_CRIT:          str = "crit chance multiplier"; return &crit_chance_multiplier_effects;
+        case P_CRIT_DAMAGE:   str = "crit damage";            return &crit_damage_effects;
+        case P_COOLDOWN:      adjust_recharge_multiplier_warning();
+                              str = "cooldown";               return &recharge_multiplier_effects;
+        default:              return nullptr;
       }
     }
     else if ( eff.subtype() == A_ADD_FLAT_MODIFIER || eff.subtype() == A_ADD_FLAT_LABEL_MODIFIER )
@@ -966,17 +935,10 @@ public:
 
       switch ( eff.misc_value1() )
       {
-        case P_CRIT:
-          str = "crit chance";
-          return &crit_chance_effects;
-
-        case P_RESOURCE_COST:
-          val_mul = spelleffect_data_t::resource_multiplier( BASE::current_resource() );
-          str = "flat cost";
-          return &flat_cost_effects;
-
-        default:
-          return nullptr;
+        case P_CRIT:          str = "crit chance"; return &crit_chance_effects;
+        case P_RESOURCE_COST: val_mul = spelleffect_data_t::resource_multiplier( BASE::current_resource() );
+                              str = "flat cost";   return &flat_cost_effects;
+        default:              return nullptr;
       }
     }
     else if ( eff.subtype() == A_MOD_RECHARGE_RATE_LABEL || eff.subtype() == A_MOD_RECHARGE_RATE_CATEGORY )
@@ -1041,18 +1003,11 @@ public:
       switch ( eff.subtype() )
       {
         case A_MOD_DAMAGE_FROM_CASTER_SPELLS:
-        case A_MOD_DAMAGE_FROM_CASTER_SPELLS_LABEL:
-          str = "damage";
-          return &target_multiplier_effects;
-        case A_MOD_CRIT_CHANCE_FROM_CASTER_SPELLS:
-          flat = true;
-          str = "crit chance";
-          return &target_crit_chance_effects;
-        case A_MOD_CRIT_DAMAGE_PCT_FROM_CASTER_SPELLS:
-          str = "crit damage";
-          return &target_crit_damage_effects;
-        default:
-          return nullptr;
+        case A_MOD_DAMAGE_FROM_CASTER_SPELLS_LABEL:    str = "damage";      return &target_multiplier_effects;
+        case A_MOD_CRIT_CHANCE_FROM_CASTER_SPELLS:     flat = true;
+                                                       str = "crit chance"; return &target_crit_chance_effects;
+        case A_MOD_CRIT_DAMAGE_PCT_FROM_CASTER_SPELLS: str = "crit damage"; return &target_crit_damage_effects;
+        default:                                       return nullptr;
       }
     }
 

--- a/engine/action/parse_effects.hpp
+++ b/engine/action/parse_effects.hpp
@@ -75,16 +75,15 @@ struct player_effect_t
 
 // effects dependent on target state
 // TODO: add value type to debuffs if it becomes necessary in the future
-template <typename TD>
 struct target_effect_t
 {
-  std::function<int( TD* )> func = nullptr;
+  std::function<int( actor_target_data_t* )> func = nullptr;
   double value = 0.0;
   bool mastery = false;
   const spelleffect_data_t* eff = &spelleffect_data_t::nil();
   uint32_t opt_enum = UINT32_MAX;
 
-  target_effect_t& set_func( std::function<int( TD* )> f )
+  target_effect_t& set_func( std::function<int( actor_target_data_t* )> f )
   { func = std::move( f ); return *this; }
 
   target_effect_t& set_value( double v )
@@ -99,43 +98,13 @@ struct target_effect_t
   target_effect_t& set_opt_enum( uint32_t e )
   { opt_enum = e; return *this; }
 
-  bool operator==( const target_effect_t<TD>&  other )
+  bool operator==( const target_effect_t& other )
   {
     return value == other.value && mastery == other.mastery && eff == other.eff && opt_enum == other.opt_enum;
   }
 
-  void print_parsed_line( report::sc_html_stream& os, const sim_t& sim, bool decorate,
-                          std::function<std::string( uint32_t )> note_fn,
-                          std::function<std::string( double )> val_str_fn ) const
-  {
-    std::vector<std::string> notes;
-
-    if ( mastery )
-      notes.emplace_back( "Mastery" );
-
-    if ( note_fn )
-      notes.emplace_back( note_fn( opt_enum ) );
-
-    range::for_each( notes, []( auto& s ) { s[ 0 ] = std::toupper( s[ 0 ] ); } );
-
-    std::string val_str = val_str_fn ? val_str_fn( value )
-                          : mastery  ? fmt::format( "{:.5f}", value * 100 )
-                                     : fmt::format( "{:.1f}%", value * 100 );
-
-    os.format(
-      "<td class=\"left\">{}</td>"
-      "<td class=\"right\">{}</td>"
-      "<td class=\"right\">{}</td>"
-      "<td class=\"right\">{}</td>"
-      "<td>{}</td>"
-      "<td>{}</td></tr>\n",
-      decorate ? report_decorators::decorated_spell_data( sim, eff->spell() ) : eff->spell()->name_cstr(),
-      eff->spell()->id(),
-      eff->index() + 1,
-      val_str,
-      "",
-      util::string_join( notes ) );
-  }
+  void print_parsed_line( report::sc_html_stream&, const sim_t&, bool, std::function<std::string( uint32_t )>,
+                          std::function<std::string( double )> ) const;
 };
 
 struct modify_effect_t
@@ -446,113 +415,8 @@ public:
   parse_effects_t( player_t* p ) : _player( p ) {}
   virtual ~parse_effects_t() = default;
 
-  // main effect parsing function with constexpr checks to handle player_effect_t vs target_effect_t
   template <typename U>
-  void parse_effect( pack_t<U>& tmp, const spell_data_t* s_data, size_t i, bool force )
-  {
-    const auto& eff = s_data->effectN( i );
-    bool mastery = s_data->flags( SX_MASTERY_AFFECTS_POINTS );
-    double val = 0.0;
-    double val_mul = 0.01;
-
-    if ( mastery )
-      val = eff.mastery_value();
-    else
-      val = eff.base_value();
-
-    if constexpr ( is_detected_v<detect_buff, U> && is_detected_v<detect_type, U> )
-    {
-      if ( tmp.data.buff && tmp.data.type == USE_DEFAULT )
-        val = tmp.data.buff->default_value * 100;
-
-      if ( !is_valid_aura( eff ) )
-        return;
-    }
-    else
-    {
-      if ( !is_valid_target_aura( eff ) )
-        return;
-    }
-
-    if ( tmp.data.value != 0.0 )
-    {
-      val = tmp.data.value;
-      val_mul = 1.0;
-      mastery = false;
-    }
-    else
-    {
-      apply_affecting_mods( tmp, val, mastery, s_data, i );
-
-      if ( mastery )
-        val_mul = 1.0;
-    }
-
-    std::string type_str;
-    bool flat = false;
-    std::vector<U>* vec;
-
-    // NOTE: get_target_effect_vector is virtual and not templated, which means:
-    // 1) only opt_enum reference is passed instead of the full data reference
-    // 2) void* is returned and needs to be re-cast to the correct vector<U>*
-    if constexpr ( is_detected_v<detect_buff, U> )
-    {
-      vec = get_effect_vector( eff, tmp.data, val_mul, type_str, flat, force );
-    }
-    else
-    {
-      vec = static_cast<std::vector<U>*>(
-          get_target_effect_vector( eff, tmp.data.opt_enum, val_mul, type_str, flat, force ) );
-    }
-
-    if ( !vec )
-      return;
-
-    if constexpr ( is_detected_v<detect_type, U> )
-    {
-      if ( !val && tmp.data.type == parse_flag_e::USE_DATA )
-        return;
-    }
-    else
-    {
-      if ( !val )
-        return;
-    }
-
-    val *= val_mul;
-
-    std::string val_str = mastery ? fmt::format( "{:.5f}*mastery", val * 100 )
-                          : flat  ? fmt::format( "{}", val )
-                                  : fmt::format( "{:.1f}%", val * ( 1 / val_mul ) );
-
-    if ( tmp.data.value != 0.0 )
-      val_str = val_str + " (overridden)";
-
-    if constexpr ( is_detected_v<detect_buff, U> )
-    {
-      if ( tmp.data.buff )
-      {
-        if ( tmp.data.type == parse_flag_e::USE_CURRENT )
-          val_str = flat ? "current value" : "current value percent";
-        else if ( tmp.data.type == parse_flag_e::USE_DEFAULT )
-          val_str = val_str + " (default value)";
-      }
-
-      debug_message( tmp.data, type_str, val_str, mastery, s_data, i );
-    }
-    else
-    {
-      target_debug_message( type_str, val_str, s_data, i );
-    }
-
-    tmp.data.value = val;
-    tmp.data.mastery = mastery;
-    tmp.data.eff = &eff;
-    vec->push_back( tmp.data );
-
-    if ( tmp.copy )
-      tmp.copy->push_back( tmp.data );
-  }
+  void parse_effect( pack_t<U>&, const spell_data_t*, size_t, bool );
 
   // Syntax: parse_effects( data[, spells|condition|ignore_mask|value|flags][,...] )
   //   (buff_t*) or
@@ -581,7 +445,7 @@ public:
   //
   // Example 4: Parse buff3, only apply if my_player_t::check2() and my_player_t::check3() returns true:
   //   parse_effects( buff3, [ this ] { return p()->check2() && p()->check3(); } );
-  virtual bool is_valid_aura( const spelleffect_data_t& /* eff */ ) const { return false; }
+  virtual bool is_valid_aura( const spelleffect_data_t& ) const { return false; }
 
   virtual std::vector<player_effect_t>* get_effect_vector( const spelleffect_data_t& eff, player_effect_t& data,
                                                            double& val_mul, std::string& str, bool& flat,
@@ -644,20 +508,20 @@ public:
   // The following optional arguments can be used in any order:
   //   (const spell_data_t*) spells: List of spells with redirect effects that modify the effects on the debuff
   //   (unsigned)       ignore_mask: Bitmask to skip effect# n corresponding to the n'th bit
-  virtual bool is_valid_target_aura( const spelleffect_data_t& /* eff */ ) const { return false; }
+  virtual bool is_valid_target_aura( const spelleffect_data_t& ) const { return false; }
 
-  // Return void* as parse_effect_t is not templated and we don't know what TD is
-  virtual void* get_target_effect_vector( const spelleffect_data_t& eff, uint32_t& opt_enum, double& val_mul,
-                                          std::string& str, bool& flat, bool force ) = 0;
+  virtual std::vector<target_effect_t>* get_target_effect_vector( const spelleffect_data_t& eff, target_effect_t& data,
+                                                                  double& val_mul, std::string& str, bool& flat,
+                                                                  bool force ) = 0;
 
   virtual void target_debug_message( std::string_view type_str, std::string_view val_str, const spell_data_t* s_data,
                                      size_t i ) = 0;
 
-  // Needs a wrapper to set TD parameter, as parse_effect_t is not templated
-  template <typename TD, typename... Ts>
-  void _parse_target_effects( const std::function<int( TD* )>& fn, const spell_data_t* spell, Ts... mods )
+  template <typename... Ts>
+  void parse_target_effects( const std::function<int( actor_target_data_t* )>& fn, const spell_data_t* spell,
+                             Ts... mods )
   {
-    pack_t<target_effect_t<TD>> pack;
+    pack_t<target_effect_t> pack;
 
     if ( !spell || !spell->ok() )
       return;
@@ -673,17 +537,17 @@ public:
         continue;
 
       // local copy of pack per effect
-      pack_t<target_effect_t<TD>> tmp = pack;
+      pack_t<target_effect_t> tmp = pack;
 
       parse_effect( tmp, spell, i, false );
     }
   }
 
-  // Needs a wrapper to set TD parameter, as parse_effect_t is not templated
-  template <typename TD, typename... Ts>
-  void _force_target_effect( const std::function<int( TD* )>& fn, const spell_data_t* spell, unsigned idx, Ts... mods )
+  template <typename... Ts>
+  void force_target_effect( const std::function<int( actor_target_data_t* )>& fn, const spell_data_t* spell,
+                            unsigned idx, Ts... mods )
   {
-    pack_t<target_effect_t<TD>> pack;
+    pack_t<target_effect_t> pack;
 
     if ( !spell || !spell->ok() )
       return;
@@ -702,24 +566,9 @@ public:
     parse_effect( pack, spell, idx, true );
   }
 
-  template <typename TD>
-  double get_target_effect_value( const target_effect_t<TD>& i, TD* td ) const
-  {
-    if ( auto check = i.func( td ) )
-    {
-      auto eff_val = i.value * check;
-
-      if ( i.mastery )
-        eff_val *= _player->cache.mastery();
-
-      return eff_val;
-    }
-
-    return 0.0;
-  }
+  double get_target_effect_value( const target_effect_t&, actor_target_data_t* ) const;
 };
 
-template <typename TD>
 struct parse_player_effects_t : public player_t, public parse_effects_t
 {
   std::vector<player_effect_t> auto_attack_speed_effects;
@@ -739,8 +588,8 @@ struct parse_player_effects_t : public player_t, public parse_effects_t
   std::vector<player_effect_t> mastery_effects;
   std::vector<player_effect_t> parry_rating_from_crit_effects;
   std::vector<player_effect_t> dodge_effects;
-  std::vector<target_effect_t<TD>> target_multiplier_effects;
-  std::vector<target_effect_t<TD>> target_pet_multiplier_effects;
+  std::vector<target_effect_t> target_multiplier_effects;
+  std::vector<target_effect_t> target_pet_multiplier_effects;
 
   // Cache Pairing, invalidate first of the pair when the second is invalidated
   std::vector<std::pair<cache_e, cache_e>> invalidate_with_parent;
@@ -749,590 +598,50 @@ struct parse_player_effects_t : public player_t, public parse_effects_t
     : player_t( sim, type, name, race ), parse_effects_t( this )
   {}
 
-  double composite_melee_auto_attack_speed() const override
-  {
-    auto ms = player_t::composite_melee_auto_attack_speed();
-
-    for ( const auto& i : auto_attack_speed_effects )
-      ms *= 1.0 / ( 1.0 + get_effect_value( i ) );
-
-    return ms;
-  }
-
-  double composite_attribute_multiplier( attribute_e attr ) const override
-  {
-    auto am = player_t::composite_attribute_multiplier( attr );
-
-    assert( attr != ATTRIBUTE_NONE && "ATTRIBUTE_NONE will be out of index" );
-
-    for ( const auto& i : attribute_multiplier_effects )
-      if ( i.opt_enum & ( 1 << ( attr - 1 ) ) )
-        am *= 1.0 + get_effect_value( i );
-
-    return am;
-  }
-
-  double composite_damage_versatility() const override
-  {
-    auto v = player_t::composite_damage_versatility();
-
-    for ( const auto& i : versatility_effects )
-      v += get_effect_value( i );
-
-    return v;
-  }
-
-  double composite_heal_versatility() const override
-  {
-    auto v = player_t::composite_heal_versatility();
-
-    for ( const auto& i : versatility_effects )
-      v += get_effect_value( i );
-
-    return v;
-  }
-
-  double composite_mitigation_versatility() const override
-  {
-    auto v = player_t::composite_mitigation_versatility();
-
-    for ( const auto& i : versatility_effects )
-      v += get_effect_value( i ) * 0.5;
-
-    return v;
-  }
-
-  double composite_player_multiplier( school_e school ) const override
-  {
-    auto m = player_t::composite_player_multiplier( school );
-
-    for ( const auto& i : player_multiplier_effects )
-      if ( i.opt_enum & dbc::get_school_mask( school ) )
-        m *= 1.0 + get_effect_value( i, true );
-
-    return m;
-  }
-
-  double composite_player_pet_damage_multiplier( const action_state_t* s, bool guardian ) const override
-  {
-    auto dm = player_t::composite_player_pet_damage_multiplier( s, guardian );
-
-    for ( const auto& i : pet_multiplier_effects )
-      if ( static_cast<bool>( i.opt_enum ) == guardian )
-        dm *= 1.0 + get_effect_value( i, true );
-
-    return dm;
-  }
-
-  double composite_attack_power_multiplier() const override
-  {
-    auto apm = player_t::composite_attack_power_multiplier();
-
-    for ( const auto& i : attack_power_multiplier_effects )
-      apm *= 1.0 + get_effect_value( i );
-
-    return apm;
-  }
-
-  double composite_melee_crit_chance() const override
-  {
-    auto mcc = player_t::composite_melee_crit_chance();
-
-    for ( const auto& i : crit_chance_effects )
-      mcc += get_effect_value( i );
-
-    return mcc;
-  }
-
-  double composite_spell_crit_chance() const override
-  {
-    auto scc = player_t::composite_spell_crit_chance();
-
-    for ( const auto& i : crit_chance_effects )
-      scc += get_effect_value( i );
-
-    return scc;
-  }
-
-  double composite_leech() const override
-  {
-    auto leech = player_t::composite_leech();
-
-    for ( const auto& i : leech_effects )
-      leech += get_effect_value( i );
-
-    return leech;
-  }
-
-  double composite_melee_expertise( const weapon_t* ) const override
-  {
-    auto me = player_t::composite_melee_expertise( nullptr );
-
-    for ( const auto& i : expertise_effects )
-      me += get_effect_value( i );
-
-    return me;
-  }
-
-  double composite_crit_avoidance() const override
-  {
-    auto ca = player_t::composite_crit_avoidance();
-
-    for ( const auto& i : crit_avoidance_effects )
-      ca += get_effect_value( i );
-
-    return ca;
-  }
-
-  double composite_parry() const override
-  {
-    auto parry = player_t::composite_parry();
-
-    for ( const auto& i : parry_effects )
-      parry += get_effect_value( i );
-
-    return parry;
-  }
-
-  double composite_armor_multiplier() const override
-  {
-    auto am = player_t::composite_armor_multiplier();
-
-    for ( const auto& i : armor_multiplier_effects )
-      am *= 1.0 + get_effect_value( i );
-
-    return am;
-  }
-
-  double composite_melee_haste() const override
-  {
-    auto mh = player_t::composite_melee_haste();
-
-    for ( const auto& i : haste_effects )
-      mh *= 1.0 / ( 1.0 + get_effect_value( i ) );
-
-    return mh;
-  }
-
-  double composite_spell_haste() const override
-  {
-    auto sh = player_t::composite_spell_haste();
-
-    for ( const auto& i : haste_effects )
-      sh *= 1.0 / ( 1.0 + get_effect_value( i ) );
-
-    return sh;
-  }
-
-  double composite_mastery() const override
-  {
-    auto m = player_t::composite_mastery();
-
-    for ( const auto& i : mastery_effects )
-      m += get_effect_value( i );
-
-    return m;
-  }
-
-  double composite_parry_rating() const override
-  {
-    auto pr = player_t::composite_parry_rating();
-
-    for ( const auto& i : parry_rating_from_crit_effects )
-      pr += player_t::composite_melee_crit_rating() * get_effect_value( i );
-
-    return pr;
-  }
-
-  double composite_dodge() const override
-  {
-    auto dodge = player_t::composite_dodge();
-
-    for ( const auto& i : dodge_effects )
-      dodge += get_effect_value( i );
-
-    return dodge;
-  }
-
-  double matching_gear_multiplier( attribute_e attr ) const override
-  {
-    double mg = player_t::matching_gear_multiplier( attr );
-
-    assert( attr != ATTRIBUTE_NONE && "ATTRIBUTE_NONE will be out of index" );
-
-    for ( const auto& i : matching_armor_attribute_multiplier_effects )
-      if ( i.opt_enum & ( 1 << ( attr - 1 ) ) )
-        mg += get_effect_value( i );
-
-    return mg;
-  }
-
-private:
-  TD* _get_td( player_t* t ) const
-  {
-    return static_cast<TD*>( get_target_data( t ) );
-  }
-
-public:
-  double composite_player_target_multiplier( player_t* target, school_e school ) const override
-  {
-    auto tm = player_t::composite_player_target_multiplier( target, school );
-    auto td = _get_td( target );
-
-    for ( const auto& i : target_multiplier_effects )
-      if ( i.opt_enum & dbc::get_school_mask( school ) )
-        tm *= 1.0 + get_target_effect_value( i, td );
-
-    return tm;
-  }
-
-  double composite_player_target_pet_damage_multiplier( player_t* target, bool guardian ) const override
-  {
-    auto tm = player_t::composite_player_target_pet_damage_multiplier( target, guardian );
-    auto td = _get_td( target );
-
-    for ( const auto& i : target_pet_multiplier_effects )
-      if ( static_cast<bool>( i.opt_enum ) == guardian )
-        tm *= 1.0 + get_target_effect_value( i, td );
-
-    return tm;
-  }
-
-  void invalidate_cache( cache_e c ) override
-  {
-    player_t::invalidate_cache( c );
-
-    for ( const auto& i : invalidate_with_parent )
-    {
-      if ( c == i.second )
-        player_t::invalidate_cache( i.first );
-    }
-  }
-
-  bool is_valid_aura( const spelleffect_data_t& eff ) const override
-  {
-    switch ( eff.type() )
-    {
-      case E_APPLY_AURA:
-      case E_APPLY_AURA_PET:
-        // TODO: more robust logic around 'party' buffs with radius
-        if ( eff.radius() )
-          return false;
-        break;
-      case E_APPLY_AREA_AURA_PARTY:
-      case E_APPLY_AREA_AURA_PET:
-        break;
-      default:
-        return false;
-    }
-
-    return true;
-  }
-
-  std::vector<player_effect_t>* get_effect_vector( const spelleffect_data_t& eff, player_effect_t& data, double& val_mul,
-                                                   std::string& str, bool& /* flat */, bool /* force */ ) override
-  {
-    auto invalidate = [ &data ]( cache_e c ) {
-      if ( data.buff )
-        data.buff->add_invalidate( c );
-    };
-
-    switch ( eff.subtype() )
-    {
-      case A_MOD_MELEE_AUTO_ATTACK_SPEED:
-      case A_MOD_RANGED_AND_MELEE_AUTO_ATTACK_SPEED:
-        str = "auto attack speed";
-        invalidate( CACHE_AUTO_ATTACK_SPEED );
-        return &auto_attack_speed_effects;
-
-      case A_MOD_TOTAL_STAT_PERCENTAGE:
-        data.opt_enum = eff.misc_value2();
-        {
-          std::vector<std::string> str_list;
-          for ( auto stat : { STAT_STRENGTH, STAT_AGILITY, STAT_STAMINA, STAT_INTELLECT, STAT_SPIRIT } )
-          {
-            if ( data.opt_enum & ( 1 << ( stat - 1 ) ) )
-            {
-              str_list.emplace_back( util::stat_type_string( stat ) );
-              invalidate( cache_from_stat( stat ) );
-            }
-          }
-          str = util::string_join( str_list );
-        }
-
-        if ( eff.spell()->equipped_class() == ITEM_CLASS_ARMOR && eff.spell()->flags( SX_REQUIRES_EQUIPPED_ARMOR_TYPE ) )
-        {
-          auto type_bit = 1U << static_cast<unsigned>( util::matching_armor_type( type ) );
-          if ( eff.spell()->equipped_subclass_mask() == type_bit )
-          {
-            str += "|with matching armor";
-            return &matching_armor_attribute_multiplier_effects;
-          }
-        }
-
-        return &attribute_multiplier_effects;
-
-      case A_MOD_VERSATILITY_PCT:
-        str = "versatility";
-        invalidate( CACHE_VERSATILITY );
-        return &versatility_effects;
-
-      case A_HASTE_ALL:
-        str = "haste";
-        invalidate( CACHE_HASTE );
-        return &haste_effects;
-
-      case A_MOD_MASTERY_PCT:
-        str = "mastery";
-        val_mul = 1.0;
-        invalidate( CACHE_MASTERY );
-        return &mastery_effects;
-
-      case A_MOD_ALL_CRIT_CHANCE:
-        str = "all crit chance";
-        invalidate( CACHE_CRIT_CHANCE );
-        return &crit_chance_effects;
-
-      case A_MOD_DAMAGE_PERCENT_DONE:
-        data.opt_enum = eff.misc_value1();
-        str = data.opt_enum == 0x7f ? "all" : util::school_type_string( dbc::get_school_type( data.opt_enum ) );
-        str += " damage";
-        invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER );
-        return &player_multiplier_effects;
-
-      case A_MOD_PET_DAMAGE_DONE:
-        data.opt_enum = 0;
-        str = "pet damage";
-        return &pet_multiplier_effects;
-
-      case A_MOD_GUARDIAN_DAMAGE_DONE:
-        data.opt_enum = 1;
-        str = "guardian damage";
-        return &pet_multiplier_effects;
-
-      case A_MOD_ATTACK_POWER_PCT:
-        str = "attack power";
-        invalidate( CACHE_ATTACK_POWER );
-        return &attack_power_multiplier_effects;
-
-      case A_MOD_LEECH_PERCENT:
-        str = "leech";
-        invalidate( CACHE_LEECH );
-        return &leech_effects;
-
-      case A_MOD_EXPERTISE:
-        str = "expertise";
-        invalidate( CACHE_EXP );
-        return &expertise_effects;
-
-      case A_MOD_ATTACKER_MELEE_CRIT_CHANCE:
-        str = "crit avoidance";
-        invalidate( CACHE_CRIT_AVOIDANCE );
-        return &crit_avoidance_effects;
-
-      case A_MOD_PARRY_PERCENT:
-        str = "parry";
-        invalidate( CACHE_PARRY );
-        return &parry_effects;
-
-      case A_MOD_RESISTANCE_PCT:
-      case A_MOD_BASE_RESISTANCE_PCT:
-        str = "armor multiplier";
-        invalidate( CACHE_ARMOR );
-        return &armor_multiplier_effects;
-
-      case A_MOD_PARRY_FROM_CRIT_RATING:
-        str = "parry rating|of crit rating";
-        invalidate_with_parent.emplace_back( CACHE_PARRY, CACHE_CRIT_CHANCE );
-        return &parry_rating_from_crit_effects;
-
-      case A_MOD_DODGE_PERCENT:
-        str = "dodge";
-        invalidate( CACHE_DODGE );
-        return &dodge_effects;
-
-      default:
-        return nullptr;
-    }
-
-    return nullptr;
-  }
-
-  void debug_message( const player_effect_t& data, std::string_view type_str, std::string_view val_str, bool mastery,
-                      const spell_data_t* s_data, size_t i ) override
-  {
-    auto splits = util::string_split<std::string_view>( type_str, "|" );
-    auto tok1 = splits[ 0 ];
-    auto tok2 = std::string( val_str );
-
-    if ( splits.size() > 1 )
-      tok2 += fmt::format( " {}", splits[ 1 ] );
-
-    if ( data.buff )
-    {
-      sim->print_debug( "player-effects: {} {} modified by {} {} buff {} ({}#{})", *this, tok1, tok2,
-                        data.use_stacks ? "per stack of" : "with", data.buff->name(), data.buff->data().id(), i );
-    }
-    else if ( mastery && !data.func )
-    {
-      sim->print_debug( "player-effects: {} {} modified by {} from {} ({}#{})", *this, tok1, tok2, s_data->name_cstr(),
-                        s_data->id(), i );
-    }
-    else if ( data.func )
-    {
-      sim->print_debug( "player-effects: {} {} modified by {} with condition from {} ({}#{})", *this, tok1, tok2,
-                        s_data->name_cstr(), s_data->id(), i );
-    }
-    else
-    {
-      sim->print_debug( "player-effects: {} {} modified by {} from {} ({}#{})", *this, tok1, tok2, s_data->name_cstr(),
-                        s_data->id(), i );
-    }
-  }
-
-  bool is_valid_target_aura( const spelleffect_data_t& eff ) const override
-  {
-    if ( eff.type() == E_APPLY_AURA )
-      return true;
-
-    return false;
-  }
-
-  void* get_target_effect_vector( const spelleffect_data_t& eff, uint32_t& opt_enum, double& /* val_mul */, std::string& str,
-                                  bool& /* flat */, bool /* force */ ) override
-  {
-    switch ( eff.subtype() )
-    {
-      case A_MOD_DAMAGE_FROM_CASTER:
-        opt_enum = eff.misc_value1();
-        str = opt_enum == 0x7f ? "all" : util::school_type_string( dbc::get_school_type( opt_enum ) );
-        return &target_multiplier_effects;
-
-      case A_MOD_DAMAGE_FROM_CASTER_PET:
-        opt_enum = 0;
-        str = "pet";
-        return &target_pet_multiplier_effects;
-
-      case A_MOD_DAMAGE_FROM_CASTER_GUARDIAN:
-        opt_enum = 1;
-        str = "guardian";
-        return &target_pet_multiplier_effects;
-
-      default:
-        return nullptr;
-    }
-
-    return nullptr;
-  }
-
-  void target_debug_message( std::string_view type_str, std::string_view val_str, const spell_data_t* s_data,
-                             size_t i ) override
-  {
-    sim->print_debug( "target-effects: Target {} damage taken modified by {} from {} ({}#{})", type_str, val_str,
-                      s_data->name_cstr(), s_data->id(), i );
-  }
-
-  template <typename... Ts>
-  void parse_target_effects( const std::function<int( TD* )>& fn, const spell_data_t* debuff, Ts&&... mods )
-  {
-    _parse_target_effects<TD>( fn, debuff, std::forward<Ts>( mods )... );
-  }
-
-  template <typename... Ts>
-  void force_target_effect( const std::function<int( TD* )>& fn, const spell_data_t* debuff, unsigned idx,
-                            Ts&&... mods )
-  {
-    _force_target_effect<TD>( fn, debuff, idx, std::forward<Ts>( mods )... );
-  }
-
-  void parsed_effects_html( report::sc_html_stream& os )
-  {
-    if ( total_effects_count() )
-    {
-      os << "<h3 class=\"toggle\">Player Effects</h3>"
-         << "<div class=\"toggle-content hide\">"
-         << "<table class=\"sc left even\">\n";
-
-      os << "<thead><tr>"
-         << "<th>Type</th>"
-         << "<th>Spell</th>"
-         << "<th>ID</th>"
-         << "<th>#</th>"
-         << "<th>Value</th>"
-         << "<th>Source</th>"
-         << "<th>Notes</th>"
-         << "</tr></thead>\n";
-
-      auto attr_note = []( uint32_t opt ) {
-        std::vector<std::string> str_list;
-
-        for ( auto stat : { STAT_STRENGTH, STAT_AGILITY, STAT_STAMINA, STAT_INTELLECT, STAT_SPIRIT } )
-          if ( opt & ( 1 << ( stat - 1 ) ) )
-            str_list.emplace_back( util::stat_type_string( stat ) );
-
-        return util::string_join( str_list );
-      };
-
-      auto mult_note = []( uint32_t opt ) {
-        return opt == 0x7f ? "All" : util::school_type_string( dbc::get_school_type( opt ) );
-      };
-
-      auto pet_note = []( uint32_t opt ) {
-        return opt ? "Guardian" : "Pet";
-      };
-
-      auto mastery_val = [ this ]( double v ) {
-        return fmt::format( "{:.1f}%", v * mastery_coefficient() * 100 );
-      };
-
-      print_parsed_type( os, auto_attack_speed_effects, "Auto Attack Speed" );
-      print_parsed_type( os, attribute_multiplier_effects, "Attribute Multiplier", attr_note );
-      print_parsed_type( os, matching_armor_attribute_multiplier_effects, "Matching Armor", attr_note );
-      print_parsed_type( os, versatility_effects, "Versatility" );
-      print_parsed_type( os, player_multiplier_effects, "Player Multiplier", mult_note );
-      print_parsed_type( os, pet_multiplier_effects, "Pet Multiplier", pet_note );
-      print_parsed_type( os, attack_power_multiplier_effects, "Attack Power Multiplier" );
-      print_parsed_type( os, crit_chance_effects, "Crit Chance" );
-      print_parsed_type( os, leech_effects, "Leech" );
-      print_parsed_type( os, expertise_effects, "Expertise" );
-      print_parsed_type( os, crit_avoidance_effects, "Crit Avoidance" );
-      print_parsed_type( os, parry_effects, "Parry" );
-      print_parsed_type( os, armor_multiplier_effects, "Armor Multiplier" );
-      print_parsed_type( os, haste_effects, "Haste" );
-      print_parsed_type( os, mastery_effects, "Mastery", nullptr, mastery_val );
-      print_parsed_type( os, parry_rating_from_crit_effects, "Parry Rating from Crit" );
-      print_parsed_type( os, dodge_effects, "Dodge" );
-      print_parsed_type( os, target_multiplier_effects, "Target Multiplier", mult_note );
-      print_parsed_type( os, target_pet_multiplier_effects, "Target Pet Multiplier", pet_note );
-      print_parsed_custom_type( os );
-
-      os << "</table>\n"
-         << "</div>\n";
-    }
-  }
-
-  virtual size_t total_effects_count()
-  {
-    return auto_attack_speed_effects.size() +
-           attribute_multiplier_effects.size() +
-           matching_armor_attribute_multiplier_effects.size() +
-           versatility_effects.size() +
-           player_multiplier_effects.size() +
-           pet_multiplier_effects.size() +
-           attack_power_multiplier_effects.size() +
-           crit_chance_effects.size() +
-           leech_effects.size() +
-           expertise_effects.size() +
-           crit_avoidance_effects.size() +
-           parry_effects.size() +
-           armor_multiplier_effects.size() +
-           haste_effects.size() +
-           mastery_effects.size() +
-           parry_rating_from_crit_effects.size() +
-           dodge_effects.size() +
-           target_multiplier_effects.size() +
-           target_pet_multiplier_effects.size();
-  }
+  double composite_melee_auto_attack_speed() const override;
+  double composite_attribute_multiplier( attribute_e ) const override;
+  double composite_damage_versatility() const override;
+  double composite_heal_versatility() const override;
+  double composite_mitigation_versatility() const override;
+  double composite_player_multiplier( school_e ) const override;
+  double composite_player_pet_damage_multiplier( const action_state_t*, bool ) const override;
+  double composite_attack_power_multiplier() const override;
+  double composite_melee_crit_chance() const override;
+  double composite_spell_crit_chance() const override;
+  double composite_leech() const override;
+  double composite_melee_expertise( const weapon_t* ) const override;
+  double composite_crit_avoidance() const override;
+  double composite_parry() const override;
+  double composite_armor_multiplier() const override;
+  double composite_melee_haste() const override;
+  double composite_spell_haste() const override;
+  double composite_mastery() const override;
+  double composite_parry_rating() const override;
+  double composite_dodge() const override;
+  double matching_gear_multiplier( attribute_e ) const override;
+  double composite_player_target_multiplier( player_t*, school_e ) const override;
+  double composite_player_target_pet_damage_multiplier( player_t*, bool ) const override;
+
+  void invalidate_cache( cache_e c ) override;
+
+  bool is_valid_aura( const spelleffect_data_t& ) const override;
+
+  std::vector<player_effect_t>* get_effect_vector( const spelleffect_data_t&, player_effect_t&, double&, std::string&,
+                                                   bool&, bool ) override;
+
+  void debug_message( const player_effect_t&, std::string_view, std::string_view, bool, const spell_data_t*,
+                      size_t ) override;
+
+  bool is_valid_target_aura( const spelleffect_data_t& ) const override;
+
+  std::vector<target_effect_t>* get_target_effect_vector( const spelleffect_data_t&, target_effect_t&, double&,
+                                                          std::string&, bool&, bool ) override;
+
+  void target_debug_message( std::string_view, std::string_view, const spell_data_t*, size_t ) override;
+
+  void parsed_effects_html( report::sc_html_stream& );
+
+  virtual size_t total_effects_count();
 
   virtual void print_parsed_custom_type( report::sc_html_stream& ) {}
 
@@ -1363,11 +672,11 @@ public:
 //  1) BASE: The base class of the action class. This is usually spell_t, melee_attack_t, or a template parameter
 //  2) TD: The target data class
 //  3) PLAYER(optional): The pet class if owner's target data should be used, instead of the pet's target data 
-template <typename BASE, typename TD, typename PLAYER = player_t >
+template <typename BASE, typename PLAYER = player_t >
 struct parse_action_effects_t : public BASE, public parse_effects_t
 {
 private:
-  using base_t = parse_action_effects_t<BASE, TD, PLAYER>;
+  using base_t = parse_action_effects_t<BASE, PLAYER>;
 
 public:
   // auto parsed dynamic effects
@@ -1383,9 +692,9 @@ public:
   std::vector<player_effect_t> crit_chance_effects;
   std::vector<player_effect_t> crit_chance_multiplier_effects;
   std::vector<player_effect_t> crit_damage_effects;
-  std::vector<target_effect_t<TD>> target_multiplier_effects;
-  std::vector<target_effect_t<TD>> target_crit_damage_effects;
-  std::vector<target_effect_t<TD>> target_crit_chance_effects;
+  std::vector<target_effect_t> target_multiplier_effects;
+  std::vector<target_effect_t> target_crit_damage_effects;
+  std::vector<target_effect_t> target_crit_chance_effects;
 
   parse_action_effects_t( std::string_view name, PLAYER* player, const spell_data_t* spell )
     : BASE( name, player, spell ), parse_effects_t( player )
@@ -1523,12 +832,12 @@ public:
 
 private:
   // method for getting target data as each module may have different action scoped method
-  TD* _get_td( player_t* t ) const
+  actor_target_data_t* _get_td( player_t* t ) const
   {
     if constexpr ( std::is_invocable_v<decltype( &pet_t::owner ), PLAYER> )
-      return static_cast<TD*>( static_cast<PLAYER*>( _player )->owner->get_target_data( t ) );
+      return static_cast<PLAYER*>( _player )->owner->get_target_data( t );
     else
-      return static_cast<TD*>( _player->get_target_data( t ) );
+      return _player->get_target_data( t );
   }
 
 public:
@@ -1732,8 +1041,9 @@ public:
     return false;
   }
 
-  void* get_target_effect_vector( const spelleffect_data_t& eff, uint32_t& /* opt_enum */, double& /* val_mul */,
-                                          std::string& str, bool& flat, bool force ) override
+  std::vector<target_effect_t>* get_target_effect_vector( const spelleffect_data_t& eff, target_effect_t& /* data */,
+                                                          double& /* val_mul */, std::string& str, bool& flat,
+                                                          bool force ) override
   {
     if ( !BASE::special && eff.subtype() == A_MOD_AUTO_ATTACK_FROM_CASTER )
     {
@@ -1772,19 +1082,6 @@ public:
   {
     BASE::sim->print_debug( "target-effects: {} ({}) {} modified by {} on targets with debuff {} ({}#{})", BASE::name(),
                             BASE::id, type_str, val_str, s_data->name_cstr(), s_data->id(), i );
-  }
-
-  template <typename... Ts>
-  void parse_target_effects( const std::function<int( TD* )>& fn, const spell_data_t* debuff, Ts&&... mods )
-  {
-    _parse_target_effects<TD>( fn, debuff, std::forward<Ts>( mods )... );
-  }
-
-  template <typename... Ts>
-  void force_target_effect( const std::function<int( TD* )>& fn, const spell_data_t* debuff, unsigned idx,
-                            Ts&&... mods )
-  {
-    _force_target_effect<TD>( fn, debuff, idx, std::forward<Ts>( mods )... );
   }
 
   void parsed_effects_html( report::sc_html_stream& os )

--- a/engine/action/parse_effects.hpp
+++ b/engine/action/parse_effects.hpp
@@ -170,15 +170,14 @@ struct pack_t
   std::vector<U>* copy = nullptr;
 };
 
+template <typename U>
+static inline U& add_parse_entry( std::vector<U>& vec ) { return vec.emplace_back(); }
+
 // input interface framework
 struct parse_base_t
 {
   parse_base_t() = default;
   virtual ~parse_base_t() = default;
-
-  template <typename U>
-  U& add_parse_entry( std::vector<U>& vec )
-  { return vec.emplace_back(); }
 
   // detectors for is_detected_v<>
   template <typename T> using detect_buff = decltype( T::buff );

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -65,7 +65,7 @@ namespace actions
 
 template <class Base>
 monk_action_t<Base>::monk_action_t( std::string_view name, monk_t *player, const spell_data_t *spell )
-  : parse_action_effects_t<Base, monk_td_t>( name, player, spell ),
+  : parse_action_effects_t<Base>( name, player, spell ),
     sef_ability( actions::sef_ability_e::SEF_NONE ),
     ww_mastery( false ),
     may_combo_strike( false ),
@@ -152,7 +152,7 @@ void monk_action_t<Base>::apply_buff_effects()
 template <class Base>
 void monk_action_t<Base>::apply_debuff_effects()
 {
-  //    parse_target_effects( []( monk_td_t* t ) { return t->debuffs.weapons_of_order->check(); },
+  //    parse_target_effects( []( actor_target_data_t* t ) { return static_cast<monk_td_t*>( t )->debuffs.weapons_of_order->check(); },
   //                          p()->shared.weapons_of_order ); // True, true
 }
 

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -82,7 +82,7 @@ enum class sef_ability_e
 };
 
 template <class Base>
-struct monk_action_t : public parse_action_effects_t<Base, monk_td_t>
+struct monk_action_t : public parse_action_effects_t<Base>
 {
   sef_ability_e sef_ability;
   bool ww_mastery;
@@ -95,7 +95,7 @@ private:
   std::array<resource_e, MONK_MISTWEAVER + 1> _resource_by_stance;
 
 public:
-  using base_t = parse_action_effects_t<Base, monk_td_t>;
+  using base_t = parse_action_effects_t<Base>;
 
   monk_action_t( std::string_view name, monk_t *player, const spell_data_t *s = spell_data_t::nil() );
   std::string full_name() const;
@@ -378,10 +378,10 @@ struct stagger_t
   void delay_tick( timespan_t delay );
 };
 
-struct monk_t : public parse_player_effects_t<monk_td_t>
+struct monk_t : public parse_player_effects_t
 {
 public:
-  using base_t = parse_player_effects_t<monk_td_t>;
+  using base_t = parse_player_effects_t;
 
   // Active
   action_t *windwalking_aura;

--- a/engine/class_modules/priest/sc_priest.hpp
+++ b/engine/class_modules/priest/sc_priest.hpp
@@ -920,7 +920,7 @@ namespace actions
  * spell_t/heal_t or absorb_t directly.
  */
 template <typename Base>
-struct priest_action_t : public parse_action_effects_t<Base, priest_td_t>
+struct priest_action_t : public parse_action_effects_t<Base>
 {
 protected:
   priest_t& priest()
@@ -1138,8 +1138,11 @@ public:
     // DISCIPLINE DEBUFF EFFECTS
     if ( p().specialization() == PRIEST_DISCIPLINE )
     {
-      parse_target_effects( []( priest_td_t* t ) { return t->buffs.schism->check(); },
-                            p().talents.discipline.schism_debuff );
+      parse_target_effects(
+          []( actor_target_data_t* t ) {
+            return static_cast<priest_td_t*>( t )->buffs.schism->check();
+          },
+          p().talents.discipline.schism_debuff );
     }
   }
 
@@ -1208,7 +1211,7 @@ public:
 
 private:
   // typedef for the templated action type, eg. spell_t, attack_t, heal_t
-  using ab = parse_action_effects_t<Base, priest_td_t>;
+  using ab = parse_action_effects_t<Base>;
 };  // namespace actions
 
 struct priest_absorb_t : public priest_action_t<absorb_t>

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -218,7 +218,7 @@ struct priest_pet_melee_t : public melee_attack_t
   }
 };
 
-struct priest_pet_spell_t : public parse_action_effects_t<spell_t, priest_pet_t>
+struct priest_pet_spell_t : public parse_action_effects_t<spell_t>
 {
   bool affected_by_shadow_weaving;
   bool triggers_atonement;
@@ -355,7 +355,7 @@ struct priest_pet_spell_t : public parse_action_effects_t<spell_t, priest_pet_t>
 
 private:
   // typedef for the templated action type, eg. spell_t, attack_t, heal_t
-  using ab = parse_action_effects_t<spell_t, priest_pet_t>;
+  using ab = parse_action_effects_t<spell_t>;
 };
 
 namespace fiend

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -218,7 +218,7 @@ struct priest_pet_melee_t : public melee_attack_t
   }
 };
 
-struct priest_pet_spell_t : public parse_action_effects_t<spell_t, priest_td_t, priest_pet_t>
+struct priest_pet_spell_t : public parse_action_effects_t<spell_t, priest_pet_t>
 {
   bool affected_by_shadow_weaving;
   bool triggers_atonement;
@@ -304,7 +304,7 @@ struct priest_pet_spell_t : public parse_action_effects_t<spell_t, priest_td_t, 
     // Doesn't work on the pet ayy lmao
     /*if ( p().o().specialization() == PRIEST_DISCIPLINE )
     {
-        parse_target_effects( []( priest_td_t* t ) { return t->buffs.schism->check(); },
+        parse_target_effects( []( actor_target_data_t* t ) { return static_cast<priest_td_t*>( t )->buffs.schism->check(); },
     p().o().talents.discipline.schism_debuff );
     }*/
   }
@@ -355,7 +355,7 @@ struct priest_pet_spell_t : public parse_action_effects_t<spell_t, priest_td_t, 
 
 private:
   // typedef for the templated action type, eg. spell_t, attack_t, heal_t
-  using ab = parse_action_effects_t<spell_t, priest_td_t, priest_pet_t>;
+  using ab = parse_action_effects_t<spell_t, priest_pet_t>;
 };
 
 namespace fiend

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -622,21 +622,29 @@ using simple_data_t = std::pair<std::string, simple_sample_data_t>;
 
 // utility to create target_effect_t compatible functions from death_knight_td_t member references
 template <typename T>
-static std::function<int( death_knight_td_t* )> d_fn( T d, bool stack = true )
+static std::function<int( actor_target_data_t* )> d_fn( T d, bool stack = true )
 {
   if constexpr ( std::is_invocable_v<T, death_knight_td_t::debuffs_t> )
   {
     if ( stack )
-      return [ d ]( death_knight_td_t* t ) { return std::invoke( d, t->debuff )->check(); };
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<death_knight_td_t*>( t )->debuff )->check();
+      };
     else
-      return [ d ]( death_knight_td_t* t ) { return std::invoke( d, t->debuff )->check() > 0; };
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<death_knight_td_t*>( t )->debuff )->check() > 0;
+      };
   }
   else if constexpr ( std::is_invocable_v<T, death_knight_td_t::dots_t> )
   {
     if ( stack )
-      return [ d ]( death_knight_td_t* t ) { return std::invoke( d, t->dot )->current_stack(); };
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<death_knight_td_t*>( t )->dot )->current_stack();
+      };
     else
-      return [ d ]( death_knight_td_t* t ) { return std::invoke( d, t->dot )->is_ticking(); };
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<death_knight_td_t*>( t )->dot )->is_ticking();
+      };
   }
   else
   {
@@ -645,7 +653,7 @@ static std::function<int( death_knight_td_t* )> d_fn( T d, bool stack = true )
   }
 }
 
-struct death_knight_t : public parse_player_effects_t<death_knight_td_t>
+struct death_knight_t : public parse_player_effects_t
 {
 public:
   // Stores the currently active death and decay ground event
@@ -4354,9 +4362,9 @@ public:
 
 // Template for common death knight action code. See priest_action_t.
 template <class Base>
-struct death_knight_action_t : public parse_action_effects_t<Base, death_knight_td_t>
+struct death_knight_action_t : public parse_action_effects_t<Base>
 {
-  using action_base_t = parse_action_effects_t<Base, death_knight_td_t>;
+  using action_base_t = parse_action_effects_t<Base>;
   using base_t        = death_knight_action_t<Base>;
 
   gain_t* gain;
@@ -13341,7 +13349,7 @@ void death_knight_t::combat_begin()
 
 void death_knight_t::invalidate_cache( cache_e c )
 {
-  parse_player_effects_t<death_knight_td_t>::invalidate_cache( c );
+  parse_player_effects_t::invalidate_cache( c );
 
   switch ( c )
   {

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -6482,7 +6482,7 @@ void druid_action_t<Base>::init()
     if ( !ab::background || ab::ground_aoe )
     {
       const auto& eff = p()->buff.lunar_amplification->data().effectN( 1 );
-      ab::add_parse_entry( persistent_multiplier_effects )
+      add_parse_entry( persistent_multiplier_effects )
         .set_buff( p()->buff.lunar_amplification )
         .set_value( eff.percent() )
         .set_eff( &eff );
@@ -8959,7 +8959,7 @@ struct druid_melee_t : public Base
       // Carnivorous Instinct has no curvepoint for effect#3 which modifies AA, so we use effect#1 value instead
       val += p->talent.carnivorous_instinct->effectN( 1 ).percent();
 
-      ab::add_parse_entry( ab::da_multiplier_effects )
+      add_parse_entry( ab::da_multiplier_effects )
         .set_buff( p->buff.tigers_fury )
         .set_value( val )
         .set_eff( &eff );

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -4803,8 +4803,7 @@ struct primal_wrath_t : public cat_finisher_t
       {
         const auto& eff = p->spec.adaptive_swarm_damage->effectN( 2 );
         add_parse_entry( target_multiplier_effects )
-          .set_func( []( actor_target_data_t* td )
-            { return static_cast<druid_td_t*>( td )->dots.adaptive_swarm_damage->is_ticking(); } )
+          .set_func( d_fn( &druid_td_t::dots_t::adaptive_swarm_damage ) )
           .set_value( eff.percent() )
           .set_eff( &eff );
       }

--- a/engine/class_modules/sc_evoker.cpp
+++ b/engine/class_modules/sc_evoker.cpp
@@ -1573,10 +1573,10 @@ public:
 
 // Template for base evoker action code.
 template <class Base>
-struct evoker_action_t : public parse_action_effects_t<Base, evoker_td_t>
+struct evoker_action_t : public parse_action_effects_t<Base>
 {
 private:
-  using ab = parse_action_effects_t<Base, evoker_td_t>;
+  using ab = parse_action_effects_t<Base>;
 
 public:
   spell_color_e spell_color;
@@ -1815,20 +1815,27 @@ public:
   //   (unsigned)       ignore_mask: Bitmask to skip effect# n corresponding to the n'th bit
   void apply_debuffs_effects()
   {
-    parse_target_effects( []( evoker_td_t* t ) { return t->debuffs.shattering_star->check(); },
-                          p()->talent.shattering_star );
+    parse_target_effects(
+        []( actor_target_data_t* t ) {
+          return static_cast<evoker_td_t*>( t )->debuffs.shattering_star->check();
+        },
+        p()->talent.shattering_star );
 
     if ( p()->talent.scalecommander.melt_armor.ok() )
     {
-      parse_target_effects( []( evoker_td_t* t ) { return t->debuffs.melt_armor->check(); },
-                            p()->talent.scalecommander.melt_armor_debuff );
+      parse_target_effects(
+          []( actor_target_data_t* t ) {
+            return static_cast<evoker_td_t*>( t )->debuffs.melt_armor->check();
+          },
+          p()->talent.scalecommander.melt_armor_debuff );
     }
     
     if ( p()->talent.scorching_embers.ok() )
     {
       parse_target_effects(
-          []( evoker_td_t* t ) {
-            return t->dots.fire_breath->is_ticking() || t->dots.fire_breath_traveling_flame->is_ticking();
+          []( actor_target_data_t* t ) {
+            return static_cast<evoker_td_t*>( t )->dots.fire_breath->is_ticking() ||
+                   static_cast<evoker_td_t*>( t )->dots.fire_breath_traveling_flame->is_ticking();
           },
           p()->spec.fire_breath_damage );
     }
@@ -3600,7 +3607,9 @@ struct disintegrate_t : public essence_spell_t
     if ( p->talent.feed_the_flames->ok() )
     {
       add_parse_entry( target_multiplier_effects )
-          .set_func( []( evoker_td_t* t ) { return t->debuffs.in_firestorm->check() > 0; } )
+          .set_func( []( actor_target_data_t* t ) {
+            return static_cast<evoker_td_t*>( t )->debuffs.in_firestorm->check() > 0;
+          } )
           .set_value( p->talent.feed_the_flames->effectN( 1 ).percent() )
           .set_eff( &p->talent.feed_the_flames->effectN( 1 ) );
     }
@@ -4336,9 +4345,11 @@ struct pyre_t : public essence_spell_t
       if ( p->talent.feed_the_flames->ok() )
       {
         add_parse_entry( target_multiplier_effects )
-          .set_func( []( evoker_td_t* t ) { return t->debuffs.in_firestorm->check() > 0; } )
-          .set_value( p->talent.feed_the_flames->effectN( 1 ).percent() )
-          .set_eff( &p->talent.feed_the_flames->effectN( 1 ) );
+            .set_func( []( actor_target_data_t* t ) {
+              return static_cast<evoker_td_t*>( t )->debuffs.in_firestorm->check() > 0;
+            } )
+            .set_value( p->talent.feed_the_flames->effectN( 1 ).percent() )
+            .set_eff( &p->talent.feed_the_flames->effectN( 1 ) );
       }
     }
 

--- a/engine/class_modules/sc_evoker.cpp
+++ b/engine/class_modules/sc_evoker.cpp
@@ -134,6 +134,39 @@ struct evoker_td_t : public actor_target_data_t
   evoker_td_t( player_t* target, evoker_t* source );
 };
 
+// utility to create target_effect_t compatible functions from evoker_td_t member references
+template <typename T>
+static std::function<int( actor_target_data_t* )> d_fn( T d, bool stack = true )
+{
+  if constexpr ( std::is_invocable_v<T, evoker_td_t::debuffs_t> )
+  {
+    if ( stack )
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<evoker_td_t*>( t )->debuff )->check();
+      };
+    else
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<evoker_td_t*>( t )->debuff )->check() > 0;
+      };
+  }
+  else if constexpr ( std::is_invocable_v<T, evoker_td_t::dots_t> )
+  {
+    if ( stack )
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<evoker_td_t*>( t )->dots )->current_stack();
+      };
+    else
+      return [ d ]( actor_target_data_t* t ) {
+        return std::invoke( d, static_cast<evoker_td_t*>( t )->dots )->is_ticking();
+      };
+  }
+  else
+  {
+    static_assert( static_false<T>, "Not a valid member of evoker_td_t" );
+    return nullptr;
+  }
+}
+
 template <typename Data, typename Base = action_state_t>
 struct evoker_action_state_t : public Base, public Data
 {
@@ -1815,19 +1848,11 @@ public:
   //   (unsigned)       ignore_mask: Bitmask to skip effect# n corresponding to the n'th bit
   void apply_debuffs_effects()
   {
-    parse_target_effects(
-        []( actor_target_data_t* t ) {
-          return static_cast<evoker_td_t*>( t )->debuffs.shattering_star->check();
-        },
-        p()->talent.shattering_star );
+    parse_target_effects( d_fn( &evoker_td_t::debuffs_t::shattering_star ), p()->talent.shattering_star );
 
     if ( p()->talent.scalecommander.melt_armor.ok() )
     {
-      parse_target_effects(
-          []( actor_target_data_t* t ) {
-            return static_cast<evoker_td_t*>( t )->debuffs.melt_armor->check();
-          },
-          p()->talent.scalecommander.melt_armor_debuff );
+      parse_target_effects( d_fn( &evoker_td_t::debuffs_t::melt_armor ), p()->talent.scalecommander.melt_armor_debuff );
     }
     
     if ( p()->talent.scorching_embers.ok() )
@@ -3607,9 +3632,7 @@ struct disintegrate_t : public essence_spell_t
     if ( p->talent.feed_the_flames->ok() )
     {
       add_parse_entry( target_multiplier_effects )
-          .set_func( []( actor_target_data_t* t ) {
-            return static_cast<evoker_td_t*>( t )->debuffs.in_firestorm->check() > 0;
-          } )
+          .set_func( d_fn( &evoker_td_t::debuffs_t::in_firestorm, false ) )
           .set_value( p->talent.feed_the_flames->effectN( 1 ).percent() )
           .set_eff( &p->talent.feed_the_flames->effectN( 1 ) );
     }
@@ -4345,9 +4368,7 @@ struct pyre_t : public essence_spell_t
       if ( p->talent.feed_the_flames->ok() )
       {
         add_parse_entry( target_multiplier_effects )
-            .set_func( []( actor_target_data_t* t ) {
-              return static_cast<evoker_td_t*>( t )->debuffs.in_firestorm->check() > 0;
-            } )
+            .set_func( d_fn( &evoker_td_t::debuffs_t::in_firestorm, false ) )
             .set_value( p->talent.feed_the_flames->effectN( 1 ).percent() )
             .set_eff( &p->talent.feed_the_flames->effectN( 1 ) );
       }

--- a/engine/class_modules/sc_evoker.cpp
+++ b/engine/class_modules/sc_evoker.cpp
@@ -142,11 +142,11 @@ static std::function<int( actor_target_data_t* )> d_fn( T d, bool stack = true )
   {
     if ( stack )
       return [ d ]( actor_target_data_t* t ) {
-        return std::invoke( d, static_cast<evoker_td_t*>( t )->debuff )->check();
+        return std::invoke( d, static_cast<evoker_td_t*>( t )->debuffs )->check();
       };
     else
       return [ d ]( actor_target_data_t* t ) {
-        return std::invoke( d, static_cast<evoker_td_t*>( t )->debuff )->check() > 0;
+        return std::invoke( d, static_cast<evoker_td_t*>( t )->debuffs )->check() > 0;
       };
   }
   else if constexpr ( std::is_invocable_v<T, evoker_td_t::dots_t> )


### PR DESCRIPTION
Instead of requiring the module derived actor_target_data_t in order to specialize target_effect_t, target_effects_t::func will now be passed a base actor_target_data_t*.

While this will now require that each module explicitly static_cast to the dervied target_data_t and/or utilize a factory function (see various d_fn() implementations), this will allow for more easier maintenance and flexiblity for future changes.