### PR TITLE
[Warlock] Optimize gems and crafts for destro and aff

### DIFF
--- a/profiles/generators/TWW2/TWW2_Generate_Warlock.simc
+++ b/profiles/generators/TWW2/TWW2_Generate_Warlock.simc
@@ -122,17 +122,17 @@ talents=CsQAAAAAAAAAAAAAAAAAAAAAAghZmZmZEzmhxsZmZY2mFzwMzsY2MWMzAAAAAjZmtlZmlZAj
 default_pet=sayaad
 
 head=spliced_fiendtraders_transcendence,id=229325,bonus_id=1527/11996/1808,gem_id=213743
-neck=semicharmed_amulet,id=228841,bonus_id=8781,ilevel=678,gem_id=213485/213467
+neck=semicharmed_amulet,id=228841,bonus_id=8781,ilevel=678,gem_id=213470/213494
 shoulders=spliced_fiendtraders_loyal_servants,id=229323,bonus_id=1527/11996
-back=undercircuit_racing_flag,id=228839,bonus_id=1527/11996/11964
+back=chef_chewies_towel,id=221054,bonus_id=3170/11996/11964
 chest=spliced_fiendtraders_surgical_gown,id=229328,ilevel=678,enchant_id=7364
-wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8793,ilevel=675,gem_id=213458,enchant_id=7397,crafted_stats=36/32
-hands=golden_handshakers,id=228872,bonus_id=1527/11996/11964
-waist=honorbound_retainers_sash,id=221121,bonus_id=3170/11996/11964/1808,gem_id=213491
+wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8791,ilevel=675,gem_id=213479,enchant_id=7397,crafted_stats=36/32
+hands=mine_rats_handwarmers,id=159231,bonus_id=11359/11996/11964
+waist=refiners_conveyor_belt,id=228882,bonus_id=1527/11996/11964/1808,gem_id=213479
 legs=spliced_fiendtraders_skin_tights,id=229324,bonus_id=11996/10356/11961/6652/1579/10255,ilevel=678,enchant_id=7534
-feet=deranged_alchemists_slippers,id=159235,bonus_id=11359/11996/11964,enchant_id=7421
+feet=cloudstrider_soles,id=221043,bonus_id=3170/11996/11964,enchant_id=7421
 finger1=cyrces_circlet,id=228411,bonus_id=12014/1498,ilevel=658,gem_id=228639/228638/228646,enchant_id=7340
-finger2=the_jastor_diamond,id=231265,bonus_id=8781,ilevel=678,gem_id=213491/213491,enchant_id=7340
+finger2=the_jastor_diamond,id=231265,bonus_id=8781,ilevel=678,gem_id=213479/213455,enchant_id=7340
 trinket1=eye_of_kezan,id=230198,ilevel=678
 trinket2=mugs_moxie_jug,id=230192,bonus_id=1527/11996/11964
 main_hand=scalding_queenmakers_shiv,id=221062,bonus_id=3170/11996/11964,enchant_id=7460

--- a/profiles/generators/TWW2/TWW2_Generate_Warlock.simc
+++ b/profiles/generators/TWW2/TWW2_Generate_Warlock.simc
@@ -122,17 +122,17 @@ talents=CsQAAAAAAAAAAAAAAAAAAAAAAghZmZmZEzmhxsZmZY2mFzwMzsY2MWMzAAAAAjZmtlZmlZAj
 default_pet=sayaad
 
 head=spliced_fiendtraders_transcendence,id=229325,bonus_id=1527/11996/1808,gem_id=213743
-neck=semicharmed_amulet,id=228841,bonus_id=8781,ilevel=678,gem_id=213470/213494
+neck=semicharmed_amulet,id=228841,bonus_id=8781,gem_id=213470/213467,ilevel=678
 shoulders=spliced_fiendtraders_loyal_servants,id=229323,bonus_id=1527/11996
 back=chef_chewies_towel,id=221054,bonus_id=3170/11996/11964
 chest=spliced_fiendtraders_surgical_gown,id=229328,ilevel=678,enchant_id=7364
-wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8791,ilevel=675,gem_id=213479,enchant_id=7397,crafted_stats=36/32
+wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8791,enchant_id=7397,gem_id=213491,ilevel=675,crafted_stats=36/32
 hands=mine_rats_handwarmers,id=159231,bonus_id=11359/11996/11964
-waist=refiners_conveyor_belt,id=228882,bonus_id=1527/11996/11964/1808,gem_id=213479
+waist=refiners_conveyor_belt,id=228882,bonus_id=1527/11996/11964/1808,gem_id=213482
 legs=spliced_fiendtraders_skin_tights,id=229324,bonus_id=11996/10356/11961/6652/1579/10255,ilevel=678,enchant_id=7534
-feet=cloudstrider_soles,id=221043,bonus_id=3170/11996/11964,enchant_id=7421
-finger1=cyrces_circlet,id=228411,bonus_id=12014/1498,ilevel=658,gem_id=228639/228638/228646,enchant_id=7340
-finger2=the_jastor_diamond,id=231265,bonus_id=8781,ilevel=678,gem_id=213479/213455,enchant_id=7340
+feet=hyperthread_boots,id=168964,bonus_id=10067/11996/11964,enchant_id=7421
+finger1=cyrces_circlet,id=228411,bonus_id=12014/1498,enchant_id=7334,gem_id=228639/228638/228646,ilevel=658
+finger2=the_jastor_diamond,id=231265,bonus_id=8781,enchant_id=7334,gem_id=213479/213455,ilevel=678
 trinket1=eye_of_kezan,id=230198,ilevel=678
 trinket2=mugs_moxie_jug,id=230192,bonus_id=1527/11996/11964
 main_hand=scalding_queenmakers_shiv,id=221062,bonus_id=3170/11996/11964,enchant_id=7460

--- a/profiles/generators/TWW2/TWW2_Generate_Warlock.simc
+++ b/profiles/generators/TWW2/TWW2_Generate_Warlock.simc
@@ -38,21 +38,21 @@ talents=CkQAAAAAAAAAAAAAAAAAAAAAAAzMzMzMjYYYMbzMzwsNAAAgZGzsYmZsMzMzmZMzAAmxCMws
 default_pet=sayaad
 
 head=spliced_fiendtraders_transcendence,id=229325,bonus_id=1808,ilevel=678,gem_id=213743
-neck=semicharmed_amulet,id=228841,bonus_id=8781,ilevel=678,gem_id=213470/213491
+neck=semicharmed_amulet,id=228841,bonus_id=8781,ilevel=678,gem_id=213470/213458
 shoulders=spliced_fiendtraders_loyal_servants,id=229323,bonus_id=1527/11996
-back=test_pilots_gopack,id=228844,bonus_id=1527/11996/11964,enchant_id=7409
+back=cloak_of_questionable_intent,id=159287,bonus_id=11359/11996/11964
 chest=spliced_fiendtraders_surgical_gown,id=229328,ilevel=678,enchant_id=7364
-wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8791,ilevel=675,gem_id=213467,enchant_id=7397,crafted_stats=36/32
-hands=golden_handshakers,id=228872,bonus_id=1527/11996/11964
-waist=honorbound_retainers_sash,id=221121,bonus_id=3170/11996/11964/1808,gem_id=213458
+wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8791,ilevel=675,gem_id=213494,enchant_id=7397,crafted_stats=36/32
+hands=kings_malicious_clutches,id=221108,bonus_id=3170/11996/11964
+waist=honorbound_retainers_sash,id=221121,bonus_id=3170/11996/11964/1808,gem_id=213491
 legs=spliced_fiendtraders_skin_tights,id=229324,bonus_id=11996/10356/11961/6652/1579/10255,ilevel=678,enchant_id=7534
 feet=cloudstrider_soles,id=221043,ilevel=678,enchant_id=7424
-finger1=the_jastor_diamond,id=231265,bonus_id=8781,ilevel=678,gem_id=213461/213461,enchant_id=7346
+finger1=the_jastor_diamond,id=231265,bonus_id=8781,ilevel=678,gem_id=213491/213482,enchant_id=7346
 finger2=cyrces_circlet,id=228411,bonus_id=12014/1498,ilevel=658,gem_id=228639/228638/228646,enchant_id=7346
 trinket1=house_of_cards,id=230027,ilevel=678
 trinket2=mugs_moxie_jug,id=230192,bonus_id=1527/11996/11964
 main_hand=scalding_queenmakers_shiv,id=221062,bonus_id=3170/11996/11964,enchant_id=7460
-off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/1485/11300/8960,crafted_stats=32/49
+off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/1485/11300/8960/8795,crafted_stats=32/49
 
 save=TWW2_Warlock_Affliction.simc
 


### PR DESCRIPTION
Aff: https://www.raidbots.com/simbot/report/1THy3b8LsLBy4XbpB1TkbD
Destro: https://www.raidbots.com/simbot/report/g573coEmBCohMtksUbXtqP

Destro gain is minor but allows having the same crafts across different specs, which is good for the community 