### PR TITLE
[Core] Fix precombat order of operations

### DIFF
--- a/engine/class_modules/apl/apl_death_knight.cpp
+++ b/engine/class_modules/apl/apl_death_knight.cpp
@@ -113,9 +113,6 @@ void blood( player_t* p )
   action_priority_list_t* deathbringer = p->get_action_priority_list( "deathbringer" );
   action_priority_list_t* sanlayn = p->get_action_priority_list( "sanlayn" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "deaths_caress" );
 
@@ -209,9 +206,6 @@ void frost( player_t* p )
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=trinket.1.has_use_buff&(talent.pillar_of_frost&!talent.breath_of_sindragosa&(trinket.1.cooldown.duration%%cooldown.pillar_of_frost.duration=0)|talent.breath_of_sindragosa&(cooldown.breath_of_sindragosa.duration%%trinket.1.cooldown.duration=0))", "Evaluates a trinkets cooldown, divided by pillar of frost, empower rune weapon, or breath of sindragosa's cooldown. If it's value has no remainder return 1, else return 0.5." );
   precombat->add_action( "variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=trinket.2.has_use_buff&(talent.pillar_of_frost&!talent.breath_of_sindragosa&(trinket.2.cooldown.duration%%cooldown.pillar_of_frost.duration=0)|talent.breath_of_sindragosa&(cooldown.breath_of_sindragosa.duration%%trinket.2.cooldown.duration=0))" );
@@ -396,9 +390,6 @@ void unholy( player_t* p )
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "raise_dead" );
   precombat->add_action( "army_of_the_dead,precombat_time=2" );

--- a/engine/class_modules/apl/apl_demon_hunter.cpp
+++ b/engine/class_modules/apl/apl_demon_hunter.cpp
@@ -58,9 +58,6 @@ void havoc( player_t* p )
   action_priority_list_t* meta = p->get_action_priority_list( "meta" );
   action_priority_list_t* opener = p->get_action_priority_list( "opener" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket1_steroids,value=trinket.1.has_stat.any_dps" );
   precombat->add_action( "variable,name=trinket2_steroids,value=trinket.2.has_stat.any_dps" );
@@ -242,9 +239,6 @@ void vengeance( player_t* p )
   action_priority_list_t* rg_sequence = p->get_action_priority_list( "rg_sequence" );
   action_priority_list_t* rg_sequence_filler = p->get_action_priority_list( "rg_sequence_filler" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=single_target,value=spell_targets.spirit_bomb=1" );
   precombat->add_action( "variable,name=small_aoe,value=spell_targets.spirit_bomb>=2&spell_targets.spirit_bomb<=5" );

--- a/engine/class_modules/apl/apl_evoker.cpp
+++ b/engine/class_modules/apl/apl_evoker.cpp
@@ -55,9 +55,6 @@ void devastation( player_t* p )
   action_priority_list_t* st = p->get_action_priority_list( "st" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "variable,name=trinket_1_buffs,value=trinket.1.has_buff.intellect|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit|trinket.1.is.mirror_of_fractured_tomorrows" );
   precombat->add_action( "variable,name=trinket_2_buffs,value=trinket.2.has_buff.intellect|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit|trinket.2.is.mirror_of_fractured_tomorrows" );
@@ -175,9 +172,6 @@ void augmentation( player_t* p )
   action_priority_list_t* items = p->get_action_priority_list( "items" );
   action_priority_list_t* opener_filler = p->get_action_priority_list( "opener_filler" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=spam_heal,default=1,op=reset" );
   precombat->add_action( "variable,name=minimum_opener_delay,op=reset,default=0" );

--- a/engine/class_modules/apl/apl_hunter.cpp
+++ b/engine/class_modules/apl/apl_hunter.cpp
@@ -61,9 +61,6 @@ void beast_mastery( player_t* p )
   action_priority_list_t* st = p->get_action_priority_list( "st" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket_1_stronger,value=!trinket.2.has_cooldown|trinket.1.has_use_buff&(!trinket.2.has_use_buff|!trinket.1.is.mirror_of_fractured_tomorrows&(trinket.2.is.mirror_of_fractured_tomorrows|trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))|!trinket.1.has_use_buff&(!trinket.2.has_use_buff&(trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))" );
@@ -136,9 +133,6 @@ void beast_mastery_ptr( player_t* p )
   action_priority_list_t* st = p->get_action_priority_list( "st" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket_1_stronger,value=!trinket.2.has_cooldown|trinket.1.has_use_buff&(!trinket.2.has_use_buff|!trinket.1.is.mirror_of_fractured_tomorrows&(trinket.2.is.mirror_of_fractured_tomorrows|trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))|!trinket.1.has_use_buff&(!trinket.2.has_use_buff&(trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))" );
@@ -211,9 +205,6 @@ void marksmanship( player_t* p )
   action_priority_list_t* trickshots = p->get_action_priority_list( "trickshots" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "summon_pet,if=!talent.lone_wolf" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket_1_stronger,value=!trinket.2.has_cooldown|trinket.1.has_use_buff&(!trinket.2.has_use_buff|!trinket.1.is.mirror_of_fractured_tomorrows&(trinket.2.is.mirror_of_fractured_tomorrows|trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))|!trinket.1.has_use_buff&(!trinket.2.has_use_buff&(trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))", "Determine the stronger trinket to sync with cooldowns. In descending priority: buff effects > damage effects, longer > shorter cooldowns, longer > shorter cast times." );
@@ -291,9 +282,6 @@ void marksmanship_ptr( player_t* p )
   action_priority_list_t* trickshots = p->get_action_priority_list( "trickshots" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "summon_pet,if=!talent.lone_wolf" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket_1_stronger,value=!trinket.2.has_cooldown|trinket.1.has_use_buff&(!trinket.2.has_use_buff|!trinket.1.is.mirror_of_fractured_tomorrows&(trinket.2.is.mirror_of_fractured_tomorrows|trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))|!trinket.1.has_use_buff&(!trinket.2.has_use_buff&(trinket.2.cooldown.duration<trinket.1.cooldown.duration|trinket.2.cast_time<trinket.1.cast_time|trinket.2.cast_time=trinket.1.cast_time&trinket.2.cooldown.duration=trinket.1.cooldown.duration))", "Determine the stronger trinket to sync with cooldowns. In descending priority: buff effects > damage effects, longer > shorter cooldowns, longer > shorter cast times." );
@@ -372,9 +360,6 @@ void survival( player_t* p )
   action_priority_list_t* sentst = p->get_action_priority_list( "sentst" );
   action_priority_list_t* sentcleave = p->get_action_priority_list( "sentcleave" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "use_item,name=imperfect_ascendancy_serum" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
@@ -482,9 +467,6 @@ void survival_ptr( player_t* p )
   action_priority_list_t* sentst = p->get_action_priority_list( "sentst" );
   action_priority_list_t* sentcleave = p->get_action_priority_list( "sentcleave" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "use_item,name=imperfect_ascendancy_serum" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );

--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -265,15 +265,6 @@ void mistweaver( player_t *p )
 {
   action_priority_list_t *pre = p->get_action_priority_list( "precombat" );
 
-  // Flask
-  pre->add_action( "flask" );
-
-  // Food
-  pre->add_action( "food" );
-
-  // Rune
-  pre->add_action( "augmentation" );
-
   // Snapshot stats
   pre->add_action( "snapshot_stats" );
 
@@ -431,13 +422,6 @@ void windwalker( player_t *p )
   //============================================================================
 
   action_priority_list_t *pre = p->get_action_priority_list( "precombat" );
-
-  // Flask
-  pre->add_action( "flask" );
-  // Food
-  pre->add_action( "food" );
-  // Rune
-  pre->add_action( "augmentation" );
 
   // Snapshot stats
   pre->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );

--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -207,9 +207,6 @@ void brewmaster( player_t *p )
 
   action_priority_list_t *item_actions = p->get_action_priority_list( "item_actions" );
   action_priority_list_t *race_actions = p->get_action_priority_list( "race_actions" );
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "potion" );
   precombat->add_action( "chi_burst" );

--- a/engine/class_modules/apl/apl_paladin.cpp
+++ b/engine/class_modules/apl/apl_paladin.cpp
@@ -15,9 +15,6 @@ void retribution( player_t* p )
   action_priority_list_t* finishers = p->get_action_priority_list( "finishers" );
   action_priority_list_t* generators = p->get_action_priority_list( "generators" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "shield_of_vengeance" );
   precombat->add_action( "variable,name=trinket_1_buffs,value=trinket.1.has_buff.strength|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit" );
@@ -85,9 +82,6 @@ void protection( player_t* p )
   action_priority_list_t* standard = p->get_action_priority_list( "standard" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "rite_of_sanctification" );
   precombat->add_action( "rite_of_adjuration" );
   precombat->add_action( "snapshot_stats" );

--- a/engine/class_modules/apl/apl_priest.cpp
+++ b/engine/class_modules/apl/apl_priest.cpp
@@ -50,9 +50,6 @@ void shadow( player_t* p )
   action_priority_list_t* heal_for_tof = p->get_action_priority_list( "heal_for_tof" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "shadowform,if=!buff.shadowform.up" );
   precombat->add_action( "variable,name=dr_force_prio,default=0,op=reset" );
@@ -174,9 +171,6 @@ void shadow_ptr( player_t* p )
   action_priority_list_t* heal_for_tof = p->get_action_priority_list( "heal_for_tof" );
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "shadowform,if=!buff.shadowform.up" );
   precombat->add_action( "variable,name=dr_force_prio,default=0,op=reset" );
@@ -292,9 +286,6 @@ void discipline( player_t* p )
   action_priority_list_t* main = p->get_action_priority_list( "main" );
   action_priority_list_t* cooldowns = p->get_action_priority_list( "cooldowns" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "smite" );
 
@@ -332,9 +323,6 @@ void holy( player_t* p )
   action_priority_list_t* generic = p->get_action_priority_list( "generic" );
   action_priority_list_t* cooldowns = p->get_action_priority_list( "cooldowns" );
 
-  precombat->add_action( "flask", "otion=elemental_potion_of_ultimate_power_ ood=fated_fortune_cooki lask=phial_of_tepid_versatility_ ugmentation=draconic_augment_run emporary_enchant=main_hand:howling_rune_" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
 
   default_->add_action( "run_action_list,name=main", "RUN ACTIONS" );
@@ -402,9 +390,6 @@ void no_spec( player_t* p )
   action_priority_list_t* precombat = p->get_action_priority_list( "precombat" );
   action_priority_list_t* def       = p->get_action_priority_list( "default" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "smite" );
   def->add_action( "mana_potion,if=mana.pct<=75" );

--- a/engine/class_modules/apl/apl_rogue.cpp
+++ b/engine/class_modules/apl/apl_rogue.cpp
@@ -70,6 +70,7 @@ void assassination( player_t* p )
   action_priority_list_t* stealthed = p->get_action_priority_list( "stealthed" );
   action_priority_list_t* vanish = p->get_action_priority_list( "vanish" );
 
+  precombat->add_action( "apply_poison" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket_sync_slot,value=1,if=trinket.1.has_stat.any_dps&(!trinket.2.has_stat.any_dps|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)&!trinket.2.is.treacherous_transmitter|trinket.1.is.treacherous_transmitter", "Check which trinket slots have Stat Values" );
   precombat->add_action( "variable,name=trinket_sync_slot,value=2,if=trinket.2.has_stat.any_dps&(!trinket.1.has_stat.any_dps|trinket.2.cooldown.duration>trinket.1.cooldown.duration)&!trinket.1.is.treacherous_transmitter|trinket.2.is.treacherous_transmitter" );

--- a/engine/class_modules/apl/apl_rogue.cpp
+++ b/engine/class_modules/apl/apl_rogue.cpp
@@ -70,10 +70,6 @@ void assassination( player_t* p )
   action_priority_list_t* stealthed = p->get_action_priority_list( "stealthed" );
   action_priority_list_t* vanish = p->get_action_priority_list( "vanish" );
 
-  precombat->add_action( "apply_poison" );
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=trinket_sync_slot,value=1,if=trinket.1.has_stat.any_dps&(!trinket.2.has_stat.any_dps|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)&!trinket.2.is.treacherous_transmitter|trinket.1.is.treacherous_transmitter", "Check which trinket slots have Stat Values" );
   precombat->add_action( "variable,name=trinket_sync_slot,value=2,if=trinket.2.has_stat.any_dps&(!trinket.1.has_stat.any_dps|trinket.2.cooldown.duration>trinket.1.cooldown.duration)&!trinket.1.is.treacherous_transmitter|trinket.2.is.treacherous_transmitter" );
@@ -194,9 +190,6 @@ void outlaw( player_t* p )
   action_priority_list_t* stealth_cds = p->get_action_priority_list( "stealth_cds" );
 
   precombat->add_action( "apply_poison,nonlethal=none,lethal=instant" );
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "use_item,name=imperfect_ascendancy_serum" );
   precombat->add_action( "stealth,precombat_seconds=2" );
@@ -289,9 +282,6 @@ void subtlety( player_t* p )
   action_priority_list_t* fill = p->get_action_priority_list( "fill" );
 
   precombat->add_action( "apply_poison" );
-  precombat->add_action( "flask" );
-  precombat->add_action( "augmentation" );
-  precombat->add_action( "food" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=priority_rotation,value=priority_rotation" );
   precombat->add_action( "variable,name=trinket_sync_slot,value=1,if=trinket.1.has_stat.any_dps&(!trinket.2.has_stat.any_dps|trinket.1.is.treacherous_transmitter|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)" );

--- a/engine/class_modules/apl/apl_shaman.cpp
+++ b/engine/class_modules/apl/apl_shaman.cpp
@@ -40,9 +40,6 @@ void elemental( player_t* p )
   action_priority_list_t* aoe = p->get_action_priority_list( "aoe" );
   action_priority_list_t* single_target = p->get_action_priority_list( "single_target" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "flametongue_weapon,if=talent.improved_flametongue_weapon.enabled", "Ensure weapon enchant is applied if you've selected Improved Flametongue Weapon." );
   precombat->add_action( "lightning_shield" );
@@ -134,9 +131,6 @@ void elemental_ptr( player_t* p )
   action_priority_list_t* aoe = p->get_action_priority_list( "aoe" );
   action_priority_list_t* single_target = p->get_action_priority_list( "single_target" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "flametongue_weapon,if=talent.improved_flametongue_weapon.enabled", "Ensure weapon enchant is applied if you've selected Improved Flametongue Weapon." );
   precombat->add_action( "lightning_shield" );

--- a/engine/class_modules/apl/apl_warrior.cpp
+++ b/engine/class_modules/apl/apl_warrior.cpp
@@ -23,9 +23,6 @@ void fury( player_t* p )
   action_priority_list_t* trinkets  = p->get_action_priority_list( "trinkets" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "berserker_stance,toggle=on" );
   precombat->add_action( "variable,name=trinket_1_exclude,value=trinket.1.is.treacherous_transmitter" );
@@ -288,9 +285,6 @@ void arms( player_t* p )
   action_priority_list_t* trinkets = p->get_action_priority_list( "trinkets" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "variable,name=trinket_1_exclude,value=trinket.1.is.treacherous_transmitter" );
   precombat->add_action( "variable,name=trinket_2_exclude,value=trinket.2.is.treacherous_transmitter" );
@@ -513,9 +507,6 @@ void protection( player_t* p )
   action_priority_list_t* aoe = p->get_action_priority_list( "aoe" );
   action_priority_list_t* generic = p->get_action_priority_list( "generic" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "battle_stance,toggle=on" );
 

--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -60,9 +60,6 @@ void arcane( player_t* p )
   action_priority_list_t* sunfury = p->get_action_priority_list( "sunfury" );
   action_priority_list_t* sunfury_aoe = p->get_action_priority_list( "sunfury_aoe" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "arcane_intellect" );
   precombat->add_action( "variable,name=aoe_target_count,op=reset,default=2" );
   precombat->add_action( "variable,name=aoe_target_count,op=set,value=9,if=!talent.arcing_cleave" );
@@ -183,9 +180,6 @@ void fire( player_t* p )
   action_priority_list_t* firestarter_fire_blasts = p->get_action_priority_list( "firestarter_fire_blasts" );
   action_priority_list_t* standard_rotation = p->get_action_priority_list( "standard_rotation" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "arcane_intellect" );
   precombat->add_action( "variable,name=firestarter_combustion,default=-1,value=talent.sun_kings_blessing,if=variable.firestarter_combustion<0", "APL Variable Option: This variable specifies whether Combustion should be used during Firestarter." );
   precombat->add_action( "variable,name=hot_streak_flamestrike,if=variable.hot_streak_flamestrike=0,value=4*(talent.quickflame|talent.flame_patch)+999*(!talent.flame_patch&!talent.quickflame)", "APL Variable Option: This variable specifies the number of targets at which Hot Streak Flamestrikes outside of Combustion should be used." );
@@ -323,9 +317,6 @@ void frost( player_t* p )
   action_priority_list_t* st_ff = p->get_action_priority_list( "st_ff" );
   action_priority_list_t* st_ss = p->get_action_priority_list( "st_ss" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "arcane_intellect" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=boltspam,value=talent.splinterstorm&talent.cold_front&talent.slick_ice&talent.deaths_chill&talent.frozen_touch|talent.frostfire_bolt&talent.deep_shatter&talent.slick_ice&talent.deaths_chill" );

--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -49,9 +49,6 @@ void affliction( player_t* p )
   action_priority_list_t* ogcd = p->get_action_priority_list( "ogcd" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "variable,name=cleave_apl,default=0,op=reset" );
   precombat->add_action( "variable,name=trinket_1_buffs,value=trinket.1.has_use_buff", "Used to set Trinket in slot 1 as Buff Trinkets for the automatic logic" );
@@ -219,9 +216,6 @@ void demonology( player_t* p )
   action_priority_list_t* tyrant = p->get_action_priority_list( "tyrant" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "snapshot_stats" );
   precombat->add_action( "variable,name=first_tyrant_time,op=set,value=12", "Sets the expected Tyrant Setup on pull to take a total 12 seconds long" );
@@ -368,9 +362,6 @@ void destruction( player_t* p )
   action_priority_list_t* ogcd = p->get_action_priority_list( "ogcd" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "summon_pet" );
   precombat->add_action( "variable,name=cleave_apl,default=0,op=reset" );
   precombat->add_action( "variable,name=trinket_1_buffs,value=trinket.1.has_use_buff", "Automatic Logic for Buff Trinkets in Trinket Slot 1" );

--- a/engine/class_modules/paladin/sc_paladin_holy.cpp
+++ b/engine/class_modules/paladin/sc_paladin_holy.cpp
@@ -610,15 +610,6 @@ void paladin_t::generate_action_prio_list_holy_dps()
 {
   action_priority_list_t* precombat = get_action_priority_list( "precombat" );
 
-  // Flask
-  precombat->add_action( "flask" );
-
-  // Food
-  precombat->add_action( "food" );
-
-  // Augmentation
-  precombat->add_action( "augmentation" );
-
   // Snapshot stats
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
 
@@ -685,15 +676,6 @@ void paladin_t::generate_action_prio_list_holy()
 
   // precombat first
   action_priority_list_t* precombat = get_action_priority_list( "precombat" );
-
-  // Flask
-  precombat->add_action( "flask" );
-
-  // Food
-  precombat->add_action( "food" );
-
-  // Augmentation
-  precombat->add_action( "augmentation" );
 
   precombat->add_action( this, "Beacon of Light", "target=healing_target" );
   // Beacon probably goes somewhere here?

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -11525,9 +11525,6 @@ void druid_t::apl_precombat()
   action_priority_list_t* precombat = get_action_priority_list( "precombat" );
 
   // Consumables
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
 }
 

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -13800,11 +13800,6 @@ void shaman_t::init_action_list_enhancement()
 
   // action_priority_list_t* cds              = get_action_priority_list( "cds" );
 
-  // Consumables
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
-
   // Self-buffs
   precombat->add_action( "windfury_weapon" );
   precombat->add_action( "flametongue_weapon" );
@@ -14084,9 +14079,6 @@ void shaman_t::init_action_list_restoration_dps()
   action_priority_list_t* def       = get_action_priority_list( "default" );
 
   // Grabs whatever Elemental is using
-  precombat->add_action( "flask" );
-  precombat->add_action( "food" );
-  precombat->add_action( "augmentation" );
   precombat->add_action( this, "Earth Elemental" );
   precombat->add_action( "snapshot_stats", "Snapshot raid buffed stats before combat begins and pre-potting is done." );
   precombat->add_action( "potion" );

--- a/engine/player/consumable.cpp
+++ b/engine/player/consumable.cpp
@@ -307,11 +307,9 @@ struct health_stone_t : public heal_t
 
 struct flask_base_t : public dbc_consumable_base_t
 {
-  flask_base_t( player_t* p, util::string_view name, util::string_view options_str ) : dbc_consumable_base_t( p, name )
+  flask_base_t( player_t* p, std::string_view name, std::string_view options_str = "" ) : dbc_consumable_base_t(p, name)
   {
-    // Backwards compatibility reasons
     parse_options( options_str );
-
     type = ITEM_SUBCLASS_FLASK;
   }
 
@@ -400,12 +398,12 @@ struct flask_base_t : public dbc_consumable_base_t
 
 struct flask_t : public flask_base_t
 {
-  flask_t( player_t* p, util::string_view options_str ) : flask_base_t( p, "flask", options_str ) {}
+  flask_t( player_t* p ) : flask_base_t( p, "flask" ) {}
 };
 
 struct oralius_whispering_crystal_t : public flask_base_t
 {
-  oralius_whispering_crystal_t( player_t* p, util::string_view options_str )
+  oralius_whispering_crystal_t( player_t* p, std::string_view options_str )
     : flask_base_t( p, "oralius_whispering_crystal", options_str )
   {}
 
@@ -417,7 +415,7 @@ struct oralius_whispering_crystal_t : public flask_base_t
 
 struct crystal_of_insanity_t : public flask_base_t
 {
-  crystal_of_insanity_t( player_t* p, util::string_view options_str )
+  crystal_of_insanity_t( player_t* p, std::string_view options_str  )
     : flask_base_t( p, "crystal_of_insanity", options_str )
   {}
 
@@ -596,10 +594,8 @@ struct potion_t : public dbc_consumable_base_t
 
 struct augmentation_t : public dbc_consumable_base_t
 {
-  augmentation_t( player_t* p, util::string_view options_str ) : dbc_consumable_base_t( p, "augmentation" )
+  augmentation_t( player_t* p ) : dbc_consumable_base_t(p, "augmentation")
   {
-    parse_options( options_str );
-
     type = ITEM_SUBCLASS_CONSUMABLE_OTHER;
   }
 
@@ -676,10 +672,8 @@ static constexpr auto __manual_food_map = util::make_static_map<util::string_vie
 
 struct food_t : public dbc_consumable_base_t
 {
-  food_t( player_t* p, util::string_view options_str ) : dbc_consumable_base_t( p, "food" )
+  food_t( player_t* p ) : dbc_consumable_base_t( p, "food" )
   {
-    parse_options( options_str );
-
     type = ITEM_SUBCLASS_FOOD;
   }
 
@@ -1020,20 +1014,33 @@ bool dbc_consumable_base_t::ready()
 // ==========================================================================
 // consumable_t::create_action
 // ==========================================================================
-
-action_t* consumable::create_action( player_t* p, std::string_view name, std::string_view options_str )
+namespace consumable
 {
-  if ( name == "potion"                   ) return new       potion_t( p, options_str );
-  if ( name == "flask" || name == "phial" ) return new        flask_t( p, options_str );
-  if ( name == "elixir"                   ) return new       elixir_t( p, options_str );
-  if ( name == "food"                     ) return new         food_t( p, options_str );
-  if ( name == "health_stone"             ) return new health_stone_t( p, options_str );
-  if ( name == "mana_potion"              ) return new  mana_potion_t( p, options_str );
-  if ( name == "augmentation"             ) return new augmentation_t( p, options_str );
+action_t* create_action( player_t* p, std::string_view name, std::string_view options_str )
+{
+  if ( name == "potion" )
+    return new potion_t( p, options_str );
+  if ( name == "elixir" )
+    return new elixir_t( p, options_str );
+  if ( name == "health_stone" )
+    return new health_stone_t( p, options_str );
+  if ( name == "mana_potion" )
+    return new mana_potion_t( p, options_str );
 
   // Misc consumables
-  if ( name == "oralius_whispering_crystal" ) return new oralius_whispering_crystal_t( p, options_str );
-  if ( name == "crystal_of_insanity"        ) return new        crystal_of_insanity_t( p, options_str );
+  if ( name == "oralius_whispering_crystal" )
+    return new oralius_whispering_crystal_t( p, options_str );
+  if ( name == "crystal_of_insanity" )
+    return new crystal_of_insanity_t( p, options_str );
 
   return nullptr;
 }
+
+void create_consumeable_actions( player_t* p )
+{
+  // Create consumable actions for effects without APL actions
+  new food_t( p );
+  new flask_t( p );
+  new augmentation_t( p );
+}
+}  // namespace consumable

--- a/engine/player/consumable.cpp
+++ b/engine/player/consumable.cpp
@@ -1039,8 +1039,8 @@ action_t* create_action( player_t* p, std::string_view name, std::string_view op
 void create_consumeable_actions( player_t* p )
 {
   // Create consumable actions for effects without APL actions
-  new food_t( p );
-  new flask_t( p );
-  new augmentation_t( p );
+  p->consumables.food_action = new food_t( p );
+  p->consumables.flask_action = new flask_t( p );
+  p->consumables.augmentation_action = new augmentation_t( p );
 }
 }  // namespace consumable

--- a/engine/player/consumable.cpp
+++ b/engine/player/consumable.cpp
@@ -1020,8 +1020,7 @@ action_t* create_action( player_t* p, std::string_view name, std::string_view op
 {
   if ( name == "flask" || name == "phial" )
   {
-    if ( p->sim->thread_index == 0 )
-      printf( "Flask Action has been depreciated and is no longer needed in the Precombat APL\n" );
+    p->sim->error( "Flask Action has been depreciated and is no longer needed in the Precombat APL\n" );
     // Since the buff was already triggered early in player_t::arise(), its safe to return the action here
     // as flask_t::ready() checks if the buff is already active. This prevents the sim from erroring out
     // due to failing to "create" the action.
@@ -1029,8 +1028,7 @@ action_t* create_action( player_t* p, std::string_view name, std::string_view op
   }
   if ( name == "food" )
   {
-    if ( p->sim->thread_index == 0 )
-      printf( "Food Action has been depreciated and is no longer needed in the Precombat APL\n" );
+    p->sim->error( "Food Action has been depreciated and is no longer needed in the Precombat APL\n" );
     // Since the buff was already triggered early in player_t::arise(), its safe to return the action here
     // as food_t::ready() checks if the buff is already active. This prevents the sim from erroring out
     // due to failing to "create" the action.
@@ -1038,8 +1036,7 @@ action_t* create_action( player_t* p, std::string_view name, std::string_view op
   }
   if ( name == "augmentation" )
   {
-    if ( p->sim->thread_index == 0 )
-      printf( "Augmentation Rune Action has been depreciated and is no longer needed in the Precombat APL\n" );
+    p->sim->error( "Augmentation Rune Action has been depreciated and is no longer needed in the Precombat APL\n" );
     // Since the buff was already triggered early in player_t::arise(), its safe to return the action here
     // as augmentation_t::ready() checks if the buff is already active. This prevents the sim from erroring out
     // due to failing to "create" the action.

--- a/engine/player/consumable.cpp
+++ b/engine/player/consumable.cpp
@@ -1018,6 +1018,34 @@ namespace consumable
 {
 action_t* create_action( player_t* p, std::string_view name, std::string_view options_str )
 {
+  if ( name == "flask" || name == "phial" )
+  {
+    if ( p->sim->thread_index == 0 )
+      printf( "Flask Action has been depreciated and is no longer needed in the Precombat APL\n" );
+    // Since the buff was already triggered early in player_t::arise(), its safe to return the action here
+    // as flask_t::ready() checks if the buff is already active. This prevents the sim from erroring out
+    // due to failing to "create" the action.
+    return p->consumables.flask_action;
+  }
+  if ( name == "food" )
+  {
+    if ( p->sim->thread_index == 0 )
+      printf( "Food Action has been depreciated and is no longer needed in the Precombat APL\n" );
+    // Since the buff was already triggered early in player_t::arise(), its safe to return the action here
+    // as food_t::ready() checks if the buff is already active. This prevents the sim from erroring out
+    // due to failing to "create" the action.
+    return p->consumables.food_action;
+  }
+  if ( name == "augmentation" )
+  {
+    if ( p->sim->thread_index == 0 )
+      printf( "Augmentation Rune Action has been depreciated and is no longer needed in the Precombat APL\n" );
+    // Since the buff was already triggered early in player_t::arise(), its safe to return the action here
+    // as augmentation_t::ready() checks if the buff is already active. This prevents the sim from erroring out
+    // due to failing to "create" the action.
+    return p->consumables.augmentation_action;
+  }
+
   if ( name == "potion" )
     return new potion_t( p, options_str );
   if ( name == "elixir" )

--- a/engine/player/consumable.hpp
+++ b/engine/player/consumable.hpp
@@ -72,4 +72,5 @@ struct consumable_buff_t : public BASE, public consumable_buff_item_data_t
 namespace consumable
 {
 action_t* create_action( player_t*, std::string_view name, std::string_view options );
+void create_consumeable_actions( player_t* );
 }  // namespace consumable

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -6592,11 +6592,11 @@ void player_t::arise()
 
   current_auto_attack_speed = cache.auto_attack_speed();
 
-  if ( consumables.flask )
+  if ( consumables.flask && consumables.flask_action )
     consumables.flask_action->execute();
-  if ( consumables.food )
+  if ( consumables.food && consumables.food_action )
     consumables.food_action->execute();
-  if ( consumables.augmentation )
+  if ( consumables.augmentation && consumables.augmentation_action )
     consumables.augmentation_action->execute();
 
   // Requires index-based lookup since on-arise callbacks may

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -6593,11 +6593,11 @@ void player_t::arise()
   current_auto_attack_speed = cache.auto_attack_speed();
 
   if ( consumables.flask )
-    consumables.flask->trigger();
+    consumables.flask_action->execute();
   if ( consumables.food )
-    consumables.food->trigger();
+    consumables.food_action->execute();
   if ( consumables.augmentation )
-    consumables.augmentation->trigger();
+    consumables.augmentation_action->execute();
 
   // Requires index-based lookup since on-arise callbacks may
   // insert new on-arise callbacks to the vector.

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -2,7 +2,6 @@
 // Dedmonwakeen's Raid DPS/TPS Simulator.
 // Send questions to natehieter@gmail.com
 // ==========================================================================
-
 #include "player.hpp"
 
 #include "action/action.hpp"
@@ -3381,6 +3380,9 @@ void player_t::init_background_actions()
 
 void player_t::create_actions()
 {
+  if( is_player() && !is_enemy() && !is_pet() )
+    consumable::create_consumeable_actions( this );
+
   if ( action_list_str.empty() )
     no_action_list_provided = true;
 
@@ -6589,6 +6591,13 @@ void player_t::arise()
   }
 
   current_auto_attack_speed = cache.auto_attack_speed();
+
+  if ( consumables.flask )
+    consumables.flask->trigger();
+  if ( consumables.food )
+    consumables.food->trigger();
+  if ( consumables.augmentation )
+    consumables.augmentation->trigger();
 
   // Requires index-based lookup since on-arise callbacks may
   // insert new on-arise callbacks to the vector.

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12830,6 +12830,8 @@ void player_t::create_options()
                          thewarwithin_opts.mereldars_toll_ally_trigger_chance, 0, 1 ) );
   add_option( opt_float( "thewarwithin.sureki_zealots_insignia_rppm_multiplier",
                          thewarwithin_opts.sureki_zealots_insignia_rppm_multiplier, 0, 1 ) );
+  add_option( opt_string( "thewarwithin.windsingers_passive_stat",
+                          thewarwithin_opts.windsingers_passive_stat ) );
 }
 
 player_t* player_t::create( sim_t*, const player_description_t& )

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -879,6 +879,7 @@ struct player_t : public actor_t
     // currently bugged to trigger on them.
     double mereldars_toll_ally_trigger_chance = 0.7;
     double sureki_zealots_insignia_rppm_multiplier = 0.9;
+    player_option_t<std::string> windsingers_passive_stat = "";
   } thewarwithin_opts;
 
 private:

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -434,6 +434,10 @@ struct player_t : public actor_t
     stat_buff_t* battle_elixir;
     buff_t* food;
     buff_t* augmentation;
+
+    action_t* flask_action;
+    action_t* food_action;
+    action_t* augmentation_action;
   } consumables;
 
   struct buffs_t

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6637,35 +6637,29 @@ void fathomdwellers_runed_citrine( special_effect_t& effect )
                   ->add_stat_from_effect( 1, stat_value );
 
   effect.player->register_on_arise_callback( effect.player, [ buff ] { buff->trigger(); } );
-  /*TODO: This all Likely needs to be run after flask and food, but before effects like Ovinax are applied.
-  In game it will snapshot on player arise, equiping the ring, or when changing zones.
-  Due to this behavior its fairly safe to assume in raids, players will spend most of the time
-  with its value calculated at that point. */
-  effect.player->register_precombat_begin( []( player_t* p ) {
-    make_event( *p->sim, 0_ms, [ p ] {
-      auto stormbringer = buff_t::find( p, "stormbringers_runed_citrine", p );
-      // TODO: Check if highest stat has changed after flask and food have been applied. If so, flip Windsinger's buff
-      // to that stat.
-      std::string suffix          = util::stat_type_abbrev( util::highest_stat( p, secondary_ratings ) );
-      std::string windsinger_name = "windsingers_runed_citrine_" + suffix;
-      auto windsinger             = buff_t::find( p, windsinger_name, p );
-      p->sim->print_debug( "Fathomdwellers Runed Citrine is active: Recalculating passive buffs" );
-      p->sim->print_debug( "Stormbringers Runed Citrine: {}", stormbringer ? "Found" : "Not Found" );
-      p->sim->print_debug( "Windsingers Runed Citrine: {}", windsinger ? "Found" : "Not Found" );
-      for ( int i = 0; i < 3; i++ )
+  effect.player->precombat_begin_functions.insert( effect.player->precombat_begin_functions.begin(), []( player_t* p ) {
+    auto stormbringer = buff_t::find( p, "stormbringers_runed_citrine", p );
+    // TODO: Check if highest stat has changed after flask and food have been applied. If so, flip Windsinger's
+    // buff to that stat.
+    std::string suffix          = util::stat_type_abbrev( util::highest_stat( p, secondary_ratings ) );
+    std::string windsinger_name = "windsingers_runed_citrine_" + suffix;
+    auto windsinger             = buff_t::find( p, windsinger_name, p );
+    p->sim->print_debug( "Fathomdwellers Runed Citrine is active: Recalculating passive buffs" );
+    p->sim->print_debug( "Stormbringers Runed Citrine: {}", stormbringer ? "Found" : "Not Found" );
+    p->sim->print_debug( "Windsingers Runed Citrine: {}", windsinger ? "Found" : "Not Found" );
+    for ( int i = 0; i < 3; i++ )
+    {
+      if ( windsinger && windsinger->check() )
       {
-        if ( windsinger && windsinger->check() )
-        {
-          p->sim->print_debug( "Recalculating Windsinger's Runed Citrine Value" );
-          debug_cast<stat_buff_current_value_t*>( windsinger )->force_recalculate();
-        }
-        if ( stormbringer && stormbringer->check() )
-        {
-          p->sim->print_debug( "Recalculating Stormbringer's Runed Citrine Value" );
-          debug_cast<stat_buff_current_value_t*>( stormbringer )->force_recalculate();
-        }
+        p->sim->print_debug( "Recalculating Windsinger's Runed Citrine Value" );
+        debug_cast<stat_buff_current_value_t*>( windsinger )->force_recalculate();
       }
-    } );
+      if ( stormbringer && stormbringer->check() )
+      {
+        p->sim->print_debug( "Recalculating Stormbringer's Runed Citrine Value" );
+        debug_cast<stat_buff_current_value_t*>( stormbringer )->force_recalculate();
+      }
+    }
   } );
 }
 

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6614,9 +6614,26 @@ void windsingers_runed_citrine( special_effect_t& effect )
                                                       b->default_value = stat_value;
                                                       buffs[ s ]       = b;
                                                     } );
+  const auto& desired_stat = effect.player->thewarwithin_opts.windsingers_passive_stat;
+  stat_e stat              = STAT_NONE;
+  if ( util::str_compare_ci( desired_stat, "haste" ) )
+    stat = STAT_HASTE_RATING;
 
-  effect.player->register_on_arise_callback(
-      effect.player, [ &, buffs ] { buffs.at( util::highest_stat( effect.player, secondary_ratings ) )->trigger(); } );
+  if ( util::str_compare_ci( desired_stat, "mastery" ) )
+    stat = STAT_MASTERY_RATING;
+
+  if ( util::str_compare_ci( desired_stat, "critical_strike" ) || util::str_compare_ci( desired_stat, "crit" ) )
+    stat = STAT_CRIT_RATING;
+
+  if ( util::str_compare_ci( desired_stat, "versatility" ) || util::str_compare_ci( desired_stat, "vers" ) )
+    stat = STAT_VERSATILITY_RATING;
+
+  if ( stat != STAT_NONE )
+    effect.player->register_on_arise_callback( effect.player, [ buffs, stat ] { buffs.at( stat )->trigger(); } );
+  else
+    effect.player->register_on_arise_callback( effect.player, [ &, buffs ] {
+      buffs.at( util::highest_stat( effect.player, secondary_ratings ) )->trigger();
+    } );
 }
 
 /** Fathomdwellers Runed Citrine

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6653,11 +6653,28 @@ void fathomdwellers_runed_citrine( special_effect_t& effect )
   auto buff = create_buff<stat_buff_t>( effect.player, "fathomdwellers_runed_citrine", effect.driver() )
                   ->add_stat_from_effect( 1, stat_value );
 
+  const auto& desired_stat = effect.player->thewarwithin_opts.windsingers_passive_stat;
+  std::string suffix = "";
+  if ( util::str_compare_ci( desired_stat, "haste" ) )
+    suffix = "Haste";
+
+  if ( util::str_compare_ci( desired_stat, "mastery" ) )
+    suffix = "Mastery";
+
+  if ( util::str_compare_ci( desired_stat, "critical_strike" ) || util::str_compare_ci( desired_stat, "crit" ) )
+    suffix = "Crit";
+
+  if ( util::str_compare_ci( desired_stat, "versatility" ) || util::str_compare_ci( desired_stat, "vers" ) )
+    suffix = "Vers";
+
   effect.player->register_on_arise_callback( effect.player, [ buff ] { buff->trigger(); } );
-  effect.player->precombat_begin_functions.insert( effect.player->precombat_begin_functions.begin(), []( player_t* p ) {
+  effect.player->precombat_begin_functions.insert( effect.player->precombat_begin_functions.begin(), [ &, suffix ]( player_t* p ) {
     auto stormbringer = buff_t::find( p, "stormbringers_runed_citrine", p );
-    std::string suffix          = util::stat_type_abbrev( util::highest_stat( p, secondary_ratings ) );
-    std::string windsinger_name = "windsingers_runed_citrine_" + suffix;
+    std::string windsinger_name = "windsingers_runed_citrine_";
+    if ( suffix == "" )
+      windsinger_name += util::stat_type_abbrev( util::highest_stat( p, secondary_ratings ) );
+    else
+      windsinger_name += suffix;
     auto windsinger             = buff_t::find( p, windsinger_name, p );
     p->sim->print_debug( "Fathomdwellers Runed Citrine is active: Recalculating passive buffs" );
     p->sim->print_debug( "Stormbringers Runed Citrine: {}", stormbringer ? "Found" : "Not Found" );

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6639,8 +6639,6 @@ void fathomdwellers_runed_citrine( special_effect_t& effect )
   effect.player->register_on_arise_callback( effect.player, [ buff ] { buff->trigger(); } );
   effect.player->precombat_begin_functions.insert( effect.player->precombat_begin_functions.begin(), []( player_t* p ) {
     auto stormbringer = buff_t::find( p, "stormbringers_runed_citrine", p );
-    // TODO: Check if highest stat has changed after flask and food have been applied. If so, flip Windsinger's
-    // buff to that stat.
     std::string suffix          = util::stat_type_abbrev( util::highest_stat( p, secondary_ratings ) );
     std::string windsinger_name = "windsingers_runed_citrine_" + suffix;
     auto windsinger             = buff_t::find( p, windsinger_name, p );


### PR DESCRIPTION
Fixes the order of event issues present due to the Singing Citrine effects. In order to accomplish this, i've removed the APL action accessibility for Flask, Food and Augmentation actions and instead trigger them early in `player_t::arise()`. This is a requirement due to the APL actions being called after precombat_callbacks that are often utilized to apply effects that will utilize the players current state on combat entry, which will include flask, food, and augment rune effects.

May also change the results with effects like Ovinax's Mercurial Egg, if the stat provided by flask or food changes the highest secondary stat, as before this wouldn't be updated until the first tick.