### PR TITLE
[Buff] Hasted buffs should use source haste, not target

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1838,8 +1838,8 @@ timespan_t buff_t::tick_time() const
   switch ( tick_time_behavior )
   {
     case buff_tick_time_behavior::HASTED:
-      assert( player );
-      return buff_period * player->cache.spell_cast_speed();
+      assert( source );
+      return buff_period * source->cache.spell_cast_speed();
     case buff_tick_time_behavior::CUSTOM:
       assert( tick_time_callback );
       return tick_time_callback( this, current_tick );


### PR DESCRIPTION
"player" is set to the target for buff_t, which can result in an issue for hasted debuffs applied by an actor to the enemy target.

Self-buffs should be unaffected.

Since the nomenclature seems a bit confusing, there may be other issues in buff.cpp that have similar problems that need review, but I believe this one should be self-contained enough to resolve on its own for now.