### PR TITLE
Adjust HTML Report DPS Chart Width

### DIFF
--- a/engine/report/charts.cpp
+++ b/engine/report/charts.cpp
@@ -1228,7 +1228,7 @@ bool chart::generate_raid_aps( highchart::bar_chart_t& bc, const sim_t& s, std::
 
   // Maximum player name length. Longer characters will be cut off and replaced by ... via the formatter function (in
   // JS) set to xAxis.labels.formatter
-  int max_name_length = 40;
+  int max_name_length = 64;
 
   bc.set( "chart.marginLeft", 7 * std::min( max_name_length + 3, as<int>( longest_name ) ) + 10 * n_chars + 50 );
 

--- a/engine/report/report_html_sim.cpp
+++ b/engine/report/report_html_sim.cpp
@@ -558,14 +558,15 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
   }
   os << "</ul>\n";
 
-  os << "<div class=\"column-charts\">\n"; // Open DIV for charts
-
   highchart::bar_chart_t raid_dps( "raid_dps", sim );
   if ( chart::generate_raid_aps( raid_dps, sim, "dps" ) )
   {
+    raid_dps.width_ = 1162;
     os << raid_dps.to_target_div();
     sim.add_chart_data( raid_dps );
   }
+
+  os << "<div class=\"column-charts\">\n"; // Open DIV for charts
 
   if ( sim.enemy_targets > 1 )
   {

--- a/engine/report/report_html_sim.cpp
+++ b/engine/report/report_html_sim.cpp
@@ -566,13 +566,12 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
     sim.add_chart_data( raid_dps );
   }
 
-  os << "<div class=\"column-charts\">\n"; // Open DIV for charts
-
   if ( sim.enemy_targets > 1 )
   {
     highchart::bar_chart_t priority_dps( "priority_dps", sim );
     if ( chart::generate_raid_aps( priority_dps, sim, "prioritydps" ) )
     {
+      priority_dps.width_ = 1162;
       os << priority_dps.to_target_div();
       sim.add_chart_data( priority_dps );
     }
@@ -581,6 +580,7 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
   highchart::bar_chart_t raid_dtps( "raid_dtps", sim );
   if ( chart::generate_raid_aps( raid_dtps, sim, "dtps" ) )
   {
+    raid_dtps.width_ = 1162;
     os << raid_dtps.to_target_div();
     sim.add_chart_data( raid_dtps );
   }
@@ -588,11 +588,10 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
   highchart::bar_chart_t raid_hps( "raid_hps", sim );
   if ( chart::generate_raid_aps( raid_hps, sim, "hps" ) )
   {
+    raid_hps.width_ = 1162;
     os << raid_hps.to_target_div();
     sim.add_chart_data( raid_hps );
   }
-
-  os << "</div>\n"; // Close DIV for charts
 
   if ( !sim.raid_events_str.empty() )
   {

--- a/engine/report/report_html_sim.cpp
+++ b/engine/report/report_html_sim.cpp
@@ -561,7 +561,7 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
   highchart::bar_chart_t raid_dps( "raid_dps", sim );
   if ( chart::generate_raid_aps( raid_dps, sim, "dps" ) )
   {
-    raid_dps.width_ = 1162;
+    raid_dps.width_ += raid_dps.width_ + 12;
     os << raid_dps.to_target_div();
     sim.add_chart_data( raid_dps );
   }
@@ -571,7 +571,7 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
     highchart::bar_chart_t priority_dps( "priority_dps", sim );
     if ( chart::generate_raid_aps( priority_dps, sim, "prioritydps" ) )
     {
-      priority_dps.width_ = 1162;
+      priority_dps.width_ += priority_dps.width_ + 12;
       os << priority_dps.to_target_div();
       sim.add_chart_data( priority_dps );
     }
@@ -580,7 +580,7 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
   highchart::bar_chart_t raid_dtps( "raid_dtps", sim );
   if ( chart::generate_raid_aps( raid_dtps, sim, "dtps" ) )
   {
-    raid_dtps.width_ = 1162;
+    raid_dtps.width_ += raid_dtps.width_ + 12;
     os << raid_dtps.to_target_div();
     sim.add_chart_data( raid_dtps );
   }
@@ -588,7 +588,7 @@ void print_html_raid_summary( report::sc_html_stream& os, sim_t& sim )
   highchart::bar_chart_t raid_hps( "raid_hps", sim );
   if ( chart::generate_raid_aps( raid_hps, sim, "hps" ) )
   {
-    raid_hps.width_ = 1162;
+    raid_hps.width_ += raid_hps.width_ + 12;
     os << raid_hps.to_target_div();
     sim.add_chart_data( raid_hps );
   }


### PR DESCRIPTION
With The War Within's release, profile name have ballooned in length causing the bar chart itself to be crushed. This moves it to it into the main "Raid Summary" `<div>` with a width setting of double the column width ( + margins) to allow for easier gleaning of detail in the stacked charts.

![image](https://github.com/user-attachments/assets/a76e5efb-b78d-4d31-9e75-bd597655b285)

