### PR TITLE
[Callbacks] handle parsed callback suppression separately

### DIFF
--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -106,10 +106,14 @@ public:
   /// If set to true, this action will not be counted toward total amount of executes in reporting. Useful for abilities with parent/children attacks.
   bool dual;
 
-  /// enables/disables proc callback system on the action, like trinkets, enchants, rppm.
+  /// enables/disables proc callback system on the action, like trinkets, enchants, rppm. this supercedes all dbc-parsed flags.
   bool callbacks;
 
-  /// does not trigger callbacks except for drivers with SX_CAN_PROC_FROM_SUPPRESSED
+  /// if true, does not trigger callbacks on caster/target.
+  bool suppress_caster_procs, suppress_target_procs;
+
+  /// can trigger callbacks on caster even if suppress_caster_proc is true, as long as the callback has can_proc_from_suppressed = true.
+  /// TODO: determine if equivalent for suppressed target procs is needed.
   bool enable_proc_from_suppressed;
 
   /// Allows triggering of procs marked to only proc from class abilities.

--- a/engine/action/dbc_proc_callback.cpp
+++ b/engine/action/dbc_proc_callback.cpp
@@ -136,11 +136,10 @@ void dbc_proc_callback_t::activate_with_buff( buff_t* buff, bool init )
 
 void dbc_proc_callback_t::trigger( action_t* a, action_state_t* state )
 {
-  // all actions with enable_proc_from_suppressed will also have callbacks = false, so check this first thing before
-  // processing further.
-  if ( a->enable_proc_from_suppressed )
-      if ( !can_proc_from_suppressed )
-        return;
+  // both action_t::enabled_proc_from_suppressed AND dbc_proc_callback_t::can_proc_from_suppressed are necessary if
+  // action_t::suppress_caster_procs is true
+  if ( a->suppress_caster_procs && ( !a->enable_proc_from_suppressed || !can_proc_from_suppressed ) )
+    return;
 
   cooldown_t* cd = get_cooldown( state->target );
 

--- a/engine/action/dbc_proc_callback.hpp
+++ b/engine/action/dbc_proc_callback.hpp
@@ -98,6 +98,7 @@ struct dbc_proc_callback_t : public action_callback_t
   bool can_only_proc_from_class_abilites;
   bool can_proc_from_procs;
   bool can_proc_from_suppressed;
+  // TODO: determine if SX_CAN_PROC_FROM_SUPPRESSED_TGT parsing is also needed
 
   dbc_proc_callback_t( const item_t& i, const special_effect_t& e );
 

--- a/engine/action/heal.cpp
+++ b/engine/action/heal.cpp
@@ -247,25 +247,30 @@ void heal_t::assess_damage( result_amount_type heal_type, action_state_t* s )
   }
 
   // New callback system; proc spells on impact.
-  // Note: direct_tick_callbacks should not be used with the new system,
-  // override action_t::proc_type() instead
-  if ( callbacks || enable_proc_from_suppressed )
+  // Note: direct_tick_callbacks should not be used with the new system override action_t::proc_type() instead
+  if ( callbacks )
   {
     proc_types pt = s->proc_type();
     proc_types2 pt2 = s->impact_proc_type2();
+
     if ( pt != PROC1_INVALID && pt2 != PROC2_INVALID )
     {
-      player->trigger_callbacks( pt, pt2, this, s );
+      if ( !suppress_caster_procs || enable_proc_from_suppressed )
+        player->trigger_callbacks( pt, pt2, this, s );
 
       // trigger healing taken callbacks
-      proc_types pt_taken = static_cast<proc_types>( pt + 1 );
-      if ( pt == PROC1_HELPFUL_PERIODIC )
-        pt_taken = PROC1_HELPFUL_PERIODIC_TAKEN;
+      if ( !suppress_target_procs )
+      {
+        proc_types pt_taken = static_cast<proc_types>( pt + 1 );
 
-      s->target->trigger_callbacks( pt_taken, pt2, this, s );
+        if ( pt == PROC1_HELPFUL_PERIODIC )
+          pt_taken = PROC1_HELPFUL_PERIODIC_TAKEN;
+
+        s->target->trigger_callbacks( pt_taken, pt2, this, s );
+      }
     }
   }
-   
+
   if ( player->spells.leech )
   {
     double leech_pct = 0;

--- a/engine/dbc/data_enums.hh
+++ b/engine/dbc/data_enums.hh
@@ -1342,6 +1342,7 @@ enum spell_attribute : unsigned
   SX_NO_DODGE                       = 247u,
   SX_NO_PARRY                       = 248u,
   SX_NO_MISS                        = 249u,
+  SX_CAN_PROC_FROM_SUPPRESSED_TGT   = 254u,
   SX_NO_BLOCK                       = 256u,
   SX_TICK_MAY_CRIT                  = 265u,
   SX_DURATION_HASTED                = 273u,

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -7835,7 +7835,7 @@ void player_t::do_damage( action_state_t* incoming_state )
 
   // New callback system; proc abilities on incoming events.
   // TODO: How to express action causing/not causing incoming callbacks?
-  if ( incoming_state->action && incoming_state->action->callbacks )
+  if ( incoming_state->action && incoming_state->action->callbacks && !incoming_state->action->suppress_target_procs )
   {
     proc_types pt = incoming_state->proc_type();
     if ( pt != PROC1_INVALID )


### PR DESCRIPTION
DBC parsed callback-related flags are handled separately from the generic action_t::callbacks variable.

* action_t::callbacks - when true disables all callbacks regardless of parsed flags

* action_t::suppress_caster_procs - disables all callbacks on the caster unless both 'enable_procs_from_suppressed' is true on the action and 'can_proc_from_suppressed' is true on the callback

* action_t::suppress_target_procs - disables all callbacks on the target

Currently the enable-can pair is only used to bypass suppressed caster procs. If necessary similar bypass can be implemented to suppressed target procs. However, there is no readily identifiable flag for 'enable procs from suppressed target proc' so it will need to be found or confirmed that the caster version works for both.