### PR TITLE
[ele] First update to 11.0.5 APL

### DIFF
--- a/engine/class_modules/apl/shaman/elemental_ptr.simc
+++ b/engine/class_modules/apl/shaman/elemental_ptr.simc
@@ -30,143 +30,109 @@ actions+=/natures_swiftness
 # Use Power Infusion on Cooldown.
 actions+=/invoke_external_buff,name=power_infusion
 actions+=/potion
-actions+=/run_action_list,name=aoe,if=spell_targets.chain_lightning>2
+actions+=/run_action_list,name=aoe,if=spell_targets.chain_lightning>=2
 actions+=/run_action_list,name=single_target
 
-actions.aoe=fire_elemental,if=!buff.fire_elemental.up
-actions.aoe+=/storm_elemental,if=!buff.storm_elemental.up
-actions.aoe+=/stormkeeper,if=!buff.stormkeeper.up
+actions.aoe=fire_elemental
+actions.aoe+=/storm_elemental
+actions.aoe+=/stormkeeper
 # Reset LMT CD as early as possible. Always for Fire, only if you can dot up 3 more targets for Lightning.
 actions.aoe+=/totemic_recall,if=cooldown.liquid_magma_totem.remains>15&(active_dot.flame_shock<(spell_targets.chain_lightning>?6)-2|talent.fire_elemental.enabled)
 actions.aoe+=/liquid_magma_totem
 # Spread Flame Shock via Primordial Wave using Surge of Power if possible.
 actions.aoe+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=buff.surge_of_power.up|!talent.surge_of_power.enabled|maelstrom<60-5*talent.eye_of_the_storm.enabled
 actions.aoe+=/ancestral_swiftness
-# {Lightning} Spread Flame Shock using Surge of Power if LMT is not picked.
-actions.aoe+=/flame_shock,target_if=refreshable,if=buff.surge_of_power.up&talent.lightning_rod.enabled&dot.flame_shock.remains<target.time_to_die-16&active_dot.flame_shock<(spell_targets.chain_lightning>?6)&!talent.liquid_magma_totem.enabled
-# {Lightning} Cast extra Flame Shock to help getting to next spender for SK+SoP on 6+ targets. Mostly opener.
-actions.aoe+=/flame_shock,target_if=min:dot.flame_shock.remains,if=buff.primordial_wave.up&buff.stormkeeper.up&spell_targets.chain_lightning>=6&active_dot.flame_shock<6
-# {Fire} Spread and refresh Flame Shock using Surge of Power (if talented) up to 6.
+# Spread Flame Shock using Surge of Power if LMT is not picked.
+actions.aoe+=/flame_shock,target_if=refreshable,if=buff.surge_of_power.up&dot.flame_shock.remains<target.time_to_die-16&active_dot.flame_shock<(spell_targets.chain_lightning>?6)&!talent.liquid_magma_totem.enabled
+# Spread and refresh Flame Shock using Surge of Power (if talented) up to 6.
 actions.aoe+=/flame_shock,target_if=refreshable,if=talent.fire_elemental.enabled&(buff.surge_of_power.up|!talent.surge_of_power.enabled)&dot.flame_shock.remains<target.time_to_die-5&(active_dot.flame_shock<6|dot.flame_shock.remains>0)
-actions.aoe+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up
+
 # JUST DO IT! https://i.kym-cdn.com/entries/icons/mobile/000/018/147/Shia_LaBeouf__Just_Do_It__Motivational_Speech_(Original_Video_by_LaBeouf__R%C3%B6nkk%C3%B6___Turner)_0-4_screenshot.jpg
 actions.aoe+=/ascendance
-# Against 6 targets or more Surge of Power should be used with Lava Beam rather than Lava Burst.
-actions.aoe+=/lava_beam,if=active_enemies>=6&buff.surge_of_power.up&buff.ascendance.remains>cast_time
+
+####buff tempest with sop
+actions.aoe+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up&(buff.surge_of_power.up|!talent.surge_of_power.enabled)
+####2t
+actions.single_target+=/lightning_bolt,if=buff.stormkeeper.up&buff.surge_of_power.up&spell_targets.chain_lightning=2
+
 # Against 6 targets or more Surge of Power should be used with Chain Lightning rather than Lava Burst.
 actions.aoe+=/chain_lightning,if=active_enemies>=6&buff.surge_of_power.up
 # Consume Primordial Wave buff immediately if you have Stormkeeper buff, fighting 6+ enemies and need maelstrom to spend.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up&buff.stormkeeper.up&maelstrom<60-5*talent.eye_of_the_storm.enabled&spell_targets.chain_lightning>=6&talent.surge_of_power.enabled
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up&(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&maelstrom<60-5*talent.eye_of_the_storm.enabled&talent.surge_of_power.enabled
 # Cast Lava burst to consume Primordial Wave proc. Wait for Lava Surge proc if possible.
 actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up&(buff.primordial_wave.remains<4|buff.lava_surge.up)
-# {Fire} Use Lava Surge proc to buff <anything> with Master of the Elements.
+# *{Fire} Use Lava Surge proc to buff <anything> with Master of the Elements.
 actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&!buff.master_of_the_elements.up&talent.master_of_the_elements.enabled&talent.fire_elemental.enabled
+
+####2t
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=spell_targets.chain_lightning=2&(maelstrom>variable.mael_cap-30|cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
 # Activate Surge of Power if next global is Primordial wave. Respect Echoes of Great Sundering.
 actions.aoe+=/earthquake,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
 # Spend if all Lightning Rods ran out or you are close to overcaping. Respect Echoes of Great Sundering.
 actions.aoe+=/earthquake,if=(lightning_rod=0&talent.lightning_rod.enabled|maelstrom>variable.mael_cap-30)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
 # Spend to buff your follow-up Stormkeeper with Surge of Power on 6+ targets. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=buff.stormkeeper.up&spell_targets.chain_lightning>=6&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# {Fire} Spend if you have Master of the elements buff or fighting 5+ enemies. Bank maelstrom during the end of Ascendance. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=(buff.master_of_the_elements.up|spell_targets.chain_lightning>=5)&(buff.fusion_of_elements_nature.up|buff.ascendance.remains>9|!buff.ascendance.up)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)&talent.fire_elemental.enabled
+actions.aoe+=/earthquake,if=(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
 # Use the talents you selected. Spread Lightning Rod to as many targets as possible.
-actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_eb.up&(lightning_rod=0|maelstrom>variable.mael_cap-30)
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_eb.up&(lightning_rod=0|maelstrom>variable.mael_cap-30|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
 # Use the talents you selected. Spread Lightning Rod to as many targets as possible.
-actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_es.up&(lightning_rod=0|maelstrom>variable.mael_cap-30)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_es.up&(lightning_rod=0|maelstrom>variable.mael_cap-30|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
 # Use Icefury for Fusion of Elements proc.
 actions.aoe+=/icefury,if=talent.fusion_of_elements.enabled&!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)
-# {Fire} Proc Master of the Elements outside Ascendance.
+# *{Fire} Proc Master of the Elements outside Ascendance.
 actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.master_of_the_elements.enabled&!buff.master_of_the_elements.up&!buff.ascendance.up&talent.fire_elemental.enabled
-# Stormkeeper is strong and should be used.
-actions.aoe+=/lava_beam,if=buff.stormkeeper.up&(buff.surge_of_power.up|spell_targets.lava_beam<6)
-# Stormkeeper is strong and should be used.
-actions.aoe+=/chain_lightning,if=buff.stormkeeper.up&(buff.surge_of_power.up|spell_targets.chain_lightning<6)
-# Power of the Maelstrom is strong and should be used.
-actions.aoe+=/lava_beam,if=buff.power_of_the_maelstrom.up&buff.ascendance.remains>cast_time&!buff.stormkeeper.up
-# Power of the Maelstrom is strong and should be used.
-actions.aoe+=/chain_lightning,if=buff.power_of_the_maelstrom.up&!buff.stormkeeper.up
-# Consume Master of the Elements with Lava Beam on 4+ targets. Just spam it over hardcasted Lava Burst on 5+ targets.
-actions.aoe+=/lava_beam,if=(buff.master_of_the_elements.up&spell_targets.lava_beam>=4|spell_targets.lava_beam>=5)&buff.ascendance.remains>cast_time&!buff.stormkeeper.up
-# Gamble away for Deeply Rooted Elements procs.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.deeply_rooted_elements.enabled
-actions.aoe+=/lava_beam,if=buff.ascendance.remains>cast_time
 actions.aoe+=/chain_lightning
 actions.aoe+=/flame_shock,moving=1,target_if=refreshable
 actions.aoe+=/frost_shock,moving=1
 
-actions.single_target=fire_elemental,if=!buff.fire_elemental.up
-actions.single_target+=/storm_elemental,if=!buff.storm_elemental.up
+
+actions.single_target=fire_elemental
+actions.single_target+=/storm_elemental
 # Just use Stormkeeper.
-actions.single_target+=/stormkeeper,if=!buff.ascendance.up&!buff.stormkeeper.up
+actions.single_target+=/stormkeeper,if=!talent.ascendance.enabled|cooldown.ascendance.remains<gcd|cooldown.ascendance.remains>10
 # {Fire} Reset LMT CD as early as possible.
+###suspend?
 actions.single_target+=/totemic_recall,if=cooldown.liquid_magma_totem.remains>15&spell_targets.chain_lightning>1&talent.fire_elemental.enabled
-# Use LMT outside Ascendance in fire builds and on 2 targets for lightning.
-actions.single_target+=/liquid_magma_totem,if=!buff.ascendance.up&(talent.fire_elemental.enabled|spell_targets.chain_lightning>1)
-# Use Primordial Wave as much as possible. Buff with Surge of power on 2 targets if not playing LMT.
-actions.single_target+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=spell_targets.chain_lightning=1|buff.surge_of_power.up|!talent.surge_of_power.enabled|maelstrom<60-5*talent.eye_of_the_storm.enabled|talent.liquid_magma_totem.enabled
-# Use Ancestral Swiftness as much as possible. Use on EB instead of LvB where possible.
+# Use Primordial Wave as much as possible.
+actions.single_target+=/primordial_wave,if=!buff.surge_of_power.up
+# *Use Ancestral Swiftness as much as possible. Use on EB instead of LvB where possible.
 actions.single_target+=/ancestral_swiftness,if=!buff.primordial_wave.up|!buff.stormkeeper.up|!talent.elemental_blast.enabled
-# {Fire} Manually refresh Flame shock if better options are not available.
-actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_enemies=1&(dot.flame_shock.remains<2|active_dot.flame_shock=0)&(dot.flame_shock.remains<cooldown.primordial_wave.remains|!talent.primordial_wave.enabled)&(dot.flame_shock.remains<cooldown.liquid_magma_totem.remains|!talent.liquid_magma_totem.enabled)&!buff.surge_of_power.up&talent.fire_elemental.enabled
-# Use Flame shock without Surge of Power if you can't spread it with SoP because it is going to be used on Stormkeeper or Surge of Power is not talented.
-actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=active_dot.flame_shock<active_enemies&spell_targets.chain_lightning>1&(talent.deeply_rooted_elements.enabled|talent.ascendance.enabled|talent.primordial_wave.enabled|talent.searing_flames.enabled|talent.magma_chamber.enabled)&(!buff.surge_of_power.up&buff.stormkeeper.up|!talent.surge_of_power.enabled|cooldown.ascendance.remains=0&talent.ascendance.enabled)&!talent.liquid_magma_totem.enabled
-# {Fire} Spread Flame Shock to multiple targets only if talents were selected that benefit from it.
-actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=spell_targets.chain_lightning>1&(talent.deeply_rooted_elements.enabled|talent.ascendance.enabled|talent.primordial_wave.enabled|talent.searing_flames.enabled|talent.magma_chamber.enabled)&(buff.surge_of_power.up&!buff.stormkeeper.up|!talent.surge_of_power.enabled)&dot.flame_shock.remains<6&talent.fire_elemental.enabled,cycle_targets=1
-actions.single_target+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up
-# Stormkeeper is strong and should be used.
-actions.single_target+=/lightning_bolt,if=buff.stormkeeper.up&buff.surge_of_power.up
-# Buff stormkeeper with MotE when not using Surge of Power.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.stormkeeper.up&!buff.master_of_the_elements.up&!talent.surge_of_power.enabled&talent.master_of_the_elements.enabled
-# Buff Stormkeeper with at least something if you can.
-actions.single_target+=/lightning_bolt,if=buff.stormkeeper.up&!talent.surge_of_power.enabled&(buff.master_of_the_elements.up|!talent.master_of_the_elements.enabled)
-# Surge of Power is strong and should be used.
-actions.single_target+=/lightning_bolt,if=buff.surge_of_power.up&!buff.ascendance.up&talent.echo_chamber.enabled
-actions.single_target+=/ascendance,if=cooldown.lava_burst.charges_fractional<1.0
-# {Fire} Lava Surge is neat. Utilize it.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&talent.fire_elemental.enabled
-# Consume Primordial wave buff.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up
-# {Fire} Spend if you have MotE buff and: not in Ascendance OR Ascendance gona last so long you will need to spend anyway OR nature fusion buff up OR close to maelstrom cap. Respect Echoes of Great Sundering.
-actions.single_target+=/earthquake,if=buff.master_of_the_elements.up&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|spell_targets.chain_lightning>1&!talent.echoes_of_great_sundering.enabled&!talent.elemental_blast.enabled)&(buff.fusion_of_elements_nature.up|maelstrom>variable.mael_cap-15|buff.ascendance.remains>9|!buff.ascendance.up)&talent.fire_elemental.enabled
-# {Fire} Spend if you have MotE buff and: not in Ascendance OR Ascendance gona last so long you will need to spend anyway OR any fusion buff up OR close to maelstrom cap.
-actions.single_target+=/elemental_blast,if=buff.master_of_the_elements.up&(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up|maelstrom>variable.mael_cap-15|buff.ascendance.remains>6|!buff.ascendance.up)&talent.fire_elemental.enabled
-# {Fire} Spend if you have MotE buff and: not in Ascendance OR Ascendance gona last so long you will need to spend anyway OR nature fusion buff up OR close to maelstrom cap.
-actions.single_target+=/earth_shock,if=buff.master_of_the_elements.up&(buff.fusion_of_elements_nature.up|maelstrom>variable.mael_cap-15|buff.ascendance.remains>9|!buff.ascendance.up)&talent.fire_elemental.enabled
-# {Lightning} Spend if Stormkeeper is active OR Pwave is coming next gcd and you arent specced into LMT. Respect Echoes of Great Sundering.
-actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|spell_targets.chain_lightning>1&!talent.echoes_of_great_sundering.enabled&!talent.elemental_blast.enabled)&(buff.stormkeeper.up|cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled&!talent.liquid_magma_totem.enabled)&talent.storm_elemental.enabled
-# {Lightning} Spend if Stormkeeper is active. Spread Lightning Rod to as many targets as possible.
-actions.single_target+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=buff.stormkeeper.up&talent.storm_elemental.enabled
-# {Lightning}[1t] Spend if you have Master of the Elements buff and Stormkeeper is not coming up soon OR Stormkeeper is active OR Lightning Rod ran out.
-actions.single_target+=/earth_shock,if=((buff.master_of_the_elements.up|lightning_rod=0)&cooldown.stormkeeper.remains>10&(rolling_thunder.next_tick>5|!talent.rolling_thunder.enabled)|buff.stormkeeper.up)&talent.storm_elemental.enabled&spell_targets.chain_lightning=1
-# {Lightning}[2t] Spend if Stormkeeper is active OR Pwave is coming next gcd and you arent specced into LMT. Spread Lightning Rod to as many targets as possible. Use Echoes of Great Sundering.
-actions.single_target+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=(cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled&!talent.liquid_magma_totem.enabled|buff.stormkeeper.up)&talent.storm_elemental.enabled&spell_targets.chain_lightning>1&talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_es.up
-# Don't waste Icefury stacks even during Ascendance.
-actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)&buff.icefury.stack=2&(talent.fusion_of_elements.enabled|!buff.ascendance.up)
-# Spam Lava burst in Ascendance.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.ascendance.up
-# {Fire} Buff your next <anything> with MotE.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.master_of_the_elements.enabled&!buff.master_of_the_elements.up&talent.fire_elemental.enabled
-# {Farseer/ES} Spend all Lava Burst charges in opener to get one Stormkeeper buffed with Surge of Power.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.stormkeeper.up&talent.elemental_reverb.enabled&talent.earth_shock.enabled&time<10
-# Spend if close to overcaping. Respect Echoes of Great Sundering.
-actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|spell_targets.chain_lightning>1&!talent.echoes_of_great_sundering.enabled&!talent.elemental_blast.enabled)&(maelstrom>variable.mael_cap-35|fight_remains<5)
-# Spend if close to overcaping.
-actions.single_target+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=maelstrom>variable.mael_cap-15|fight_remains<5
-# Spend if close to overcaping.
-actions.single_target+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=maelstrom>variable.mael_cap-15|fight_remains<5
+actions.single_target+=/ascendance
+
+#Surge of Power is strong and should be used. ©
+actions.single_target+=/tempest,if=buff.surge_of_power.up
 actions.single_target+=/lightning_bolt,if=buff.surge_of_power.up
+
+# Use LMT to apply Flame Shock.
+actions.single_target+=/liquid_magma_totem,if=active_dot.flame_shock=0
+# Manually refresh Flame shock if better options are not available.
+actions.single_target+=/flame_shock,if=active_dot.flame_shock=0|(dot.flame_shock.remains<6&(dot.flame_shock.remains<cooldown.primordial_wave.remains|!talent.primordial_wave.enabled)&(dot.flame_shock.remains<cooldown.liquid_magma_totem.remains|!talent.liquid_magma_totem.enabled)&!buff.surge_of_power.up&!buff.master_of_the_elements.up)
+
+# Spend if close to overcaping. Respect Echoes of Great Sundering.
+actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(maelstrom>variable.mael_cap-15|fight_remains<5)
+actions.single_target+=/elemental_blast,if=maelstrom>variable.mael_cap-15|fight_remains<5
+actions.single_target+=/earth_shock,if=maelstrom>variable.mael_cap-15|fight_remains<5
+
+# Use Icefury to proc Fusion of Elements if Master of the Elements buff is not up or cant be used on smth better.
+actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)&talent.fusion_of_elements.enabled
+
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=charges_fractional>=max_charges-0.8
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=!talent.master_of_the_elements.enabled
+# Dont waste Primordial Wave buff.
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up&buff.primordial_wave.remains<4
+# Buff your next spender with MotE.
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.master_of_the_elements.enabled&!buff.master_of_the_elements.up&((buff.tempest.up|buff.stormkeeper.up)&maelstrom>52-5*talent.eye_of_the_storm.enabled-3*buff.ascendance.up+(25-5*talent.eye_of_the_storm.enabled)*talent.elemental_blast.enabled|maelstrom>variable.mael_cap-15)
+
+# Spend to activate Surge of Power buff for Tempest or Stormkeeper.
+actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power.enabled
+actions.single_target+=/elemental_blast,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power.enabled
+actions.single_target+=/earth_shock,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power.enabled
+
+# Use Icefury-buffed Frost Shock.
+#actions.single_target+=/frost_shock,if=buff.icefury_dmg.up
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=!buff.master_of_the_elements.up&(buff.tempest.up|buff.stormkeeper.up)
+actions.single_target+=/tempest
 # Use Icefury if you won't overwrite Fusion of Elements buffs.
 actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)
-# Use Icefury-buffed Frost Shock against 1 target or if you need to generate for SoP buff on Stormkeeper.
-actions.single_target+=/frost_shock,if=buff.icefury_dmg.up&(spell_targets.chain_lightning=1|buff.stormkeeper.up&talent.surge_of_power.enabled)
-# Utilize the Power of the Maelstrom buff.
-actions.single_target+=/chain_lightning,if=buff.power_of_the_maelstrom.up&spell_targets.chain_lightning>1&!buff.stormkeeper.up
-# Utilize the Power of the Maelstrom buff.
-actions.single_target+=/lightning_bolt,if=buff.power_of_the_maelstrom.up&!buff.stormkeeper.up
-# Fish for DRE procs.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.deeply_rooted_elements.enabled
-# Casting Chain Lightning at two targets is more efficient than Lightning Bolt.
-actions.single_target+=/chain_lightning,if=spell_targets.chain_lightning>1&!buff.stormkeeper.up
 # Filler spell. Always available. Always the bottom line.
 actions.single_target+=/lightning_bolt
 actions.single_target+=/flame_shock,moving=1,target_if=refreshable


### PR DESCRIPTION
- Moved 2t into AoE APL and added main 2t features to aoe: SoP_SK_LB and EB instead of EQ as spender
- Did some basic cleanup on AoE apl, will need much more work later
- ST apl boils down to:  
try to get all tempests and SKs Soped
keep up FS and dont sit on LvB charges, while also trying to mote spenders/unlucky tempests/Sks
IF for fusion, only delayed to not waste mote on it if sop combo is executed
FrS in the bin

some sims as food for thoughts:
ES+Pwave builds
https://mimiron.raidbots.com/simbot/report/1MaMKy3CtqjAJXPQ3Fe4EG 
EB+Pwave builds
https://mimiron.raidbots.com/simbot/report/2er1MDo93MsSgd1EfiSJUC
Unity+no pwave builds
https://mimiron.raidbots.com/simbot/report/rB8angvipv3FAxjTwjWV9L