### PR TITLE
[Gear] Add new option to Soulletting Ruby trinket

### DIFF
--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -958,12 +958,14 @@ void soulletting_ruby( special_effect_t& effect )
     stat_buff_t* buff;
     double base_crit_value;
     double max_crit_bonus;
+    double fixed_percentage_targethealth;
 
     soulletting_ruby_t( const special_effect_t& e, stat_buff_t* b ) :
       proc_spell_t( "soulletting_ruby", e.player, e.player->find_spell( 345802 ) ),
       buff( b ),
       base_crit_value( e.player->find_spell( 345807 )->effectN( 1 ).average( e.item ) ),
-      max_crit_bonus( e.player->find_spell( 345807 )->effectN( 2 ).average( e.item ) )
+      max_crit_bonus( e.player->find_spell( 345807 )->effectN( 2 ).average( e.item ) ),
+      fixed_percentage_targethealth( e.player->sim->shadowlands_opts.soulletting_ruby_fixed_percent_targethealth )
     {}
 
     void execute() override
@@ -971,7 +973,7 @@ void soulletting_ruby( special_effect_t& effect )
       proc_spell_t::execute();
 
       make_event( *sim, travel_time(), [ this, t = execute_state->target ] {
-        double bonus_mul = 1.0 - ( t->is_active() ? t->health_percentage() * 0.01 : 0.0 );
+        double bonus_mul = 1.0 - ( ( fixed_percentage_targethealth < 0.0 ) ? ( t->is_active() ? t->health_percentage() * 0.01 : 0.0 ) : ( fixed_percentage_targethealth ));
 
         buff->stats.back().amount = base_crit_value + max_crit_bonus * bonus_mul;
         buff->trigger();

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -4043,6 +4043,7 @@ void sim_t::create_options()
   add_option( opt_string( "shadowlands.volatile_solvent_type", shadowlands_opts.volatile_solvent_type ) );
   add_option( opt_bool( "shadowlands.disable_soul_igniter_second_use", shadowlands_opts.disable_soul_igniter_second_use ) );
   add_option( opt_string( "shadowlands.unbound_changeling_stat_type", shadowlands_opts.unbound_changeling_stat_type ) );
+  add_option( opt_float( "shadowlands.soulletting_ruby_fixed_percent_targethealth", shadowlands_opts.soulletting_ruby_fixed_percent_targethealth, -1.0, 1.0 ) );
   add_option( opt_float( "shadowlands.anima_field_emitter_mean", shadowlands_opts.anima_field_emitter_mean, 0.0, std::numeric_limits<double>::max() ) );
   add_option( opt_float( "shadowlands.anima_field_emitter_stddev", shadowlands_opts.anima_field_emitter_stddev, 0.0, std::numeric_limits<double>::max() ) );
   add_option( opt_timespan( "shadowlands.retarget_shadowgrasp_totem", shadowlands_opts.retarget_shadowgrasp_totem ) );

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -387,6 +387,9 @@ struct sim_t : private sc_thread_t
     // strings. Anything else will result in the item's bonus IDs being
     // used to determine which version the player is currently using.
     std::string unbound_changeling_stat_type = "default";
+    // Sets a fixed health percentage [between 0.0 and 1.0] for the target when using the Soulletting Ruby trinket
+    // The default value of -1.0 disables this option and uses the target's health percentage instead
+    double soulletting_ruby_fixed_percent_targethealth = -1.0;
     /// Chance player is getting overhealed by Gluttonous Spike proc.
     double gluttonous_spike_overheal_chance = 1.0;
     /// Anima Field Emitter buff duration distribution, defaults to full duration.


### PR DESCRIPTION
The new option allows setting a fixed health percentage for the target when using the SR trinket