### PR TITLE
[ele] fix aberrant spellforge

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1250,6 +1250,7 @@ public:
   void init_assessors() override;
   void init_rng() override;
   void init_items() override;
+  void init_special_effects() override;
   std::string create_profile( save_e ) override;
   void create_special_effects() override;
   void action_init_finished( action_t& action ) override;
@@ -12468,6 +12469,23 @@ void shaman_t::init_items()
   {
     sets->enable_set_bonus( specialization(), T31 , B4 );
   }
+}
+
+void shaman_t::init_special_effects()
+{
+  callbacks.register_callback_trigger_function(
+      452030, dbc_proc_callback_t::trigger_fn_type::CONDITION,
+      [ id = 51505 ]( const dbc_proc_callback_t*, action_t* a, action_state_t* state ) {
+        if ( a->data().id() == id )
+        {
+          lava_burst_t* lvb = debug_cast<lava_burst_t*>(a);
+          return lvb->exec_type == spell_variant::NORMAL;
+        }
+        return false;
+      } );
+
+    player_t::init_special_effects();
+
 }
 
 // shaman_t::apply_affecting_auras ==========================================

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12475,7 +12475,7 @@ void shaman_t::init_special_effects()
 {
   callbacks.register_callback_trigger_function(
       452030, dbc_proc_callback_t::trigger_fn_type::CONDITION,
-      [ id = 51505 ]( const dbc_proc_callback_t*, action_t* a, action_state_t* state ) {
+      [ id = 51505 ]( const dbc_proc_callback_t*, action_t* a, action_state_t*) {
         if ( a->data().id() == id )
         {
           lava_burst_t* lvb = debug_cast<lava_burst_t*>(a);


### PR DESCRIPTION
only proc Spellforge on real lavabursts

If @gastank or somebody could have a look if this seems sensible. Didn't find a simple way to access the empowered spell without hardcoding it though.