### PR TITLE
[shaman] Update EQ SP Coefficient for TWW changes

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7468,7 +7468,7 @@ struct earthquake_overload_damage_t : public earthquake_damage_base_t
     earthquake_damage_base_t( player, "earthquake_overload_damage", player->find_spell( 298765 ), parent )
   {
     // Earthquake modifier is hardcoded rather than using effects, so we set the modifier here
-    spell_power_mod.direct = 0.3195 * player->talent.mountains_will_fall->effectN( 1 ).percent();
+    spell_power_mod.direct = 0.3884 * player->talent.mountains_will_fall->effectN( 1 ).percent();
     // TODO: implement spellpower coefficient extracttion from spell variable
     // auto spell_desc = player->dbc->spell_desc_vars( this->data().id() );
     // spell_desc.desc_vars()
@@ -7505,7 +7505,7 @@ struct earthquake_damage_t : public earthquake_damage_base_t
     earthquake_damage_base_t( player, "earthquake_damage", player->find_spell( 77478 ), parent )
   {
     // Earthquake modifier is hardcoded rather than using effects, so we set the modifier here
-    spell_power_mod.direct = 0.3195;
+    spell_power_mod.direct = 0.3884;
   }
 };
 


### PR DESCRIPTION
Recent hotfixes reset the scaling effects on the elemental
specialization aura to 0% and moved buffs baseline into abilities.

As a result Earthquake's spell power modifier is actually being
increased, while still reflecting the overall nerf of 15% in-game.

While #9137 is in review, I wanted to get this change out so at least
Earthquake numbers will be accurate (on Beta).
