### PR TITLE
[shaman] fix incorrect sp coefficient for earthquake

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7499,7 +7499,7 @@ struct earthquake_damage_t : public earthquake_damage_base_t
     earthquake_damage_base_t( player, "earthquake_damage", player->find_spell( 77478 ), parent )
   {
     // Earthquake modifier is hardcoded rather than using effects, so we set the modifier here
-    spell_power_mod.direct = 0.3915;
+    spell_power_mod.direct = 0.3195;
   }
 };
 


### PR DESCRIPTION
While looking into testing the upcoming beta changes in #9136, I
discovered a small inconsistency in the spell power coefficient for
earthquake which was updated in f7d78966614.

In this change, Earthquake's Spell Power Coefficient was mistakenly set
to `39.15%` instead of `31.95%` (Earthquake Overload has the correct
value).

A quick check of the underlying spell data confirms this is a mistake:

```
Description      : Causes the earth within $a1 yards of the target location to tremble and break, dealing $<damage> Physical damage over $d and has a $77478s2% chance to knock the enemy down. Multiple uses of Earthquake may overlap.

|cFFFFFFFFThis spell is cast at a selected location.|r
Variables        : $mawPower=$?a329580[${1+($329580m5/100)}][${1}]
$maelSup=$?a443447[${1+($443447s3/100)}][${1}]
$warWithinSet=$?a453684[${1+($453684s2/100)}][${1}]
$voltaicSurge=$?a454919[${1+($454919s1/100)}][${1}]
$damage=${$SPN*0.3195*$d/$t2*(1+$@versadmg)*(($137040s1+100)/100)*$<mawPower>*$<maelSup>*$<warWithinSet>*$<voltaicSurge>}
```

While #9137 should ideally prevent this sort of error from happening
again, that may take some time to iron out, so in the interim let's at
least fix the hard-coded value.
