### PR TITLE
[Subtlety] Trinket APL tweak

### DIFF
--- a/engine/class_modules/apl/rogue/subtlety.simc
+++ b/engine/class_modules/apl/rogue/subtlety.simc
@@ -2,8 +2,8 @@
 actions.precombat=apply_poison
 actions.precombat+=/snapshot_stats
 actions.precombat+=/variable,name=priority_rotation,value=priority_rotation
-actions.precombat+=/variable,name=trinket_sync_slot,value=1,if=trinket.1.has_stat.any_dps&(!trinket.2.has_stat.any_dps|trinket.1.is.treacherous_transmitter|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)
-actions.precombat+=/variable,name=trinket_sync_slot,value=2,if=trinket.2.has_stat.any_dps&(!trinket.1.has_stat.any_dps|trinket.2.cooldown.duration>trinket.1.cooldown.duration)
+actions.precombat+=/variable,name=trinket_sync_slot,value=1,if=trinket.1.has_use_buff&(!trinket.2.has_use_buff|trinket.1.is.treacherous_transmitter|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)
+actions.precombat+=/variable,name=trinket_sync_slot,value=2,if=trinket.2.has_use_buff&(!trinket.1.has_use_buff|trinket.2.cooldown.duration>trinket.1.cooldown.duration)
 actions.precombat+=/stealth
 
 actions=stealth
@@ -11,7 +11,7 @@ actions=stealth
 actions+=/variable,name=stealth,value=buff.shadow_dance.up|buff.stealth.up|buff.vanish.up
 actions+=/variable,name=targets,value=spell_targets.shuriken_storm
 actions+=/variable,name=skip_rupture,value=buff.shadow_dance.up|buff.darkest_night.up|variable.targets>=8&!talent.replicating_shadows&talent.unseen_blade
-actions+=/variable,name=maintenance,value=(dot.rupture.ticking|variable.skip_rupture)
+actions+=/variable,name=maintenance,value=(dot.rupture.ticking|variable.skip_rupture)&(buff.slice_and_dice.up|variable.targets<=2)
 actions+=/variable,name=secret,value=buff.shadow_dance.up|(cooldown.flagellation.remains<40&cooldown.flagellation.remains>20&talent.death_perception)
 actions+=/variable,name=racial_sync,value=(buff.shadow_blades.up&buff.shadow_dance.up)|!talent.shadow_blades&buff.symbols_of_death.up|fight_remains<20
 actions+=/variable,name=shd_cp,value=combo_points<=1|buff.darkest_night.up&combo_points>=7|effective_combo_points>=6&talent.unseen_blade
@@ -38,6 +38,7 @@ actions.cds+=/shadow_blades,if=variable.maintenance&variable.shd_cp&buff.shadow_
 actions.cds+=/thistle_tea,if=buff.shadow_dance.remains>2&!buff.thistle_tea.up
 actions.cds+=/flagellation,if=combo_points>=5&cooldown.shadow_blades.remains<=3|fight_remains<=25
 
+
 # Race Cooldowns
 actions.race=blood_fury,if=variable.racial_sync
 actions.race+=/berserking,if=variable.racial_sync
@@ -50,8 +51,8 @@ actions.item=use_item,name=treacherous_transmitter,if=cooldown.flagellation.rema
 actions.item+=/do_treacherous_transmitter_task,if=buff.shadow_dance.up|fight_remains<=15
 actions.item+=/use_item,name=imperfect_ascendancy_serum,use_off_gcd=1,if=dot.rupture.ticking&buff.flagellation_buff.up
 actions.item+=/use_item,name=mad_queens_mandate,if=(!talent.lingering_darkness|buff.lingering_darkness.up|equipped.treacherous_transmitter)&(!equipped.treacherous_transmitter|trinket.treacherous_transmitter.cooldown.remains>20)|fight_remains<=15
-actions.item+=/use_items,slots=trinket1,if=(variable.trinket_sync_slot=1&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=2&(!trinket.2.cooldown.ready&!buff.shadow_blades.up&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
-actions.item+=/use_items,slots=trinket2,if=(variable.trinket_sync_slot=2&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=1&(!trinket.1.cooldown.ready&!buff.shadow_blades.up&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
+actions.item+=/use_items,slots=trinket1,if=(variable.trinket_sync_slot=1&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=2&(!trinket.2.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
+actions.item+=/use_items,slots=trinket2,if=(variable.trinket_sync_slot=2&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=1&(!trinket.1.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
 
 # Shadow Dance, Vanish, Shadowmeld
 actions.stealth_cds=shadow_dance,if=variable.shd_cp&variable.maintenance&cooldown.secret_technique.remains<=24&(buff.symbols_of_death.remains>=6|buff.shadow_blades.remains>=6)|fight_remains<=10
@@ -62,7 +63,7 @@ actions.finish=secret_technique,if=variable.secret
 # Maintenance Finisher
 actions.finish+=/rupture,if=!variable.skip_rupture&(!dot.rupture.ticking|refreshable)&target.time_to_die-remains>6
 actions.finish+=/rupture,cycle_targets=1,if=!variable.skip_rupture&!variable.priority_rotation&&target.time_to_die>=(2*combo_points)&refreshable&variable.targets>=2
-actions.finish+=/rupture,if=talent.unseen_blade&cooldown.flagellation.remains<10
+actions.finish+=/rupture,if=talent.unseen_blade&cooldown.flagellation.remains<10&dot.rupture.remains<fight_remains
 # Direct Damage Finisher
 actions.finish+=/coup_de_grace,if=debuff.fazed.up&cooldown.flagellation.remains>=20
 actions.finish+=/black_powder,if=!variable.priority_rotation&variable.maintenance&(((variable.targets>=2&talent.deathstalkers_mark&(!buff.darkest_night.up|buff.shadow_dance.up&variable.targets>=5))|talent.unseen_blade&variable.targets>=7)|action.coup_de_grace.ready)
@@ -81,6 +82,7 @@ actions.build+=/shadowstrike
 actions.build+=/goremaws_bite,if=combo_points.deficit>=3
 actions.build+=/gloomblade
 actions.build+=/backstab
+
 # This list usually contains Cooldowns with neglectable impact that causes global cooldowns
 actions.fill=arcane_torrent,if=energy.deficit>=15+energy.regen
 actions.fill+=/arcane_pulse


### PR DESCRIPTION
- Change has_stat to has_use_buff as its more supported and not bugged with trinkets like pacemaker and priory signet.
- Add evis snd back into the opener on aoe