### PR TITLE
[gear] Bump gear aoe scaling coefficient to `0.3` from `0.15`.

### DIFF
--- a/engine/player/unique_gear_helper.hpp
+++ b/engine/player/unique_gear_helper.hpp
@@ -584,7 +584,7 @@ struct base_generic_aoe_proc_t : public base_generic_proc_t<BASE>
     {
       // For some reason, using std::min here barfs Visual Studio 2017, so use clamp
       // instead which seems to work.
-      am *= 1.0 + 0.15 * clamp( state->n_targets - 1u, 0u, max_scaling_targets );
+      am *= 1.0 + 0.3 * clamp( state->n_targets - 1u, 0u, max_scaling_targets );
     }
 
     return am;


### PR DESCRIPTION
Item effects that increase their damage for each enemy struck while splitting between all enemies (sometimes known as “meteor damage”) increased by 100%.

    Developers’ notes: Trinkets of this type tend to scale very poorly compared to stat trinkets in area-of-effect situations. While this change is not necessarily intended to put them on par with each other, it should make them more competitive overall.

https://us.forums.blizzard.com/en/wow/t/undermined-development-notes/2031155/4