### PR TITLE
[shaman] if PTR, enable maelstrom generation via LMT

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9199,13 +9199,17 @@ struct liquid_magma_totem_spell_t : public shaman_totem_t<spell_totem_pet_t, sha
   {
     add_child( eruption );
 
+    if ( p->is_ptr() )
+    {
+      maelstrom_gain = p->spec.maelstrom->effectN( 13 ).resource( RESOURCE_MAELSTROM );
+    }
+
     ancestor_trigger = ancestor_cast::CHAIN_LIGHTNING;
   }
 
   void execute() override
   {
     shaman_totem_t<spell_totem_pet_t, shaman_spell_t>::execute();
-
     eruption->execute_on_target( execute_state->target );
   }
 };


### PR DESCRIPTION
On the 11.0.5 PTR, Liquid Magma Totem now generates 8 maelstrom.

Like other Maelstrom-generating spells, this value is stored on the
special specialization spell "Maelstrom" as an effect.
