### PR TITLE
[DH] Don't trigger Reaver's Glaive if we already have it

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -7171,7 +7171,7 @@ void demon_hunter_t::create_buffs()
             if ( new_ > old )
             {
               int target_stacks = static_cast<int>( b->default_value );
-              if ( b->current_stack >= target_stacks )
+              if ( b->current_stack >= target_stacks && !buff.reavers_glaive->up() )
               {
                 // using an event
                 make_event( *sim, 0_ms, [ b, target_stacks, this ]() {


### PR DESCRIPTION
In game, you continue stacking to 6+ stacks of art of the glaive if you already are holding a reaver's glaive buff

Sim was munchin stacks and refreshing reaver's glaive buff