### PR TITLE
[shaman] Add support for 11.0.5 Wind Gust buff (Storm Elemental)

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -5856,7 +5856,12 @@ struct chain_lightning_t : public chained_base_t
   {
     auto mul = chained_base_t::execute_time_pct_multiplier();
 
-    mul *= 1.0 + p()->buff.wind_gust->stack_value();
+    // On 11.0.5 PTR, Wind Gust no longer scales spell cast speed for Chain Lightning
+    // or Lightning Bolt, and instead applies a stacking haste buff
+    if ( !p()->is_ptr() )
+    {
+        mul *= 1.0 + p()->buff.wind_gust->stack_value();
+    }
 
     return mul;
   }
@@ -5877,13 +5882,20 @@ struct chain_lightning_t : public chained_base_t
   timespan_t gcd() const override
   {
     timespan_t t = chained_base_t::gcd();
-    t *= 1.0 + p()->buff.wind_gust->stack_value();
+
+    // On 11.0.5 PTR, Wind Gust no longer scales spell cast speed for Chain Lightning
+    // or Lightning Bolt, and instead applies a stacking haste buff
+    if ( !p()->is_ptr() )
+    {
+        t *= 1.0 + p()->buff.wind_gust->stack_value();
+    }
 
     // testing shows the min GCD is 0.6 sec
     if ( t < timespan_t::from_millis( 600 ) )
     {
-      t = timespan_t::from_millis( 600 );
+        t = timespan_t::from_millis( 600 );
     }
+
     return t;
   }
 
@@ -6847,7 +6859,12 @@ struct lightning_bolt_t : public shaman_spell_t
   {
     auto mul = shaman_spell_t::execute_time_pct_multiplier();
 
-    mul *= 1.0 + p()->buff.wind_gust->stack_value();
+    // On 11.0.5 PTR, Wind Gust no longer scales spell cast speed for Chain Lightning
+    // or Lightning Bolt, and instead applies a stacking haste buff
+    if ( !p()->is_ptr() )
+    {
+        mul *= 1.0 + p()->buff.wind_gust->stack_value();
+    }
 
     return mul;
   }
@@ -6855,7 +6872,13 @@ struct lightning_bolt_t : public shaman_spell_t
   timespan_t gcd() const override
   {
     timespan_t t = shaman_spell_t::gcd();
-    t *= 1.0 + p()->buff.wind_gust->stack_value();
+
+    // On 11.0.5 PTR, Wind Gust no longer scales spell cast speed for Chain Lightning
+    // or Lightning Bolt, and instead applies a stacking haste buff
+    if ( !p()->is_ptr() )
+    {
+        t *= 1.0 + p()->buff.wind_gust->stack_value();
+    }
 
     // testing shows the min GCD is 0.6 sec
     if ( t < timespan_t::from_millis( 600 ) )
@@ -12361,8 +12384,17 @@ void shaman_t::create_buffs()
   buff.master_of_the_elements = make_buff( this, "master_of_the_elements", talent.master_of_the_elements->effectN(1).trigger() )
           ->set_default_value( talent.master_of_the_elements->effectN( 2 ).percent() );
 
+  // On 11.0.5 PTR, Wind Gust applies a stacking Haste buff of 4% up to 4 times
+  // On 11.0.2 Live, Wind Gust applies a stacking 3% GCD + Cast Speed reduction to Lightning Bolt and Chain Lightning
+  // In both cases, this value is stored in effect 1.
   buff.wind_gust = make_buff( this, "wind_gust", find_spell( 263806 ) )
-                       ->set_default_value( find_spell( 263806 )->effectN( 1 ).percent() );
+        ->set_default_value( find_spell( 263806 )->effectN( 1 ).percent() );
+
+  if ( is_ptr() )
+  {
+      buff.wind_gust->set_pct_buff_type( STAT_PCT_BUFF_HASTE );
+      buff.wind_gust->set_default_value_from_effect_type( A_HASTE_ALL );
+  }
 
   buff.echoes_of_great_sundering_es =
       make_buff( this, "echoes_of_great_sundering_es", find_spell( 336217 ) )


### PR DESCRIPTION
On the 11.0.5 PTR the Wind Gust buff has been changed from a stacking
cast speed increase and GCD reduction to a generic haste buff.
