### PR TITLE
Fix casc_extract on Python >= 3.12 (`ConfigParser.readfp()` -> `read_file()`)

### DIFF
--- a/casc_extract/build_cfg.py
+++ b/casc_extract/build_cfg.py
@@ -156,7 +156,7 @@ class BuildCfg(object):
 		# Slight hack to get the configuration file read easily
 		conf_str = '[base]\n' + open(build_cfg_path, 'r').read()
 		conf_str_fp = io.StringIO(conf_str)
-		self.cfg.readfp(conf_str_fp)
+		self.cfg.read_file(conf_str_fp)
 
 		print(f'Wow build: {build_version}')
 


### PR DESCRIPTION
`ConfigParser.readfp()` was removed in Python 3.12 (released 2023).

[`ConfigParser.read_file()`]( https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file) is available on Python 3.2 and later. Given that was released in 2011, I don't think there's any need for backward compatibility that far back. :)