### PR TITLE
[Warlock] [Demonology] Updates conversion rates of Felguard and G.Felguard

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -880,8 +880,8 @@ void felguard_pet_t::init_base_stats()
   melee_attack = new felguard_melee_t( this, 1.0, "melee" );
 
   // 2023-09-20: Validated coefficients
-  owner_coeff.ap_from_sp = 0.862;
-  owner_coeff.sp_from_sp = 1.322;
+  owner_coeff.ap_from_sp = 0.9487;
+  owner_coeff.sp_from_sp = 1.4542;
 
   melee_attack->base_dd_multiplier *= 1.42;
 
@@ -1059,8 +1059,8 @@ void grimoire_felguard_pet_t::init_base_stats()
   main_hand_weapon.type = WEAPON_AXE_2H;
   melee_attack = new warlock_pet_melee_t( this );
 
-  // 2023-09-20: Validated coefficients
-  owner_coeff.ap_from_sp = 0.741;
+  // 2023-09-20: Validated coefficients.
+  owner_coeff.ap_from_sp = 0.9487;
 
   melee_attack->base_dd_multiplier *= 1.42;
 }

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -881,7 +881,7 @@ void felguard_pet_t::init_base_stats()
 
   // 2023-09-20: Validated coefficients
   owner_coeff.ap_from_sp = 0.9487;
-  owner_coeff.sp_from_sp = 1.4542;
+  owner_coeff.sp_from_sp = 1.4519;
 
   melee_attack->base_dd_multiplier *= 1.42;
 


### PR DESCRIPTION
Updating the Conversion rates of AP and SP for Felguard and G.Felguard, apparently, any buff/change to Conversion rates of Felguard ingame will reflect to G.Felguard. 

On a side note, i opted to not update the Conversion Rates of Dreadstalkers at this PRequest and will do it on a different PR in the future.

https://imgur.com/EzfMdEp 

As you can see, at a 16743 Attack Power with  17647 Intellect  would indicate the new values for AP/SP conversion rates.  