### PR TITLE
[shaman] Fix Ancestor Elemental Blast casts

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -3692,7 +3692,10 @@ struct ancestor_t : public shaman_pet_t
   struct elemental_blast_t : public pet_spell_t<ancestor_t>
   {
     elemental_blast_t( ancestor_t* p ) : super( p, "elemental_blast", p->find_spell( 447427 ) )
-    { background = true; }
+    {
+        background = true;
+        spell_power_mod.direct = data().effectN( 1 ).sp_coeff();
+    }
   };
 
   ancestor_t( shaman_t* owner ) : shaman_pet_t( owner, "ancestor", true, false ),


### PR DESCRIPTION
It seems a recent spell data change resulted in simc considering this
spell power coefficient to be 0. This seems to roughly align with the
Ancestor Elemental Blast spell (447427) receiving a change that resulted
in its tooltop showing a `0` value rather than the spell power
coefficient.

Thankfully it still has a Dummy effect holding the correct spell power
coefficient, so we can use that with an override.
