### PR TITLE
[Monk] Explicitly set Weapons of Order buff cooldown to zero

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -8191,7 +8191,8 @@ void monk_t::create_buffs()
 
   buff.weapons_of_order = make_buff_fallback( talent.brewmaster.weapons_of_order->ok(), this, "weapons_of_order",
                                               talent.brewmaster.weapons_of_order )
-                              ->set_trigger_spell( talent.brewmaster.weapons_of_order );
+                              ->set_trigger_spell( talent.brewmaster.weapons_of_order )
+                              ->set_cooldown( timespan_t::zero() );
 
   buff.recent_purifies = make_buff_fallback<buffs::purifying_buff_t>(
       talent.brewmaster.improved_invoke_niuzao_the_black_ox->ok(), this, "recent_purifies" );


### PR DESCRIPTION
The Weapons of Order buff has the same spell ID as the ability, so it has a cooldown of 2 minutes. When WoO's cooldown is reduced by other effects, the buff's cooldown remains at 2 minutes. This cooldown override was removed as a part of a recent refactor [#8951](https://github.com/simulationcraft/simc/pull/8951/files#diff-2912bd33a4bb4d7aa74376e8eb6428fcf319f56eb84e2ccec85845982ec1ad72L7662).

I prefer setting the buff cooldown to zero rather than applying various CDR effects manually to both the buff and the triggering ability.

@renanthera for 👀 