### PR TITLE
[shaman] Add 11.0.5 PTR Primordial Wave support

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9655,6 +9655,13 @@ struct primordial_wave_t : public shaman_spell_t
 
       p()->buff.primordial_wave->trigger();
 
+      // On 11.0.5 PTR, the Primordial Wave projectile hitting the mob triggers
+      // a Lava Surge
+      if ( p()->is_ptr() )
+      {
+          p()->buff.lava_surge->trigger();
+      }
+
       p()->trigger_secondary_flame_shock( s );
     }
   };
@@ -9677,6 +9684,12 @@ struct primordial_wave_t : public shaman_spell_t
     // Spell data claims Maelstrom Weapon (still) affects Primordia Wave, however in-game
     // this is not true
     affected_by_maelstrom_weapon = false;
+
+    // On 11.0.5 PTR, casting Primordial Wave generates (3) Maelstrom
+    if ( p()->is_ptr() )
+    {
+        maelstrom_gain = p()->spec.maelstrom->effectN( 12 ).resource( RESOURCE_MAELSTROM );
+    }
   }
 
   void execute() override

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -9655,13 +9655,6 @@ struct primordial_wave_t : public shaman_spell_t
 
       p()->buff.primordial_wave->trigger();
 
-      // On 11.0.5 PTR, the Primordial Wave projectile hitting the mob triggers
-      // a Lava Surge
-      if ( p()->is_ptr() )
-      {
-          p()->buff.lava_surge->trigger();
-      }
-
       p()->trigger_secondary_flame_shock( s );
     }
   };
@@ -9709,6 +9702,13 @@ struct primordial_wave_t : public shaman_spell_t
     {
       p()->action.feral_spirit_t31->set_target( execute_state->target );
       p()->action.feral_spirit_t31->execute();
+    }
+
+    // On 11.0.5 PTR, the Primordial Wave projectile hitting the mob triggers
+    // a Lava Surge
+    if ( p()->is_ptr() )
+    {
+        p()->buff.lava_surge->trigger();
     }
   }
 };


### PR DESCRIPTION
On 11.0.5 PTR, Primordial Wave has been updated to generate maelstrom
and proc Lava Surge in addition to all of its current effects.

I am unsure if the Lava Surge is actually on projectile hit, but going
off the tooltip it seems somewhat likely that it may be. Worst case,
this is fairly trivial to change.
