### PR TITLE
[ele] fix lava surge proc rate

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8078,7 +8078,7 @@ public:
     double active_flame_shocks = p()->get_active_dots( d );
     p()->lava_surge_attempts_normalized += 1 / active_flame_shocks;
     double proc_chance =
-        std::max( 0.0, 0.5 / ( 1 + std::exp( 10 - p()->lava_surge_attempts_normalized ) ) );
+        std::max( 0.0, 0.5 / ( 1 + std::exp( 11 - p()->lava_surge_attempts_normalized ) ) );
 
     if ( p()->spec.lava_surge->ok() && p()->spec.restoration_shaman->ok() )
     {

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -8076,9 +8076,9 @@ public:
     // TODO: TWW proc chance
 
     double active_flame_shocks = p()->get_active_dots( d );
-    p()->lava_surge_attempts_normalized += 1 / active_flame_shocks;
+    p()->lava_surge_attempts_normalized += 1.0/active_flame_shocks;
     double proc_chance =
-        std::max( 0.0, 0.5 / ( 1 + std::exp( 11 - p()->lava_surge_attempts_normalized ) ) );
+        std::max( 0.0, 0.6-std::pow(1.16, -2*(p()->lava_surge_attempts_normalized-5)));
 
     if ( p()->spec.lava_surge->ok() && p()->spec.restoration_shaman->ok() )
     {


### PR DESCRIPTION
Logs are indicating a 10% proc rate

![grafik](https://github.com/user-attachments/assets/c8ddde74-a7da-4c18-9154-5480802d2642)


This seems to be matching 0.5/(1+e^(11-x)), normalized to target count (the above image is a 2 target test).

This implementation seems to be underperforming, only proccing 90% of the intended proc rate.