### PR TITLE
[Affliction] Count Jackpot UA for dot count

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -222,6 +222,9 @@ int warlock_td_t::count_affliction_dots() const
   if ( dots_unstable_affliction->is_ticking() )
     count++;
 
+  if ( dots_jackpot_ua->is_ticking() )
+    count++;
+
   if ( dots_vile_taint->is_ticking() )
     count++;
 


### PR DESCRIPTION
Noticed this was not being counted when i was trying to test something briefly for Wark
`https://www.raidbots.com/simbot/report/9RKEeJbx7v6LNGepfh1KN8` was the APL
(Skip UA on pull and get the jackpot from DGL instead. Very basic test case.)

Not the bugged behaviour just a "normal" opener