### PR TITLE
[Death Knight] Minor change to breath_dying variable

### DIFF
--- a/engine/class_modules/apl/apl_death_knight.cpp
+++ b/engine/class_modules/apl/apl_death_knight.cpp
@@ -366,7 +366,7 @@ void frost( player_t* p )
   variables->add_action( "variable,name=pooling_runes,value=rune<variable.oblit_rune_pooling&talent.obliteration&(!talent.breath_of_sindragosa|variable.true_breath_cooldown)&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time" );
   variables->add_action( "variable,name=pooling_runic_power,value=talent.breath_of_sindragosa&variable.true_breath_cooldown<variable.breath_pooling_time|talent.obliteration&runic_power<35&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time" );
   variables->add_action( "variable,name=ga_priority,value=(!talent.shattered_frost&talent.shattering_blade&active_enemies>=4)|(!talent.shattered_frost&!talent.shattering_blade&active_enemies>=2)" );
-  variables->add_action( "variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2&rune.time_to_2>runic_power%variable.breath_rp_cost" );
+  variables->add_action( "variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2*gcd.max&rune.time_to_2>runic_power%variable.breath_rp_cost" );
 }
 //frost_apl_end
 

--- a/profiles/TWW1/TWW1_Death_Knight_Frost.simc
+++ b/profiles/TWW1/TWW1_Death_Knight_Frost.simc
@@ -201,7 +201,7 @@ actions.variables+=/variable,name=breath_pooling_time,op=setif,value=((variable.
 actions.variables+=/variable,name=pooling_runes,value=rune<variable.oblit_rune_pooling&talent.obliteration&(!talent.breath_of_sindragosa|variable.true_breath_cooldown)&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time
 actions.variables+=/variable,name=pooling_runic_power,value=talent.breath_of_sindragosa&variable.true_breath_cooldown<variable.breath_pooling_time|talent.obliteration&runic_power<35&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time
 actions.variables+=/variable,name=ga_priority,value=(!talent.shattered_frost&talent.shattering_blade&active_enemies>=4)|(!talent.shattered_frost&!talent.shattering_blade&active_enemies>=2)
-actions.variables+=/variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2&rune.time_to_2>runic_power%variable.breath_rp_cost
+actions.variables+=/variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2*gcd.max&rune.time_to_2>runic_power%variable.breath_rp_cost
 
 head=wrathbark_greathelm,id=178694,bonus_id=10878,ilevel=639,gem_id=213743
 neck=trailspinner_pendant,id=178707,bonus_id=1611/8781,ilevel=639,gem_id=213473/213482

--- a/profiles/TWW1/TWW1_Death_Knight_Frost_Rider.simc
+++ b/profiles/TWW1/TWW1_Death_Knight_Frost_Rider.simc
@@ -201,7 +201,7 @@ actions.variables+=/variable,name=breath_pooling_time,op=setif,value=((variable.
 actions.variables+=/variable,name=pooling_runes,value=rune<variable.oblit_rune_pooling&talent.obliteration&(!talent.breath_of_sindragosa|variable.true_breath_cooldown)&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time
 actions.variables+=/variable,name=pooling_runic_power,value=talent.breath_of_sindragosa&variable.true_breath_cooldown<variable.breath_pooling_time|talent.obliteration&runic_power<35&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time
 actions.variables+=/variable,name=ga_priority,value=(!talent.shattered_frost&talent.shattering_blade&active_enemies>=4)|(!talent.shattered_frost&!talent.shattering_blade&active_enemies>=2)
-actions.variables+=/variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2&rune.time_to_2>runic_power%variable.breath_rp_cost
+actions.variables+=/variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2*gcd.max&rune.time_to_2>runic_power%variable.breath_rp_cost
 
 head=wrathbark_greathelm,id=178694,bonus_id=10878,ilevel=639,gem_id=213743
 neck=locket_of_broken_memories,id=212448,bonus_id=6652/10354/10269/1540/10255/10394/10879,gem_id=213473/213482

--- a/profiles/TWW1/TWW1_Death_Knight_Frost_Shattering_Deathbringer.simc
+++ b/profiles/TWW1/TWW1_Death_Knight_Frost_Shattering_Deathbringer.simc
@@ -201,7 +201,7 @@ actions.variables+=/variable,name=breath_pooling_time,op=setif,value=((variable.
 actions.variables+=/variable,name=pooling_runes,value=rune<variable.oblit_rune_pooling&talent.obliteration&(!talent.breath_of_sindragosa|variable.true_breath_cooldown)&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time
 actions.variables+=/variable,name=pooling_runic_power,value=talent.breath_of_sindragosa&variable.true_breath_cooldown<variable.breath_pooling_time|talent.obliteration&runic_power<35&cooldown.pillar_of_frost.remains<variable.oblit_pooling_time
 actions.variables+=/variable,name=ga_priority,value=(!talent.shattered_frost&talent.shattering_blade&active_enemies>=4)|(!talent.shattered_frost&!talent.shattering_blade&active_enemies>=2)
-actions.variables+=/variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2&rune.time_to_2>runic_power%variable.breath_rp_cost
+actions.variables+=/variable,name=breath_dying,value=runic_power<variable.breath_rp_cost*2*gcd.max&rune.time_to_2>runic_power%variable.breath_rp_cost
 
 head=wrathbark_greathelm,id=178694,bonus_id=10878,ilevel=639,gem_id=213743
 neck=trailspinner_pendant,id=178707,bonus_id=1611/8781,ilevel=639,gem_id=213473/213482


### PR DESCRIPTION
Increases rp threshold of variable by scaling by gcd to avoid situations where the sim just doesn't horn and lets breath die, mostly a low gear/bad luck problem. Example here:
https://www.raidbots.com/simbot/report/87axYZsy81FBWnzdCM52RZ 
https://www.raidbots.com/simbot/report/kaiakS6aBx6P1F4YuaZ1gf

No/neutral impact in current bis profile: https://www.raidbots.com/simbot/report/2T3sApNks81j1jYoZQXR1G