### PR TITLE
[Outlaw] Disable nonlethal poisons in the APL

### DIFF
--- a/engine/class_modules/apl/apl_rogue.cpp
+++ b/engine/class_modules/apl/apl_rogue.cpp
@@ -172,7 +172,7 @@ void outlaw( player_t* p )
   action_priority_list_t* stealth = p->get_action_priority_list( "stealth" );
   action_priority_list_t* stealth_cds = p->get_action_priority_list( "stealth_cds" );
 
-  precombat->add_action( "apply_poison" );
+  precombat->add_action( "apply_poison,nonlethal=none,lethal=instant" );
   precombat->add_action( "flask" );
   precombat->add_action( "augmentation" );
   precombat->add_action( "food" );

--- a/engine/class_modules/apl/rogue/outlaw.simc
+++ b/engine/class_modules/apl/rogue/outlaw.simc
@@ -1,5 +1,5 @@
 # Executed before combat begins. Accepts non-harmful actions only.
-actions.precombat=apply_poison
+actions.precombat=apply_poison,nonlethal=none,lethal=instant
 actions.precombat+=/flask
 actions.precombat+=/augmentation
 actions.precombat+=/food


### PR DESCRIPTION
Doing so seems to reduce sim time in my local trials (admittedly, debug builds under a profiler, so gains in a release build may be more modest) - for an 8 target sim, anywhere from 10-15% total sim time can be cut off by doing this.

There's not much downside to disabling nonlethal poisons right now - nobody needs to track the debuffs (they're always up), and they don't affect DPS. Users can always opt-in to them again with a custom APL, and we can always swap it back on if a nonlethal poison becomes important for damage again in the future.

cc @EvanMichaels 