### PR TITLE
[shaman] Revert RNG getter guard.

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12523,11 +12523,8 @@ void shaman_t::init_rng()
   if ( options.ancient_fellowship_total == 0 ) {
     options.ancient_fellowship_total = talent.ancient_fellowship->effectN( 2 ).base_value();
   }
-  if ( talent.ancient_fellowship.ok() )
-  {
-    rng_obj.ancient_fellowship =
-        get_shuffled_rng( "ancient_fellowship", options.ancient_fellowship_positive, options.ancient_fellowship_total );
-  }
+  rng_obj.ancient_fellowship =
+    get_shuffled_rng( "ancient_fellowship", options.ancient_fellowship_positive, options.ancient_fellowship_total );
   if ( options.icefury_positive == 0 ) {
     options.icefury_positive = talent.icefury->effectN( 1 ).base_value();
   }
@@ -12535,10 +12532,7 @@ void shaman_t::init_rng()
   if ( options.icefury_total == 0 ) {
     options.icefury_total = talent.icefury->effectN( 2 ).base_value();
   }
-  if ( talent.icefury.ok() )
-  {
-    rng_obj.icefury = get_shuffled_rng( "icefury", options.icefury_positive, options.icefury_total );
-  }
+  rng_obj.icefury = get_shuffled_rng( "icefury", options.icefury_positive, options.icefury_total );
 }
 
 // shaman_t::init_items =====================================================

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -3768,12 +3768,9 @@ struct ancestor_t : public shaman_pet_t
     }
 
     shaman_pet_t::dismiss( expiration );
-    if ( o()->talent.ancient_fellowship.ok() )
+    if ( expiration && o()->rng_obj.ancient_fellowship->trigger() )
     {
-      if ( expiration && o()->rng_obj.ancient_fellowship->trigger() )
-      {
-        o()->summon_ancestor();
-      }
+      o()->summon_ancestor();
     }
   }
 };
@@ -6581,13 +6578,11 @@ struct lava_burst_t : public shaman_spell_t
     }
 
     p()->buff.t29_2pc_ele->trigger();
-    if ( p()->talent.icefury.ok() )
+    if ( exec_type == spell_variant::NORMAL && p()->rng_obj.icefury->trigger() )
     {
-      if ( exec_type == spell_variant::NORMAL && p()->rng_obj.icefury->trigger() )
-      {
-        p()->buff.icefury_cast->trigger();
-      }
+      p()->buff.icefury_cast->trigger();
     }
+    
 
     if ( p()->talent.routine_communication.ok() && exec_type == spell_variant::NORMAL )
     {


### PR DESCRIPTION
Broken behaviour introduced by #9217 fixed in #9222, no longer requiring guarding of RNG getter that was implemented in #9223.