### PR TITLE
[Rogue] Implement fazed parry debuff

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -2387,6 +2387,16 @@ public:
   virtual bool consumes_escalating_blade() const
   { return false; }
 
+  double parry_chance( double exp, player_t* target ) const override
+  {
+    auto chance = ab::parry_chance(exp, target);
+    if ( chance > 0.0 && td( target )->debuffs.fazed->up() )
+    {
+      chance += td( target )->debuffs.fazed->data().effectN( 2 ).percent();
+    }
+    return std::max(0.0, chance);
+  }
+
 public:
   // Ability triggers
   void spend_combo_points( const action_state_t* );


### PR DESCRIPTION
Fazed lowers the impact of being `position=front` for outlaw from ~3% output (base parry rate) to ~0.5% (since fazed doesn't have 100% uptime). That might be relevant if you sim with `position=front` because you, eg, use gouge, which requires frontal positioning.

Do note, there is the *distinct* possibility that fazed, as the spell data currently lays out, actually reduces the enemy parry rate for *everyone*, making it a (exceedingly minor, but definitely measurable) raid buff. I have not implemented *that* here - only the applying rogue's parry benefits.