### PR TITLE
[Gear] Fix Twilight Devastation decaying multiplier in aoe

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -574,27 +574,14 @@ void twilight_devastation( special_effect_t& effect )
       aoe = 10;
     }
 
-    double composite_da_multiplier( const action_state_t* s ) const override
+    double composite_aoe_multiplier( const action_state_t* s ) const override
     {
-      double m = generic_proc_t::composite_da_multiplier( s );
+      double m = generic_proc_t::composite_aoe_multiplier( s );
 
-      m *= current_mult;
+      if ( s->chain_target > 0 )
+        m *= pow( 0.65, s->chain_target );
 
       return m;
-    }
-
-    void execute() override
-    {
-      current_mult = 1.0;
-      generic_proc_t::execute();
-    }
-
-    void impact( action_state_t* s ) override
-    {
-      if ( s->chain_target >= 1 )
-        current_mult *= 0.65;
-
-      generic_proc_t::impact( s );
     }
   };
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/69eadc94-ddb1-4a8d-bddf-dcee5700be61)

Currently the use of `composite_da_multiplier` doesn't actually update the mult per impact:

<https://www.raidbots.com/reports/gJQLbP18dncHb8SG6an2dX/output.txt>
![image](https://github.com/user-attachments/assets/15e4328b-92a1-4ca5-b4e4-20dc9e13d8ad)
