### PR TITLE
Immediately enter Carved Blazikon Wax light

### DIFF
--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -846,8 +846,9 @@ struct player_t : public actor_t
     timespan_t entropic_skardyn_core_pickup_delay = 4_s;
     timespan_t entropic_skardyn_core_pickup_stddev = 1_s;
     // when to enter and how long to stay in light for carved blazikon wax
-    timespan_t carved_blazikon_wax_enter_light_delay = 4_s;
-    timespan_t carved_blazikon_wax_enter_light_stddev = 1_s;
+    // as of at least 11.1.5, the candle always spawns in range, so enter immediately
+    timespan_t carved_blazikon_wax_enter_light_delay = 0_s;
+    timespan_t carved_blazikon_wax_enter_light_stddev = 0_s;
     timespan_t carved_blazikon_wax_stay_in_light_duration = 0_s;  // remain until the end
     timespan_t carved_blazikon_wax_stay_in_light_stddev = 0_s;
     // allies with signet of the priory


### PR DESCRIPTION
I tested around ~30~ 50 procs and the candle always spawned within player range, so change these constants to make the "In Light" buff 100% uptime, assuming the player does not move.

Sample spawns across my testing:

furthest case:
![image](https://github.com/user-attachments/assets/8ff91384-4105-4a30-82c9-24f25d006eee)

closest case:
![image](https://github.com/user-attachments/assets/a11ae09d-0c4e-4dfd-a70b-f8f136690923)
