### PR TITLE
[shaman] Flash of Lightning reduces cooldown on Primordial Wave and Ancestral Swiftness

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -11642,6 +11642,16 @@ void shaman_t::trigger_flash_of_lightning()
     cooldown.totemic_recall->adjust( reduction, false );
   }
 
+  if ( talent.primordial_wave.enabled() )
+  {
+    cooldown.primordial_wave->adjust( reduction, false );
+  }
+
+  if ( talent.ancestral_swiftness.enabled() )
+  {
+    cooldown.ancestral_swiftness->adjust( reduction, false );
+  }
+
   cooldown.flame_shock->adjust( reduction, false );
 
   proc.flash_of_lightning->occur();


### PR DESCRIPTION
Looks like these talents were not included, though in-game behavior
demonstrates both get reduced.
