### PR TITLE
[Warlock] [Demonology] Change Soul Strike Priority.

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -461,13 +461,13 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
 {
   action_list_str = "travel";
 
-  if ( owner->talents.soul_strike.ok() )
-    action_list_str += "/soul_strike";
-
   action_list_str += "/felstorm_demonic_strength";
   if ( !owner->disable_auto_felstorm )
     action_list_str += "/felstorm";
   action_list_str += "/legion_strike,if=energy>=" + util::to_string( max_energy_threshold );
+
+  if ( owner->talents.soul_strike.ok() )
+    action_list_str += "/soul_strike";
 
   felstorm_cd = get_cooldown( "felstorm" );
   dstr_cd = get_cooldown( "felstorm_demonic_strength" );


### PR DESCRIPTION
After performing some tests i have noticed that Soulstrike priority is lower than Legion Strike, in a way that if Felguard have enough energy to cast Legion Strike it will wait to cast Soul Strike


https://github.com/user-attachments/assets/7df6aa4c-ee5c-4731-aed5-b024e63ed135

In this video i allow the Felguard to be at 200 energy before turning Legion Strike with the Soul Strike avaliable, this results in 3 Legion Strikes being cast before Felguard casts 1 Soul Strike. 