### PR TITLE
[Demonology][Warlock] Excludes Greater Dreadstalkers from Wild Imps Expendable Buff

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -166,7 +166,7 @@ double warlock_pet_t::composite_player_multiplier( school_e school ) const
   if ( ( pet_type == PET_DREADSTALKER || pet_type == PET_FELHUNTER ) && o()->talents.dread_calling.ok() )
     m *= 1.0 + buffs.dread_calling->check_value();
 
-  if ( o()->talents.the_expendables.ok() )
+  if ( ( pet_type != PET_FELHUNTER ) && o()->talents.the_expendables.ok() )
     m *= 1.0 + buffs.the_expendables->check_stack_value();
 
   m *= 1.0 + buffs.demonic_power->check_value();


### PR DESCRIPTION


Greater Dreadstalkers does not benefit of stacks of The Expendables when Wild Imps vanish.

This is a small but noticeable consideration in AOE, as Imploding 10 imps will cause Greater Dreadstalkers to gain 10 stacks, increasing its damage by 10% in the simulation but not in the game.