### PR TITLE
[Mage] Remove GS and GS Flurry Line from AOE

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -312,8 +312,6 @@ void frost( player_t* p )
   aoe->add_action( "ice_nova,if=freezable&!prev_off_gcd.freeze&(prev_gcd.1.glacial_spike)" );
   aoe->add_action( "frost_nova,if=freezable&!prev_off_gcd.freeze&(prev_gcd.1.glacial_spike&!remaining_winters_chill)" );
   aoe->add_action( "shifting_power,if=cooldown.comet_storm.remains>10" );
-  aoe->add_action( "flurry,if=cooldown_react&!debuff.winters_chill.remains&buff.icicles.react=4&talent.glacial_spike&!freezable" );
-  aoe->add_action( "glacial_spike,if=buff.icicles.react=5&cooldown.blizzard.remains>gcd.max" );
   aoe->add_action( "flurry,if=(freezable|!talent.glacial_spike)&cooldown_react&!debuff.winters_chill.remains&(buff.brain_freeze.react|!buff.fingers_of_frost.react)" );
   aoe->add_action( "ice_lance,if=buff.fingers_of_frost.react|debuff.frozen.remains>travel_time|remaining_winters_chill" );
   aoe->add_action( "ice_nova,if=active_enemies>=4&(!talent.glacial_spike|!freezable)" );


### PR DESCRIPTION
Removing these is a 3% dps increase in AOE (4t is FF, 5t SS to show gain for each spec. Very significant at 3% for SS, more minor at .8% and gaining for FF based on target count).

4t: https://www.raidbots.com/simbot/report/fV56UjAi9JXQzbF8weTjz9
5t: https://www.raidbots.com/simbot/report/iSF3vDaFRzVFhZnToMaEwd

