### PR TITLE
[shaman] Update Magma Chamber stack value for spelldb

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12021,7 +12021,7 @@ void shaman_t::create_buffs()
                             ->set_default_value( talent.flux_melting->effectN( 1 ).trigger()->effectN(1).percent() );
 
   buff.magma_chamber = make_buff( this, "magma_chamber", find_spell( 381933 ) )
-                            ->set_default_value( talent.magma_chamber->effectN( 1 ).percent() );
+                            ->set_default_value( talent.magma_chamber->effectN( 1 ).base_value() * ( 1 / 1000.0) );
 
   buff.power_of_the_maelstrom =
       make_buff( this, "power_of_the_maelstrom", talent.power_of_the_maelstrom->effectN( 1 ).trigger() )


### PR DESCRIPTION
In 5a02c1f326f98e19acc7941a63617404b06a6d81 the implementation of Magma
Chamber was adjusted upstream.

The old implementation:

* spell effect 1 with value 1.5 (used by simc to determine the
  value of each stack on the buff)
* spell effect 2 with value 15 (used in the tooltip)

The new implementation:

* spell effect 1 with value 15 (used in the tooltip)

While the in-game behavior of Magma Chamber hasn't changed, the change
to the spell effects and their values has resulted in the current
implementation granting each Magma Chamber 10x more value than it should
have.

To mitigate this change in behavior, we now divide the value of this
spell effect by 1000 rather than calling `percent()` on it.
