### PR TITLE
[Warlock] Dimension Ripper talent adjust to 2.25%

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -459,7 +459,7 @@ public:
     const spell_data_t* chaos_barrage_tick;
     const spell_data_t* chaos_tear_summon; // This only creates the "pet"
     const spell_data_t* rift_chaos_bolt; // Separate ID from Warlock's Chaos Bolt
-    player_talent_t dimension_ripper; // TODO: After 11.1 goes live, removed outdated RNG option and outdated trigger flags
+    player_talent_t dimension_ripper; // TODO: implement the correct proc behavior based on the spell data
 
     player_talent_t decimation; // Crits can proc Soul Fire cooldown reset. Proc chance is not in spell data
     const spell_data_t* decimation_buff;
@@ -807,7 +807,7 @@ public:
 
     // Destruction
     rng_setting_t decimation = { 0.10, 0.10, "decimation" };
-    rng_setting_t dimension_ripper = { 0.05, 0.05, "dimension_ripper" };
+    rng_setting_t dimension_ripper = { 0.0225, 0.0225, "dimension_ripper" };
 
     // Diabolist
 

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -341,35 +341,6 @@ using namespace helpers;
         p()->procs.decimation->occur();
       }
 
-      if ( destruction() && triggers.dimension_ripper && !p()->min_version_check( VERSION_11_1_0 ) && rng().roll( p()->rng_settings.dimension_ripper.setting_value )  )
-      {
-        if ( p()->talents.dimensional_rift.ok() )
-        {
-          p()->cooldowns.dimensional_rift->reset( true, 1 );
-        }
-        else
-        {
-          int rift = rng().range( 3 );
-
-          switch ( rift )
-          {
-          case 0:
-            p()->warlock_pet_list.shadow_rifts.spawn( p()->talents.shadowy_tear_summon->duration() );
-            break;
-          case 1:
-            p()->warlock_pet_list.unstable_rifts.spawn( p()->talents.unstable_tear_summon->duration() );
-            break;
-          case 2:
-            p()->warlock_pet_list.chaos_rifts.spawn( p()->talents.chaos_tear_summon->duration() );
-            break;
-          default:
-            break;
-          }
-        }
-
-        p()->procs.dimension_ripper->occur();
-      }
-
       if ( destruction() && active_2pc( TWW2 ) && triggers.jackpot_destruction )
       {
         if ( p()->jackpot_destruction_rng->trigger() )
@@ -399,7 +370,7 @@ using namespace helpers;
           p()->procs.reverse_entropy->occur();
       }
 
-      if ( destruction() && triggers.dimension_ripper && p()->min_version_check( VERSION_11_1_0 ) && rng().roll( p()->talents.dimension_ripper->effectN( 1 ).percent() * ( p()->bugs ? 0.45 : 1.0 ) ) )
+      if ( destruction() && triggers.dimension_ripper && rng().roll( p()->rng_settings.dimension_ripper.setting_value ) )
       {
         int rift = rng().range( 3 );
 
@@ -3517,8 +3488,6 @@ using namespace helpers;
         affected_by.chaotic_energies = true;
         affected_by.ashen_remains = p->talents.ashen_remains.ok();
 
-        triggers.dimension_ripper = p->talents.dimension_ripper.ok();
-
         base_multiplier *= p->talents.fire_and_brimstone->effectN( 1 ).percent();
 
         base_dd_multiplier *= 1.0 + p->talents.sargerei_technique->effectN( 2 ).percent(); // TOCHECK: Does this apply in-game correctly?
@@ -3605,7 +3574,6 @@ using namespace helpers;
       affected_by.havoc = true;
       affected_by.ashen_remains = p->talents.ashen_remains.ok();
 
-      triggers.dimension_ripper = p->talents.dimension_ripper.ok();
       triggers.jackpot_destruction = true;
 
       add_child( fnb_action );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -399,7 +399,7 @@ using namespace helpers;
           p()->procs.reverse_entropy->occur();
       }
 
-      if ( destruction() && triggers.dimension_ripper && p()->min_version_check( VERSION_11_1_0 ) && rng().roll( p()->talents.dimension_ripper->effectN( 1 ).percent() / ( p()->bugs ? 2.0 : 1.0 ) ) )
+      if ( destruction() && triggers.dimension_ripper && p()->min_version_check( VERSION_11_1_0 ) && rng().roll( p()->talents.dimension_ripper->effectN( 1 ).percent() * ( p()->bugs ? 0.45 : 1.0 ) ) )
       {
         int rift = rng().range( 3 );
 


### PR DESCRIPTION
1️⃣#10186 &#8594; 2️⃣#10194 &#8594; 3️⃣**this**

In the latest merged PR 2️⃣#10194, the [Dimension Ripper](https://www.wowhead.com/spell=457025/dimension-ripper) proc value is adjusted to half of its original value (`5 / 2 = 2.5`), but this is not the good value. The observed value in the ingame tests for this proc is `2.25`. In this PR, this is adjusted to give the expected result (`5 * 0.45 = 2.25`).