### PR TITLE
Revert "[Warlock][Demonology][BUG] Demonic Power Cost reduction Apply's to Grimoire Felguard"

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -587,16 +587,6 @@ struct legion_strike_t : public warlock_pet_melee_attack_t
 
     return m;
   }
-
-  double cost_pct_multiplier() const override
-  {
-    double c = warlock_pet_melee_attack_t::cost_pct_multiplier();
-
-    if ( !main_pet && p()->buffs.demonic_power->check() && p()->bugs )
-      c *= 1.0 + p()->o()->talents.demonic_power_buff->effectN( 4 ).percent();
-
-    return c;
-  }
 };
 
 struct immutable_hatred_t : public warlock_pet_melee_attack_t


### PR DESCRIPTION
Reverts simulationcraft/simc#9869

The bug have been hotfixed as of april 15/2025, with the following hotfix 
https://us.forums.blizzard.com/en/wow/t/the-war-within-hotfixes-april-15/2066311/272 