### PR TITLE
[Warlock][Demonology] Improvements towards the Felguard Rotation

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -473,7 +473,7 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
   action_list_str = "travel";
 
  if ( owner->talents.soul_strike.ok() )
-    action_list_str += "/soul_strike,if=movement.remains";   // Soulstrike have a lower priority than Felstorm and Legionstrike, it does have a 50yard cast-range meaning on pull/while moving, he will cast this first.
+    action_list_str += "/soul_strike,if=movement.remains|time<10";   // Soulstrike have a lower priority than Felstorm and Legionstrike, it does have a 50yard cast-range meaning on pull/while moving, he will cast this first.
   
   action_list_str += "/felstorm_demonic_strength";
   if ( !owner->disable_auto_felstorm )

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -472,12 +472,15 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
 {
   action_list_str = "travel";
 
+ if ( owner->talents.soul_strike.ok() )
+    action_list_str += "/soul_strike,if=movement.remains";   // Soulstrike have a lower priority than Felstorm and Legionstrike, it does have a 50yard cast-range meaning on pull/while moving, he will cast this first.
+  
   action_list_str += "/felstorm_demonic_strength";
   if ( !owner->disable_auto_felstorm )
     action_list_str += "/felstorm";
   action_list_str += "/legion_strike,if=energy>=" + util::to_string( max_energy_threshold );
 
-  if ( owner->talents.soul_strike.ok() )
+  if ( owner->talents.soul_strike.ok() )   // Soulstrike Priority is lower than Legion Strike, this means while in range of the target, it will only cast Soulstrike while bellow the max energy threshold.
     action_list_str += "/soul_strike";
 
   felstorm_cd = get_cooldown( "felstorm" );


### PR DESCRIPTION
Previously i pushed https://github.com/simulationcraft/simc/pull/9880   but i have left something out of the consideration. 

Legino Strike will only be cast in Melee Range,  while sousltrike  will be placed in the queue even while at range due to its 50 yards range

This means that on a pul the felguard will cast Soulstrike  1 before Legion Strike 1 or Felstorm 1, but any subsequent soulstrike/felstorm will have higher priority than Soulstrike.