### PR TITLE
[gear] Fix Entropic Skardyn Core Segfault

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -3325,7 +3325,7 @@ struct pickup_entropic_skardyn_core_t : public action_t
 
   bool ready() override
   {
-      return tracker && tracker->check();
+    return tracker && tracker->check();
   }
 
   void execute() override

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -3325,8 +3325,7 @@ struct pickup_entropic_skardyn_core_t : public action_t
 
   bool ready() override
   {
-    if ( tracker )
-      return tracker->check();
+      return tracker && tracker->check();
   }
 
   void execute() override

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -3325,7 +3325,8 @@ struct pickup_entropic_skardyn_core_t : public action_t
 
   bool ready() override
   {
-    return tracker->check();
+    if ( tracker )
+      return tracker->check();
   }
 
   void execute() override


### PR DESCRIPTION
Ready Action seems to be executed before conditionals are being checked, which leads to a segfault if the profile is not running the trinket (as is the case in profileset sims).

Just check for existence of the tracker before calling it.