### PR TITLE
add spelleffect_data_t::average( special_effect_t )

### DIFF
--- a/engine/dbc/spell_data.cpp
+++ b/engine/dbc/spell_data.cpp
@@ -13,6 +13,7 @@
 #include "dbc/item_database.hpp"
 #include "fmt/format.h"
 #include "item/item.hpp"
+#include "item/special_effect.hpp"
 #include "player/player.hpp"
 #include "util/generic.hpp"
 #include "util/util.hpp"
@@ -100,10 +101,9 @@ double spelleffect_data_t::delta( const player_t* p, unsigned level ) const
 
 double spelleffect_data_t::delta( const item_t* item ) const
 {
-  double m_scale = 0;
+  assert( item && "spelleffect_data_t::delta( item ) called without a valid item." );
 
-  if ( !item )
-    return 0;
+  double m_scale = 0;
 
   // Spells that do not have Scales with Casting Item's Level (354) attribute will instead return player-scaled value.
   // If the scaling is -7, despite being tied to an item it seems to get a combat rating multiplier of 1.5. It remains
@@ -112,8 +112,13 @@ double spelleffect_data_t::delta( const item_t* item ) const
   if ( !_spell->flags( spell_attribute::SX_SCALE_ILEVEL ) )
     return delta( item->player );
 
+  // If the spell_data_t::_max_scaling_level is set, it will be used as the maximum level for scaling.
+  auto item_level = item->item_level();
+  if ( _spell->max_scaling_level() > 0 )
+    item_level = std::min( item_level, _spell->max_scaling_level() );
+
   if ( _m_delta != 0 )
-    m_scale = item_database::item_budget( item, _spell->max_scaling_level() );
+    m_scale = item_database::item_budget( item, item_level);
 
   if ( scaling_class() == PLAYER_SPECIAL_SCALE7 )
   {
@@ -121,11 +126,58 @@ double spelleffect_data_t::delta( const item_t* item ) const
   }
   else if ( scaling_class() == PLAYER_SPECIAL_SCALE8 )
   {
-    const auto& props = item->player->dbc->random_property( item->item_level() );
+    const auto& props = item->player->dbc->random_property( item_level );
     m_scale = props.damage_replace_stat;
+  }
+  else if ( scaling_class() == PLAYER_SPECIAL_SCALE9 )
+  {
+    const auto& props = item->player->dbc->random_property( item_level );
+    m_scale = props.damage_secondary;
   }
 
   return scaled_delta( m_scale );
+}
+
+double spelleffect_data_t::delta( const special_effect_t& effect ) const
+{
+  // Use player scaling if spell does not have the scale with item level flag
+  if ( !_spell->flags( spell_attribute::SX_SCALE_ILEVEL ) )
+    return delta( effect.player );
+
+  // Use item scaling if a valid item exists
+  if ( effect.item )
+    return delta( effect.item );
+
+  // If we need item scaling but there is no item, max scaling level seems to be used as the item level
+  if ( _spell->max_scaling_level() > 0 )
+  {
+    auto level = _spell->max_scaling_level();
+
+    double m_scale = 0;
+    if ( _m_delta != 0 )
+      m_scale = item_database::item_budget( effect.player, level );
+
+    if ( scaling_class() == PLAYER_SPECIAL_SCALE7 )
+    {
+      // TODO: confirm which combat rating multiplier is used
+      m_scale = item_database::apply_combat_rating_multiplier( effect.player, CR_MULTIPLIER_TRINKET, level, m_scale );
+    }
+    else if ( scaling_class() == PLAYER_SPECIAL_SCALE8 )
+    {
+      const auto& props = effect.player->dbc->random_property( level );
+      m_scale = props.damage_replace_stat;
+    }
+    else if ( scaling_class() == PLAYER_SPECIAL_SCALE9 )
+    {
+      const auto& props = effect.player->dbc->random_property( level );
+      m_scale = props.damage_secondary;
+    }
+
+    return scaled_delta( m_scale );
+  }
+
+  assert( false && "spelleffect_data_t::delta( special_effect_t ) unable to calculate scaling." );
+  return 0;
 }
 
 double spelleffect_data_t::bonus( const player_t* p, unsigned level ) const
@@ -146,6 +198,11 @@ double spelleffect_data_t::min( const item_t* item ) const
   return scaled_min( average( item ), delta( item ) );
 }
 
+double spelleffect_data_t::min( const special_effect_t& effect ) const
+{
+  return scaled_min( average( effect ), delta( effect ) );
+}
+
 double spelleffect_data_t::max( const player_t* p, unsigned level ) const
 {
   assert( level <= MAX_SCALING_LEVEL );
@@ -156,6 +213,11 @@ double spelleffect_data_t::max( const player_t* p, unsigned level ) const
 double spelleffect_data_t::max( const item_t* item ) const
 {
   return scaled_max( average( item ), delta( item ) );
+}
+
+double spelleffect_data_t::max( const special_effect_t& effect ) const
+{
+  return scaled_max( average( effect ), delta( effect ) );
 }
 
 double spelleffect_data_t::average( const player_t* p, unsigned level ) const
@@ -199,8 +261,7 @@ double spelleffect_data_t::average( const player_t* p, unsigned level ) const
 
 double spelleffect_data_t::average( const item_t* item ) const
 {
-  if ( !item )
-    return 0;
+  assert( item && "spelleffect_data_t::average( item ) called without a valid item." );
 
   // Spells that do not have Scales with Casting Item's Level (354) attribute will instead return player-scaled value.
   // If the scaling is -7, despite being tied to an item it seems to get a combat rating multiplier of 1.5. It remains
@@ -209,24 +270,69 @@ double spelleffect_data_t::average( const item_t* item ) const
   if ( !_spell->flags( spell_attribute::SX_SCALE_ILEVEL ) )
     return average( item->player );
 
-  auto budget = item_database::item_budget( item, _spell->max_scaling_level() );
+  // If the spell_data_t::_max_scaling_level is set, it will be used as the maximum level for scaling.
+  auto item_level = item->item_level();
+  if ( _spell->max_scaling_level() > 0 )
+    item_level = std::min( item_level, _spell->max_scaling_level() );
+
+  auto budget = item_database::item_budget( item, item_level );
+
   if ( scaling_class() == PLAYER_SPECIAL_SCALE7 )
   {
-    budget = item_database::apply_combat_rating_multiplier( *item, budget, _spell->max_scaling_level() );
+    budget = item_database::apply_combat_rating_multiplier( *item, budget, item_level );
   }
   else if ( scaling_class() == PLAYER_SPECIAL_SCALE8 )
   {
-    const auto& props = item->player->dbc->random_property( item->item_level() );
+    const auto& props = item->player->dbc->random_property( item_level );
     budget = props.damage_replace_stat;
   }
-  else if ( ( scaling_class() == PLAYER_NONE || scaling_class() == PLAYER_SPECIAL_SCALE9 ) &&
-            _spell->flags( spell_attribute::SX_SCALE_ILEVEL ) )
+  else if ( scaling_class() == PLAYER_NONE || scaling_class() == PLAYER_SPECIAL_SCALE9 )
   {
-    const auto& props = item->player->dbc->random_property( item->item_level() );
+    const auto& props = item->player->dbc->random_property( item_level );
     budget = props.damage_secondary;
   }
 
   return _m_coeff * budget;
+}
+
+double spelleffect_data_t::average( const special_effect_t& effect ) const
+{
+  // Use player scaling if spell does not have the scale with item level flag
+  if ( !_spell->flags( spell_attribute::SX_SCALE_ILEVEL ) )
+    return average( effect.player );
+
+  // Use item scaling if a valid item exists
+  if ( effect.item )
+    return average( effect.item );
+
+  // If we need item scaling but there is no item, max scaling level seems to be used as the item level
+  if ( _spell->max_scaling_level() > 0 )
+  {
+    auto level = _spell->max_scaling_level();
+
+    auto budget = item_database::item_budget( effect.player, level );
+
+    if ( scaling_class() == PLAYER_SPECIAL_SCALE7 )
+    {
+      // TODO: confirm which combat rating multiplier is used
+      budget = item_database::apply_combat_rating_multiplier( effect.player, CR_MULTIPLIER_TRINKET, level, budget );
+    }
+    else if ( scaling_class() == PLAYER_SPECIAL_SCALE8 )
+    {
+      const auto& props = effect.player->dbc->random_property( level );
+      budget = props.damage_replace_stat;
+    }
+    else if ( scaling_class() == PLAYER_SPECIAL_SCALE9 )
+    {
+      const auto& props = effect.player->dbc->random_property( level );
+      budget = props.damage_secondary;
+    }
+
+    return _m_coeff * budget;
+  }
+
+  assert( false && "spelleffect_data_t::average( special_effect_t ) unable to calculate scaling." );
+  return 0;
 }
 
 double spelleffect_data_t::scaled_delta( double budget ) const

--- a/engine/dbc/spell_data.hpp
+++ b/engine/dbc/spell_data.hpp
@@ -21,6 +21,7 @@
 class dbc_t;
 struct item_t;
 struct player_t;
+struct special_effect_t;
 struct spell_data_t;
 struct spelleffect_data_t;
 struct spelllabel_data_t;
@@ -367,6 +368,11 @@ struct spelleffect_data_t
   double delta( const item_t& item ) const { return delta( &item ); }
   double min( const item_t& item ) const { return min( &item ); }
   double max( const item_t& item ) const { return max( &item ); }
+
+  double average( const special_effect_t& effect ) const;
+  double delta( const special_effect_t& effect ) const;
+  double min( const special_effect_t& effect ) const;
+  double max( const special_effect_t& effect ) const;
 
   bool override_field( util::string_view field, double value );
   double get_field( util::string_view field ) const;

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -127,7 +127,7 @@ void create_all_stat_buffs( const special_effect_t& effect, const spell_data_t* 
     auto stat_str = util::stat_type_abbrev( stats.front() );
 
     auto buff = create_buff<stat_buff_t>( effect.player, fmt::format( "{}_{}", buff_name, stat_str ), buff_data )
-      ->add_stat( stats.front(), amount ? amount : eff.average( effect.item ) )
+      ->add_stat( stats.front(), amount ? amount : eff.average( effect ) )
       ->set_name_reporting( stat_str );
 
     add_fn( stats.front(), buff );
@@ -221,7 +221,7 @@ custom_cb_t selector_food( unsigned id, bool highest, bool major = true )
 
     auto coeff = effect.player->find_spell( food_coeff_spell_id );
 
-    effect.stat_amount = coeff->effectN( 4 ).average( effect.player );
+    effect.stat_amount = coeff->effectN( 4 ).average( effect );
     if ( !major )
       effect.stat_amount *= coeff->effectN( 1 ).base_value() * 0.1;
 
@@ -240,7 +240,7 @@ custom_cb_t primary_food( unsigned id, stat_e stat, size_t primary_idx = 3, bool
     
     if ( primary_idx )
     {
-      auto _amt = coeff->effectN( primary_idx ).average( effect.player );
+      auto _amt = coeff->effectN( primary_idx ).average( effect );
       if ( !major )
         _amt *= coeff->effectN( 1 ).base_value() * 0.1;
 
@@ -249,7 +249,7 @@ custom_cb_t primary_food( unsigned id, stat_e stat, size_t primary_idx = 3, bool
 
     if ( primary_idx == 3 )
     {
-      auto _amt = coeff->effectN( 8 ).average( effect.player );
+      auto _amt = coeff->effectN( 8 ).average( effect );
       if ( !major )
         _amt *= coeff->effectN( 1 ).base_value() * 0.1;
 
@@ -271,12 +271,12 @@ custom_cb_t secondary_food( unsigned id, stat_e stat1, stat_e stat2 = STAT_NONE 
 
     if ( stat2 == STAT_NONE )
     {
-      auto _amt = coeff->effectN( 4 ).average( effect.player );
+      auto _amt = coeff->effectN( 4 ).average( effect );
       buff->add_stat( stat1, _amt );
     }
     else
     {
-      auto _amt = coeff->effectN( 5 ).average( effect.player );
+      auto _amt = coeff->effectN( 5 ).average( effect );
       buff->add_stat( stat1, _amt );
       buff->add_stat( stat2, _amt );
     }
@@ -301,8 +301,8 @@ void flask_of_alchemical_chaos( special_effect_t& effect )
 
     flask_of_alchemical_chaos_buff_t( const special_effect_t& e ) : consumable_buff_t( e.player, e.name(), e.driver() )
     {
-      auto bonus = e.driver()->effectN( 5 ).average( e.item );
-      auto penalty = -( e.driver()->effectN( 6 ).average( e.item ) );
+      auto bonus = e.driver()->effectN( 5 ).average( e );
+      auto penalty = -( e.driver()->effectN( 6 ).average( e ) );
 
       auto add_vers = create_buff<stat_buff_t>( e.player, "flask_of_alchemical_chaos_vers", e.driver() )
         ->add_stat( STAT_VERSATILITY_RATING, bonus )->set_name_reporting( "Vers" );
@@ -362,7 +362,7 @@ void tempered_potion( special_effect_t& effect )
       tempered_stat = static_cast<stat_buff_t*>( _buff )->stats.front().stat;
 
   auto buff = create_buff<stat_buff_t>( effect.player, effect.driver() );
-  auto amount = effect.driver()->effectN( 1 ).average( effect.item );
+  auto amount = effect.driver()->effectN( 1 ).average( effect );
 
   for ( auto s : secondary_ratings )
     if ( s != tempered_stat )
@@ -414,7 +414,7 @@ void potion_of_unwavering_focus( special_effect_t& effect )
 // Oils
 void oil_of_deep_toxins( special_effect_t& effect )
 {
-  effect.discharge_amount = effect.driver()->effectN( 1 ).average( effect.player );
+  effect.discharge_amount = effect.driver()->effectN( 1 ).average( effect );
 
   new dbc_proc_callback_t( effect.player, effect );
 }
@@ -427,12 +427,12 @@ void authority_of_radiant_power( special_effect_t& effect )
   auto found = effect.player->find_action( "authority_of_radiant_power" );
 
   auto damage = create_proc_action<generic_proc_t>( "authority_of_radiant_power", effect, 448744 );
-  auto damage_val = effect.driver()->effectN( 1 ).average( effect.player );
+  auto damage_val = effect.driver()->effectN( 1 ).average( effect );
   damage->base_dd_min += damage_val;
   damage->base_dd_max += damage_val;
 
   auto buff = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( 448730 ) )
-    ->add_stat_from_effect_type( A_MOD_STAT, effect.driver()->effectN( 2 ).average( effect.player ) );
+    ->add_stat_from_effect_type( A_MOD_STAT, effect.driver()->effectN( 2 ).average( effect ) );
 
   if ( found )
     return;
@@ -454,7 +454,7 @@ void authority_of_the_depths( special_effect_t& effect )
   auto found = effect.player->find_action( "suffocating_darkness" );
 
   auto damage = create_proc_action<generic_proc_t>( "suffocating_darkness", effect, 449217 );
-  damage->base_td += effect.driver()->effectN( 1 ).average( effect.player );
+  damage->base_td += effect.driver()->effectN( 1 ).average( effect );
 
   if ( found )
     return;
@@ -474,7 +474,7 @@ void secondary_weapon_enchant( special_effect_t& effect )
   auto found = buff_t::find( effect.player, buff_name );
 
   auto buff = create_buff<stat_buff_t>( effect.player, buff_name, buff_data )
-    ->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 1 ).average( effect.player ) );
+    ->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 1 ).average( effect ) );
 
   if ( found )
     return;
@@ -507,7 +507,7 @@ void blessed_weapon_grip( special_effect_t& effect )
 {
   std::unordered_map<stat_e, buff_t*> buffs;
 
-  create_all_stat_buffs( effect, effect.trigger(), effect.trigger()->effectN( 6 ).average( effect.item ),
+  create_all_stat_buffs( effect, effect.trigger(), effect.trigger()->effectN( 6 ).average( effect ),
     [ &buffs ]( stat_e s, buff_t* b ) { buffs[ s ] = b->set_reverse( true ); } );
 
   effect.player->callbacks.register_callback_execute_function( effect.spell_id,
@@ -539,7 +539,7 @@ void pouch_of_pocket_grenades( special_effect_t& effect )
   auto missile = driver->effectN( 1 ).trigger();
   auto damage = missile->effectN( 1 ).trigger();
   // TODO: determine which coeff is the correct one. assuming driver is correct.
-  auto amount = driver->effectN( 1 ).average( effect.item );
+  auto amount = driver->effectN( 1 ).average( effect );
 
   effect.spell_id = driver->id();
 
@@ -571,7 +571,7 @@ void elemental_focusing_lens( special_effect_t& effect )
   if ( !gems.size() )
     return;
 
-  auto amount = effect.driver()->effectN( 1 ).average( effect.item );
+  auto amount = effect.driver()->effectN( 1 ).average( effect );
 
   effect.spell_id = effect.trigger()->id();
 
@@ -638,7 +638,7 @@ void dawn_dusk_thread_lining( special_effect_t& effect )
   bool first = !buff->manual_stats_added;
   // In some cases, the buff values from separate items don't stack. This seems to fix itself
   // when the player loses and regains the buff, so we just assume they stack properly.
-  buff->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 1 ).average( effect.item ) );
+  buff->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 1 ).average( effect ) );
 
   // In case the player has two copies of this embellishment, set up the buff events only once.
   if ( first && effect.player->thewarwithin_opts.dawn_dusk_thread_lining_uptime > 0.0 )
@@ -683,7 +683,7 @@ void deepening_darkness( special_effect_t& effect )
     create_proc_action<generic_aoe_proc_t>( "deepening_darkness", effect, effect.player->find_spell( 446753 ), true );
 
   damage->base_dd_min = damage->base_dd_max =
-    effect.driver()->effectN( 2 ).average( effect.item ) * role_mult( effect ) * writhing_mul( effect.player );
+    effect.driver()->effectN( 2 ).average( effect ) * role_mult( effect ) * writhing_mul( effect.player );
 
   auto buff = create_buff<buff_t>( effect.player, effect.player->find_spell( 446743 ) )
                   ->set_expire_callback( [ damage ]( buff_t*, int, timespan_t d ) {
@@ -718,9 +718,9 @@ void spark_of_beledar( special_effect_t& effect )
     {
       bonus_damage =
           create_proc_action<generic_proc_t>( "blazing_spark_of_beledar", e, e.player->find_spell( 446402 ) );
-      bonus_damage->base_dd_min = bonus_damage->base_dd_max = e.driver()->effectN( 3 ).average( e.item );
+      bonus_damage->base_dd_min = bonus_damage->base_dd_max = e.driver()->effectN( 3 ).average( e );
 
-      base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e.item );
+      base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e );
 
       add_child( bonus_damage );
     }
@@ -759,7 +759,7 @@ void adrenal_surge( special_effect_t& effect )
 {
   // create primary stat buff
   auto primary_stat_trigger = effect.driver()->effectN( 1 ).trigger();
-  auto primary_value = primary_stat_trigger->effectN( 1 ).average( effect.item ) * writhing_mul( effect.player );
+  auto primary_value = primary_stat_trigger->effectN( 1 ).average( effect ) * writhing_mul( effect.player );
   auto primary_stat_buff = create_buff<stat_buff_t>( effect.player, "adrenal_surge_primary", primary_stat_trigger )
     ->set_stat_from_effect_type( A_MOD_STAT, primary_value );
 
@@ -767,7 +767,7 @@ void adrenal_surge( special_effect_t& effect )
   // create mastery loss debuff
   // TODO: currently this does not scale with item level
   auto mastery_loss_trigger = primary_stat_trigger->effectN( 3 ).trigger();
-  auto mastery_value = mastery_loss_trigger->effectN( 1 ).average( effect.item ) * writhing_mul( effect.player );
+  auto mastery_value = mastery_loss_trigger->effectN( 1 ).average( effect ) * writhing_mul( effect.player );
   auto mastery_loss_buff = create_buff<stat_buff_t>( effect.player, "adrenal_surge_mastery", mastery_loss_trigger )
     ->set_stat_from_effect_type( A_MOD_RATING, mastery_value );
 
@@ -823,7 +823,7 @@ void spymasters_web( special_effect_t& effect )
   auto buff_data = equip->trigger();
 
   auto stacking_buff = create_buff<stat_buff_t>( effect.player, buff_data )
-    ->set_stat_from_effect_type( A_MOD_STAT, equip_data->effectN( 1 ).average( effect.item ) );
+    ->set_stat_from_effect_type( A_MOD_STAT, equip_data->effectN( 1 ).average( effect ) );
 
   // TODO: confirm there is an animation delay for the spiders to return before buff is applied
   effect.player->callbacks.register_callback_execute_function( equip_id,
@@ -839,7 +839,7 @@ void spymasters_web( special_effect_t& effect )
   new dbc_proc_callback_t( effect.player, *equip );
 
   auto use_buff = create_buff<stat_buff_t>( effect.player, effect.driver() )
-    ->set_stat_from_effect_type( A_MOD_STAT, equip_data->effectN( 2 ).average( effect.item ) )
+    ->set_stat_from_effect_type( A_MOD_STAT, equip_data->effectN( 2 ).average( effect ) )
     ->set_max_stack( stacking_buff->max_stack() )
     ->set_cooldown( 0_ms );
 
@@ -891,7 +891,7 @@ void void_reapers_chime( special_effect_t& effect )
     {
       auto damage_spell = effect.player->find_spell( 448669 );
       auto damage_name = std::string( damage_spell->name_cstr() );
-      auto damage_amount = effect.driver()->effectN( 1 ).average( effect.item );
+      auto damage_amount = effect.driver()->effectN( 1 ).average( effect );
 
       major = create_proc_action<generic_aoe_proc_t>( damage_name, effect, damage_spell );
       major->base_dd_min = major->base_dd_max = damage_amount;
@@ -993,7 +993,7 @@ void aberrant_spellforge( special_effect_t& effect )
                    ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
 
   auto haste = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( 451845 ) )
-    ->set_stat_from_effect_type( A_MOD_RATING, data->effectN( 2 ).average( effect.item ) );
+    ->set_stat_from_effect_type( A_MOD_RATING, data->effectN( 2 ).average( effect ) );
 
   // proc damage action
   struct aberrant_shadows_t : public generic_proc_t
@@ -1003,7 +1003,7 @@ void aberrant_spellforge( special_effect_t& effect )
     aberrant_shadows_t( const special_effect_t& e, const spell_data_t* data, buff_t* b )
       : generic_proc_t( e, "aberrant_shadows", 451866 ), stack( b )
     {
-      base_dd_min = base_dd_max = data->effectN( 1 ).average( e.item );
+      base_dd_min = base_dd_max = data->effectN( 1 ).average( e );
       base_multiplier *= role_mult( e );
 
       for ( auto a : player->action_list )
@@ -1140,7 +1140,7 @@ void sikrans_endless_arsenal( special_effect_t& effect )
 
       // setup flourish
       auto f_dam = create_proc_action<generic_proc_t>( "surekian_flourish", e, 445434 );
-      f_dam->base_td = data->effectN( 1 ).average( e.item ) * f_dam->base_tick_time / f_dam->dot_duration;
+      f_dam->base_td = data->effectN( 1 ).average( e ) * f_dam->base_tick_time / f_dam->dot_duration;
       f_dam->base_multiplier *= role_mult( e );
       add_child( f_dam );
 
@@ -1153,7 +1153,7 @@ void sikrans_endless_arsenal( special_effect_t& effect )
       // setup decimation
       auto d_dam = create_proc_action<generic_aoe_proc_t>( "surekian_decimation", e, 448090 );
       // TODO: confirm there is no standard +15% per target up to five
-      d_dam->base_dd_min = d_dam->base_dd_max = data->effectN( 4 ).average( e.item ) * role_mult( e );
+      d_dam->base_dd_min = d_dam->base_dd_max = data->effectN( 4 ).average( e ) * role_mult( e );
       d_dam->base_multiplier *= role_mult( e );
       add_child( d_dam );
 
@@ -1193,7 +1193,7 @@ void sikrans_endless_arsenal( special_effect_t& effect )
       auto b_dam = create_proc_action<generic_aoe_proc_t>( "surekian_barrage", e, 445475 );
       // TODO: confirm damage isn't split and has no diminishing returns
       b_dam->split_aoe_damage = false;
-      b_dam->base_dd_min = b_dam->base_dd_max = data->effectN( 6 ).average( e.item ) * role_mult( e );
+      b_dam->base_dd_min = b_dam->base_dd_max = data->effectN( 6 ).average( e ) * role_mult( e );
       b_dam->base_multiplier *= role_mult( e );
       add_child( b_dam );
 
@@ -1290,7 +1290,7 @@ void swarmlords_authority( special_effect_t& effect )
         : absorb_buff_t( e.player, "ravenous_scarab", s ), absorb_pct( s->effectN( 2 ).percent() )
       {
         // TODO: set high priority & add to player absorb priority if necessary
-        set_default_value( data->effectN( 2 ).average( e.item ) );
+        set_default_value( data->effectN( 2 ).average( e ) );
       }
 
       double consume( double a, action_state_t* s ) override
@@ -1305,7 +1305,7 @@ void swarmlords_authority( special_effect_t& effect )
     ravenous_scarab_t( const special_effect_t& e, const spell_data_t* data )
       : generic_proc_t( e, "ravenous_scarab", e.trigger() )
     {
-      base_dd_min = base_dd_max = data->effectN( 1 ).average( e.item );
+      base_dd_min = base_dd_max = data->effectN( 1 ).average( e );
 
       auto return_spell = e.player->find_spell( 447097 );
       shield = make_buff<ravenous_scarab_buff_t>( e, return_spell->effectN( 2 ).trigger(), data );
@@ -1352,7 +1352,7 @@ void foul_behemoths_chelicera( special_effect_t& effect )
       tasty_juices_t( const special_effect_t& e, const spell_data_t* data )
         : generic_heal_t( e, "tasty_juices", 446805 )
       {
-        base_dd_min = base_dd_max = data->effectN( 2 ).average( e.item );
+        base_dd_min = base_dd_max = data->effectN( 2 ).average( e );
 
         // TODO: determine out of combat decay
         buff = create_buff<buff_t>( e.player, e.player->find_spell( 446886 ) )
@@ -1386,7 +1386,7 @@ void foul_behemoths_chelicera( special_effect_t& effect )
     {
       auto data = e.player->find_spell( 444258 );
       // TODO: confirm effect value is for the entire dot and not per tick
-      base_td = data->effectN( 1 ).average( e.item ) * ( base_tick_time / dot_duration );
+      base_td = data->effectN( 1 ).average( e ) * ( base_tick_time / dot_duration );
 
       auto driver = new special_effect_t( e.player );
       driver->name_str = data->name_cstr();
@@ -1466,7 +1466,7 @@ void ovinaxs_mercurial_egg( special_effect_t& effect )
 
   // setup stat buffs
   auto primary = create_buff<ovinax_stat_buff_t>( effect.player, effect.player->find_spell( 449578 ), data )
-    ->set_stat_from_effect_type( A_MOD_STAT, data->effectN( 1 ).average( effect.item ) )
+    ->set_stat_from_effect_type( A_MOD_STAT, data->effectN( 1 ).average( effect ) )
     ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
 
   static constexpr std::array<unsigned, 4> buff_ids = { 449595, 449594, 449581, 449593 };
@@ -1480,7 +1480,7 @@ void ovinaxs_mercurial_egg( special_effect_t& effect )
     auto name = fmt::format( "{}_{}", spell->name_cstr(), stat_str );
 
     auto buff = create_buff<ovinax_stat_buff_t>( effect.player, name, spell, data )
-      ->set_stat_from_effect_type( A_MOD_RATING, data->effectN( 2 ).average( effect.item ) )
+      ->set_stat_from_effect_type( A_MOD_RATING, data->effectN( 2 ).average( effect ) )
       ->set_name_reporting( stat_str )
       ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
 
@@ -1597,7 +1597,7 @@ void treacherous_transmitter( special_effect_t& effect )
 
       stat_buff =
           create_buff<stat_buff_t>( e.player, e.player->find_spell( 449954 ) )
-              ->set_stat_from_effect_type( A_MOD_STAT, e.player->find_spell( 446209 )->effectN( 1 ).average( e.item ) );
+              ->set_stat_from_effect_type( A_MOD_STAT, e.player->find_spell( 446209 )->effectN( 1 ).average( e ) );
 
       for ( auto& a : e.player->action_list )
       {
@@ -1696,14 +1696,14 @@ void mad_queens_mandate( special_effect_t& effect )
         heal_speed( e.trigger()->missile_speed() ),
         hp_mul( data->effectN( 3 ).percent() )
     {
-      base_dd_min = base_dd_max = data->effectN( 1 ).average( e.item ) * role_mult( e );
+      base_dd_min = base_dd_max = data->effectN( 1 ).average( e ) * role_mult( e );
       base_multiplier *= role_mult( e );
 
       heal = create_proc_action<generic_heal_t>( "abyssal_gluttony_heal", e, "abyssal_gluttony_heal",
                                                  e.trigger()->effectN( 2 ).trigger() );
       heal->name_str_reporting = "abyssal_gluttony";
       // TODO: confirm heal coeff is for entire hot
-      heal->base_td = data->effectN( 2 ).average( e.item ) * ( heal->base_tick_time / heal->dot_duration );
+      heal->base_td = data->effectN( 2 ).average( e ) * ( heal->base_tick_time / heal->dot_duration );
     }
 
     bool usable_moving() const override { return true; }
@@ -1878,7 +1878,7 @@ void sigil_of_algari_concordance( special_effect_t& e )
       : algari_concodance_pet_spell_t( name, p, p->find_spell( 452335 ), a )
     {
       name_str_reporting = "thunder_bolt";
-      base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e.item );
+      base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e );
     }
   };
 
@@ -1888,7 +1888,7 @@ void sigil_of_algari_concordance( special_effect_t& e )
       : algari_concodance_pet_spell_t( name, p, p->find_spell( 452334 ), a )
     {
       aoe = -1;
-      base_dd_min = base_dd_max = e.driver()->effectN( 3 ).average( e.item );
+      base_dd_min = base_dd_max = e.driver()->effectN( 3 ).average( e );
     }
   };
 
@@ -1900,7 +1900,7 @@ void sigil_of_algari_concordance( special_effect_t& e )
       aoe = -1;
       split_aoe_damage = true;
       scale_aoe_damage = true;
-      base_dd_min = base_dd_max = e.driver()->effectN( 4 ).average( e.item );
+      base_dd_min = base_dd_max = e.driver()->effectN( 4 ).average( e );
     }
   };
 
@@ -1912,7 +1912,7 @@ void sigil_of_algari_concordance( special_effect_t& e )
       aoe = -1;
       split_aoe_damage = true;
       scale_aoe_damage = true;
-      base_dd_min = base_dd_max = e.driver()->effectN( 9 ).average( e.item );
+      base_dd_min = base_dd_max = e.driver()->effectN( 9 ).average( e );
     }
   };
 
@@ -2066,7 +2066,7 @@ void sigil_of_algari_concordance( special_effect_t& e )
 
   auto earthen_ire_damage = create_proc_action<generic_aoe_proc_t>( "earthen_ire", e, e.player->find_spell( 452890 ), true );
 
-  earthen_ire_damage->base_dd_min = earthen_ire_damage->base_dd_max = e.driver()->effectN( 10 ).average( e.item );
+  earthen_ire_damage->base_dd_min = earthen_ire_damage->base_dd_max = e.driver()->effectN( 10 ).average( e );
 
   auto earthen_ire_buff_spell = e.player->find_spell( 452514 );
   e.player->buffs.earthen_ire =
@@ -2084,10 +2084,10 @@ void sigil_of_algari_concordance( special_effect_t& e )
 void skarmorak_shard( special_effect_t& e )
 {
   auto main_buff = create_buff<stat_buff_t>( e.player, e.driver() )
-                       ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 1 ).average( e.item ) );
+                       ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 1 ).average( e ) );
 
   auto on_kill_buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 449792 ) )
-                          ->add_stat_from_effect_type( A_MOD_RATING, e.player->find_spell( 449792 )->effectN( 1 ).average( e.item ) );
+                          ->add_stat_from_effect_type( A_MOD_RATING, e.player->find_spell( 449792 )->effectN( 1 ).average( e ) );
 
   e.player->register_on_kill_callback( [ e, on_kill_buff ]( player_t* ) {
     if ( !e.player->sim->event_mgr.canceled )
@@ -2105,10 +2105,10 @@ void void_pactstone( special_effect_t& e )
 {
   auto buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 450962 ) )
                   // Will Throw a warning currently, as the mod rating misc_value1 is empty. Does not work in game either. 
-                  ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 2 ).average( e.item ) );
+                  ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 2 ).average( e ) );
 
   auto damage         = create_proc_action<generic_aoe_proc_t>( "void_pulse", e, 450960 );
-  damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e.item );
+  damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e );
   damage->base_multiplier *= role_mult( e );
   damage->split_aoe_damage = true;
 
@@ -2211,7 +2211,7 @@ void overclocked_geararang_launcher( special_effect_t& e )
   auto overclock_buff    = create_buff<buff_t>( e.player, damage_buff_spell );
 
   auto overclock_strike = create_proc_action<generic_proc_t>( "overclocked_strike", e, e.player->find_spell( 449828 ) );
-  overclock_strike->base_dd_min = overclock_strike->base_dd_max = equip_driver->effectN( 2 ).average( e.item );
+  overclock_strike->base_dd_min = overclock_strike->base_dd_max = equip_driver->effectN( 2 ).average( e );
   overclock_strike->base_multiplier *= role_mult( e );
 
   auto damage      = new special_effect_t( e.player );
@@ -2245,14 +2245,14 @@ void overclocked_geararang_launcher( special_effect_t& e )
 void remnant_of_darkness( special_effect_t& e )
 {
   auto damage         = create_proc_action<generic_aoe_proc_t>( "dark_swipe", e, 452032 );
-  damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 2 ).average( e.item );
+  damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 2 ).average( e );
   damage->base_multiplier *= role_mult( e );
 
   auto transform_buff = create_buff<buff_t>( e.player, e.player->find_spell( 451602 ) )
                             ->set_tick_callback( [ damage ]( buff_t*, int, timespan_t ) { damage->execute(); } );
 
   auto stat_buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 451369 ) )
-                       ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e.item ) )
+                       ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e ) )
                        ->set_stack_change_callback( [ transform_buff ]( buff_t* b, int, int ) {
                          if ( b->at_max_stacks() )
                          {
@@ -2280,7 +2280,7 @@ void opressive_orators_larynx( special_effect_t& e )
       : generic_aoe_proc_t( e, "dark_oration", e.player->find_spell( 451015 ) ), mult( 0 )
     {
       background  = true;
-      base_dd_min = base_dd_max = equip_driver->effectN( 2 ).average( e.item );
+      base_dd_min = base_dd_max = equip_driver->effectN( 2 ).average( e );
       base_multiplier = role_mult( e );
     }
 
@@ -2322,7 +2322,7 @@ void opressive_orators_larynx( special_effect_t& e )
   auto equip_driver = equip_effect->driver();
 
   auto buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 451011 ) )
-                  ->add_stat_from_effect_type( A_MOD_STAT, equip_driver->effectN( 1 ).average( e.item ) )
+                  ->add_stat_from_effect_type( A_MOD_STAT, equip_driver->effectN( 1 ).average( e ) )
                   ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
 
   auto equip         = new special_effect_t( e.player );
@@ -2359,7 +2359,7 @@ void arakara_sacbrood( special_effect_t& e )
       : dbc_proc_callback_t( e.player, e ), damage( nullptr ), missile( nullptr ), buff( buff )
     {
       damage                 = create_proc_action<generic_proc_t>( "spidersting", e, e.player->find_spell( 452229 ) );
-      damage->base_td        = e.player->find_spell( 443541 )->effectN( 2 ).average( e.item );
+      damage->base_td        = e.player->find_spell( 443541 )->effectN( 2 ).average( e );
       damage->base_multiplier = role_mult( e );
       missile                = create_proc_action<generic_proc_t>( "spiderfling", e, e.player->find_spell( 452227 ) );
       missile->impact_action = damage;
@@ -2386,7 +2386,7 @@ void arakara_sacbrood( special_effect_t& e )
   spiderling_cb->activate_with_buff( spiderling_buff, true );
 
   auto buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 452146 ) )
-                  ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e.item ) )
+                  ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e ) )
                   ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
                   ->set_stack_change_callback( [ spiderling_buff ]( buff_t*, int old_, int new_ ) {
                     if ( old_ > new_ )
@@ -2415,7 +2415,7 @@ void skyterrors_corrosive_organ( special_effect_t& e )
       background       = true;
       aoe              = data().max_targets();
       split_aoe_damage = false;
-      base_dd_min = base_dd_max = equip_driver->effectN( 2 ).average( e.item ) * role_mult( e );
+      base_dd_min = base_dd_max = equip_driver->effectN( 2 ).average( e ) * role_mult( e );
       base_multiplier *= role_mult( e );
     }
 
@@ -2451,7 +2451,7 @@ void skyterrors_corrosive_organ( special_effect_t& e )
   auto dot            = create_proc_action<generic_proc_t>( "volatile_acid", e, 447471 );
   auto aoe_damage     = create_proc_action<volatile_acid_splash_t>( "volatile_acid_splash", e, equip_driver, dot );
   dot->dot_behavior   = DOT_NONE;  // Doesnt Refresh, just stacks
-  dot->base_td        = equip_driver->effectN( 1 ).average( e.item ) * role_mult( e );
+  dot->base_td        = equip_driver->effectN( 1 ).average( e ) * role_mult( e );
   dot->execute_action = aoe_damage;
   dot->add_child( aoe_damage );
 
@@ -2499,7 +2499,7 @@ void high_speakers_accretion( special_effect_t& effect )
       high_speakers_accretion_damage_t( const special_effect_t& e, std::vector<player_t*>& tl )
         : generic_aoe_proc_t( e, "high_speakers_accretion_damage", 450921, true ), targets_hit( tl )
       {
-        base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e.item );
+        base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e );
         base_multiplier *= role_mult( e );
       }
 
@@ -2524,7 +2524,7 @@ void high_speakers_accretion( special_effect_t& effect )
 
       // TODO: confirm buff increases by 15% per extra target hit, up to 5.
       auto buff = create_buff<stat_buff_with_multiplier_t>( e.player, e.player->find_spell( 451248 ) );
-      buff->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 3 ).average( e.item ) );
+      buff->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 3 ).average( e ) );
 
       // TODO: confirm ticks once a second, not hasted
       // TODO: confirm buff return has 500ms delay
@@ -2615,7 +2615,7 @@ void entropic_skardyn_core( special_effect_t& effect )
         delay( timespan_t::from_seconds( e.trigger()->missile_speed() ) )
     {
       buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 449254 ) )
-        ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e.item ) );
+        ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e ) );
 
       tracker = create_buff<buff_t>( e.player, e.trigger()->effectN( 1 ).trigger() )
         ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
@@ -2699,7 +2699,7 @@ void mereldars_toll( special_effect_t& effect )
 
   // TODO: move to external/passive/custom buff system
   auto vers = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( 450551 ) )
-    ->add_stat_from_effect_type( A_MOD_RATING, data->effectN( 1 ).average( effect.item ) );
+    ->add_stat_from_effect_type( A_MOD_RATING, data->effectN( 1 ).average( effect ) );
 
   struct mereldars_toll_t : public generic_proc_t
   {
@@ -2714,7 +2714,7 @@ void mereldars_toll( special_effect_t& effect )
       target_debuff = e.trigger();
 
       impact_action = create_proc_action<generic_proc_t>( "mereldars_toll_damage", e, e.trigger() );
-      impact_action->base_dd_min = impact_action->base_dd_max = data->effectN( 2 ).average( e.item ) * role_mult( e );
+      impact_action->base_dd_min = impact_action->base_dd_max = data->effectN( 2 ).average( e ) * role_mult( e );
       // TODO: confirm 950ms delay in damage
       impact_action->travel_delay = e.driver()->effectN( 2 ).misc_value1() * 0.001;
       impact_action->stats = stats;
@@ -2785,11 +2785,11 @@ void carved_blazikon_wax( special_effect_t& effect )
       auto buff_spell = e.player->find_spell( 451367 );
       light =
         create_buff<stat_buff_t>( e.player, util::tokenize_fn( light_spell->name_cstr() ) + "_light", light_spell )
-          ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 2 ).average( e.item ) )
+          ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 2 ).average( e ) )
           ->set_name_reporting( "In Light" );
 
       buff = create_buff<stat_buff_t>( e.player, buff_spell )
-        ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 1 ).average( e.item ) );
+        ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 1 ).average( e ) );
     }
 
     void execute( action_t*, action_state_t* ) override
@@ -2838,10 +2838,10 @@ void signet_of_the_priory( special_effect_t& effect )
         party_use( e.player->thewarwithin_opts.signet_of_the_priory_party_use_cooldown,
                    e.player->thewarwithin_opts.signet_of_the_priory_party_use_stddev, e.driver()->cooldown() )
     {
-      create_all_stat_buffs( e, e.driver(), data->effectN( 2 ).average( e.item ),
+      create_all_stat_buffs( e, e.driver(), data->effectN( 2 ).average( e ),
         [ this ]( stat_e s, buff_t* b ) { buffs[ s ] = b; } );
 
-      create_all_stat_buffs( e, e.player->find_spell( 450882 ), data->effectN( 1 ).average( e.item ),
+      create_all_stat_buffs( e, e.player->find_spell( 450882 ), data->effectN( 1 ).average( e ),
         [ this ]( stat_e s, buff_t* b ) { party_buffs[ s ] = b; } );
     }
 
@@ -2904,12 +2904,12 @@ void harvesters_edict( special_effect_t& effect )
   // TODO: confirm damage doesn't increase per extra target
   auto damage = create_proc_action<generic_aoe_proc_t>( "volatile_blood_blast", effect, effect.driver() );
   damage->base_dd_min = damage->base_dd_max =
-    effect.driver()->effectN( 1 ).average( effect.item ) * role_mult( effect );
+    effect.driver()->effectN( 1 ).average( effect ) * role_mult( effect );
   // TODO: determine travel speed to hit target, assuming 5yd/s based on 443549 range/duration
   damage->travel_speed = 5.0; 
 
   auto buff = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( 451303 ) )
-    ->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 2 ).average( effect.item ) );
+    ->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 2 ).average( effect ) );
 
   // TODO: determine reasonable delay to intercept
   effect.player->callbacks.register_callback_execute_function(
@@ -2936,7 +2936,7 @@ void conductors_wax_whistle( special_effect_t& effect )
 {
   // TODO: confirm damage does not increase per extra target
   auto damage = create_proc_action<generic_aoe_proc_t>( "collision", effect, 450429 );
-  damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect.item );
+  damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
   damage->base_multiplier *= role_mult( effect );
   // TODO: determine travel speed/delay, assuming 7.5yd/s based on summed cart path(?) radius/duration
   damage->travel_speed = 7.5;
@@ -2957,7 +2957,7 @@ void charged_stormrook_plume( special_effect_t& effect )
 {
   // TODO: confirm damage does not increase per extra target
   auto damage = create_proc_action<generic_aoe_proc_t>( "charged_stormrook_plume", effect, 448892 );
-  damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect.item );
+  damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
   damage->base_multiplier *= role_mult( effect );
   // TODO: determine if cast time changes
   damage->base_execute_time = effect.driver()->cast_time();
@@ -2997,7 +2997,7 @@ void twin_fang_instruments( special_effect_t& effect )
       : generic_proc_t( e, "twin_fang_instruments", e.driver() )
     {
       melee = create_proc_action<generic_aoe_proc_t>( "nxs_shadow_strike", e, e.player->find_spell( 450119 ) );
-      melee->base_dd_min = melee->base_dd_max = data->effectN( 1 ).average( e.item ) * 0.5;
+      melee->base_dd_min = melee->base_dd_max = data->effectN( 1 ).average( e ) * 0.5;
       melee->base_multiplier *= role_mult( e );
       // TODO: confirm melee damage does not split
       melee->split_aoe_damage = false;
@@ -3005,7 +3005,7 @@ void twin_fang_instruments( special_effect_t& effect )
 
       // TODO: confirm range damage does not increase per extra target
       range = create_proc_action<generic_aoe_proc_t>( "vxs_frost_slash", e, e.player->find_spell( 450158 ) );
-      range->base_dd_min = range->base_dd_max = data->effectN( 1 ).average( e.item );
+      range->base_dd_min = range->base_dd_max = data->effectN( 1 ).average( e );
       range->base_multiplier *= role_mult( e );
       range->travel_speed = range->data().effectN( 3 ).trigger()->missile_speed();
       add_child( range );
@@ -3101,9 +3101,9 @@ void darkmoon_deck_symbiosis( special_effect_t& effect )
 
   double value = 0;
   if ( is_embellishment )
-    value = effect.player->find_spell( 463232 )->effectN( 2 ).average( effect.item ) * writhing_mul( effect.player );
+    value = effect.player->find_spell( 463232 )->effectN( 2 ).average( effect ) * writhing_mul( effect.player );
   else
-    value = effect.driver()->effectN( 2 ).average( effect.item );
+    value = effect.driver()->effectN( 2 ).average( effect );
 
   // TODO: confirm buff value once TWW goes live. currently has -9 scaling with no ilevel scaling.
   // Assuming here since the embellishment and trinket use the same driver and buff that the effects are just added.
@@ -3147,36 +3147,36 @@ void darkmoon_deck_vivacity( special_effect_t& effect )
       auto values = e.player->find_spell( 454857 );
       
       impact = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454862 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       shadow = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454975 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       nature = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454976 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       frost = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454977 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       holy = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454978 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       arcane = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454979 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       force = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454980 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
 
       magical_multi = create_buff<stat_buff_t>( e.player, e.player->find_spell( 454982 ) )
-        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e.item ) )
-        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e.item ) );
+        ->add_stat_from_effect( 1, values->effectN( 1 ).average( e ) )
+        ->add_stat_from_effect( 2, values->effectN( 2 ).average( e ) );
     }
 
     void execute( action_t*, action_state_t* s ) override
@@ -3236,7 +3236,7 @@ void algari_alchemist_stone( special_effect_t& e )
   }
 
   auto buff = create_buff<stat_buff_t>( e.player, buff_spell )
-    ->add_stat_from_effect( 1, e.driver()->effectN( 1 ).average( e.item ) );
+    ->add_stat_from_effect( 1, e.driver()->effectN( 1 ).average( e ) );
 
   e.custom_buff = buff;
   new dbc_proc_callback_t( e.player, e );
@@ -3277,9 +3277,9 @@ void darkmoon_deck_ascension( special_effect_t& effect )
         double value = 0;
         // TODO: confirm that embellishment counts as a nerubian embellishement, but the card does not.
         if ( embellish )
-          value = e.driver()->effectN( 2 ).average( e.item ) * writhing_mul( e.player );
+          value = e.driver()->effectN( 2 ).average( e ) * writhing_mul( e.player );
         else
-          value = e.player->find_spell( 463059 )->effectN( 1 ).average( e.item );
+          value = e.player->find_spell( 463059 )->effectN( 1 ).average( e );
 
         auto buff = create_buff<stat_buff_t>( e.player, fmt::format( "{}_{}", s_data->name_cstr(), stat ), s_data )
           ->add_stat_from_effect_type( A_MOD_RATING, value )
@@ -3395,14 +3395,14 @@ void darkmoon_deck_radiance( special_effect_t& effect )
     radiant_focus_debuff_t( actor_pair_t td, const special_effect_t& e, util::string_view n, const spell_data_t* s, bool embelish )
       : buff_t( td, n, s ), accumulated_damage( 0 ), max_damage( 0 ), max_buff_value( 0 ), buff(nullptr)
     {
-      max_damage = data().effectN( 1 ).average( e.player );
+      max_damage = data().effectN( 1 ).average( e );
       set_default_value( max_damage );
 
       auto buff_spell = e.player->find_spell( 454785 );
       if( embelish )
-        max_buff_value = player->find_spell( 454558 )->effectN( 2 ).average( e.item );
+        max_buff_value = player->find_spell( 454558 )->effectN( 2 ).average( e );
       else
-        max_buff_value = player->find_spell( 463108 )->effectN( 1 ).average( e.item );
+        max_buff_value = player->find_spell( 463108 )->effectN( 1 ).average( e );
 
       // Very oddly setup buff, scripted to provide the highest secondary stat of the player
       // Data doesnt contain the other stats like usual, manually setting things up here.
@@ -3576,7 +3576,7 @@ void nerubian_phearomone_secreter( special_effect_t& effect )
       : dbc_proc_callback_t( e.player, e ), stat_buff( nullptr ), orb( nullptr ), apl_actions()
     {
       stat_buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 441428 ) )
-        ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e.item ) );
+        ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e ) );
 
       for ( auto& a : e.player->action_list )
       {
@@ -3645,13 +3645,13 @@ void shadowed_essence( special_effect_t& effect )
       : buff_t( e.player, "shadowed_essence_periodic", e.trigger() ), tick_n( 0 )
     {
       auto shadowed_essence = create_buff<stat_buff_t>( e.player, e.player->find_spell( 455966 ) )
-                                  ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 2 ).average( e.item ) );
+                                  ->add_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 2 ).average( e ) );
 
       auto dark_embrace = create_buff<stat_buff_t>( e.player, e.player->find_spell( 455656 ) )
-                              ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 3 ).average( e.item ) );
+                              ->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 3 ).average( e ) );
 
       auto damage         = create_proc_action<generic_proc_t>( "shadowed_essence_damage", e, 455654 );
-      damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e.item );
+      damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e );
 
       auto missile           = create_proc_action<generic_proc_t>( "shadowed_essence", e, 455653 );
       missile->add_child( damage );
@@ -3722,7 +3722,7 @@ void void_reapers_claw( special_effect_t& effect )
   effect.tick = effect.trigger()->effectN( 1 ).period();
   // TODO: confirm effect value is for the entire dot and not per tick
   effect.discharge_amount =
-    effect.driver()->effectN( 1 ).average( effect.item ) * effect.tick / effect.duration_ * role_mult( effect );
+    effect.driver()->effectN( 1 ).average( effect ) * effect.tick / effect.duration_ * role_mult( effect );
 
   new dbc_proc_callback_t( effect.player, effect );
 }
@@ -3748,11 +3748,11 @@ void fateweaved_needle( special_effect_t& effect )
       : dbc_proc_callback_t( e.player, e ),
       buff_spell( e.player->find_spell( 443590 ) ),
       debuff_spell( e.player->find_spell( 443519 ) ),
-      stat_amt( e.driver()->effectN( 2 ).average( e.item ) )
+      stat_amt( e.driver()->effectN( 2 ).average( e ) )
     {
       // TODO: damage spell data is shadowfrost and not cosmic
       damage = create_proc_action<generic_proc_t>( "fated_pain", e, 443585 );
-      damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e.item );
+      damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e );
       damage->base_multiplier *= role_mult( e );
     }
 
@@ -3807,7 +3807,7 @@ void befoulers_syringe( special_effect_t& effect )
     befouled_blood_t( const special_effect_t& e, buff_t* b )
       : generic_proc_t( e, "befouled_blood", e.trigger() ), bloodlust( b )
     {
-      base_td = e.driver()->effectN( 1 ).average( e.item );
+      base_td = e.driver()->effectN( 1 ).average( e );
       base_multiplier *= role_mult( e );
       // TODO: confirm it uses psuedo-async behavior found in other similarly worded dots
       dot_max_stack = 1;
@@ -3852,14 +3852,14 @@ void befoulers_syringe( special_effect_t& effect )
     befouling_strike_t( const special_effect_t& e )
       : generic_proc_t( e, "befouling_strike", e.player->find_spell( 442280 ) )
     {
-      base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e.item );
+      base_dd_min = base_dd_max = e.driver()->effectN( 2 ).average( e );
       base_multiplier *= role_mult( e );
     }
   };
 
   // create on-next melee damage
   auto strike = create_proc_action<generic_proc_t>( "befouling_strike", effect, 442280 );
-  strike->base_dd_min = strike->base_dd_max = effect.driver()->effectN( 2 ).average( effect.item );
+  strike->base_dd_min = strike->base_dd_max = effect.driver()->effectN( 2 ).average( effect );
 
   // create on-next melee buff
   auto bloodlust = create_buff<buff_t>( effect.player, effect.player->find_spell( 442267 ) );
@@ -3899,10 +3899,10 @@ void voltaic_stormcaller( special_effect_t& effect )
 
     voltaic_stormstrike_t( const special_effect_t& e ) : generic_aoe_proc_t( e, "voltaic_stormstrike", 455910, true )
     {
-      base_dd_min = base_dd_max = e.driver()->effectN( 1 ).average( e.item ) * role_mult( e );
+      base_dd_min = base_dd_max = e.driver()->effectN( 1 ).average( e ) * role_mult( e );
 
       buff = create_buff<stat_buff_with_multiplier_t>( e.player, e.player->find_spell( 456652 ) );
-      buff->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 2 ).average( e.item ) );
+      buff->add_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 2 ).average( e ) );
     }
 
     void execute() override
@@ -3925,7 +3925,7 @@ void voltaic_stormcaller( special_effect_t& effect )
 void harvesters_interdiction( special_effect_t& effect )
 {
   auto dot = create_proc_action<generic_proc_t>( "interdictive_injection", effect, 455821 );
-  dot->base_td = effect.driver()->effectN( 1 ).average( effect.item );
+  dot->base_td = effect.driver()->effectN( 1 ).average( effect );
   dot->base_multiplier *= role_mult( effect );
 
   effect.execute_action = dot;
@@ -3947,7 +3947,7 @@ void seal_of_the_poisoned_pact( special_effect_t& effect )
 
   auto dot = create_proc_action<generic_proc_t>( "venom_shock", effect, 457928 );
   // TODO: confirm coeff is for entire dot and not per tick
-  dot->base_td = effect.driver()->effectN( 1 ).average( effect.item ) * dot->base_tick_time / dot->dot_duration;
+  dot->base_td = effect.driver()->effectN( 1 ).average( effect ) * dot->base_tick_time / dot->dot_duration;
   dot->base_multiplier *= role_mult( effect );
 
   auto counter = create_buff<buff_t>( effect.player, effect.player->find_spell( 457925 ) )
@@ -4131,10 +4131,10 @@ void imperfect_ascendancy_serum( special_effect_t& effect )
 
   auto buff_spell = effect.driver();
   buff_t* buff    = create_buff<stat_buff_t>( effect.player, buff_spell )
-                     ->add_stat_from_effect( 1, effect.driver()->effectN( 1 ).average( effect.item ) )
-                     ->add_stat_from_effect( 2, effect.driver()->effectN( 2 ).average( effect.item ) )
-                     ->add_stat_from_effect( 4, effect.driver()->effectN( 4 ).average( effect.item ) )
-                     ->add_stat_from_effect( 5, effect.driver()->effectN( 5 ).average( effect.item ) )
+                     ->add_stat_from_effect( 1, effect.driver()->effectN( 1 ).average( effect ) )
+                     ->add_stat_from_effect( 2, effect.driver()->effectN( 2 ).average( effect ) )
+                     ->add_stat_from_effect( 4, effect.driver()->effectN( 4 ).average( effect ) )
+                     ->add_stat_from_effect( 5, effect.driver()->effectN( 5 ).average( effect ) )
                      ->set_cooldown( 0_ms );
 
   auto action           = new ascension_channel_t( effect, buff );
@@ -4156,7 +4156,7 @@ void woven_dusk( special_effect_t& effect )
 
   // Need to force player sccaling for equipment set
   auto buff = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( 457630 ) )
-                  ->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 2 ).average( effect.player ) );
+                  ->add_stat_from_effect_type( A_MOD_RATING, effect.driver()->effectN( 2 ).average( effect ) );
 
   effect.custom_buff = buff;
 
@@ -4212,7 +4212,7 @@ void embrace_of_the_cinderbee( special_effect_t& effect )
 
     embrace_of_the_cinderbee_t( const special_effect_t& e ) : dbc_proc_callback_t( e.player, e ), player( e.player )
     {
-      auto value = e.player->find_spell( 451699 )->effectN( 5 ).average( e.player );
+      auto value = e.player->find_spell( 451699 )->effectN( 5 ).average( e );
       create_all_stat_buffs( e, e.player->find_spell( 451699 ), value,
                              [ this ]( stat_e s, buff_t* b ) { buffs[ s ] = b; } );
 


### PR DESCRIPTION
when passed a special_effect_t argument, average() will determine the appropriate scaling based on the spell's attributes.

1. if the spell does not have SX_SCALE_ILEVEL, it will use player level scaling.
2. if the spell has SX_SCALE_ILEVEL and a valid item, it will use item level scaling with the item level capped by the maximum scaling level of the spell.
3. if the spell has SX_SCALE_ILEVEL, no item, a valid a maximum scaling level, it will use item level scaling with the item level equal to the maximum scaling level of the spell.
4. if the spell has SX_SCALE_ILEVEL, no vaild item, and no maximum scaling level, it will assert as this situation requires manual intervention.