### PR TITLE
[shaman] fix warnings

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1979,15 +1979,16 @@ public:
       m *= 1.0 + p()->buff.amplification_core->value();
     }
 
-    if ( affected_by_elemental_unity_fe_ta && p()->talent.elemental_unity.ok() && p()->buff.fire_elemental->check() ||
-         ( ( affected_by_elemental_unity_fe_ta && p()->talent.elemental_unity.ok() &&
-             p()->buff.lesser_fire_elemental->check() ) ) )
+    if ( ( affected_by_elemental_unity_fe_ta && p()->talent.elemental_unity.ok() &&
+           p()->buff.fire_elemental->check() ) ||
+         ( affected_by_elemental_unity_fe_ta && p()->talent.elemental_unity.ok() &&
+           p()->buff.lesser_fire_elemental->check() ) )
     {
       m *= 1.0 + std::max( p()->buff.fire_elemental->data().effectN( 5 ).percent(),
                            p()->buff.lesser_fire_elemental->data().effectN( 5 ).percent() );
     }
 
-    if ( (affected_by_elemental_unity_se_ta && p()->talent.elemental_unity.ok() &&
+    if ( ( affected_by_elemental_unity_se_ta && p()->talent.elemental_unity.ok() &&
            p()->buff.storm_elemental->check() ) ||
          ( affected_by_elemental_unity_se_ta && p()->talent.elemental_unity.ok() &&
            p()->buff.lesser_storm_elemental->check() ) )


### PR DESCRIPTION
In #9517 a divergence between simc behavior around Elemental damage amps
and the in-game behavior was fixed, but the fixes introduced some
warnings to the module.

This should not alter any behavior but address the compile-time
warnings.

cc @HawkCorrigan
