### PR TITLE
[shaman] Allow background casts to consume Master of the Elements

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -2653,8 +2653,7 @@ struct shaman_spell_t : public shaman_spell_base_t<spell_t>
   {
     base_t::execute();
 
-    // BfA Elemental talent - Master of the Elements
-    if ( affected_by_master_of_the_elements && !background && p()->buff.master_of_the_elements->check() )
+    if ( affected_by_master_of_the_elements && p()->buff.master_of_the_elements->check() )
     {
       p()->buff.master_of_the_elements->decrement();
       proc_moe->occur();


### PR DESCRIPTION
Somewhat counterintuitively, background casts of spells like Flame Shock do
consume this buff in-game (eg assume MOTE is proc'd, casting Primordial
Wave does not consume MOTE, and the Flame Shock it triggers does).

It's likely we set this to never proc on-background on the assumption we
wanted to avoid overloads eating this proc. However, since the proc is
consumed on execute, and the base spell execute for abilities like
Lightning Bolt and Chain Lightning will still consume this before their
respective overloads.

It's unclear if this will brick some other assumptions elsewhere in the
module so I'm leaving this as a draft for now.
