### PR TITLE
[shaman] Set a base cooldown on the Ancestral Swiftness buff

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12276,7 +12276,8 @@ void shaman_t::create_buffs()
     ->apply_affecting_aura( talent.heed_my_call )
     ->set_trigger_spell( talent.call_of_the_ancestors );
   buff.ancestral_swiftness = make_buff( this, "ancestral_swiftness", find_spell( 443454 ) )
-    ->set_trigger_spell( talent.ancestral_swiftness );
+    ->set_trigger_spell( talent.ancestral_swiftness )
+    ->set_cooldown( 0_ms );
   buff.thunderstrike_ward = make_buff( this, "thunderstrike_ward", talent.thunderstrike_ward );
 
   //


### PR DESCRIPTION
We can see the actions vs buff interval behavior on `HEAD` of the `thewarwithin` below:

```
ancestral_swiftness               Count=  18.0| 17.176sec  DPE=     0| 0.00%  DPET=     0  DPR=   0  pDPS=     0

ancestral_swiftness             : start=  9.3 refresh=  0.0 interval= 34.1 trigger= 34.6 duration=  0.0 uptime=  0.00%
```

This is clearly wrong! We're casting it on average every 17 seconds, but the buffs are only being applied every 34 seconds on average. This struck me as suspicious since it's nearly exactly twice the cast frequency, implying that while we're casting at the expected frequency, we're not activating the buff on every cast.

To track this down, I utilized a simplified APL intended to exercise just these spells and the cooldown reduction interaction:

```
actions=/natures_swiftness,if=talent.natures_swiftness.enabled&!talent.ancestral_swiftness.enabled
actions+=/ancestral_swiftness,if=talent.ancestral_swiftness.enabled
actions+=/lightning_bolt
```

After trying out a few potential fixes, I noticed the aura spell we're looking up when constructing the buff has an associated cooldown of 30 seconds. However, the buff itself has no ICD type behavior. Instead the only limitation for buff application is the cooldown of the triggering spell.

Plugging in a dummy value of 2 seconds for the cooldown for application of the Ancestral Swiftness aura yields the correct behavior, with a buff activated aligned with every cast:

```
ancestral_swiftness               Count=  18.0| 17.116sec  DPE=     0| 0.00%  DPET=     0  DPR=   0  pDPS=     0

ancestral_swiftness             : start= 18.0 refresh=  0.0 interval= 17.0 trigger= 17.1 duration=  0.0 uptime=  0.00%
```
