### PR TITLE
[Gear] add daybreak spellthread mana

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -536,6 +536,12 @@ void culminating_blasphemite( special_effect_t& effect )
   effect.player->base.crit_damage_multiplier *= 1.0 + pct;
   effect.player->base.crit_healing_multiplier *= 1.0 + pct;
 }
+
+void daybreak_spellthread( special_effect_t& effect )
+{
+  effect.player->resources.base_multiplier[ RESOURCE_MANA ] *= 1.0 + effect.driver()->effectN( 1 ).percent();
+}
+
 }  // namespace enchants
 
 namespace embellishments
@@ -4808,6 +4814,7 @@ void register_special_effects()
                              449112, 449113, 449114,                                          // stonebound artistry (mastery)
                              449120, 449118, 449117 }, enchants::secondary_weapon_enchant );  // oathsworn tenacity (vers)
   register_special_effect( 435500, enchants::culminating_blasphemite );
+  register_special_effect( { 457615, 457616, 457617 }, enchants::daybreak_spellthread );
 
 
   // Embellishments & Tinkers


### PR DESCRIPTION
Add the maximum mana part of the Daybreak Spellthread enchantment.
Heavily inspired by the Temporal Spellthread implementation from dragonflight.