### PR TITLE
Use uniform distribution instead of gaussian for ready-related RNG

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -6249,7 +6249,7 @@ void player_t::trigger_ready()
 void player_t::schedule_off_gcd_ready( timespan_t delta_time )
 {
   if ( delta_time < 0_ms )
-    delta_time = rng().gauss( 100_ms, 10_ms );
+    delta_time = rng().range( 90_ms, 110_ms );
 
   if ( active_off_gcd_list == nullptr )
   {
@@ -6298,7 +6298,7 @@ void player_t::schedule_off_gcd_ready( timespan_t delta_time )
 void player_t::schedule_cwc_ready( timespan_t delta_time )
 {
   if ( delta_time < 0_ms )
-    delta_time = rng().gauss( 100_ms, 10_ms );
+    delta_time = rng().range( 90_ms, 110_ms );
 
   if ( active_cast_while_casting_list == nullptr )
   {
@@ -6588,7 +6588,7 @@ void player_t::arise()
 
 timespan_t player_t::available() const
 {
-  return rng().gauss( 100_ms, 10_ms );
+  return rng().range( 90_ms, 110_ms );
 }
 
 /**


### PR DESCRIPTION
We add a small randomness to various ready-related functions to avoid APL artifcats arising from artificial sychronizations. Instead of using the more computationally expensive gaussian distribution, we can use a uniform distribution to achieve the same effect with better performance.