### PR TITLE
[Warlock][Demonology][BUG] Demonic Power Cost reduction Apply's to Grimoire Felguard

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -576,11 +576,12 @@ struct legion_strike_t : public warlock_pet_melee_attack_t
 
     return m;
   }
+
   double cost_pct_multiplier() const override
   {
     double c = warlock_pet_melee_attack_t::cost_pct_multiplier();
 
-    if ( !main_pet && p()->buffs.demonic_power->check() )
+    if ( !main_pet && p()->buffs.demonic_power->check() && p()->bugs )
       c *= 1.0 + p()->o()->talents.demonic_power_buff->effectN( 4 ).percent();
 
     return c;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -576,6 +576,15 @@ struct legion_strike_t : public warlock_pet_melee_attack_t
 
     return m;
   }
+  double cost_pct_multiplier() const override
+  {
+    double c = warlock_pet_melee_attack_t::cost_pct_multiplier();
+
+    if ( !main_pet && p()->buffs.demonic_power->check() )
+      c *= 1.0 + p()->o()->talents.demonic_power_buff->effectN( 4 ).percent();
+
+    return c;
+  }
 };
 
 struct immutable_hatred_t : public warlock_pet_melee_attack_t


### PR DESCRIPTION
Demonic Tyrant Demonic Power effect nº 4 currently affects Grimoire Felguard, reducing its energy cost to 0 during Demonic Tyrant, this means for the Tyrant Duration Grimoire Felguard will constantly spam Legion Strike after its done with any higher priority spell (Felstorm).

This bug have been reported in the past a few times, but given it's still an active issue i think it would be fair to apply it until a correction is made.

This behavior still exists as of PTR 11.1 
so i am attempting to apply it for simc https://github.com/SimCMinMax/WoW-BugTracker/issues/1302