### PR TITLE
[Warlock] [Demonology] Update AP/SP conversion rates for Dreadstalkers

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1265,7 +1265,7 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "drea
   resource_regeneration  = regen_type::DISABLED;
 
   // 2023-09-20: Coefficient updated
-  owner_coeff.ap_from_sp = 0.686;
+  owner_coeff.ap_from_sp = 0.825;
 
   owner_coeff.health = 0.4;
 
@@ -1455,8 +1455,8 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   action_list_str += "/travel";
   action_list_str += "/headbutt";
 
-  owner_coeff.ap_from_sp = 0.45;
-  owner_coeff.sp_from_sp = 1.95;
+  owner_coeff.ap_from_sp = 0.538;
+  owner_coeff.sp_from_sp = 2.33;
 
   owner_coeff.health = 0.75;
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1455,8 +1455,8 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   action_list_str += "/travel";
   action_list_str += "/headbutt";
 
-  owner_coeff.ap_from_sp = 0.538;
-  owner_coeff.sp_from_sp = 2.33;
+  owner_coeff.ap_from_sp = 0.45;
+  owner_coeff.sp_from_sp = 1.95;
 
   owner_coeff.health = 0.75;
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1264,7 +1264,7 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "drea
   action_list_str = "leap/dreadbite";
   resource_regeneration  = regen_type::DISABLED;
 
-  // 2023-09-20: Coefficient updated
+  // 2024-11-16: Coefficient updated
   owner_coeff.ap_from_sp = 0.825;
 
   owner_coeff.health = 0.4;


### PR DESCRIPTION
https://i.imgur.com/Fs1UHL5.png

Character had a 17647 intellect. 

AP/SP values

https://www.warcraftlogs.com/reports/nWmwA2pc139PyJNH#fight=last&type=resources&source=9&spell=1001 Dreadstalkers AP ( 14559)

as such we get the values of:

Dreadstalkers SP TO AP: 0.8250127500425001


