### PR TITLE
[Warlock][Diabolist] Adds Flame of Xoroth to Guardians and a small change in effect order.

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -363,11 +363,8 @@ double warlock_t::composite_player_pet_damage_multiplier( const action_state_t* 
       m *= 1.0 + talents.summoners_embrace->effectN( 2 ).percent();
   }
 
-  if ( hero.flames_of_xoroth.ok() && !guardian )
-    m *= 1.0 + hero.flames_of_xoroth->effectN( 4 ).percent();
-
-   if ( hero.flames_of_xoroth.ok() && guardian )
-    m *= 1.0 + hero.flames_of_xoroth->effectN( 3 ).percent();
+  if ( hero.flames_of_xoroth.ok() )
+    m *= 1.0 + hero.flames_of_xoroth->effectN( guardian ? 3 : 4 ).percent();
 
   if ( hero.abyssal_dominion.ok() && buffs.abyssal_dominion->check() )
     m *= 1.0 + hero.abyssal_dominion_buff->effectN( guardian ? 1 : 2 ).percent();

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -364,6 +364,9 @@ double warlock_t::composite_player_pet_damage_multiplier( const action_state_t* 
   }
 
   if ( hero.flames_of_xoroth.ok() && !guardian )
+    m *= 1.0 + hero.flames_of_xoroth->effectN( 4 ).percent();
+
+   if ( hero.flames_of_xoroth.ok() && guardian )
     m *= 1.0 + hero.flames_of_xoroth->effectN( 3 ).percent();
 
   if ( hero.abyssal_dominion.ok() && buffs.abyssal_dominion->check() )


### PR DESCRIPTION
Attempt at adding Flame of Xoroth damage modifier to Guardian Pets,  additionally, i noticed the effect 4 is the one responsible to buffing primary pet, and effect 3 is for guardians. 

I  hope i have done this right...