### PR TITLE
[mage] Frost Frostfire Cleave update

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -395,16 +395,15 @@ void frost( player_t* p )
   cleave_ff->add_action( "comet_storm,if=prev_gcd.1.flurry" );
   cleave_ff->add_action( "frostfire_bolt,if=talent.deaths_chill&buff.icy_veins.remains>9&(buff.deaths_chill.stack<6|buff.deaths_chill.stack=6&!action.frostfire_bolt.in_flight)" );
   cleave_ff->add_action( "freeze,if=freezable&prev_gcd.1.glacial_spike" );
-  cleave_ff->add_action( "flurry,if=cooldown_react&remaining_winters_chill=0&debuff.winters_chill.down&(prev_gcd.1.frostfire_bolt&buff.icicles.react>2|prev_gcd.1.glacial_spike|buff.icicles.react=4)&!prev_off_gcd.freeze" );
-  cleave_ff->add_action( "flurry,target_if=min:debuff.winters_chill.stack,if=cooldown_react&prev_gcd.1.glacial_spike&!prev_off_gcd.freeze" );
   cleave_ff->add_action( "ice_nova,if=freezable&prev_gcd.1.glacial_spike&remaining_winters_chill=0&debuff.winters_chill.down&!prev_off_gcd.freeze" );
+  cleave_ff->add_action( "flurry,if=cooldown_react&remaining_winters_chill=0&debuff.winters_chill.down&(prev_gcd.1.glacial_spike|buff.icicles.react>=3)&!prev_off_gcd.freeze" );
+  cleave_ff->add_action( "flurry,target_if=min:debuff.winters_chill.stack,if=cooldown_react&prev_gcd.1.glacial_spike&!prev_off_gcd.freeze" );
   cleave_ff->add_action( "glacial_spike,if=buff.icicles.react=5" );
-  cleave_ff->add_action( "ray_of_frost,target_if=max:debuff.winters_chill.stack,if=remaining_winters_chill&!buff.fingers_of_frost.react" );
+  cleave_ff->add_action( "ray_of_frost,target_if=max:debuff.winters_chill.stack,if=remaining_winters_chill" );
   cleave_ff->add_action( "frostfire_bolt,if=buff.frostfire_empowerment.react&!buff.excess_frost.react&!buff.excess_fire.react" );
   cleave_ff->add_action( "frozen_orb,if=!buff.fingers_of_frost.react" );
-  cleave_ff->add_action( "shifting_power,if=cooldown.icy_veins.remains>10&(!talent.comet_storm|cooldown.comet_storm.remains>10)&cooldown.frozen_orb.remains>10&(fight_remains+10>cooldown.icy_veins.remains)" );
-  cleave_ff->add_action( "ice_lance,target_if=max:debuff.winters_chill.stack,if=buff.fingers_of_frost.react&!prev_gcd.1.glacial_spike|remaining_winters_chill&buff.excess_fire.react" );
-  cleave_ff->add_action( "blizzard,if=talent.ice_caller&buff.freezing_rain.up&!talent.deaths_chill" );
+  cleave_ff->add_action( "shifting_power,if=cooldown.icy_veins.remains>10&cooldown.frozen_orb.remains>10&(!talent.comet_storm|cooldown.comet_storm.remains>10)&(!talent.ray_of_frost|cooldown.ray_of_frost.remains>10)&(fight_remains+10>cooldown.icy_veins.remains)" );
+  cleave_ff->add_action( "ice_lance,target_if=max:debuff.winters_chill.stack,if=buff.fingers_of_frost.react&!prev_gcd.1.glacial_spike|remaining_winters_chill&!variable.boltspam" );
   cleave_ff->add_action( "frostfire_bolt" );
   cleave_ff->add_action( "call_action_list,name=movement" );
 


### PR DESCRIPTION
**Changes in 2t Cleave**
- Found a simplification for the Flurry line that also allowed to throw out Blizzard entirely for all builds
- Made an adjustement to the Ice Lane line to not force the boltspam gameplay onto all builds in Cleave (this change is roughly a -0.5% ish loss for ff builds that do have boltspam talents, but completely neutral for builds that dont - and much less cringe to play)
- Adjustements to ice nova priority to get another +0.5% to +1.1% gains against freezable targets for all profiles
- Adjustements to Shifting Power line to simply make it consinstent with the single target rotation (dps neutral)
- Small simplification for Ray that is only a very tiny loss