### PR TITLE
[Gear] Set ICD for Moxie trinket activation buff proc

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6895,6 +6895,7 @@ void mugs_moxie_jug( special_effect_t& effect )
   auto second_proc = new dbc_proc_callback_t( effect.player, *buff_driver );
   second_proc->activate_with_buff( crit_buff, true );
 
+  effect.cooldown_    = effect.duration();
   effect.proc_flags_  = PF_ALL_DAMAGE | PF_ALL_HEAL;
   effect.proc_flags2_ = PF2_ALL_HIT | PF2_ALL_CAST | PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL | PF2_LANDED;
   effect.custom_buff  = crit_buff;


### PR DESCRIPTION
This PR is a small change that sets an internal cooldown for the [effect (471548)](https://www.wowhead.com/spell=471548/mugs-moxie-jug) that triggers the activation (the first stack) of [Moxie Frenzy buff (474285)](https://www.wowhead.com/spell=474285/moxie-frenzy) from the [Mug's Moxie Jug trinket](https://www.wowhead.com/item=230192/mugs-moxie-jug).

Once the buff is active, the proc effect that increases the stacks will be performed by another [effect (474376)](https://www.wowhead.com/spell=474376/mugs-moxie-jug) (the hidden buff driver), and the main activation proc [effect (471548)](https://www.wowhead.com/spell=471548/mugs-moxie-jug) will not occur in the meantime. In the current implementation of simc, the activation proc effect continues to occur even if the buff is active, adding a stack if the proc's rppm rng results in activation.

It has been verified ingame that the main activation [effect (471548)](https://www.wowhead.com/spell=471548/mugs-moxie-jug) doesn't occur while the buff is active, or if it does, it does so silently without anything happening. We know this because no increase in the number of buff stacks has been detected outside the hidden buff driver's internal cooldown time window (750ms). We also know that the proc that triggers the buff's initial effect doesn't share an ICD with the hidden buff driver: there may be less than a 750ms difference between stacks 1 and 2 (1 from main activation effect, 2 from hidden debuff driver), but not for any other stack increment (e.g.: 2 to 3, 4 to 5, 5 to 6, 8 to 9, ...).

Therefore, this PR sets an ICD for the main item activation effect equal to the buff duration (currently 15 seconds) in simc, thus preventing the main item activation proc effect from being triggered while the buff is active.