### PR TITLE
[Warlock] Allow the Felguard pet to use some spells during Felstorm

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -478,7 +478,7 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
   action_list_str += "/legion_strike,if=energy>=" + util::to_string( max_energy_threshold );
 
   if ( owner->talents.soul_strike.ok() )
-    action_list_str += "/soul_strike";
+    action_list_str += "/soul_strike,use_while_casting=1";
 
   felstorm_cd = get_cooldown( "felstorm" );
   dstr_cd = get_cooldown( "felstorm_demonic_strength" );
@@ -541,6 +541,7 @@ struct axe_toss_t : public warlock_pet_spell_t
 
     may_miss = may_block = may_dodge = may_parry = false;
     ignore_false_positive = is_interrupt = true;
+    usable_while_casting = true;
   }
 };
 
@@ -749,6 +750,7 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
 
     cooldown->duration = p->o()->talents.soul_strike_pet->cooldown();
     trigger_gcd = p->o()->talents.soul_strike_pet->gcd();
+    usable_while_casting = true;
 
     soul_cleave = new soul_cleave_t( p );
     add_child( soul_cleave );


### PR DESCRIPTION
Ingame, the [Felguard](https://www.wowhead.com/npc=17252/felguard)'s [Soul Strike](https://www.wowhead.com/spell=267964/soul-strike) spell and the interrupt/stun [Axe Toss](https://www.wowhead.com/spell=89766/axe-toss) spell can be used while the Felguard is channeling [Felstorm](https://www.wowhead.com/spell=89751/felstorm), and it is not necessary to wait for the channeling to end to use it, as is currently happening in simc. This is an exceptional behavior of those spells, and other pet spells (such as [Legion Strike](https://www.wowhead.com/spell=30213/legion-strike)) must wait for the channeling to end before being used.

This PR makes the necessary changes to allow [Soul Strike](https://www.wowhead.com/spell=267964/soul-strike) to be used in these circumstances. To achieve this, only two changes are necessary. The first is to set the `usable_while_casting` boolean to `true` for the `soul_strike_t` spell. The second change is to modify the pet's APL to include `,use_while_casting=1` in the `/soul_strike` action. For [Axe Toss](https://www.wowhead.com/spell=89766/axe-toss), the `usable_while_casting` boolean is also set in the code.

Other "damage proc" style pet spells that can occur during [Felstorm](https://www.wowhead.com/spell=89751/felstorm), such as [Fiendish Wrath](https://www.wowhead.com/spell=386702/fiendish-wrath) and [Immutable Hatred](https://www.wowhead.com/spell=405670/immutable-hatred), already trigger their damage even when in [Felstorm](https://www.wowhead.com/spell=89751/felstorm) in the current simc implementation, so no changes are needed. The same goes for [Soul Cleave](https://www.wowhead.com/spell=387502/soul-cleave), a child spell of [Soul Strike](https://www.wowhead.com/spell=267964/soul-strike), which doesn't seem to need any changes to properly apply its damage when [Soul Strike](https://www.wowhead.com/spell=267964/soul-strike) deals damage during [Felstorm](https://www.wowhead.com/spell=89751/felstorm) (with the new changes).