### PR TITLE
[shaman] Adjust Elemental Blast procs to trigger on spell_variant::NORMAL

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7113,19 +7113,23 @@ struct elemental_blast_t : public shaman_spell_t
       // talents
       p()->buff.storm_frenzy->trigger();
 
-      p()->track_magma_chamber();
-      p()->buff.magma_chamber->expire();
-
-      // set bonuses and other external systems
-      p()->track_t29_2pc_ele();
-      p()->buff.t29_2pc_ele->expire();
-      p()->buff.t29_4pc_ele->trigger();
-
       if ( p()->buff.whirling_earth->up() )
       {
         p()->buff.whirling_earth->decrement();
         cooldown->adjust( -p()->buff.whirling_earth->data().effectN( 1 ).time_value() );
       }
+
+      // set bonuses and other external systems
+      p()->track_t29_2pc_ele();
+      p()->buff.t29_2pc_ele->expire();
+      p()->buff.t29_4pc_ele->trigger();
+    }
+
+    // Magma Chamber is consumed by PWave and Normal, but not FoE
+    if ( exec_type == spell_variant::NORMAL || exec_type == spell_variant::PRIMORDIAL_WAVE )
+    {
+      p()->track_magma_chamber();
+      p()->buff.magma_chamber->expire();
     }
 
     // for some reason, background EBs *can* proc SoP still

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7105,7 +7105,7 @@ struct elemental_blast_t : public shaman_spell_t
     // these are effects which ONLY trigger when the player cast the spell directly
     if ( exec_type == spell_variant::NORMAL )
     {
-      if ( p->talent.echoes_of_great_sundering.ok() )
+      if ( p()->talent.echoes_of_great_sundering.ok() )
       {
         p()->buff.echoes_of_great_sundering_eb->trigger();
       }

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7102,36 +7102,37 @@ struct elemental_blast_t : public shaman_spell_t
       trigger_elemental_blast_proc( p() );
     }
 
-    if ( p()->talent.echoes_of_great_sundering.ok() )
+    // these are effects which ONLY trigger when the player cast the spell directly
+    if ( exec_type == spell_variant::NORMAL )
     {
-      p()->buff.echoes_of_great_sundering_es->expire();
-      p()->buff.echoes_of_great_sundering_eb->trigger();
+      if ( p->talent.echoes_of_great_sundering.ok() )
+      {
+        p()->buff.echoes_of_great_sundering_eb->trigger();
+      }
+
+      // talents
+      p()->buff.storm_frenzy->trigger();
+
+      p()->track_magma_chamber();
+      p()->buff.magma_chamber->expire();
+
+      // set bonuses and other external systems
+      p()->track_t29_2pc_ele();
+      p()->buff.t29_2pc_ele->expire();
+      p()->buff.t29_4pc_ele->trigger();
+
+      if ( p()->buff.whirling_earth->up() )
+      {
+        p()->buff.whirling_earth->decrement();
+        cooldown->adjust( -p()->buff.whirling_earth->data().effectN( 1 ).time_value() );
+      }
     }
 
+    // for some reason, background EBs *can* proc SoP still
     if ( p()->talent.surge_of_power->ok() )
     {
       p()->buff.surge_of_power->trigger();
-    }
-
-    p()->track_magma_chamber();
-    p()->buff.magma_chamber->expire();
-
-    p()->track_t29_2pc_ele();
-    p()->buff.t29_2pc_ele->expire();
-
-
-    p()->buff.t29_4pc_ele->trigger();
-
-    if ( p()->buff.whirling_earth->up() )
-    {
-      p()->buff.whirling_earth->decrement();
-      cooldown->adjust( -p()->buff.whirling_earth->data().effectN( 1 ).time_value() );
-    }
-
-    if ( exec_type == spell_variant::NORMAL )
-    {
-      p()->buff.storm_frenzy->trigger();
-    }
+    }    
   }
 
   void impact( action_state_t* state ) override

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -7125,18 +7125,17 @@ struct elemental_blast_t : public shaman_spell_t
       p()->buff.t29_4pc_ele->trigger();
     }
 
-    // Magma Chamber is consumed by PWave and Normal, but not FoE
+    // Magma Chamber is consumed and SoP triggered by PWave and Normal, but not FoE
     if ( exec_type == spell_variant::NORMAL || exec_type == spell_variant::PRIMORDIAL_WAVE )
     {
       p()->track_magma_chamber();
       p()->buff.magma_chamber->expire();
-    }
 
-    // for some reason, background EBs *can* proc SoP still
-    if ( p()->talent.surge_of_power->ok() )
-    {
-      p()->buff.surge_of_power->trigger();
-    }    
+      if ( p()->talent.surge_of_power->ok() )
+      {
+        p()->buff.surge_of_power->trigger();
+      }
+    }
   }
 
   void impact( action_state_t* state ) override


### PR DESCRIPTION
In TWW Beta, procs such as Echoes of Great Sundering only occur on normal casts of Elemental Blast.

Exceptions to this appear to be:

* Surge of Power procs on both normal and PWave EB casts, but not FoE
* Magma Chamber interacts on both normal and PWave EB casts, but not FoE