### PR TITLE
[Warlock][Hellcaller] Seeds of Their Demise Effect nº3

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1436,15 +1436,18 @@ using namespace helpers;
       affected_by.chaotic_energies = destruction();
 
       triggers.decimation = false;
+      
+      base_dd_multiplier *=1.0 + p->hero.seeds_of_their_demise->effectN( 3 ).percent();
+      
     }
-
+    
     double composite_target_multiplier( player_t* target ) const override
     {
       double m = warlock_spell_t::composite_target_multiplier( target );
 
       if ( p()->hero.mark_of_xavius.ok() )
         m *= 1.0 + td( target )->dots_wither->current_stack() * p()->hero.mark_of_xavius->effectN( 3 ).percent();
-
+      
       return m;
     }
 

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1438,16 +1438,15 @@ using namespace helpers;
       triggers.decimation = false;
       
       base_dd_multiplier *=1.0 + p->hero.seeds_of_their_demise->effectN( 3 ).percent();
-      
     }
-    
+
     double composite_target_multiplier( player_t* target ) const override
     {
       double m = warlock_spell_t::composite_target_multiplier( target );
 
       if ( p()->hero.mark_of_xavius.ok() )
         m *= 1.0 + td( target )->dots_wither->current_stack() * p()->hero.mark_of_xavius->effectN( 3 ).percent();
-      
+
       return m;
     }
 


### PR DESCRIPTION
Back in Beta, Seeds of their Demise had an effect who increase the damage of blackened soul by 30%, this effect should have been removed once they reworked the talent.

But, they have forgotten to actually removing the spell effect and only changed the tooltip to not have any implication of the same. 

I would consider calling this a bug/not intended as similar issues existed on one of the DH talents and they eventually fixed that. 

Based on tests done by Txt, both affliction and destruction have a damage gap of 30% towards their Blackened Soul damage.