### PR TITLE
Fix hunter background action names

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1062,6 +1062,7 @@ public:
     }
 
     auto action        = new T( n, this, std::forward<Ts>( args )... );
+    assert( action->name_str == n && "Created background action does not match requested name" );
     action->background = true;
     background_actions.push_back( action );
     return action;

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -990,6 +990,7 @@ public:
       return dynamic_cast<T*>( *it );
 
     auto action = new T( n, this, std::forward<Ts>( args )... );
+    assert( action->name_str == n && "Created background action does not match requested name" );
     action -> background = true;
     background_actions.push_back( action );
     return action;
@@ -3809,7 +3810,7 @@ struct arcane_shot_t : public arcane_shot_base_t
 {
   struct arcane_shot_etf_t : public arcane_shot_base_t
   {
-    arcane_shot_etf_t( util::string_view n, hunter_t* p ) : arcane_shot_base_t( p )
+    arcane_shot_etf_t( hunter_t* p ) : arcane_shot_base_t( p )
     {
       background = dual = true;
       base_multiplier *= p->talents.eagletalons_true_focus->effectN( 3 ).percent();
@@ -3825,7 +3826,7 @@ struct arcane_shot_t : public arcane_shot_base_t
 
     if ( p->talents.eagletalons_true_focus.ok() )
     {
-      arcane_shot_etf = p->get_background_action<arcane_shot_etf_t>( "arcane_shot_etf" );
+      arcane_shot_etf = new arcane_shot_etf_t( p );
       add_child( arcane_shot_etf );
     }
   }
@@ -3951,7 +3952,7 @@ struct serpent_sting_base_t: public hunter_ranged_attack_t
 // Explosive Venom (Talent)
 struct serpent_sting_explosive_venom_t final : public serpent_sting_base_t
 {
-  serpent_sting_explosive_venom_t( util::string_view /*name*/, hunter_t* p ):
+  serpent_sting_explosive_venom_t( hunter_t* p ):
     serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
   {
     dual = true;
@@ -3982,7 +3983,7 @@ struct explosive_shot_t : public hunter_ranged_attack_t
       aoe = -1;
       background = dual = true;
 
-      serpent_sting = p -> get_background_action<serpent_sting_explosive_venom_t>( "serpent_sting_explosive_venom" );
+      serpent_sting = new serpent_sting_explosive_venom_t( p );
     }
 
     void impact( action_state_t* s ) override
@@ -4087,7 +4088,7 @@ struct explosive_shot_background_t : public explosive_shot_t
 {
   size_t targets = 0;
 
-  explosive_shot_background_t( util::string_view, hunter_t* p ) : explosive_shot_t( p, "" )
+  explosive_shot_background_t( hunter_t* p ) : explosive_shot_t( p, "" )
   {
     dual = true;
     base_costs[ RESOURCE_FOCUS ] = 0;
@@ -4111,7 +4112,7 @@ struct kill_shot_t : hunter_ranged_attack_t
   // Venoms Bite (Talent)
   struct serpent_sting_venoms_bite_t final : public serpent_sting_base_t
   {
-    serpent_sting_venoms_bite_t( util::string_view /*name*/, hunter_t* p ):
+    serpent_sting_venoms_bite_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
     {
       dual = true;
@@ -4156,7 +4157,7 @@ struct kill_shot_t : hunter_ranged_attack_t
     if ( p->specialization() == HUNTER_BEAST_MASTERY )
       se_recharge_cooldown = p->cooldowns.barbed_shot;
 
-    serpent_sting = p -> get_background_action<serpent_sting_venoms_bite_t>( "serpent_sting_venoms_bite" );
+    serpent_sting = new serpent_sting_venoms_bite_t( p );
   }
 
   void execute() override
@@ -4442,7 +4443,7 @@ struct multishot_bm_t: public hunter_ranged_attack_t
     aoe = -1;
     reduced_aoe_targets = data().effectN( 1 ).base_value();
 
-    serpent_sting = p -> get_background_action<serpent_sting_explosive_venom_t>( "serpent_sting_explosive_venom" );
+    serpent_sting = new serpent_sting_explosive_venom_t( p );
   }
 
   void execute() override
@@ -4744,7 +4745,7 @@ struct chimaera_shot_t : public chimaera_shot_base_t
 {
   struct chimaera_shot_etf_t : public chimaera_shot_base_t
   {
-    chimaera_shot_etf_t( util::string_view n, hunter_t* p ) : chimaera_shot_base_t( p )
+    chimaera_shot_etf_t( hunter_t* p ) : chimaera_shot_base_t( p )
     {
       background = dual = true;
       base_multiplier *= p->talents.eagletalons_true_focus->effectN( 3 ).percent();
@@ -4760,7 +4761,7 @@ struct chimaera_shot_t : public chimaera_shot_base_t
 
     if ( p->talents.eagletalons_true_focus.ok() )
     {
-      chimaera_shot_etf = p->get_background_action<chimaera_shot_etf_t>( "chimaera_shot_etf" );
+      chimaera_shot_etf = new chimaera_shot_etf_t( p );
       add_child( chimaera_shot_etf );
     }
   }
@@ -4791,7 +4792,7 @@ struct aimed_shot_base_t : public hunter_ranged_attack_t
 {
   struct serpent_sting_sst_t final : public serpent_sting_base_t
   {
-    serpent_sting_sst_t( util::string_view /*name*/, hunter_t* p ):
+    serpent_sting_sst_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
     {
       dual = true;
@@ -4800,7 +4801,7 @@ struct aimed_shot_base_t : public hunter_ranged_attack_t
 
   struct serpent_sting_hb_t final : public serpent_sting_base_t
   {
-    serpent_sting_hb_t( util::string_view /*name*/, hunter_t* p ):
+    serpent_sting_hb_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
     {
       dual = true;
@@ -4872,7 +4873,7 @@ struct aimed_shot_base_t : public hunter_ranged_attack_t
     }
 
     if ( p -> talents.serpentstalkers_trickery.ok() )
-      serpentstalkers_trickery = p -> get_background_action<serpent_sting_sst_t>( "serpent_sting_sst" );
+      serpentstalkers_trickery = new serpent_sting_sst_t( p );
 
     if ( p -> talents.surging_shots.ok() )
     {
@@ -4892,7 +4893,7 @@ struct aimed_shot_base_t : public hunter_ranged_attack_t
     }
 
     if ( p->talents.hydras_bite.ok() )
-      hydras_bite = p->get_background_action<serpent_sting_hb_t>( "serpent_sting_hb" );
+      hydras_bite = new serpent_sting_hb_t( p );
   }
 
   double composite_target_da_multiplier( player_t* t ) const override
@@ -5372,7 +5373,7 @@ struct multishot_mm_base_t: public hunter_ranged_attack_t
 
     if ( p -> talents.salvo.ok() )
     {
-      explosive = p -> get_background_action<attacks::explosive_shot_background_t>( "explosive_shot_salvo" );
+      explosive = new attacks::explosive_shot_background_t( p );
       explosive -> targets = as<size_t>( p -> talents.salvo -> effectN( 1 ).base_value() );
     }
   }
@@ -5439,7 +5440,7 @@ struct multishot_mm_t : public multishot_mm_base_t
 {
   struct multishot_mm_etf_t : public multishot_mm_base_t
   {
-    multishot_mm_etf_t( util::string_view n, hunter_t* p ) : multishot_mm_base_t( p )
+    multishot_mm_etf_t( hunter_t* p ) : multishot_mm_base_t( p )
     {
       background = dual = true;
       base_multiplier *= p->talents.eagletalons_true_focus->effectN( 3 ).percent();
@@ -5455,7 +5456,7 @@ struct multishot_mm_t : public multishot_mm_base_t
 
     if ( p->talents.eagletalons_true_focus.ok() )
     {
-      multishot_mm_etf = p->get_background_action<multishot_mm_etf_t>( "multishot_etf" );
+      multishot_mm_etf = new multishot_mm_etf_t( p );
       add_child( multishot_mm_etf );
     }
   }
@@ -5501,7 +5502,7 @@ struct melee_focus_spender_t: hunter_melee_attack_t
 {
   struct serpent_sting_vv_t final : public serpent_sting_base_t
   {
-    serpent_sting_vv_t( util::string_view /*name*/, hunter_t* p ):
+    serpent_sting_vv_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 259491 ) )
     {
       dual = true;
@@ -5534,7 +5535,7 @@ struct melee_focus_spender_t: hunter_melee_attack_t
     hunter_melee_attack_t( n, p, s )
   {
     if ( p -> talents.vipers_venom.ok() )
-      vipers_venom_serpent_sting = p->get_background_action<serpent_sting_vv_t>( "serpent_sting_vv" );
+      vipers_venom_serpent_sting = new serpent_sting_vv_t( p );
 
     wildfire_infusion_chance = p->talents.wildfire_infusion->effectN( 1 ).percent();
   }
@@ -6254,7 +6255,7 @@ struct kill_command_t: public hunter_spell_t
 {
   struct arcane_shot_qs_t final : public attacks::arcane_shot_t
   {
-    arcane_shot_qs_t( util::string_view /*name*/, hunter_t* p ):
+    arcane_shot_qs_t( hunter_t* p ):
       arcane_shot_t( p, "" )
     {
       dual = true;
@@ -6269,7 +6270,7 @@ struct kill_command_t: public hunter_spell_t
 
   struct explosive_shot_qs_t final : public attacks::explosive_shot_background_t
   {
-    explosive_shot_qs_t( util::string_view /*name*/, hunter_t* p ) : explosive_shot_background_t( "", p )
+    explosive_shot_qs_t( hunter_t* p ) : explosive_shot_background_t( p )
     {
       base_dd_multiplier *= p->talents.sulfur_lined_pockets->effectN( 2 ).percent();
     }
@@ -6317,12 +6318,12 @@ struct kill_command_t: public hunter_spell_t
       if ( p -> talents.quick_shot.ok() )
       {
         quick_shot.chance = p -> talents.quick_shot -> effectN( 1 ).percent();
-        quick_shot.arcane = p->get_background_action<arcane_shot_qs_t>( "arcane_shot_qs" );
+        quick_shot.arcane = new arcane_shot_qs_t( p );
         add_child( quick_shot.arcane );
 
         if ( p->talents.sulfur_lined_pockets.ok() )
         {
-          quick_shot.explosive = p->get_background_action<explosive_shot_qs_t>( "explosive_shot_quick_shot" );
+          quick_shot.explosive = new explosive_shot_qs_t( p );
           add_child( quick_shot.explosive );
         }
       }
@@ -6800,7 +6801,7 @@ struct volley_t : public hunter_spell_t
       background = dual = ground_aoe = true;
 
       if ( p -> talents.salvo.ok() ) {
-        explosive = p -> get_background_action<attacks::explosive_shot_background_t>( "explosive_shot_salvo" );
+        explosive = new attacks::explosive_shot_background_t( p );
         explosive -> targets = as<size_t>( p -> talents.salvo -> effectN( 1 ).base_value() );
       }
     }
@@ -6962,7 +6963,7 @@ struct wildfire_bomb_t: public hunter_spell_t
 {
   struct explosive_shot_grenade_juggler_t final : public attacks::explosive_shot_background_t
   {
-    explosive_shot_grenade_juggler_t( util::string_view /*name*/, hunter_t* p ) : explosive_shot_background_t( "", p )
+    explosive_shot_grenade_juggler_t( hunter_t* p ) : explosive_shot_background_t( p )
     {
       base_dd_multiplier *= p->talents.grenade_juggler->effectN( 5 ).percent();
     }
@@ -7081,7 +7082,7 @@ struct wildfire_bomb_t: public hunter_spell_t
     if ( p->talents.grenade_juggler.ok() )
     {
       grenade_juggler.chance = p->talents.grenade_juggler->effectN( 2 ).percent();
-      grenade_juggler.explosive = p->get_background_action<explosive_shot_grenade_juggler_t>( "explosive_shot_grenade_juggler" );
+      grenade_juggler.explosive = new explosive_shot_grenade_juggler_t( p );
     }
   }
 

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -3955,7 +3955,7 @@ struct serpent_sting_explosive_venom_t final : public serpent_sting_base_t
   serpent_sting_explosive_venom_t( hunter_t* p ):
     serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
   {
-    dual = true;
+    background = dual = true;
     base_costs[ RESOURCE_FOCUS ] = 0;
   }
 };
@@ -4090,7 +4090,7 @@ struct explosive_shot_background_t : public explosive_shot_t
 
   explosive_shot_background_t( hunter_t* p ) : explosive_shot_t( p, "" )
   {
-    dual = true;
+    background = dual = true;
     base_costs[ RESOURCE_FOCUS ] = 0;
   }
 };
@@ -4115,7 +4115,7 @@ struct kill_shot_t : hunter_ranged_attack_t
     serpent_sting_venoms_bite_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
     {
-      dual = true;
+      background = dual = true;
       base_costs[ RESOURCE_FOCUS ] = 0;
     }
   };
@@ -4795,7 +4795,7 @@ struct aimed_shot_base_t : public hunter_ranged_attack_t
     serpent_sting_sst_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
     {
-      dual = true;
+      background = dual = true;
     }
   };
 
@@ -4804,7 +4804,7 @@ struct aimed_shot_base_t : public hunter_ranged_attack_t
     serpent_sting_hb_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 271788 ) )
     {
-      dual = true;
+      background = dual = true;
       aoe = as<int>( p->talents.hydras_bite->effectN( 3 ).base_value() );
     }
 
@@ -5505,7 +5505,7 @@ struct melee_focus_spender_t: hunter_melee_attack_t
     serpent_sting_vv_t( hunter_t* p ):
       serpent_sting_base_t( p, "", p -> find_spell( 259491 ) )
     {
-      dual = true;
+      background = dual = true;
     }
 
     timespan_t travel_time() const override
@@ -6258,7 +6258,7 @@ struct kill_command_t: public hunter_spell_t
     arcane_shot_qs_t( hunter_t* p ):
       arcane_shot_t( p, "" )
     {
-      dual = true;
+      background = dual = true;
       base_costs[ RESOURCE_FOCUS ] = 0;
       base_dd_multiplier *= p->talents.quick_shot->effectN( 2 ).percent();
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -1455,6 +1455,7 @@ public:
     }
 
     auto action = new T( n, this, std::forward<Ts>( args )... );
+    assert( action->name_str == n && "Created background action does not match requested name" );
     action->background = true;
     background_actions.push_back( action );
     return action;


### PR DESCRIPTION
Stumbled upon this when fixing compiler warnings. The fix is based on my understanding of how the `get_background_action` functionality is supposed to work.

Should be reviewed by some actual hunters though ;)