### PR TITLE
[Warlock] Adjust Felguard Soul Cleave behavior

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -722,7 +722,7 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
     {
       background = dual = true;
       aoe = -1;
-      ignores_armor = true;
+      ignores_armor = !p->bugs; // TOCHECK: 2025-04-17 This spell currently does not ignore armor (bug?)
       base_dd_min = base_dd_max = 0;
     }
 
@@ -730,7 +730,10 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
     {
       warlock_pet_melee_attack_t::init_finished();
 
-      snapshot_flags &= STATE_NO_MULTIPLIER;
+      // TOCHECK: 2025-04-17 Although this spell is not supposed to be affected by modifiers, it is currently affected by them (bug?)
+      if (!p()->bugs)
+        snapshot_flags &= STATE_NO_MULTIPLIER;
+
     }
 
     size_t available_targets( std::vector<player_t*>& tl ) const override

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -731,7 +731,7 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
       warlock_pet_melee_attack_t::init_finished();
 
       // TOCHECK: 2025-04-17 Although this spell is not supposed to be affected by modifiers, it is currently affected by them (bug?)
-      if (!p()->bugs)
+      if ( !p()->bugs )
         snapshot_flags &= STATE_NO_MULTIPLIER;
 
     }


### PR DESCRIPTION
We believe that the correct behavior of [Soul Cleave](https://www.wowhead.com/spell=387502/soul-cleave) is to simply do 25% of the damage of [Soul Strike](https://www.wowhead.com/spell=267964/soul-strike), without applying any other damage modifiers. This is how it is currently working in simc.

However, this is not currently how it works ingame. Several things are happening with this spell ingame:
- It seems to be affected by all global/player/pet modifiers, just as if it were any other pet spell. Some of the tested warlock modifiers are the following:
  - [Demonology Warlock](https://www.wowhead.com/spell=137044/demonology-warlock): +3%
  - [Flames of Xoroth](https://www.wowhead.com/spell=429657/flames-of-xoroth): +2%
  - [Wrathful Minion](https://www.wowhead.com/spell=386864/wrathful-minion?spellModifier=137044): +5%
  - [Rune of Shadows](https://www.wowhead.com/spell=453744/rune-of-shadows): +4%
  - [Antoran Armaments](https://www.wowhead.com/spell=387496/antoran-armaments): +20%
  - [Annihilan Training](https://www.wowhead.com/spell=386176/annihilan-training): +20%
  - [The Expendables](https://www.wowhead.com/spell=387601/the-expendables): +10% max (1% per stack, max 10 stacks)
  - [Demonic Power](https://www.wowhead.com/spell=265273/demonic-power): +15%
  - [Abyssal Dominion](https://www.wowhead.com/spell=456323/abyssal-dominion): +20%
  - [Cloven Soul](https://www.wowhead.com/spell=434424/cloven-soul):+5% (debuff in target)
  - [Fel Sunder](https://www.wowhead.com/spell=387402/fel-sunder): +5% max (1% per stack, max 5 stacks) (debuff in target)
- In addition to spell modifiers, it is also affected by **Versatility** and **Mastery** modifiers.
- It's also affected by the target **armor damage reduction**. The school damage of this spell is physical, and while it is believed that this damage should ignore armor, it currently does not.

The changes in this PR are intended to adjust the simc behavior of this spell to work in the same way that it does ingame. If the ``bug`` flag is set to ``false``, the behavior will remain as it was (which is believed to be the expected behavior without this alleged ingame bug).

Related: https://github.com/SimCMinMax/WoW-BugTracker/issues/1328