### PR TITLE
[Buff] Do not extend pandemic buffs above their pandemic limit

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -2175,6 +2175,13 @@ void buff_t::extend_duration( player_t* p, timespan_t extra_seconds )
 
   assert( expiration.size() == 1 );
 
+  // Do not refresh above pandemic buff limit
+  if ( refresh_behavior == buff_refresh_behavior::PANDEMIC )
+  {
+    extra_seconds = std::min( expiration.front()->remains() + extra_seconds, buff_duration() * 1.3 ) -
+                    expiration.front()->remains();
+  }
+
   extra_seconds = extra_seconds * get_time_duration_multiplier();
 
   if ( extra_seconds > timespan_t::zero() )

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -2143,16 +2143,7 @@ struct hammer_of_light_damage_t : public holy_power_consumer_t<paladin_melee_att
         p()->buffs.templar.shake_the_heavens->execute();
       else
       {
-        // 2024-08-03 Shake the Heavens is only extended by 4s if it's already up
-        // Currently extend_duration ignores the pandemic limits, workaround for now, real fix later via PR
-        timespan_t maxDur      = p()->buffs.templar.shake_the_heavens->base_buff_duration * 1.3;
-        timespan_t extendedDur = p()->buffs.templar.shake_the_heavens->remains() + timespan_t::from_seconds( 4 );
-        double extension       = 4.0;
-        if ( maxDur < extendedDur )
-        {
-          extension -= ( extendedDur - maxDur ).total_seconds();
-        }
-        p()->buffs.templar.shake_the_heavens->extend_duration( p(), timespan_t::from_seconds( extension ) );
+        p()->buffs.templar.shake_the_heavens->extend_duration( p(), timespan_t::from_seconds( 4 ) );
       }
     }
   }


### PR DESCRIPTION
`buff.extend_duration` has been extending pandemic buffs up to infinity, while they should only have a maximum duration of 1.3 times their buff length.