### PR TITLE
[config] Remove CISO646

### DIFF
--- a/engine/config.hpp
+++ b/engine/config.hpp
@@ -82,19 +82,6 @@
 
 
 // ==========================================================================
-// Compiler Workarounds
-// ==========================================================================
-
-/* This header defines eleven macro constants with alternative spellings for those C++ operators
- * not supported by the ISO646 standard character set.
- * eg. and == &&, or == ||, etc.
- * This is required for MSVC, which without the /ZA option does not conform to the standard, but which
- * we don't want to use for other reasons.
- */
-#include <ciso646>
-
-
-// ==========================================================================
 // General Macros/Defines
 // ==========================================================================
 


### PR DESCRIPTION
Clang has begun to warn about the deprecation of CISO646 in C++17, and its removal for C++20.

This PR exists to test whether or not CI passes for other compiler configurations, and to remove it if MSVC supports alternate operator representations with the configuration we currently provide.
