### PR TITLE
[WARLOCK][HELLCALLER] Removes blackened Soul ICD.

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -594,7 +594,7 @@ namespace warlock
     hero.malevolence_buff = find_spell( 442726 );
     hero.malevolence_dmg = find_spell( 446285 );
 
-    cooldowns.blackened_soul->duration = 500_ms; // TODO: Set using data once hotfix is in using hero.blackened_soul->internal_cooldown();
+    cooldowns.blackened_soul->duration = 0_ms; // TODO: Set using data once hotfix is in using hero.blackened_soul->internal_cooldown();
     cooldowns.seeds_of_their_demise->duration = 15_s;
   }
 


### PR DESCRIPTION
Removed ICD at hotfix https://www.wowhead.com/pt/news/affliction-and-destruction-blackened-soul-hotfix-icd-removed-376601 

This hotfix aims to allow stack generation in cases of Cast followed by Instant Cast (like CB>SBurn on destro).