### PR TITLE
[Callbacks] handle bypassing suppressed procs

### DIFF
--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -109,6 +109,9 @@ public:
   /// enables/disables proc callback system on the action, like trinkets, enchants, rppm.
   bool callbacks;
 
+  /// does not trigger callbacks except for drivers with SX_CAN_PROC_FROM_SUPPRESSED
+  bool enable_proc_from_suppressed;
+
   /// Allows triggering of procs marked to only proc from class abilities.
   bool allow_class_ability_procs;
 

--- a/engine/action/dbc_proc_callback.cpp
+++ b/engine/action/dbc_proc_callback.cpp
@@ -136,6 +136,12 @@ void dbc_proc_callback_t::activate_with_buff( buff_t* buff, bool init )
 
 void dbc_proc_callback_t::trigger( action_t* a, action_state_t* state )
 {
+  // all actions with enable_proc_from_suppressed will also have callbacks = false, so check this first thing before
+  // processing further.
+  if ( a->enable_proc_from_suppressed )
+      if ( !can_proc_from_suppressed )
+        return;
+
   cooldown_t* cd = get_cooldown( state->target );
 
   // Fully overridden trigger condition check; if allowed, perform normal proc chance
@@ -235,7 +241,8 @@ dbc_proc_callback_t::dbc_proc_callback_t( const item_t& i, const special_effect_
     trigger_fn( nullptr ),
     execute_fn( nullptr ),
     can_only_proc_from_class_abilites( false ),
-    can_proc_from_procs( false )
+    can_proc_from_procs( false ),
+    can_proc_from_suppressed( false )
 {
   assert( e.proc_flags() != 0 );
 }
@@ -259,7 +266,8 @@ dbc_proc_callback_t::dbc_proc_callback_t( const item_t* i, const special_effect_
     trigger_fn( nullptr ),
     execute_fn( nullptr ),
     can_only_proc_from_class_abilites( false ),
-    can_proc_from_procs( false )
+    can_proc_from_procs( false ),
+    can_proc_from_suppressed( false )
 {
   assert( e.proc_flags() != 0 );
 }
@@ -283,7 +291,8 @@ dbc_proc_callback_t::dbc_proc_callback_t( player_t* p, const special_effect_t& e
     trigger_fn( nullptr ),
     execute_fn( nullptr ),
     can_only_proc_from_class_abilites( false ),
-    can_proc_from_procs( false )
+    can_proc_from_procs( false ),
+    can_proc_from_suppressed( false )
 {
   assert( e.proc_flags() != 0 );
 }
@@ -359,6 +368,7 @@ void dbc_proc_callback_t::initialize()
 
   can_only_proc_from_class_abilites = effect.can_only_proc_from_class_abilites();
   can_proc_from_procs = effect.can_proc_from_procs();
+  can_proc_from_suppressed = effect.can_proc_from_suppressed();
 }
 
 // Determine target for the callback (action).

--- a/engine/action/dbc_proc_callback.hpp
+++ b/engine/action/dbc_proc_callback.hpp
@@ -97,6 +97,7 @@ struct dbc_proc_callback_t : public action_callback_t
 
   bool can_only_proc_from_class_abilites;
   bool can_proc_from_procs;
+  bool can_proc_from_suppressed;
 
   dbc_proc_callback_t( const item_t& i, const special_effect_t& e );
 

--- a/engine/action/heal.cpp
+++ b/engine/action/heal.cpp
@@ -249,7 +249,7 @@ void heal_t::assess_damage( result_amount_type heal_type, action_state_t* s )
   // New callback system; proc spells on impact.
   // Note: direct_tick_callbacks should not be used with the new system,
   // override action_t::proc_type() instead
-  if ( callbacks )
+  if ( callbacks || enable_proc_from_suppressed )
   {
     proc_types pt = s->proc_type();
     proc_types2 pt2 = s->impact_proc_type2();

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9638,7 +9638,7 @@ void shaman_t::action_init_finished( action_t& action )
          ( action.id == 1 || action.id == 2 ) ||
          // Actions with spell data associated
          ( action.data().id() != 0 &&
-           !action.data().flags( spell_attribute::SX_DISABLE_PLAYER_PROCS ) &&
+           !action.data().flags( spell_attribute::SX_SUPPRESS_CASTER_PROCS ) &&
            action.data().dmg_class() == 2U )
        ) )
   {

--- a/engine/dbc/data_enums.hh
+++ b/engine/dbc/data_enums.hh
@@ -1326,8 +1326,8 @@ enum spell_attribute : unsigned
   SX_FOOD_AURA                      = 95u,
   SX_NOT_A_PROC                     = 105u,
   SX_REQ_MAIN_HAND                  = 106u,
-  SX_DISABLE_PLAYER_PROCS           = 112u,
-  SX_DISABLE_TARGET_PROCS           = 113u,
+  SX_SUPPRESS_CASTER_PROCS          = 112u,
+  SX_SUPPRESS_TARGET_PROCS          = 113u,
   SX_ALWAYS_HIT                     = 114u,
   SX_REQ_OFF_HAND                   = 120u,
   SX_TREAT_AS_PERIODIC              = 121u,
@@ -1354,6 +1354,8 @@ enum spell_attribute : unsigned
   SX_TARGET_SPECIFIC_COOLDOWN       = 330u,
   SX_ROLLING_PERIODIC               = 334u,
   SX_SCALE_ILEVEL                   = 354u,
+  SX_ENABLE_PROCS_FROM_SUPPRESSED   = 384u,  // requires SX_CAN_PROC_FROM_SUPPRESSED on driver
+  SX_CAN_PROC_FROM_SUPPRESSED       = 385u,  // requires SX_ENABLE_PROCS_FROM_SUPPRESSED on action
   SX_ONLY_PROC_FROM_CLASS_ABILITIES = 415u,
   SX_ALLOW_CLASS_ABILITY_PROCS      = 416u,
   SX_REFRESH_EXTENDS_DURATION       = 436u,

--- a/engine/item/special_effect.cpp
+++ b/engine/item/special_effect.cpp
@@ -774,6 +774,11 @@ bool special_effect_t::can_proc_from_procs() const
   return driver()->flags( spell_attribute::SX_CAN_PROC_FROM_PROCS );
 }
 
+bool special_effect_t::can_proc_from_suppressed() const
+{
+  return driver()->flags( spell_attribute::SX_CAN_PROC_FROM_SUPPRESSED );
+}
+
 bool special_effect_t::can_only_proc_from_class_abilites() const
 {
   if ( override_can_only_proc_from_class_abilites )

--- a/engine/item/special_effect.hpp
+++ b/engine/item/special_effect.hpp
@@ -165,6 +165,7 @@ public:
   bool has_target_specific_cooldown() const;
 
   bool can_proc_from_procs() const;
+  bool can_proc_from_suppressed() const;
   bool can_only_proc_from_class_abilites() const;
   void set_can_proc_from_procs( bool );
   void set_can_only_proc_from_class_abilites( bool );


### PR DESCRIPTION
Normally suppress_caster_procs flag will completely disable all callbacks on the action. However, if the action has enable_proc_from_suppressed_procs AND the callback has can_proc_from_suppressed_procs, then and ONLY then can the action proc the callback.