### PR TITLE
[shaman] Only harmful spells proc Fusion of Elements

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -2660,7 +2660,7 @@ struct shaman_spell_t : public shaman_spell_base_t<spell_t>
       proc_moe->occur();
     }
 
-    if ( exec_type == spell_variant::NORMAL && !background) //TODO: Make this proc on impact
+    if ( exec_type == spell_variant::NORMAL && !background && this->harmful ) //TODO: Make this proc on impact
     {
       p()->trigger_fusion_of_elements( execute_state );
     }


### PR DESCRIPTION
During some APL examination, we discovered that Ancestral Swiftness was
consuming buffs for Fusion of Elements while it does not do so in-game.

There is technically one incorrect behavior induced by this change,
which is that Wind Shear (interrupt) _does_ trigger Fusion of Elements
on Beta, but being as it's the only spell to do so, we believe this to
be a bug that will get fixed.
