### PR TITLE
[ele] Fix multidoting with FS, preAsc LMT, remove st EOGS, profile update

### DIFF
--- a/engine/class_modules/apl/shaman/elemental.simc
+++ b/engine/class_modules/apl/shaman/elemental.simc
@@ -57,7 +57,7 @@ actions.aoe+=/stormkeeper
 actions.aoe+=/liquid_magma_totem,if=(cooldown.primordial_wave.remains<5*gcd|!talent.primordial_wave)&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))
 actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&active_dot.flame_shock=0&(talent.primordial_wave|spell_targets.chain_lightning<=3)&cooldown.ascendance.remains>10
 
-actions.aoe+=/primordial_wave,if=active_dot.flame_shock=active_enemies>?6|cooldown.liquid_magma_totem.remains>15|!talent.liquid_magma_totem
+actions.aoe+=/primordial_wave,if=active_dot.flame_shock=active_enemies>?6|(cooldown.liquid_magma_totem.remains>15|!talent.liquid_magma_totem)&cooldown.ascendance.remains>15
 actions.aoe+=/ancestral_swiftness
 
 actions.aoe+=/ascendance,if=(talent.first_ascendant|fight_remains>200|fight_remains<80|buff.spymasters_web.up|variable.trinket_1_buffs&!trinket.1.is.spymasters_web&trinket.1.ready_cooldown|variable.trinket_2_buffs&!trinket.2.is.spymasters_web&trinket.2.ready_cooldown|equipped.neural_synapse_enhancer&cooldown.neural_synapse_enhancer.remains=0|equipped.bestinslots&cooldown.bestinslots.remains=0)&(buff.fury_of_storms.up|!talent.fury_of_the_storms)

--- a/engine/class_modules/apl/shaman/elemental.simc
+++ b/engine/class_modules/apl/shaman/elemental.simc
@@ -54,8 +54,8 @@ actions.aoe+=/storm_elemental,if=!buff.storm_elemental.up|!talent.echo_of_the_el
 actions.aoe+=/stormkeeper
 
 # Spread Flame shocks for Pwave.
-actions.aoe+=/liquid_magma_totem,if=(cooldown.primordial_wave.remains<5*gcd|!talent.primordial_wave)&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))&cooldown.ascendance.remains>10
-actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&!dot.flame_shock.ticking&(talent.primordial_wave|spell_targets.chain_lightning<=3)&cooldown.ascendance.remains>10
+actions.aoe+=/liquid_magma_totem,if=(cooldown.primordial_wave.remains<5*gcd|!talent.primordial_wave)&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))
+actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&active_dot.flame_shock=0&(talent.primordial_wave|spell_targets.chain_lightning<=3)&cooldown.ascendance.remains>10
 
 actions.aoe+=/primordial_wave,if=active_dot.flame_shock=active_enemies>?6|cooldown.liquid_magma_totem.remains>15|!talent.liquid_magma_totem
 actions.aoe+=/ancestral_swiftness
@@ -130,8 +130,7 @@ actions.single_target+=/liquid_magma_totem,if=dot.flame_shock.refreshable&!buff.
 # Maintain Flame shock if talented into Erupting Lava.
 actions.single_target+=/flame_shock,if=dot.flame_shock.refreshable&!buff.surge_of_power.up&!buff.master_of_the_elements.up&talent.erupting_lava
 
-# Spend if close to overcaping or MotE buff is up. Respect Echoes of Great Sundering.
-actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(maelstrom>variable.mael_cap-15|buff.master_of_the_elements.up)
+# Spend if close to overcaping or MotE buff is up. Friendship ended with Echoes of Great Sundering.
 actions.single_target+=/elemental_blast,if=maelstrom>variable.mael_cap-15|buff.master_of_the_elements.up
 actions.single_target+=/earth_shock,if=maelstrom>variable.mael_cap-15|buff.master_of_the_elements.up
 
@@ -141,7 +140,7 @@ actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusi
 actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>=2,if=!buff.master_of_the_elements.up&(!talent.master_of_the_elements|buff.lava_surge.up|buff.tempest.up|buff.stormkeeper.up|cooldown.lava_burst.charges_fractional>1.8|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))
 
 # Spend to activate Surge of Power buff for Tempest or Stormkeeper.
-actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
+actions.single_target+=/earthquake,if=buff.echoes_of_great_sundering_eb.up&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 actions.single_target+=/elemental_blast,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 actions.single_target+=/earth_shock,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 

--- a/engine/class_modules/apl/shaman/elemental_ptr.simc
+++ b/engine/class_modules/apl/shaman/elemental_ptr.simc
@@ -57,7 +57,7 @@ actions.aoe+=/stormkeeper
 actions.aoe+=/liquid_magma_totem,if=(cooldown.primordial_wave.remains<5*gcd|!talent.primordial_wave)&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))
 actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&active_dot.flame_shock=0&(talent.primordial_wave|spell_targets.chain_lightning<=3)&cooldown.ascendance.remains>10
 
-actions.aoe+=/primordial_wave,if=active_dot.flame_shock=active_enemies>?6|cooldown.liquid_magma_totem.remains>15|!talent.liquid_magma_totem
+actions.aoe+=/primordial_wave,if=active_dot.flame_shock=active_enemies>?6|(cooldown.liquid_magma_totem.remains>15|!talent.liquid_magma_totem)&cooldown.ascendance.remains>15
 actions.aoe+=/ancestral_swiftness
 
 actions.aoe+=/ascendance,if=(talent.first_ascendant|fight_remains>200|fight_remains<80|buff.spymasters_web.up|variable.trinket_1_buffs&!trinket.1.is.spymasters_web&trinket.1.ready_cooldown|variable.trinket_2_buffs&!trinket.2.is.spymasters_web&trinket.2.ready_cooldown|equipped.neural_synapse_enhancer&cooldown.neural_synapse_enhancer.remains=0|equipped.bestinslots&cooldown.bestinslots.remains=0)&(buff.fury_of_storms.up|!talent.fury_of_the_storms)

--- a/engine/class_modules/apl/shaman/elemental_ptr.simc
+++ b/engine/class_modules/apl/shaman/elemental_ptr.simc
@@ -54,8 +54,8 @@ actions.aoe+=/storm_elemental,if=!buff.storm_elemental.up|!talent.echo_of_the_el
 actions.aoe+=/stormkeeper
 
 # Spread Flame shocks for Pwave.
-actions.aoe+=/liquid_magma_totem,if=(cooldown.primordial_wave.remains<5*gcd|!talent.primordial_wave)&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))&cooldown.ascendance.remains>10
-actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&!dot.flame_shock.ticking&(talent.primordial_wave|spell_targets.chain_lightning<=3)&cooldown.ascendance.remains>10
+actions.aoe+=/liquid_magma_totem,if=(cooldown.primordial_wave.remains<5*gcd|!talent.primordial_wave)&(active_dot.flame_shock<=active_enemies-3|active_dot.flame_shock<(active_enemies>?3))
+actions.aoe+=/flame_shock,target_if=min:debuff.lightning_rod.remains,if=cooldown.primordial_wave.remains<gcd&active_dot.flame_shock=0&(talent.primordial_wave|spell_targets.chain_lightning<=3)&cooldown.ascendance.remains>10
 
 actions.aoe+=/primordial_wave,if=active_dot.flame_shock=active_enemies>?6|cooldown.liquid_magma_totem.remains>15|!talent.liquid_magma_totem
 actions.aoe+=/ancestral_swiftness
@@ -130,8 +130,7 @@ actions.single_target+=/liquid_magma_totem,if=dot.flame_shock.refreshable&!buff.
 # Maintain Flame shock if talented into Erupting Lava.
 actions.single_target+=/flame_shock,if=dot.flame_shock.refreshable&!buff.surge_of_power.up&!buff.master_of_the_elements.up&talent.erupting_lava
 
-# Spend if close to overcaping or MotE buff is up. Respect Echoes of Great Sundering.
-actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(maelstrom>variable.mael_cap-15|buff.master_of_the_elements.up)
+# Spend if close to overcaping or MotE buff is up. Friendship ended with Echoes of Great Sundering.
 actions.single_target+=/elemental_blast,if=maelstrom>variable.mael_cap-15|buff.master_of_the_elements.up
 actions.single_target+=/earth_shock,if=maelstrom>variable.mael_cap-15|buff.master_of_the_elements.up
 
@@ -141,7 +140,7 @@ actions.single_target+=/icefury,if=!(buff.fusion_of_elements_nature.up|buff.fusi
 actions.single_target+=/lava_burst,target_if=dot.flame_shock.remains>=2,if=!buff.master_of_the_elements.up&(!talent.master_of_the_elements|buff.lava_surge.up|buff.tempest.up|buff.stormkeeper.up|cooldown.lava_burst.charges_fractional>1.8|maelstrom>82-10*talent.eye_of_the_storm|maelstrom>52-5*talent.eye_of_the_storm&(buff.echoes_of_great_sundering_eb.up|!talent.elemental_blast))
 
 # Spend to activate Surge of Power buff for Tempest or Stormkeeper.
-actions.single_target+=/earthquake,if=(buff.echoes_of_great_sundering_es.up|buff.echoes_of_great_sundering_eb.up)&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
+actions.single_target+=/earthquake,if=buff.echoes_of_great_sundering_eb.up&(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 actions.single_target+=/elemental_blast,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 actions.single_target+=/earth_shock,if=(buff.tempest.up|buff.stormkeeper.up)&talent.surge_of_power&!talent.master_of_the_elements
 

--- a/profiles/generators/TWW2/TWW2_Generate_Shaman.simc
+++ b/profiles/generators/TWW2/TWW2_Generate_Shaman.simc
@@ -41,17 +41,18 @@ head=,id=229262,bonus_id=4800/4786/1527/11996/523,gem_id=213743
 neck=,id=228841,bonus_id=4800/4786/1527/11996/8781,gem_id=213473/213494
 shoulder=,id=229260,bonus_id=4800/4786/1527/11996
 back=,id=222817,bonus_id=10421/9633/8902/12043/12040/1485/10520/8960,enchant_id=7403,crafted_stats=40/36
-chest=,id=229265,bonus_id=4800/4786/1527/11996,enchant_id=7364,enchant=crystalline_radiance_3
+chest=,id=229265,bonus_id=4800/4786/1527/11996,enchant_id=7364
 wrist=,id=219342,bonus_id=10421/9633/8902/12043/12040/1485/1808/10520/8960,enchant_id=7385,gem_id=213494,crafted_stats=40/36
 hands=,id=229263,bonus_id=4800/4786/1527/11996
 waist=,id=221101,bonus_id=3170/11996/11964/1808,gem_id=213494
-legs=,id=158341,bonus_id=4786/11359/11996,enchant_id=7534,enchant=sunset_spellthread_3
+legs=,id=158341,bonus_id=4786/11359/11996,enchant_id=7534
 feet=,id=168982,bonus_id=10067/11996/11964,enchant_id=7424
-finger1=,id=231265,bonus_id=4800/4786/1527/11996/8781,enchant_id=7346,enchant=radiant_mastery_3,gem_id=213482/213458
+finger1=,id=231265,bonus_id=4800/4786/1527/11996/8781,enchant_id=7346,gem_id=213482/213458
 finger2=,id=228411,bonus_id=1511/11988/11964,enchant_id=7346,gem_id=228639/228638/228646
 trinket1=,id=230027,bonus_id=4800/4786/1527/11996
 trinket2=,id=230192,bonus_id=1527/11996/11964
-main_hand=,id=232805,bonus_id=4800/4786/1527/11996,enchant_id=7463,enchant=authority_of_radiant_power_3
+main_hand=,id=228901,bonus_id=1527/11996/11964,enchant_id=7460
+off_hand=,id=228889,bonus_id=1527/11996/11964
 
 save=TWW2_Shaman_Elemental.simc
 


### PR DESCRIPTION
1) Fix an unintended desperate attempt to multidot with Flame shock
2) LMT before Ascendance (allows to pwave if it reaches max FS count that way)
3) Remove EOGS from st rotation 
4) clean up profile from duplicated enchants and update weapons