### PR TITLE
[Warlock] Adjust Felguard Fiendish Wrath behavior

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -494,27 +494,9 @@ struct felguard_melee_t : public warlock_pet_melee_t
   {
     fiendish_wrath_t( warlock_pet_t* p ) : warlock_pet_melee_attack_t( "Fiendish Wrath", p, p->o()->talents.fiendish_wrath_dmg )
     {
+      weapon_multiplier = 1.0;
       background = dual = true;
       aoe = -1;
-    }
-
-    void init_finished() override
-    {
-      warlock_pet_melee_attack_t::init_finished();
-
-      // Disable multipliers: its base damage comes from its parent felguard's melee base damage after modifiers and should not be applied again
-      // Its crit roll is independent of its parent felguard's melee crit roll. Keep STATE_CRIT and STATE_TGT_CRIT flags: required to be able to crit
-      // Keep STATE_TGT_ARMOR flag to be affected by armor
-      snapshot_flags &= ~STATE_AP;
-      snapshot_flags &= ~STATE_MUL_SPELL_DA;
-      snapshot_flags &= ~STATE_MUL_SPELL_TA;
-      snapshot_flags &= ~STATE_VERSATILITY;
-      snapshot_flags &= ~STATE_MUL_PERSISTENT;
-      snapshot_flags &= ~STATE_TGT_MUL_DA;
-      snapshot_flags &= ~STATE_TGT_MUL_TA;
-      snapshot_flags &= ~STATE_MUL_PLAYER_DAM;
-      snapshot_flags &= ~STATE_MUL_PET;
-      snapshot_flags &= ~STATE_TGT_MUL_PET;
     }
 
     size_t available_targets( std::vector<player_t*>& tl ) const override
@@ -543,12 +525,10 @@ struct felguard_melee_t : public warlock_pet_melee_t
 
   void impact( action_state_t* s ) override
   {
-    auto amount = s->result_raw;
-
     warlock_pet_melee_t::impact( s );
 
     if ( p()->buffs.fiendish_wrath->check() )
-      fiendish_wrath->execute_on_target( s->target, amount );
+      fiendish_wrath->execute_on_target( s->target );
   }
 };
 
@@ -905,6 +885,7 @@ void felguard_pet_t::init_base_stats()
   owner_coeff.sp_from_sp = 1.4519;
 
   melee_attack->base_dd_multiplier *= 1.42;
+  debug_cast<felguard_melee_t*>( melee_attack )->fiendish_wrath->base_dd_multiplier = melee_attack->base_dd_multiplier;
 
   special_action = new axe_toss_t( this, "" );
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -502,9 +502,19 @@ struct felguard_melee_t : public warlock_pet_melee_t
     {
       warlock_pet_melee_attack_t::init_finished();
 
+      // Disable multipliers: its base damage comes from its parent felguard's melee base damage after modifiers and should not be applied again
+      // Its crit roll is independent of its parent felguard's melee crit roll. Keep STATE_CRIT and STATE_TGT_CRIT flags: required to be able to crit
+      // Keep STATE_TGT_ARMOR flag to be affected by armor
+      snapshot_flags &= ~STATE_AP;
+      snapshot_flags &= ~STATE_MUL_SPELL_DA;
+      snapshot_flags &= ~STATE_MUL_SPELL_TA;
+      snapshot_flags &= ~STATE_VERSATILITY;
+      snapshot_flags &= ~STATE_MUL_PERSISTENT;
+      snapshot_flags &= ~STATE_TGT_MUL_DA;
+      snapshot_flags &= ~STATE_TGT_MUL_TA;
+      snapshot_flags &= ~STATE_MUL_PLAYER_DAM;
       snapshot_flags &= ~STATE_MUL_PET;
       snapshot_flags &= ~STATE_TGT_MUL_PET;
-      snapshot_flags &= ~STATE_VERSATILITY;
     }
 
     size_t available_targets( std::vector<player_t*>& tl ) const override


### PR DESCRIPTION
The ingame damage of [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath) is a simple `Deal Weapon Damage` aoe effect (excluding the primary target). So, in other words, the damage of each [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath) hit the same damage amount as the Felguard's **melee** damage.

In simc the damage of [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath) attack is currently implemented by setting its damage to the `result_raw` damage of the parent **melee** attack. This `result_raw` damage already includes increases from modifiers, so we need to prevent these from being reapplied again to [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath). This is already partially done in the current code, but more modifiers still need to be added (and that is what is done in this PR).

This `result_raw` does not include armor damage reduction or any crit damage increases, but this is not a problem because they will also be calculated independently for [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath). Just remember that for this reason, the `STATE_TGT_ARMOR`, `STATE_CRIT`, and `STATE_TGT_CRIT` flags should not be disabled.

Finally, as additional information, note that the crit roll chance of each [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath) attack is independent of the crit roll chance of the parent **melee** attack, which is not a problem because that is already how it behaves in simc in this case.