### PR TITLE
[monk] Replace brew CDR system

### DIFF
--- a/profiles/DF4/DF4_Monk_Brewmaster.simc
+++ b/profiles/DF4/DF4_Monk_Brewmaster.simc
@@ -13,6 +13,9 @@ load_default_gear=1
 # spec_talents=press_the_advantage:0
 
 actions.ogcd+=/fortifying_brew
+actions.ogcd+=/fortifying_brew
+actions.ogcd+=/fortifying_brew
+actions.ogcd+=/fortifying_brew
 actions.ogcd+=/dampen_harm
 actions.ogcd+=/diffuse_magic
 actions.ogcd+=/black_ox_brew


### PR DESCRIPTION
To register an action in order to benefit from brew CDR, instead derive from the `brew_t<action_base_t>` template.

To trigger brew CDR, invoke the `brews_t::adjust( timespan_t duration )` method.