### PR TITLE
[Outlaw] Default Outlaw Rogue position to front

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -1286,6 +1286,7 @@ public:
   }
 
   // Character Definition
+  void        init_position() override;
   void        init_spells() override;
   void        init_base_stats() override;
   void        init_talents() override;
@@ -10129,6 +10130,21 @@ std::string rogue_t::default_rune() const
 std::string rogue_t::default_temporary_enchant() const
 {
   return rogue_apl::temporary_enchant( this );
+}
+
+// rogue_t::init_position ==================================================
+
+void rogue_t::init_position()
+{
+  if ( specialization() == ROGUE_OUTLAW && position_str.empty() )
+  {
+    // default outlaw to front when we have an unspecified position
+    base.position = POSITION_FRONT;
+    position_str = util::position_type_string( base.position );
+    sim->print_debug( "{}: Position defaulted to {}", name(), position_str );
+  }
+
+  player_t::init_position();
 }
 
 // rogue_t::init_actions ====================================================


### PR DESCRIPTION
Unlike sub rogue, outlaw has no back-requiring attacks. That means front and back only differ by the 3% parry rate applied to frontal melees. Since trickster actually has a buff which affects this rate now, outlaw can get a sim that takes into account the effects of its' available talents a bit more by setting its' default position to front instead of back. This will probably overstate the parry debuff trickster applies a little bit (not every enemy actually parries, you won't always be in the enemy's face), but does make considering it *at all* a baseline behavior (for outlaw). Adding a `position=back` to your input to override it is also, as always, pretty easy, if you know you don't want to consider parry possibility at all.


cc @EvanMichaels 