### PR TITLE
[Warlock][Demonology] Demonic Brutality Pet fix

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -348,7 +348,7 @@ public:
     player_talent_t the_houndmasters_gambit;
     const spell_data_t* houndmasters_aura; // Contains actual referenced % increase
     player_talent_t improved_demonic_tactics;
-    player_talent_t demonic_brutality; // TOCHECK: Pets may not be properly benefitting from this in-game
+    player_talent_t demonic_brutality;
 
     player_talent_t pact_of_the_eredruin;
     const spell_data_t* doomguard;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -181,7 +181,7 @@ double warlock_pet_t::composite_player_critical_damage_multiplier( const action_
 {
   double m = pet_t::composite_player_critical_damage_multiplier( s );
 
-  m += o()->talents.demonic_brutality->effectN( 1 ).percent() / 2.0;
+  m += o()->talents.demonic_brutality->effectN( 1 ).percent();
 
   return m;
 }


### PR DESCRIPTION
Demonic Brutality effect is multiplicative, meaning the 4% increase pushes crit not towards 204% but to 208%.

Note:  Apparently this effect don't work on Wicked Cleave ingame from Diabolist Overlord but behaves correctly with both other pets.