### PR TITLE
Fix comment typo in warlock_demonology.simc

### DIFF
--- a/ActionPriorityLists/warlock_demonology.simc
+++ b/ActionPriorityLists/warlock_demonology.simc
@@ -18,7 +18,7 @@ actions.precombat+=/variable,name=first_tyrant_time,op=add,value=action.summon_v
 actions.precombat+=/variable,name=first_tyrant_time,op=add,value=gcd.max,if=talent.grimoire_felguard.enabled|talent.summon_vilefiend.enabled
 # Accounts for Tyrant own Cast Time and an additional Shadowbolt cast time
 actions.precombat+=/variable,name=first_tyrant_time,op=sub,value=action.summon_demonic_tyrant.execute_time+action.shadow_bolt.execute_time
-# Sets an absolute minimun of 10s for the First Tyrant Setup
+# Sets an absolute minimum of 10s for the First Tyrant Setup
 actions.precombat+=/variable,name=first_tyrant_time,op=min,value=10
 actions.precombat+=/variable,name=in_opener,op=set,value=1
 # Defines if the the Trinket 1 is a buff Trinket in the trinket logic


### PR DESCRIPTION
Taking a look at the Simc codebase to see where I can help contribute and found a small typo in demo lock's APL. Feel free to close if its too minor to care about.