### PR TITLE
[DungeonRoute] Mark unused keystone and hp percent options as obsolete

### DIFF
--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -1473,8 +1473,6 @@ sim_t::sim_t()
     dbc_override( std::make_unique<dbc_override_t>() ),
     timewalk( -1 ),
     scale_to_itemlevel( -1 ),
-    keystone_level( 10 ),
-    keystone_pct_hp( 27 ),
     dungeon_route_smart_targeting( true ),
     challenge_mode( false ),
     scale_itemlevel_down_only( false ),
@@ -3788,8 +3786,8 @@ void sim_t::create_options()
   add_option( opt_int( "desired_tank_targets", desired_tank_targets ) );
   add_option( opt_bool( "enable_taunts", enable_taunts ) );
   add_option( opt_bool( "use_item_verification", use_item_verification ) );
-  add_option( opt_int( "keystone_level", keystone_level, 1, 50 ) );
-  add_option( opt_int( "keystone_pct_hp", keystone_pct_hp, 1, 100 ) );
+  add_option( opt_obsoleted( "keystone_level" ) );
+  add_option( opt_obsoleted( "keystone_pct_hp" ) );
   add_option( opt_bool( "dungeon_route_smart_targeting", dungeon_route_smart_targeting ) );
 
   // Character Creation

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -167,8 +167,6 @@ struct sim_t : private sc_thread_t
 
   int timewalk;
   int scale_to_itemlevel; //itemlevel to scale to. if -1, we don't scale down
-  int keystone_level; // keystone difficulty for scaling purposes
-  int keystone_pct_hp;     // keystone mob health percent
   bool dungeon_route_smart_targeting;            // sets whether the list of mobs will be sorted by their hp
   bool challenge_mode; // if active, players will get scaled down to 620 and set bonuses are deactivated
   bool scale_itemlevel_down_only; // Items below the value of scale_to_itemlevel will not be scaled up.


### PR DESCRIPTION
These options have no bearing on the sim, but their presence in an input implies that users could sim a higher or lower keystone by changing a single number. Marking these as obsolete for now as popular methods of generating DungeonRoute strings still include them and need time to update. The goal is to improve clarity on how the strings are generated by making it obvious that the mob hp values for each pull are what need to change to simulate higher/lower keys.