### PR TITLE
[Gear] Alternative option for Moxie trinket buff stacking

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12922,6 +12922,11 @@ void player_t::create_options()
   add_option( opt_string( "thewarwithin.jastor_diamond_ally_stat", thewarwithin_opts.jastor_diamond_ally_stat ) );
   add_option( opt_float( "thewarwithin.suspicious_energy_drink_bonus_chance",
                          thewarwithin_opts.suspicious_energy_drink_bonus_chance, 0, 1 ) );
+  add_option( opt_string( "thewarwithin.moxie_frenzy_buff_stack_mode", thewarwithin_opts.moxie_frenzy_buff_stack_mode ) );
+  add_option( opt_timespan( "thewarwithin.moxie_frenzy_buff_stack_gain_interval", thewarwithin_opts.moxie_frenzy_buff_stack_gain_interval, 0_ms, 14_s ) );
+  add_option( opt_timespan( "thewarwithin.moxie_frenzy_buff_stack_gain_interval_stddev", thewarwithin_opts.moxie_frenzy_buff_stack_gain_interval_stddev, 0_ms, 14_s ) );
+  add_option( opt_timespan( "thewarwithin.moxie_frenzy_buff_stack_first_tick", thewarwithin_opts.moxie_frenzy_buff_stack_first_tick, 0_ms, 14_s ) );
+  add_option( opt_timespan( "thewarwithin.moxie_frenzy_buff_stack_first_tick_stddev", thewarwithin_opts.moxie_frenzy_buff_stack_first_tick_stddev, 0_ms, 14_s ) );
   add_option( opt_timespan( "thewarwithin.additional_gcd_time", thewarwithin_opts.additional_gcd_time, 0_s, 10_s ) );
 }
 

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -886,6 +886,16 @@ struct player_t : public actor_t
     player_option_t<std::string> mister_locknstalk_mode = "dynamic";
     player_option_t<std::string> jastor_diamond_ally_stat = "none";
     double suspicious_energy_drink_bonus_chance           = 0;
+    // Which method to use to determine Moxie Frenzy buff stack gain. Accepts "normal" (default) or "timed"
+    // "Normal": Most casts, damage effects and healing effects increase the buff stack
+    // "Timed": The buff gain a stack periodically based on custom 'interval' and 'first_tick' times
+    // Whichever method is selected, the ICD of buff stack gain will always be respected
+    player_option_t<std::string> moxie_frenzy_buff_stack_mode = "normal";
+    timespan_t moxie_frenzy_buff_stack_gain_interval          = 900_ms;
+    timespan_t moxie_frenzy_buff_stack_gain_interval_stddev   = 250_ms;
+    timespan_t moxie_frenzy_buff_stack_first_tick             = 25_ms;
+    timespan_t moxie_frenzy_buff_stack_first_tick_stddev      = 350_ms;
+    // Additional GCD time
     timespan_t additional_gcd_time                        = 0_s;
   } thewarwithin_opts;
 

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6885,15 +6885,46 @@ void mugs_moxie_jug( special_effect_t& effect )
                        ->add_stat_from_effect( 1, effect.driver()->effectN( 1 ).average( effect ) )
                        ->set_refresh_behavior( buff_refresh_behavior::DISABLED );
 
-  auto buff_driver          = new special_effect_t( effect.player );
-  buff_driver->name_str     = util::tokenize_fn( effect.driver()->effectN( 1 ).trigger()->name_cstr() );
-  buff_driver->spell_id     = effect.driver()->effectN( 1 ).trigger_spell_id();
-  buff_driver->proc_flags2_ = PF2_ALL_HIT | PF2_ALL_CAST | PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL;
-  buff_driver->custom_buff  = crit_buff;
-  effect.player->special_effects.push_back( buff_driver );
+  if ( !( effect.player->thewarwithin_opts.moxie_frenzy_buff_stack_mode == "timed" ) )
+  {
+    auto buff_driver          = new special_effect_t( effect.player );
+    buff_driver->name_str     = util::tokenize_fn( effect.driver()->effectN( 1 ).trigger()->name_cstr() );
+    buff_driver->spell_id     = effect.driver()->effectN( 1 ).trigger_spell_id();
+    buff_driver->proc_flags2_ = PF2_ALL_HIT | PF2_ALL_CAST | PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL;
+    buff_driver->custom_buff  = crit_buff;
+    effect.player->special_effects.push_back( buff_driver );
 
-  auto second_proc = new dbc_proc_callback_t( effect.player, *buff_driver );
-  second_proc->activate_with_buff( crit_buff, true );
+    auto second_proc = new dbc_proc_callback_t( effect.player, *buff_driver );
+    second_proc->activate_with_buff( crit_buff, true );
+  }
+  else
+  {
+    const timespan_t opt_s_interval = effect.player->thewarwithin_opts.moxie_frenzy_buff_stack_gain_interval > effect.trigger()->internal_cooldown()
+                                          ? effect.player->thewarwithin_opts.moxie_frenzy_buff_stack_gain_interval
+                                          : effect.trigger()->internal_cooldown();
+    const timespan_t opt_s_interval_stddev = effect.player->thewarwithin_opts.moxie_frenzy_buff_stack_gain_interval_stddev;
+    const timespan_t opt_s_first_tick = effect.player->thewarwithin_opts.moxie_frenzy_buff_stack_first_tick;
+    const timespan_t opt_s_first_tick_stddev = effect.player->thewarwithin_opts.moxie_frenzy_buff_stack_first_tick_stddev;
+
+    crit_buff->set_tick_behavior( buff_tick_behavior::CLIP )
+             ->set_tick_time_behavior( buff_tick_time_behavior::CUSTOM )
+             ->set_tick_time_callback( [ &effect, opt_s_interval, opt_s_interval_stddev, opt_s_first_tick, opt_s_first_tick_stddev ] ( const buff_t*, unsigned current_tick ) {
+               timespan_t period;
+               if ( current_tick == 0 )
+               {
+                 // For the first tick using a Left-Censored Gaussian Distribution is more appropriate
+                 period = timespan_t::from_millis( effect.player->rng().gauss( opt_s_first_tick.total_millis(), opt_s_first_tick_stddev.total_millis() ) );
+                 if ( period <= 0_ms )
+                   period = 1_ms;
+               }
+               else
+               {
+                 // For the rest of the ticks we use a Left-Truncated Gaussian Distribution
+                 period = effect.player->rng().gauss_a( opt_s_interval, opt_s_interval_stddev, effect.trigger()->internal_cooldown() );
+               }
+               return period;
+             } );
+  }
 
   effect.cooldown_    = effect.duration();
   effect.proc_flags_  = PF_ALL_DAMAGE | PF_ALL_HEAL;


### PR DESCRIPTION
The [Mug's Moxie Jug](https://www.wowhead.com/item=230192/mugs-moxie-jug) trinket presents some [issues](https://github.com/simulationcraft/simc/issues/10116) in Simc. This trinket has two drivers: the [main driver](https://www.wowhead.com/spell=471548/mugs-moxie-jug), which is responsible for processing the buff activation (15sec ICD), and the [secondary driver](https://www.wowhead.com/spell=474376/mugs-moxie-jug), which increases the stacks while the buff is active (750ms ICD). Both effects can be triggered by a multitude of player actions: healing effects, damage effects, energize effects, some gain/drop/refresh auras, and even some triggers from periodic hidden auras/spells that don't appear in the combatlog or the logs.

Simc doesn't include the implementation of many of these effects, which causes some issues with the trinket. For the main driver, this isn't a big problem, as it's RPPM-based. In Simc it has been established for main driver that it can be triggered by many casts, damage effects, and healing effects. This should be sufficient for it to trigger periodically based on RPPM, so no major changes are needed. The problem is the secondary driver that increases stacks while the buff is present, which is not RPPM-based and always increases the buff by one stack with any of its activations (is 100% chance, so it is activating all the time with all these effects/spells, as long as they occur after its 750ms ICD). In Simc, many of these effects are not implemented, so the buff doesn't increase stacks as quickly as it does ingame for many specs, and that's the problem.

Commit 46eea1600ecc42f00279902b9e6f17f44a1fb907 has attempted to make the secondary driver increase stacks more quickly, including most damage and healing casts and effects. This isn't entirely accurate, but it makes its effectiveness more similar to ingame.

While this 46eea1600ecc42f00279902b9e6f17f44a1fb907  commit is a great improvement, it may still be insufficient for some specs or classes. For example, for the Demonology Warlock in ST and 5T, the following average uptimes for each buff stack is currently being simulated (normalizing in this context means transforming average buff-stack uptimes relative to the entire fight, which is what Simc reports, to average buff-stack uptimes relative to only when the buff is active; we only really care about the normalized values):
- <ins>**ST (1 Target) (simc current implementation):**</ins>
![imagen](https://github.com/user-attachments/assets/ada46cd7-f8a8-45dd-b9fb-4689279d89b9)
- <ins>**5 Targets (simc current implementation):**</ins>
![imagen](https://github.com/user-attachments/assets/d1befa5c-8acc-4b46-8fbf-96ae7ad8147c)

It can be seen that it rarely reaches 14 or 15 stacks in sims. However, looking at the logs, we can see that the ingame effect is greater. [Here](https://www.warcraftlogs.com/reports/ca2G3fRLMPDWj9Nd?fight=last&source=4&type=auras&target=4&ability=474285&view=events) is an example of a 1-hour log on a ST dummy (ST Raid Talents and rotation), and [here](https://www.warcraftlogs.com/reports/TmPkbpHxM9h2jZNF?fight=last&type=auras&source=1&target=1&ability=474285&view=events) is another 1-hour log on 5T dummies (M+ AoE Talents and rotation). The normalized average uptimes of this trinket for these logs are the following:
- <ins>**1T (extracted from [logs](https://www.warcraftlogs.com/reports/ca2G3fRLMPDWj9Nd?fight=last&source=4&type=auras&target=4&ability=474285&view=events)):**</ins>
![imagen](https://github.com/user-attachments/assets/2890acd1-c2e9-4155-aefe-85804c3347b9)
- <ins>**5T (extracted from [logs](https://www.warcraftlogs.com/reports/TmPkbpHxM9h2jZNF?fight=last&type=auras&source=1&target=1&ability=474285&view=events)):**</ins>
![imagen](https://github.com/user-attachments/assets/9af81446-260f-4547-bbe9-be5d5b132c7b)

We can see that the average buff-stack uptime difference between the current simulations and the ingame results (logs) is significant, at least for this spec.

This PR adds an additional and completely optional setting that lets you configure the trinket buff to gain stacks at time intervals instead of tying stack gains to player actions. This new mode is more difficult to use and requires more setup work, but allows for more accurate results when configured properly. To activate this new mode, the user must set the new option `thewarwithin.moxie_frenzy_buff_stack_mode=timed`. If set to `normal`, the functionality will remain exactly the same as the current implementation without any changes. `normal` mode is the default mode, so the new mode would only be activated if the user manually sets this option.

In order for the user to set the time interval between stack gains (only for the new `timed` mode) they must use the new option `thewarwithin.moxie_frenzy_buff_stack_gain_interval`. Because of how the ingame trinket works, the first activation (stack 1) is done by the main driver, and the second activation (stack 2) and subsequent ones are done by the secondary driver, and these two drivers do not share the same ICD. This is why ingame the time of this buff from stack 1 to stack 2 is much faster than the rest of the stack time intervals. This is why we also included an additional option `thewarwithin.moxie_frenzy_buff_stack_first_tick` that allows you to set the time between the interval of this first-stack-to-the-second. Finally, to give them a less rigid timings more similar to the stack gains intervals of the game, you can also set a standard deviation for these two intervals (`thewarwithin.moxie_frenzy_buff_stack_gain_interval_stddev` and `thewarwithin.moxie_frenzy_buff_stack_first_tick_stddev` options), so that the intervals vary slightly in each tick depending on rng. You can always set these values to `0` for fixed time intervals.

With this new mode, a user who knows approximately how often the trinket gains stacks for their character (this data can be obtained by analyzing logs, for example) can set these new option values to the desired ones, thus achieving a simulation of the trinket that more accurately reflects what happens to their character ingame. This trinket is one of the best for many classes, and many people now with dinars want to simulate it to compare with others. Therefore, with this new option, an advanced user can better test its actual effectiveness on their character. Also, remember that these options are completely optional and disabled by default, so for normal users, the current simulation implementation will continue to be used, but for those who specifically want to use them, it gives them the opportunity to achieve more consistent results with those observed ingame.

At last, since we previously discussed the case of the demonology warlock for 1T and 5T, I'm posting here the simulation results after using this new option with an appropriate configuration for this character (according to data extracted from the logs):

<ins>**Configuration used in Simc (for both, 1T and 5T):**</ins>
```
thewarwithin.moxie_frenzy_buff_stack_mode=timed
thewarwithin.moxie_frenzy_buff_stack_gain_interval=0.900
thewarwithin.moxie_frenzy_buff_stack_gain_interval_stddev=0.250
thewarwithin.moxie_frenzy_buff_stack_first_tick=0.025
thewarwithin.moxie_frenzy_buff_stack_first_tick_stddev=0.350
```
<ins>***Results:**</ins>
- <ins>**1T (simc new trinket mode):**</ins>
![imagen](https://github.com/user-attachments/assets/0338e8bd-338e-4948-bc2b-f34875f16828)
- <ins>**5T (simc new trinket mode):**</ins>
![imagen](https://github.com/user-attachments/assets/d278e52f-dd72-4f57-9f65-3e10cbd8987b)

We can see that the normalized average uptimes are now more consistent with the ones seen in the logs. These examples were for the Demonology Warlock, for which the "normal" implementation doesn't give particularly accurate results. It's possible that for other specs the "normal" implementation will be sufficient and the new mode may not be necessary, but there are surely some other specs that could also benefit from this new mode (with its correspondingly appropriate configuration) to achieve more accurate results.