### PR TITLE
[ele] Restructure&Update AoE APL, fix 2 min Asc for st

### DIFF
--- a/engine/class_modules/apl/shaman/elemental.simc
+++ b/engine/class_modules/apl/shaman/elemental.simc
@@ -146,4 +146,3 @@ actions.single_target+=/flame_shock,moving=1,target_if=refreshable
 actions.single_target+=/flame_shock,moving=1,if=movement.distance>6
 # Frost Shock is our movement filler.
 actions.single_target+=/frost_shock,moving=1
-

--- a/engine/class_modules/apl/shaman/elemental.simc
+++ b/engine/class_modules/apl/shaman/elemental.simc
@@ -22,8 +22,8 @@ actions+=/blood_fury,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.a
 actions+=/berserking,if=!talent.ascendance.enabled|buff.ascendance.up
 actions+=/fireblood,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50
 actions+=/ancestral_call,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50
-actions+=/use_item,slot=trinket1,if=!variable.spymaster_in_1st|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25|buff.spymasters_report.stack<5)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.stormkeeper.up&cooldown.stormkeeper.remains>40|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
-actions+=/use_item,slot=trinket2,if=!variable.spymaster_in_2nd|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25|buff.spymasters_report.stack<5)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.stormkeeper.up&cooldown.stormkeeper.remains>40|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
+actions+=/use_item,slot=trinket1,if=!variable.spymaster_in_1st|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
+actions+=/use_item,slot=trinket2,if=!variable.spymaster_in_2nd|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
 actions+=/use_item,slot=main_hand
 actions+=/lightning_shield,if=buff.lightning_shield.down
 actions+=/natures_swiftness
@@ -37,50 +37,64 @@ actions.aoe=fire_elemental
 actions.aoe+=/storm_elemental
 actions.aoe+=/stormkeeper
 
-# Reset LMT CD as early as possible. Always for Fire, only if you can dot up 3 more targets for Lightning.
-actions.aoe+=/totemic_recall,if=cooldown.liquid_magma_totem.remains>15&(active_dot.flame_shock<(spell_targets.chain_lightning>?6)-2|talent.fire_elemental.enabled)
-actions.aoe+=/liquid_magma_totem,if=cooldown.ascendance.remains>15&!buff.ascendance.up
-
 # Spread Flame Shock via Primordial Wave using Surge of Power if possible.
-actions.aoe+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=buff.surge_of_power.up|!talent.surge_of_power.enabled|maelstrom<60-5*talent.eye_of_the_storm.enabled
+actions.aoe+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=buff.surge_of_power.up|!talent.surge_of_power|maelstrom<60-5*talent.eye_of_the_storm
 actions.aoe+=/ancestral_swiftness
+actions.aoe+=/liquid_magma_totem,if=buff.primordial_wave.up&buff.call_of_the_ancestors.up&!buff.ascendance.up
 
 # JUST DO IT! https://i.kym-cdn.com/entries/icons/mobile/000/018/147/Shia_LaBeouf__Just_Do_It__Motivational_Speech_(Original_Video_by_LaBeouf__R%C3%B6nkk%C3%B6___Turner)_0-4_screenshot.jpg
-actions.aoe+=/ascendance
+actions.aoe+=/ascendance,if=(time<10|buff.spymasters_web.up|talent.first_ascendant|!(variable.spymaster_in_1st|variable.spymaster_in_2nd))&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)
 
-# Spread Flame Shock using Surge of Power if LMT is not picked.
-actions.aoe+=/flame_shock,target_if=refreshable,if=buff.surge_of_power.up&dot.flame_shock.remains<target.time_to_die-16&active_dot.flame_shock<(spell_targets.chain_lightning>?6)&!talent.liquid_magma_totem.enabled
-# Spread and refresh Flame Shock using Surge of Power (if talented) up to 6.
-actions.aoe+=/flame_shock,target_if=refreshable,if=talent.fire_elemental.enabled&(buff.surge_of_power.up|!talent.surge_of_power.enabled)&dot.flame_shock.remains<target.time_to_die-5&(active_dot.flame_shock<6|dot.flame_shock.remains>0)
+# Add more Flame shocks for better Pwave value.
+actions.aoe+=/liquid_magma_totem,if=buff.primordial_wave.up&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))
+actions.aoe+=/flame_shock,target_if=min:dot.flame_shock.remains,if=buff.primordial_wave.up&active_dot.flame_shock<2&spell_targets.chain_lightning<=3
 
-#Buff Tempest with SoP or LB if two target
-actions.aoe+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up&(buff.surge_of_power.up|!talent.surge_of_power.enabled)
+# Surge of Power is strong and should be used. ©
+actions.aoe+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up&(buff.surge_of_power.up|!talent.surge_of_power)
 actions.aoe+=/lightning_bolt,if=buff.stormkeeper.up&buff.surge_of_power.up&spell_targets.chain_lightning=2
-
-# Against 6 targets or more Surge of Power should be used with Chain Lightning rather than Lava Burst.
 actions.aoe+=/chain_lightning,if=active_enemies>=6&buff.surge_of_power.up
-# Consume Primordial Wave buff immediately if you have Stormkeeper buff, fighting 6+ enemies and need maelstrom to spend.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up&(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&maelstrom<60-5*talent.eye_of_the_storm.enabled&talent.surge_of_power.enabled
-# Cast Lava burst to consume Primordial Wave proc. Wait for Lava Surge proc if possible.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up
-# *{Fire} Use Lava Surge proc to buff <anything> with Master of the Elements.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&!buff.master_of_the_elements.up&talent.master_of_the_elements.enabled&talent.fire_elemental.enabled
 
-#Two Target
-actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=spell_targets.chain_lightning=2&(maelstrom>variable.mael_cap-30|cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
+# Cast Lava burst to consume Primordial Wave proc.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=buff.primordial_wave.up&(maelstrom<variable.mael_cap-10*(active_dot.flame_shock+1)|buff.primordial_wave.remains<4)
+
+actions.aoe+=/chain_lightning,if=buff.storm_frenzy.stack=2&!talent.surge_of_power&maelstrom<variable.mael_cap-(15+buff.stormkeeper.up*spell_targets.chain_lightning*spell_targets.chain_lightning)
+
 # Activate Surge of Power if next global is Primordial wave. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# Spend if all Lightning Rods ran out or you are close to overcaping. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=(lightning_rod=0&talent.lightning_rod.enabled|maelstrom>variable.mael_cap-30)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# Spend to buff your follow-up Stormkeeper with Surge of Power on 6+ targets. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# Use the talents you selected. Spread Lightning Rod to as many targets as possible.
-actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_eb.up&(lightning_rod=0|maelstrom>variable.mael_cap-30|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
-actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_es.up&(lightning_rod=0|maelstrom>variable.mael_cap-30|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
-# Use Icefury for Fusion of Elements proc.
-actions.aoe+=/icefury,if=talent.fusion_of_elements.enabled&!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)&(cooldown.primordial_wave.remains<5|((spell_targets.chain_lightning=2|(!spell_targets.chain_lightning>=5&talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_eb.up))&talent.elemental_blast.enabled))
-# *{Fire} Proc Master of the Elements outside Ascendance.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.master_of_the_elements.enabled&!buff.master_of_the_elements.up&!buff.ascendance.up&talent.fire_elemental.enabled
+actions.aoe+=/earthquake,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+# Use Lava Surge procs to consume fire part of fusion if you can also buff Earthquake with it.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&buff.fusion_of_elements_fire.up&!buff.master_of_the_elements.up&(maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering))
+
+# Spend if you are close to cap, Master of the Elements buff is up or Ascendance is about to expire.
+actions.aoe+=/earthquake,if=(maelstrom>variable.mael_cap-10*(spell_targets.chain_lightning+1)|buff.master_of_the_elements.up|buff.ascendance.up&buff.ascendance.remains<3|fight_remains<5)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=(maelstrom>variable.mael_cap-10*(spell_targets.chain_lightning+1)|buff.master_of_the_elements.up|buff.ascendance.up&buff.ascendance.remains<3|fight_remains<5)&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=(maelstrom>variable.mael_cap-10*(spell_targets.chain_lightning+1)|buff.master_of_the_elements.up|buff.ascendance.up&buff.ascendance.remains<3|fight_remains<5)&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+# Spend to spread Lightning Rod if Tempest or Stormkeeper is up.
+actions.aoe+=/earthquake,if=talent.lightning_rod&lightning_rod<active_enemies&(buff.stormkeeper.up|buff.tempest.up|!talent.surge_of_power)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=talent.lightning_rod&lightning_rod<active_enemies&(buff.stormkeeper.up|buff.tempest.up|!talent.surge_of_power)&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=talent.lightning_rod&lightning_rod<active_enemies&(buff.stormkeeper.up|buff.tempest.up|!talent.surge_of_power)&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+# Use Icefury to proc Fusion of Elements.
+actions.aoe+=/icefury,if=talent.fusion_of_elements&!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)
+
+# [2-3t] Use Lava Surge procs to buff <anything> with MotE on 2-3 targets.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&!buff.master_of_the_elements.up&talent.master_of_the_elements&active_enemies<=3
+# [2-3t]{Farseer} Use all Lava bursts to buff spenders, SK_CL and Tempest with MotE on 2-3 targets if not talented into Lightning Rod.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>execute_time,if=!buff.master_of_the_elements.up&talent.master_of_the_elements&(buff.stormkeeper.up|buff.tempest.up|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))&active_enemies<=3&!talent.lightning_rod&talent.call_of_the_ancestors
+# [2t] Use all Lava bursts to buff <anything> with MotE on 2 targets.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>execute_time,if=!buff.master_of_the_elements.up&active_enemies=2
+actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=active_dot.flame_shock=0&buff.fusion_of_elements_fire.up&!talent.primordial_wave
+
+# Spend to buff SK_CL (on 6+) or Tempest with SoP.
+actions.aoe+=/earthquake,if=((buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=((buff.stormkeeper.up&active_enemies>=6|buff.tempest.up)&talent.surge_of_power)&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=((buff.stormkeeper.up&active_enemies>=6|buff.tempest.up)&talent.surge_of_power)&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+actions.aoe+=/frost_shock,if=buff.icefury_dmg.up&!buff.ascendance.up&!buff.stormkeeper.up&(active_enemies=2|talent.call_of_the_ancestors)
+
 actions.aoe+=/chain_lightning
 actions.aoe+=/flame_shock,moving=1,target_if=refreshable
 actions.aoe+=/frost_shock,moving=1
@@ -93,15 +107,13 @@ actions.single_target+=/stormkeeper
 # Use Primordial Wave as much as possible.
 actions.single_target+=/primordial_wave,if=!buff.surge_of_power.up
 actions.single_target+=/ancestral_swiftness
-actions.single_target+=/ascendance,if=(time<10|buff.spymasters_web.up|!(variable.spymaster_in_1st|variable.spymaster_in_2nd))&(buff.stormkeeper.up&cooldown.stormkeeper.remains>40|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)
+actions.single_target+=/ascendance,if=(time<10|buff.spymasters_web.up|talent.first_ascendant|!(variable.spymaster_in_1st|variable.spymaster_in_2nd))&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)
 
 # Surge of Power is strong and should be used.©
 actions.single_target+=/tempest,if=buff.surge_of_power.up
 actions.single_target+=/lightning_bolt,if=buff.surge_of_power.up
 
-# Dont waste Storm Frenzy (minimal gain).
 actions.single_target+=/tempest,if=buff.storm_frenzy.stack=2&!talent.surge_of_power.enabled
-actions.single_target+=/lightning_bolt,if=buff.storm_frenzy.stack=2&!talent.surge_of_power.enabled
 
 # Use LMT to apply Flame Shock.
 actions.single_target+=/liquid_magma_totem,if=dot.flame_shock.refreshable&!buff.master_of_the_elements.up&cooldown.primordial_wave.remains>dot.flame_shock.remains+3
@@ -118,7 +130,7 @@ actions.single_target+=/earth_shock,if=maelstrom>variable.mael_cap-15|buff.maste
 # Use Icefury to proc Fusion of Elements.
 actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)
 # Use Lava Burst to proc Master of the Elements.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>=execute_time,if=!buff.master_of_the_elements.up&(!talent.master_of_the_elements|buff.lava_surge.up|cooldown.lava_burst.charges_fractional>1.5|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>=execute_time,if=!buff.master_of_the_elements.up&(!talent.master_of_the_elements|buff.lava_surge.up|buff.tempest.up|cooldown.lava_burst.charges_fractional>1.8|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))
 
 # Spend to activate Surge of Power buff for Tempest or Stormkeeper.
 actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
@@ -126,7 +138,7 @@ actions.single_target+=/elemental_blast,if=(buff.tempest.up|buff.stormkeeper.up)
 actions.single_target+=/earth_shock,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 
 actions.single_target+=/tempest
-#Use Icefury-empowered Frost Shocks outside of Ascendance (neutral to minimal gain).
+# Use Icefury-empowered Frost Shocks outside of Ascendance.
 actions.single_target+=/frost_shock,if=buff.icefury_dmg.up&!buff.ascendance.up&!buff.stormkeeper.up
 # Filler spell. Always available. Always the bottom line.
 actions.single_target+=/lightning_bolt
@@ -134,3 +146,4 @@ actions.single_target+=/flame_shock,moving=1,target_if=refreshable
 actions.single_target+=/flame_shock,moving=1,if=movement.distance>6
 # Frost Shock is our movement filler.
 actions.single_target+=/frost_shock,moving=1
+

--- a/engine/class_modules/apl/shaman/elemental_ptr.simc
+++ b/engine/class_modules/apl/shaman/elemental_ptr.simc
@@ -22,8 +22,8 @@ actions+=/blood_fury,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.a
 actions+=/berserking,if=!talent.ascendance.enabled|buff.ascendance.up
 actions+=/fireblood,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50
 actions+=/ancestral_call,if=!talent.ascendance.enabled|buff.ascendance.up|cooldown.ascendance.remains>50
-actions+=/use_item,slot=trinket1,if=!variable.spymaster_in_1st|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25|buff.spymasters_report.stack<5)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.stormkeeper.up&cooldown.stormkeeper.remains>40|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
-actions+=/use_item,slot=trinket2,if=!variable.spymaster_in_2nd|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25|buff.spymasters_report.stack<5)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.stormkeeper.up&cooldown.stormkeeper.remains>40|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
+actions+=/use_item,slot=trinket1,if=!variable.spymaster_in_1st|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
+actions+=/use_item,slot=trinket2,if=!variable.spymaster_in_2nd|(fight_remains>180-60*talent.first_ascendant&(buff.spymasters_report.stack>25)|buff.spymasters_report.stack>35|fight_remains<80)&cooldown.ascendance.ready&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)|fight_remains<21
 actions+=/use_item,slot=main_hand
 actions+=/lightning_shield,if=buff.lightning_shield.down
 actions+=/natures_swiftness
@@ -37,50 +37,64 @@ actions.aoe=fire_elemental
 actions.aoe+=/storm_elemental
 actions.aoe+=/stormkeeper
 
-# Reset LMT CD as early as possible. Always for Fire, only if you can dot up 3 more targets for Lightning.
-actions.aoe+=/totemic_recall,if=cooldown.liquid_magma_totem.remains>15&(active_dot.flame_shock<(spell_targets.chain_lightning>?6)-2|talent.fire_elemental.enabled)
-actions.aoe+=/liquid_magma_totem,if=cooldown.ascendance.remains>15&!buff.ascendance.up
-
 # Spread Flame Shock via Primordial Wave using Surge of Power if possible.
-actions.aoe+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=buff.surge_of_power.up|!talent.surge_of_power.enabled|maelstrom<60-5*talent.eye_of_the_storm.enabled
+actions.aoe+=/primordial_wave,target_if=min:dot.flame_shock.remains,if=buff.surge_of_power.up|!talent.surge_of_power|maelstrom<60-5*talent.eye_of_the_storm
 actions.aoe+=/ancestral_swiftness
+actions.aoe+=/liquid_magma_totem,if=buff.primordial_wave.up&buff.call_of_the_ancestors.up&!buff.ascendance.up
 
 # JUST DO IT! https://i.kym-cdn.com/entries/icons/mobile/000/018/147/Shia_LaBeouf__Just_Do_It__Motivational_Speech_(Original_Video_by_LaBeouf__R%C3%B6nkk%C3%B6___Turner)_0-4_screenshot.jpg
-actions.aoe+=/ascendance
+actions.aoe+=/ascendance,if=(time<10|buff.spymasters_web.up|talent.first_ascendant|!(variable.spymaster_in_1st|variable.spymaster_in_2nd))&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)
 
-# Spread Flame Shock using Surge of Power if LMT is not picked.
-actions.aoe+=/flame_shock,target_if=refreshable,if=buff.surge_of_power.up&dot.flame_shock.remains<target.time_to_die-16&active_dot.flame_shock<(spell_targets.chain_lightning>?6)&!talent.liquid_magma_totem.enabled
-# Spread and refresh Flame Shock using Surge of Power (if talented) up to 6.
-actions.aoe+=/flame_shock,target_if=refreshable,if=talent.fire_elemental.enabled&(buff.surge_of_power.up|!talent.surge_of_power.enabled)&dot.flame_shock.remains<target.time_to_die-5&(active_dot.flame_shock<6|dot.flame_shock.remains>0)
+# Add more Flame shocks for better Pwave value.
+actions.aoe+=/liquid_magma_totem,if=buff.primordial_wave.up&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))
+actions.aoe+=/flame_shock,target_if=min:dot.flame_shock.remains,if=buff.primordial_wave.up&active_dot.flame_shock<2&spell_targets.chain_lightning<=3
 
-#Buff Tempest with SoP or LB if two target
-actions.aoe+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up&(buff.surge_of_power.up|!talent.surge_of_power.enabled)
+# Surge of Power is strong and should be used. ©
+actions.aoe+=/tempest,target_if=min:debuff.lightning_rod.remains,if=!buff.arc_discharge.up&(buff.surge_of_power.up|!talent.surge_of_power)
 actions.aoe+=/lightning_bolt,if=buff.stormkeeper.up&buff.surge_of_power.up&spell_targets.chain_lightning=2
-
-# Against 6 targets or more Surge of Power should be used with Chain Lightning rather than Lava Burst.
 actions.aoe+=/chain_lightning,if=active_enemies>=6&buff.surge_of_power.up
-# Consume Primordial Wave buff immediately if you have Stormkeeper buff, fighting 6+ enemies and need maelstrom to spend.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up&(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&maelstrom<60-5*talent.eye_of_the_storm.enabled&talent.surge_of_power.enabled
-# Cast Lava burst to consume Primordial Wave proc. Wait for Lava Surge proc if possible.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=buff.primordial_wave.up
-# *{Fire} Use Lava Surge proc to buff <anything> with Master of the Elements.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&!buff.master_of_the_elements.up&talent.master_of_the_elements.enabled&talent.fire_elemental.enabled
 
-#Two Target
-actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=spell_targets.chain_lightning=2&(maelstrom>variable.mael_cap-30|cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
+# Cast Lava burst to consume Primordial Wave proc.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=buff.primordial_wave.up&(maelstrom<variable.mael_cap-10*(active_dot.flame_shock+1)|buff.primordial_wave.remains<4)
+
+actions.aoe+=/chain_lightning,if=buff.storm_frenzy.stack=2&!talent.surge_of_power&maelstrom<variable.mael_cap-(15+buff.stormkeeper.up*spell_targets.chain_lightning*spell_targets.chain_lightning)
+
 # Activate Surge of Power if next global is Primordial wave. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# Spend if all Lightning Rods ran out or you are close to overcaping. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=(lightning_rod=0&talent.lightning_rod.enabled|maelstrom>variable.mael_cap-30)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# Spend to buff your follow-up Stormkeeper with Surge of Power on 6+ targets. Respect Echoes of Great Sundering.
-actions.aoe+=/earthquake,if=(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering.enabled)
-# Use the talents you selected. Spread Lightning Rod to as many targets as possible.
-actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_eb.up&(lightning_rod=0|maelstrom>variable.mael_cap-30|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
-actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_es.up&(lightning_rod=0|maelstrom>variable.mael_cap-30|(buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power.enabled)
-# Use Icefury for Fusion of Elements proc.
-actions.aoe+=/icefury,if=talent.fusion_of_elements.enabled&!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)&(cooldown.primordial_wave.remains<5|((spell_targets.chain_lightning=2|(!spell_targets.chain_lightning>=5&talent.echoes_of_great_sundering.enabled&!buff.echoes_of_great_sundering_eb.up))&talent.elemental_blast.enabled))
-# *{Fire} Proc Master of the Elements outside Ascendance.
-actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>2,if=talent.master_of_the_elements.enabled&!buff.master_of_the_elements.up&!buff.ascendance.up&talent.fire_elemental.enabled
+actions.aoe+=/earthquake,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&talent.surge_of_power&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+# Use Lava Surge procs to consume fire part of fusion if you can also buff Earthquake with it.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&buff.fusion_of_elements_fire.up&!buff.master_of_the_elements.up&(maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering))
+
+# Spend if you are close to cap, Master of the Elements buff is up or Ascendance is about to expire.
+actions.aoe+=/earthquake,if=(maelstrom>variable.mael_cap-10*(spell_targets.chain_lightning+1)|buff.master_of_the_elements.up|buff.ascendance.up&buff.ascendance.remains<3|fight_remains<5)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=(maelstrom>variable.mael_cap-10*(spell_targets.chain_lightning+1)|buff.master_of_the_elements.up|buff.ascendance.up&buff.ascendance.remains<3|fight_remains<5)&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=(maelstrom>variable.mael_cap-10*(spell_targets.chain_lightning+1)|buff.master_of_the_elements.up|buff.ascendance.up&buff.ascendance.remains<3|fight_remains<5)&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+# Spend to spread Lightning Rod if Tempest or Stormkeeper is up.
+actions.aoe+=/earthquake,if=talent.lightning_rod&lightning_rod<active_enemies&(buff.stormkeeper.up|buff.tempest.up|!talent.surge_of_power)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=talent.lightning_rod&lightning_rod<active_enemies&(buff.stormkeeper.up|buff.tempest.up|!talent.surge_of_power)&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=talent.lightning_rod&lightning_rod<active_enemies&(buff.stormkeeper.up|buff.tempest.up|!talent.surge_of_power)&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+# Use Icefury to proc Fusion of Elements.
+actions.aoe+=/icefury,if=talent.fusion_of_elements&!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)
+
+# [2-3t] Use Lava Surge procs to buff <anything> with MotE on 2-3 targets.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains,if=cooldown_react&buff.lava_surge.up&!buff.master_of_the_elements.up&talent.master_of_the_elements&active_enemies<=3
+# [2-3t]{Farseer} Use all Lava bursts to buff spenders, SK_CL and Tempest with MotE on 2-3 targets if not talented into Lightning Rod.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>execute_time,if=!buff.master_of_the_elements.up&talent.master_of_the_elements&(buff.stormkeeper.up|buff.tempest.up|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))&active_enemies<=3&!talent.lightning_rod&talent.call_of_the_ancestors
+# [2t] Use all Lava bursts to buff <anything> with MotE on 2 targets.
+actions.aoe+=/lava_burst,target_if=dot.flame_shock.remains>execute_time,if=!buff.master_of_the_elements.up&active_enemies=2
+actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=active_dot.flame_shock=0&buff.fusion_of_elements_fire.up&!talent.primordial_wave
+
+# Spend to buff SK_CL (on 6+) or Tempest with SoP.
+actions.aoe+=/earthquake,if=((buff.stormkeeper.up&spell_targets.chain_lightning>=6|buff.tempest.up)&talent.surge_of_power)&(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up|!talent.echoes_of_great_sundering&(!talent.elemental_blast|active_enemies>1+talent.tempest))
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=((buff.stormkeeper.up&active_enemies>=6|buff.tempest.up)&talent.surge_of_power)&(active_enemies<=1+talent.tempest|talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_eb.up)
+actions.aoe+=/earth_shock,target_if=min:debuff.lightning_rod.remains,if=((buff.stormkeeper.up&active_enemies>=6|buff.tempest.up)&talent.surge_of_power)&talent.echoes_of_great_sundering&!buff.echoes_of_great_sundering_es.up
+
+actions.aoe+=/frost_shock,if=buff.icefury_dmg.up&!buff.ascendance.up&!buff.stormkeeper.up&(active_enemies=2|talent.call_of_the_ancestors)
+
 actions.aoe+=/chain_lightning
 actions.aoe+=/flame_shock,moving=1,target_if=refreshable
 actions.aoe+=/frost_shock,moving=1
@@ -93,15 +107,13 @@ actions.single_target+=/stormkeeper
 # Use Primordial Wave as much as possible.
 actions.single_target+=/primordial_wave,if=!buff.surge_of_power.up
 actions.single_target+=/ancestral_swiftness
-actions.single_target+=/ascendance,if=(time<10|buff.spymasters_web.up|!(variable.spymaster_in_1st|variable.spymaster_in_2nd))&(buff.stormkeeper.up&cooldown.stormkeeper.remains>40|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)
+actions.single_target+=/ascendance,if=(time<10|buff.spymasters_web.up|talent.first_ascendant|!(variable.spymaster_in_1st|variable.spymaster_in_2nd))&(buff.fury_of_storms.up|!talent.fury_of_the_storms)&(buff.primordial_wave.up|!talent.primordial_wave)
 
 # Surge of Power is strong and should be used.©
 actions.single_target+=/tempest,if=buff.surge_of_power.up
 actions.single_target+=/lightning_bolt,if=buff.surge_of_power.up
 
-# Dont waste Storm Frenzy (minimal gain).
 actions.single_target+=/tempest,if=buff.storm_frenzy.stack=2&!talent.surge_of_power.enabled
-actions.single_target+=/lightning_bolt,if=buff.storm_frenzy.stack=2&!talent.surge_of_power.enabled
 
 # Use LMT to apply Flame Shock.
 actions.single_target+=/liquid_magma_totem,if=dot.flame_shock.refreshable&!buff.master_of_the_elements.up&cooldown.primordial_wave.remains>dot.flame_shock.remains+3
@@ -118,7 +130,7 @@ actions.single_target+=/earth_shock,if=maelstrom>variable.mael_cap-15|buff.maste
 # Use Icefury to proc Fusion of Elements.
 actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusion_of_elements_fire.up)
 # Use Lava Burst to proc Master of the Elements.
-actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>=execute_time,if=!buff.master_of_the_elements.up&(!talent.master_of_the_elements|buff.lava_surge.up|cooldown.lava_burst.charges_fractional>1.5|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))
+actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>=execute_time,if=!buff.master_of_the_elements.up&(!talent.master_of_the_elements|buff.lava_surge.up|buff.tempest.up|cooldown.lava_burst.charges_fractional>1.8|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))
 
 # Spend to activate Surge of Power buff for Tempest or Stormkeeper.
 actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
@@ -126,7 +138,7 @@ actions.single_target+=/elemental_blast,if=(buff.tempest.up|buff.stormkeeper.up)
 actions.single_target+=/earth_shock,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 
 actions.single_target+=/tempest
-#Use Icefury-empowered Frost Shocks outside of Ascendance (neutral to minimal gain).
+# Use Icefury-empowered Frost Shocks outside of Ascendance.
 actions.single_target+=/frost_shock,if=buff.icefury_dmg.up&!buff.ascendance.up&!buff.stormkeeper.up
 # Filler spell. Always available. Always the bottom line.
 actions.single_target+=/lightning_bolt


### PR DESCRIPTION
For ST:
- Fixed 2 min Ascendance being delayed
- Removed LB storm frenzy line (stopped being a gain, dont ask me why)
- Slightly altered LvB usage (biggest mote gain is to use spenders when buff is up, next one is just not wasting buff. All other conditions are just an icing on a cake)

For AoE:
- Restructured whole block similar to how ST one is rn
- Removed remains of old iterations (FS management, random LvB lines left from fire builds etc)
- Reactivated consumption of fire part of Fusion proc: IF used same way as in st, lava surges if fire fusion up AND can buff EQ, Flame shock as last resort for builds that lack FS uptime
- Lava burst usage for 2-3t count (2t same as st, 3t - only surges and buffing big hits if not specced into LR, all of that with mote in mind)