### PR TITLE
[DH] Update Intent Pursuit & add some talent checks

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4976,10 +4976,6 @@ struct blade_dance_base_t : public demon_hunter_attack_t
           p()->spawn_soul_fragment( soul_fragment::LESSER );
         }
       }
-      if ( p()->talent.aldrachi_reaver.intent_pursuit->ok() )
-      {
-        p()->cooldown.the_hunt->adjust( -p()->talent.aldrachi_reaver.intent_pursuit->effectN( 1 ).time_value() );
-      }
     }
 
     if ( p()->set_bonuses.tww1_havoc_4pc->ok() )
@@ -5283,10 +5279,6 @@ struct chaos_strike_base_t : public demon_hunter_attack_t
           p()->proc.soul_fragment_from_aldrachi_tactics->occur();
           p()->spawn_soul_fragment( soul_fragment::LESSER );
         }
-      }
-      if ( p()->talent.aldrachi_reaver.intent_pursuit->ok() )
-      {
-        p()->cooldown.the_hunt->adjust( -p()->talent.aldrachi_reaver.intent_pursuit->effectN( 1 ).time_value() );
       }
     }
 
@@ -5868,10 +5860,6 @@ struct fracture_t : public demon_hunter_attack_t
             p()->spawn_soul_fragment( soul_fragment::LESSER );
           }
         }
-        if ( p()->talent.aldrachi_reaver.intent_pursuit->ok() )
-        {
-          p()->cooldown.the_hunt->adjust( -p()->talent.aldrachi_reaver.intent_pursuit->effectN( 1 ).time_value() );
-        }
       }
 
       if ( p()->talent.aldrachi_reaver.warblades_hunger && p()->buff.warblades_hunger->up() )
@@ -5952,10 +5940,6 @@ struct shear_t : public demon_hunter_attack_t
             p()->proc.soul_fragment_from_aldrachi_tactics->occur();
             p()->spawn_soul_fragment( soul_fragment::LESSER );
           }
-        }
-        if ( p()->talent.aldrachi_reaver.intent_pursuit->ok() )
-        {
-          p()->cooldown.the_hunt->adjust( -p()->talent.aldrachi_reaver.intent_pursuit->effectN( 1 ).time_value() );
         }
       }
 
@@ -6178,10 +6162,6 @@ struct soul_cleave_base_t : public demon_hunter_attack_t
           p()->proc.soul_fragment_from_aldrachi_tactics->occur();
           p()->spawn_soul_fragment( soul_fragment::LESSER );
         }
-      }
-      if ( p()->talent.aldrachi_reaver.intent_pursuit->ok() )
-      {
-        p()->cooldown.the_hunt->adjust( -p()->talent.aldrachi_reaver.intent_pursuit->effectN( 1 ).time_value() );
       }
     }
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3744,13 +3744,15 @@ struct metamorphosis_t : public demon_hunter_spell_t
         p()->buff.restless_hunter->trigger();
       }
 
-      for ( demonsurge_ability ability : demonsurge_havoc_abilities )
+      if ( p()->talent.felscarred.demonsurge->ok() )
       {
-        p()->buff.demonsurge_abilities[ ability ]->trigger();
+        for ( demonsurge_ability ability : demonsurge_havoc_abilities )
+        {
+          p()->buff.demonsurge_abilities[ ability ]->trigger();
+        }
+        p()->buff.demonsurge_demonic->trigger();
+        p()->buff.demonsurge_hardcast->trigger();
       }
-      p()->buff.demonsurge_demonic->trigger();
-      p()->buff.demonsurge_hardcast->trigger();
-
       // Buff is gained at the start of the leap.
       p()->buff.metamorphosis->extend_duration_or_trigger();
       p()->buff.inner_demon->trigger();
@@ -4315,7 +4317,10 @@ struct the_hunt_t : public demon_hunter_spell_t
       p()->consume_nearby_soul_fragments( soul_fragment::LESSER );
     }
 
-    p()->buff.reavers_glaive->trigger();
+    if ( p()->talent.aldrachi_reaver.intent_pursuit->ok() )
+    {
+      p()->buff.reavers_glaive->trigger();
+    }
   }
 
   timespan_t travel_time() const override

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3780,12 +3780,15 @@ struct metamorphosis_t : public demon_hunter_spell_t
     }
     else  // DEMON_HUNTER_VENGEANCE
     {
-      for ( demonsurge_ability ability : demonsurge_vengeance_abilities )
+      if ( p()->talent.felscarred.demonsurge->ok() )
       {
-        p()->buff.demonsurge_abilities[ ability ]->trigger();
+        for ( demonsurge_ability ability : demonsurge_vengeance_abilities )
+        {
+          p()->buff.demonsurge_abilities[ ability ]->trigger();
+        }
+        p()->buff.demonsurge_demonic->trigger();
+        p()->buff.demonsurge_hardcast->trigger();
       }
-      p()->buff.demonsurge_demonic->trigger();
-      p()->buff.demonsurge_hardcast->trigger();
       p()->buff.metamorphosis->trigger();
 
       if ( p()->talent.felscarred.violent_transformation->ok() )


### PR DESCRIPTION
* Intent pursuit no longer reduces the cooldown of The Hunt as of the most recent beta update
* Added talent checks for demonsurge & intent pursuit procs to avoid extraneous buffs filling the report