### PR TITLE
[shaman][elemental] fix erupting lava time consumption

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -6163,7 +6163,7 @@ struct lava_beam_t : public chained_base_t
     double tick_base_damage = state->result_raw;
 
     timespan_t consumed_time =
-        std::min( dot->remains(), timespan_t::from_seconds( p()->talent.erupting_lava->effectN( 2 ).base_value() ) );
+        std::min( dot->remains(), p()->talent.erupting_lava->effectN( 2 ).time_value() );
     if ( is_overload )
     {
       consumed_time *= p()->talent.erupting_lava->effectN( 3 ).percent();


### PR DESCRIPTION
spell data of effectN(2):
```
#2 (id=1182431)  : Apply Aura (6) | Dummy (4)
                   Base Value: 3000 | Scaled Value: 3000 | PvP Coefficient: 1.00000 | Target: Self (1)
```
Previous version accidentally consumed full Flame Shock durations.