### PR TITLE
Revert "[Warlock] Update beta Channel Demonfire to reflect pre-patch note"

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -69,8 +69,7 @@ using namespace helpers;
 
     warlock_spell_t( util::string_view token, warlock_t* p, const spell_data_t* s = spell_data_t::nil() )
     : spell_t( token, p, s ),
-      affected_by(),
-      triggers()
+      affected_by()
     {
       may_crit = true;
       tick_may_crit = true;
@@ -3352,8 +3351,6 @@ using namespace helpers;
         travel_speed = p->talents.channel_demonfire_travel->missile_speed();
 
         affected_by.chaotic_energies = true;
-
-        triggers.decimation = false;
 
         spell_power_mod.direct = p->talents.channel_demonfire_tick->effectN( 1 ).sp_coeff();
 


### PR DESCRIPTION
Reverts simulationcraft/simc#9095, may just be a tooltip change