### PR TITLE
[shaman] Use CI to generate code-gen'd APL files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -535,6 +535,50 @@ jobs:
         with:
           name: apl-${{ github.sha }}-*
 
+  update-generated-apl-modules:
+    name: Action Priority List Dump / Regenerate Profiles
+    runs-on: ${{ matrix.os }}
+    needs: [ spec-test, spelldata-dump ]
+    if: github.event_name == 'push' && ( success() || failure() ) && github.repository == 'simulationcraft/simc'
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        cppVersion: [17]
+        compiler: [clang++-15]
+        include:
+          - compiler: clang++-15
+            os: ubuntu-22.04
+        classes:
+          - name: shaman
+
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.workspace }}/b/ninja/simc
+          key: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
+
+      - uses: actions/checkout@v4
+
+      - name: Setup
+        run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
+      - name: Run
+        env:
+          UBSAN_OPTIONS: print_stacktrace=1
+          SIMC_CLI_PATH: ${{ runner.workspace }}/b/ninja/simc
+        run: ${{ github.workspace }}/generate_apl_modules.sh
+
+      - name: Commit APLs
+        continue-on-error: true
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'Update generated APL modules ${{ env.SHORT_SHA }}'
+          default_author: github_actions
+          fetch: --no-tags --force --prune --no-recurse-submodules --depth=1 origin ${{ github.ref_name }}
+          add: 'engine/class_modules/apl'
+      
   ubuntu-run:
     name: ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -549,8 +549,6 @@ jobs:
         include:
           - compiler: clang++-15
             os: ubuntu-22.04
-        classes:
-          - name: shaman
 
     steps:
       - uses: actions/cache@v4
@@ -568,9 +566,9 @@ jobs:
         env:
           UBSAN_OPTIONS: print_stacktrace=1
           SIMC_CLI_PATH: ${{ runner.workspace }}/b/ninja/simc
-        run: ${{ github.workspace }}/generate_apl_modules.sh
+        run: ${{ github.workspace }}/generate_apl_modules_ci.sh
 
-      - name: Commit APLs
+      - name: Commit code-generated APLs
         continue-on-error: true
         uses: EndBug/add-and-commit@v9
         with:

--- a/generate_apl_modules_ci.sh
+++ b/generate_apl_modules_ci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -e
+
+alias py=python3
+
+ROOT=$(cd $(dirname $0)/.. && pwd)
+
+if [ "$(pwd)" != "${ROOT}" ]; then
+  echo "you must run this script in the root directory for this repository" >&2
+  exit 1
+fi
+
+classes_to_generate=(
+  shaman
+)
+
+for class in $classes_to_generate; do
+  pushd "engine/class_modules/apl/${class}"
+  ./generate_${class}.sh
+  popd
+done
+
+echo 'done'


### PR DESCRIPTION
We've got some APL contributors who are a little less technical, and thus are primarily submitting pull requests via the web editor and unable to run utility scripts to update generated code such as the shaman APL.

This is a spike towards moving to CI doing this on our behalf instead so that when APL changes land (on the default branch) that the script will run and the results will be committed.