### PR TITLE
[shaman] `debug()` for temp enchants over imbues

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -5233,9 +5233,12 @@ struct weapon_imbue_t : public shaman_spell_t
     if ( player->items[ slot ].active() &&
          player->items[ slot ].selected_temporary_enchant() > 0 )
     {
-      sim->error( "Player {} has a temporary enchant {} on slot {}, disabling {}",
-        player->name(), util::slot_type_string( slot ),
-        player->items[ slot ].selected_temporary_enchant(), name() );
+      sim->print_debug( "Player {} has a temporary enchant {} on slot {}, disabling {}",
+        player->name(),
+        util::slot_type_string( slot ),
+        player->items[ slot ].selected_temporary_enchant(),
+        name()
+      );
     }
   }
 


### PR DESCRIPTION
This is a bit noisy, and there might be some better ways we could handle
this in the future given different shaman specializations have different
constraints with regards to imbues (eg. Elemental only taking them when
certain talents are present, but Enhancement almost always taking them,
etc).

For now, make this a `debug()` log statement to get rid of the warning
bloat at the top of the page.
