### PR TITLE
[Mage] Frost Gear Update & Corruption Enchants

### DIFF
--- a/profiles/generators/TWW2/TWW2_Generate_Mage.simc
+++ b/profiles/generators/TWW2/TWW2_Generate_Mage.simc
@@ -12,7 +12,7 @@ food=feast_of_the_midnight_masquerade
 augmentation=crystallized
 temporary_enchant=main_hand:algari_mana_oil_3
 
-head=aspectral_emissarys_crystalline_cowl,id=229343,gem_id=213743,ilevel=684
+head=aspectral_emissarys_crystalline_cowl,id=229343,gem_id=213743,ilevel=684,enchant_id=7933
 neck=semicharmed_amulet,id=228841,gem_id=213494/213455,ilevel=684
 shoulder=aspectral_emissarys_arcane_vents,id=229341,ilevel=684
 back=trashmasters_mantle,id=168970,enchant_id=7415,ilevel=684
@@ -44,7 +44,7 @@ food=feast_of_the_midnight_masquerade
 augmentation=crystallized
 temporary_enchant=main_hand:algari_mana_oil_3
 
-head=aspectral_emissarys_crystalline_cowl,id=229343,gem_id=213743,ilevel=684
+head=aspectral_emissarys_crystalline_cowl,id=229343,gem_id=213743,ilevel=684,enchant_id=7933
 neck=semicharmed_amulet,id=228841,gem_id=213494/213455,ilevel=684
 shoulder=aspectral_emissarys_arcane_vents,id=229341,ilevel=684
 back=trashmasters_mantle,id=168970,enchant_id=7415,ilevel=684
@@ -76,7 +76,7 @@ food=the_sushi_special
 augmentation=crystallized
 temporary_enchant=main_hand:algari_mana_oil_3
 
-head=,id=229343,bonus_id=11996/10356/11960/6652/12176/1579/10255,gem_id=213743,ilevel=684
+head=,id=229343,bonus_id=11996/10356/11960/6652/12176/1579/10255,gem_id=213743,ilevel=684,enchant_id=7927
 neck=semicharmed_amulet,id=228841,ilevel=684,gem_id=213494/213455
 shoulder=,id=229341,bonus_id=11996/10356/11962/6652/1579/10255,ilevel=684
 feet=,id=229345,bonus_id=11996/10356/6652/1579/10255,ilevel=684
@@ -110,7 +110,7 @@ food=the_sushi_special
 augmentation=crystallized
 temporary_enchant=main_hand:algari_mana_oil_3
 
-head=aspectral_emissarys_crystalline_cowl,id=229343,bonus_id=11996/10356/11960/6652/12176/1579/10255,gem_id=213743,ilevel=684
+head=aspectral_emissarys_crystalline_cowl,id=229343,bonus_id=11996/10356/11960/6652/12176/1579/10255,gem_id=213743,ilevel=684,enchant_id=7927
 neck=amulet_of_earthen_craftsmanship,id=215136,bonus_id=10421/10520/9633/8902/10879/10396/9627/10222/8792,ilevel=681,gem_id=213455/213485
 shoulder=aspectral_emissarys_arcane_vents,id=229341,bonus_id=11996/10356/11962/6652/1579/10255,ilevel=684
 back=consecrated_cloak,id=222817,bonus_id=11304/8960,ilevel=681,enchant_id=7403,crafted_stats=36/40
@@ -142,22 +142,22 @@ food=feast_of_the_midnight_masquerade
 augmentation=crystallized
 temporary_enchant=main_hand:algari_mana_oil_3
 
-head=inventors_ingenious_trifocals,id=235226,bonus_id=3170/11996/11964/1808,ilevel=684,gem_id=213743
-neck=flickering_glowtorc,id=221103,bonus_id=3170/11996/11964/8781,ilevel=684,gem_id=213461/213485
-shoulder=aspectral_emissarys_arcane_vents,id=229341,bonus_id=11996/10356/11962/6652/1579/10255,ilevel=684
-back=undercircuit_racing_flag,id=228839,ilevel=684,enchant_id=7403
-chest=aspectral_emissarys_primal_robes,id=229346,bonus_id=11996/10356/11958/6652/1579/10255,ilevel=684,enchant_id=7364
-wrist=consecrated_cuffs,id=222815,bonus_id=10421/8960,gem_id=213497,enchant_id=7385,crafted_stats=32/36,ilevel=681
-hands=aspectral_emissarys_hardened_grasp,id=229344,bonus_id=1579/11996,ilevel=684
-waist=tuneup_toolbelt,id=228861,bonus_id=1527/11996/11964/1808,ilevel=684,gem_id=213485
-legs=aspectral_emissarys_trousers,id=229342,bonus_id=11996/10356/11961/6652/1579/10255,ilevel=684,enchant_id=7534
-feet=nonconductive_killosocks,id=234497,bonus_id=4786/1527/11996,ilevel=684,enchant_id=7424
-finger1=wicks_golden_loop,id=221099,bonus_id=8781,ilevel=684,gem_id=213470/213455,enchant_id=7340
-finger2=the_jastor_diamond,id=231265,bonus_id=4800/4786/1527/11996/8781,ilevel=684,gem_id=213485/213485,enchant_id=7340
-trinket1=candle_confidant,id=225648,ilevel=671
-trinket2=house_of_cards,id=230027,ilevel=684
-main_hand=blastfurious_machete,id=231268,ilevel=684,enchant_id=7460
-off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/9627/10222/11300/8960/8795/11144,ilevel=681,crafted_stats=40/32
+head=inventors_ingenious_trifocals,id=235226,bonus_id=3176/12376/11964/1808,gem_id=213743,enchant_id=7924
+neck=flickering_glowtorc,id=221103,bonus_id=3176/12376/11964/8781,gem_id=213467/213467
+shoulder=aspectral_emissarys_arcane_vents,id=229341,bonus_id=12179/1533/12376
+back=electricians_siphoning_filter,id=234507,bonus_id=4786/1533/12376,enchant_id=7409
+chest=aspectral_emissarys_primal_robes,id=229346,bonus_id=12178/1533/12376,enchant_id=7364
+wrist=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/12043/12040/1485/12373/11109/8960/1808,gem_id=213467,enchant_id=7397,crafted_stats=32/40
+hands=aspectral_emissarys_hardened_grasp,id=229344,bonus_id=12179/1533/12376
+waist=tuneup_toolbelt,id=228861,bonus_id=1533/12376/11964/1808,gem_id=213467
+legs=aspectral_emissarys_trousers,id=229342,bonus_id=12178/1533/12376,enchant_id=7534
+feet=nonconductive_killosocks,id=234497,bonus_id=1533/12376/11964,enchant_id=7418
+finger1=the_jastor_diamond,id=231265,bonus_id=1533/12376/11964/8781,gem_id=213467/213497,enchant_id=7352
+finger2=miniature_roulette_wheel,id=228843,bonus_id=1533/12376/11964/8781,gem_id=213461/213485,enchant_id=7352,crafted_stats=36/40
+trinket1=house_of_cards,id=230027,bonus_id=1533/12376/11964
+trinket2=entropic_skardyn_core,id=219296,bonus_id=3176/12376/11964
+main_hand=blastfurious_machete,id=231268,bonus_id=1533/12376/11964,enchant_id=7460
+off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/1485/12373/11300/8960,crafted_stats=36/40
 
 save=TWW2_Mage_Frost_Spellslinger.simc
 
@@ -175,21 +175,21 @@ food=feast_of_the_midnight_masquerade
 augmentation=crystallized
 temporary_enchant=main_hand:algari_mana_oil_3
 
-head=inventors_ingenious_trifocals,id=235226,bonus_id=3170/11996/11964/1808,ilevel=684,gem_id=213743
-neck=flickering_glowtorc,id=221103,bonus_id=3170/11996/11964/8781,ilevel=684,gem_id=213485/213455
-shoulder=aspectral_emissarys_arcane_vents,id=229341,bonus_id=11996/10356/11962/6652/1579/10255,ilevel=684
-back=candlebearers_shroud,id=221109,ilevel=684,enchant_id=7403
-chest=aspectral_emissarys_primal_robes,id=229346,bonus_id=11996/10356/11958/6652/1579/10255,ilevel=684,enchant_id=7364
-wrist=consecrated_cuffs,id=222815,bonus_id=10421/8960,gem_id=213497,enchant_id=7385,crafted_stats=32/36,ilevel=681
-hands=aspectral_emissarys_hardened_grasp,id=229344,bonus_id=1579/11996,ilevel=684
-waist=tuneup_toolbelt,id=228861,bonus_id=1527/11996/11964/1808,ilevel=684,gem_id=213467
-legs=aspectral_emissarys_trousers,id=229342,bonus_id=11996/10356/11961/6652/1579/10255,ilevel=684,enchant_id=7534
-feet=nonconductive_killosocks,id=234497,bonus_id=4786/1527/11996,ilevel=684,enchant_id=7424
-finger1=wicks_golden_loop,id=221099,bonus_id=8781,ilevel=684,gem_id=213467/213467,enchant_id=7352
-finger2=bloodoath_signet,id=178871,ilevel=684,gem_id=213467/213467,enchant_id=7352
+head=inventors_ingenious_trifocals,id=235226,bonus_id=3176/12376/11964/1808,gem_id=213743,enchant_id=7924
+neck=flickering_glowtorc,id=221103,bonus_id=3176/12376/11964/8781,gem_id=213467/213467
+shoulder=aspectral_emissarys_arcane_vents,id=229341,bonus_id=12179/1533/12376
+back=trashmasters_mantle,id=199921,bonus_id=11346/12376/11964,enchant_id=7409
+chest=aspectral_emissarys_primal_robes,id=229346,bonus_id=12178/1533/12376,enchant_id=7364
+wrist=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/12043/12040/1485/12373/11109/8960/1808,gem_id=213467,enchant_id=7397,crafted_stats=32/40
+hands=aspectral_emissarys_hardened_grasp,id=229344,bonus_id=12179/1533/12376
+waist=tuneup_toolbelt,id=228861,bonus_id=1533/12376/11964/1808,gem_id=213467
+legs=aspectral_emissarys_trousers,id=229342,bonus_id=12178/1533/12376,enchant_id=7534
+feet=nonconductive_killosocks,id=234497,bonus_id=1533/12376/11964,enchant_id=7418
+finger1=wicks_golden_loop,id=221099,bonus_id=3176/12376/11964/8781,gem_id=213467/213497,enchant_id=7352
+finger2=bloodoath_signet,id=178871,bonus_id=9993/12376/11964/8781,gem_id=213485/213461,enchant_id=7352
 trinket1=candle_confidant,id=225648,ilevel=671
-trinket2=mister_locknstalk,id=230193,ilevel=684
-main_hand=blastfurious_machete,id=231268,ilevel=684,enchant_id=7460
-off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/9627/10222/11300/8960/11144/8792,ilevel=681,crafted_stats=40/32
+trinket2=mister_locknstalk,id=230193,bonus_id=1533/12376/11964
+main_hand=blastfurious_machete,id=231268,bonus_id=1533/12376/11964,enchant_id=7460
+off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/1485/12373/11300/8960,crafted_stats=36/40
 
 save=TWW2_Mage_Frost.simc


### PR DESCRIPTION
**Frost Frostfire:** https://www.raidbots.com/simbot/report/5jPHvsVmWjhcumd7unsBHZ
- readded second embellishment on bracer
- added Infinite Stars corruption
- cleaned up item IDs (no change in dps)

**Frost Spellslinger:** https://www.raidbots.com/simbot/report/c5YvMKCMsx6Qgv8rXWPGWG
- readded second embellishment on bracer
- switched out trinkets, finger and back for a more haste heavy setup for another +0.3%
- added Infinite Stars corruption
- cleaned up item IDs (no change in dps)

**Fire:** https://www.raidbots.com/simbot/report/78ysRewrwQApM1ns81rppN
- added Gushing Wounds corruption for both FF/SF

**Arcane:** https://www.raidbots.com/simbot/report/99Zmxikj5wr9xbt9GoQc1H
- added Greater Void Ritual corruption for both SF/SS