### PR TITLE
[Outlaw] Confirm Killing Spree applies both fazed and flawless form once

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -5129,12 +5129,17 @@ struct killing_spree_t : public rogue_attack_t
 
     if ( p()->talent.trickster.flawless_form->ok() )
     {
-      p()->buffs.flawless_form->trigger(); // TOCHECK ALPHA -- Once or per tick?
+      p()->buffs.flawless_form->trigger();
     }
 
     if ( p()->talent.trickster.disorienting_strikes->ok() )
     {
       p()->buffs.disorienting_strikes->trigger();
+    }
+
+    if ( p()->talent.trickster.devious_distraction->ok() )
+    {
+      p()->get_target_data( execute_state->target )->debuffs.fazed->trigger();
     }
   }
 
@@ -5146,12 +5151,6 @@ struct killing_spree_t : public rogue_attack_t
     attack_oh->set_target( d->target );
     attack_mh->execute();
     attack_oh->execute();
-
-    // ALPHA TOCHECK -- Once or refreshing per impact?
-    if ( p()->talent.trickster.devious_distraction->ok() )
-    {
-      p()->get_target_data( d->target )->debuffs.fazed->trigger();
-    }
   }
 };
 


### PR DESCRIPTION
...At the start of the Killing Spree, meaning presumably KS's "ticks" all benefit from both the buff and the debuff. It's a bit difficult to know if one or both are applied *by* the first hit (and that hit doesn't benefit from them), or are applied *before* the first hit. A use looks like this in the log
<img width="316" alt="image" src="https://github.com/simulationcraft/simc/assets/2932786/6df6da1b-1481-4d47-bd7d-48d4208f8306">
or this
<img width="299" alt="image" src="https://github.com/simulationcraft/simc/assets/2932786/ca37c726-3587-4ad6-9058-f4b7bc38f2f5">
it doesn't seem like the first hit is consistently 5-8% lower, so I wager they're applied before damage, but I wouldn't call this survey scientific. In any case, both the buff and debuff are only applied once.