### PR TITLE
[shaman] if PTR, disable Flash of Lightning CDR

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -11618,6 +11618,11 @@ void shaman_t::trigger_flash_of_lightning()
     return;
   }
 
+  if ( is_ptr() ) {
+    // The Cooldown Reduction of Flash of Lightning is removed on the 11.0.5 PTR
+    return;
+  }
+
   auto reduction = talent.flash_of_lightning.spell()->effectN( 1 ).time_value();
 
   if ( talent.storm_elemental.enabled() )


### PR DESCRIPTION
The 11.0.5 PTR has removed the CDR effect from the Flash of Lightning
talent, so let's short-circuit the CDR if we're on PTR.
