### PR TITLE
[Warlock] Class adjustments for more faithful behavior of Mug's Moxie Jug trinket procs

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -143,21 +143,21 @@ void warlock_td_t::target_demise()
   {
     warlock.sim->print_log( "Player {} demised. Warlock {} gains a shard from Unstable Affliction.", target->name(), warlock.name() );
 
-    warlock.resource_gain( RESOURCE_SOUL_SHARD, warlock.talents.unstable_affliction_2->effectN( 1 ).base_value(), warlock.gains.unstable_affliction_refund );
+    warlock.energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, warlock.talents.unstable_affliction_2->effectN( 1 ).base_value(), warlock.gains.unstable_affliction_refund );
   }
 
   if ( dots_jackpot_ua->is_ticking() )
   {
     warlock.sim->print_log( "Player {} demised. Warlock {} gains a shard from Unstable Affliction.", target->name(), warlock.name() );
 
-    warlock.resource_gain( RESOURCE_SOUL_SHARD, warlock.talents.unstable_affliction_2->effectN( 1 ).base_value(), warlock.gains.unstable_affliction_refund );
+    warlock.energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, warlock.talents.unstable_affliction_2->effectN( 1 ).base_value(), warlock.gains.unstable_affliction_refund );
   }
 
   if ( dots_drain_soul->is_ticking() )
   {
     warlock.sim->print_log( "Player {} demised. Warlock {} gains a shard from Drain Soul.", target->name(), warlock.name() );
 
-    warlock.resource_gain( RESOURCE_SOUL_SHARD, 1.0, warlock.gains.drain_soul );
+    warlock.energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, 1.0, warlock.gains.drain_soul );
   }
 
   if ( debuffs_haunt->check() )
@@ -175,7 +175,7 @@ void warlock_td_t::target_demise()
    
     warlock.sim->print_log( "Player {} demised. Warlock {} gains 1 shard from Shadowburn.", target->name(), warlock.name() );
 
-    warlock.resource_gain( RESOURCE_SOUL_SHARD, debuffs_shadowburn->check_value(), warlock.gains.shadowburn_refund );
+    warlock.energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, debuffs_shadowburn->check_value(), warlock.gains.shadowburn_refund );
   }
 
   if ( warlock.hero.demonic_soul.ok() && warlock.hero.shared_fate.ok() )
@@ -192,7 +192,7 @@ void warlock_td_t::target_demise()
 
       warlock.sim->print_log( "Player {} demised. Warlock {} triggers Shared Fate on {}.", target->name(), warlock.name(), t->name() );
 
-      tdata->debuffs_shared_fate->trigger();
+      warlock.buff_apply_action->trigger_buff( tdata->debuffs_shared_fate );
 
       break;
     }
@@ -994,7 +994,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
 
       if ( rng().roll( chance ) )
       {
-        buffs.succulent_soul->trigger();
+        buff_apply_action->trigger_buff( buffs.succulent_soul );
         procs.succulent_soul->occur();
       }
     }
@@ -1005,9 +1005,9 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
 
 void warlock_t::feast_of_souls_gain()
 {
-  player_t::resource_gain( RESOURCE_SOUL_SHARD, 1.0, gains.feast_of_souls );
+  player_t::resource_gain( RESOURCE_SOUL_SHARD, hero.feast_of_souls_energize->effectN( 1 ).base_value() / 10.0, gains.feast_of_souls );
 
-  buffs.succulent_soul->trigger();
+  buff_apply_action->trigger_buff( buffs.succulent_soul );
   procs.succulent_soul->occur();
   procs.feast_of_souls->occur();
 }

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -119,6 +119,7 @@ public:
     // Affliction
     const spell_data_t* agony;
     const spell_data_t* agony_2; // Rank 2 still a separate spell (learned automatically). Grants increased max stacks
+    const spell_data_t* agony_energize; // Agony soul shard generation proc
     const spell_data_t* xavian_teachings; // Passive granted only to Affliction. Instant cast data in this spell, points to base Corruption spell (172) for the direct damage
     const spell_data_t* malefic_rapture; // This contains an old sp_coeff value, but it is most likely no longer in use
     const spell_data_t* malefic_rapture_dmg;
@@ -130,6 +131,7 @@ public:
     const spell_data_t* hog_impact; // Secondary spell responsible for impact damage
     const spell_data_t* wild_imp; // Data for pet summoning
     const spell_data_t* fel_firebolt_2; // Still a separate spell (learned automatically). Reduces pet's energy cost
+    const spell_data_t* infernal_command_buff; // This still applies but with 0 value
     const spell_data_t* master_demonologist; // Demonology Mastery - Increased demon damage
     const spell_data_t* demonology_warlock; // Spec aura
 
@@ -191,6 +193,7 @@ public:
     player_talent_t sargerei_technique;
     player_talent_t demonic_tactics;
     player_talent_t soul_conduit;
+    const spell_data_t* soul_conduit_energize;  // Soul Shard refund spell effect
     player_talent_t soulburn;
     const spell_data_t* soulburn_buff; // This buff is applied after using Soulburn and prevents another usage unless cleared
 
@@ -291,9 +294,11 @@ public:
     player_talent_t carnivorous_stalkers; // Chance for Dreadstalkers to perform additional Dreadbites
 
     player_talent_t inner_demons;
+    const spell_data_t* inner_demons_wild_imp; // Data for pet summoning (spawned from Inner Demons talent)
     player_talent_t soul_strike;
     const spell_data_t* soul_strike_pet;
     const spell_data_t* soul_strike_dmg;
+    const spell_data_t* soul_strike_energize;
     player_talent_t bilescourge_bombers;
     const spell_data_t* bilescourge_bombers_aoe; // Ground AoE data
     player_talent_t demonic_strength;
@@ -552,6 +557,7 @@ public:
     const spell_data_t* shared_fate_debuff;
     const spell_data_t* shared_fate_dmg;
     player_talent_t feast_of_souls;
+    const spell_data_t* feast_of_souls_energize;
 
     player_talent_t wicked_reaping;
     const spell_data_t* wicked_reaping_dmg;
@@ -577,6 +583,147 @@ public:
     action_t* jackpot_ua;
     action_t* jackpot_cdf;
   } proc_actions;
+
+  // Action that applies a buff
+  // Useful for allowing trinket and spells procs to occur when a buff/debuff is applied
+  struct buff_apply_action_t : public spell_t
+  {
+  private:
+    bool is_trigger_call;
+    bool result;
+    buff_t* buff;
+    int stacks;
+    double value;
+    double chance;
+    timespan_t duration;
+  public:
+    buff_apply_action_t( util::string_view n, warlock_t* p )
+      : spell_t( n, p )
+    {
+      may_crit = may_miss = false;
+      background = dual = quiet = true;
+      harmful = true;
+      weapon_multiplier = 0.0;
+    }
+
+    bool trigger_buff( propagate_const<buff_t*> tbuff, timespan_t tduration )
+    {
+      return trigger_buff( tbuff, -1, tduration );
+    }
+
+    bool trigger_buff( propagate_const<buff_t*> tbuff, int tstacks, timespan_t tduration )
+    {
+      return trigger_buff( tbuff, tstacks, buff_t::DEFAULT_VALUE(), -1, tduration );
+    }
+
+    bool trigger_buff( propagate_const<buff_t*> tbuff, action_t* taction, int tstacks = -1, double tvalue = buff_t::DEFAULT_VALUE(), double tchance = -1.0, timespan_t tduration = timespan_t::min() )
+    {
+      if ( tbuff->can_trigger( taction ) )
+        return trigger_buff( tbuff, tstacks, tvalue, tchance, tduration );
+
+      return false;
+    }
+
+    // Triggers a buff doing a dummy action to allow procs
+    bool trigger_buff( propagate_const<buff_t*> tbuff, int tstacks = -1, double tvalue = buff_t::DEFAULT_VALUE(), double tchance = -1.0, timespan_t tduration = timespan_t::min() )
+    {
+      // Set func mode
+      is_trigger_call = true;
+      // Set buff and buff->trigger call args
+      buff = tbuff;
+      stacks = tstacks;
+      value = tvalue;
+      chance = tchance;
+      duration = tduration;
+      // Execute action that triggers the buff
+      execute();
+      // Return the result of the buff trigger call
+      return result;
+    }
+
+    // Execute a buff doing a dummy action to allow procs
+    void execute_buff( propagate_const<buff_t*> tbuff, int tstacks = -1, double tvalue = buff_t::DEFAULT_VALUE(), timespan_t tduration = timespan_t::min() ) {
+      // Set func mode
+      is_trigger_call = false;
+      // Set buff and buff->execute call args
+      buff = tbuff;
+      stacks = tstacks;
+      value = tvalue;
+      duration = tduration;
+      // Execute action that execute the buff
+      execute();
+    }
+
+    void execute() override
+    {
+      if ( is_trigger_call )
+      {
+        result = buff->trigger( stacks, value, chance, duration );
+        if ( result )
+          spell_t::execute(); // only on sucesfull buff triggers
+      }
+      else
+      {
+        buff->execute( stacks, value, duration );
+        spell_t::execute();
+      }
+    }
+  } *buff_apply_action;
+  
+  // Action for energize (resource gain) effects
+  // Useful for allowing energizing effects to proc trinkets and spells
+  struct energize_action_t : public spell_t
+  {
+  private:
+    double result;
+    resource_e resource_type;
+    double amount;
+    gain_t* source;
+    action_t* action;
+  public:
+    energize_action_t( util::string_view n, warlock_t* p )
+      : spell_t( n, p )
+    {
+      may_crit = may_miss = false;
+      background = dual = quiet = true;
+      harmful = true;
+      weapon_multiplier = 0.0;
+    }
+
+    // Execute a resource_gain doing a dummy action to allow procs
+    double execute_resource_gain( resource_e tresource_type, double tamount, gain_t* tsource = nullptr, action_t* taction = nullptr )
+    {
+      // Set resource_gain call args
+      resource_type = tresource_type;
+      amount = tamount;
+      source = tsource;
+      action = taction;
+      // Execute action that does the resource_gain call
+      execute();
+      // Return the result of the resource_gain call
+      return result;
+    }
+
+    void execute() override
+    {
+      result = static_cast<warlock_t*>( player )->resource_gain( resource_type, amount, source, action );
+
+      spell_t::execute();
+    }
+  } *energize_action;
+
+  struct pet_summon_actions_t
+  {
+    // Diabolist
+    propagate_const<action_t*> overlord;
+    propagate_const<action_t*> mother_of_chaos;
+    propagate_const<action_t*> pit_lord;
+
+    // Demonology
+    propagate_const<action_t*> wild_imp;
+    propagate_const<action_t*> inner_demons_wild_imp;
+    propagate_const<action_t*> greater_dreadstalker;
+  } pet_summon_actions;
 
   struct tier_sets_t
   {
@@ -860,6 +1007,9 @@ public:
   void create_diabolist_proc_actions();
   void create_hellcaller_proc_actions();
   void create_soul_harvester_proc_actions();
+  void create_demonology_pet_summon_actions();
+  void create_diabolist_pet_summon_actions();
+  void create_helper_actions();
   action_t* create_action( util::string_view name, util::string_view options ) override;
   pet_t* create_pet( util::string_view name, util::string_view type = {} ) override;
   void create_pets() override;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -220,7 +220,7 @@ using namespace helpers;
               }
               else
               {
-                p()->buffs.ritual_overlord->trigger();
+                p()->buff_apply_action->trigger_buff( p()->buffs.ritual_overlord );
                 make_event( sim, 1_ms, [ this, adjustment ] { p()->buffs.ritual_overlord->extend_duration( p(), adjustment ); } );
               }
               break;
@@ -231,7 +231,7 @@ using namespace helpers;
               }
               else
               {
-                p()->buffs.ritual_mother->trigger();
+                p()->buff_apply_action->trigger_buff( p()->buffs.ritual_mother );
                 make_event( sim, 1_ms, [ this, adjustment ] { p()->buffs.ritual_mother->extend_duration( p(), adjustment ); } );
               }
               break;
@@ -242,7 +242,7 @@ using namespace helpers;
               }
               else
               {
-                p()->buffs.ritual_pit_lord->trigger();
+                p()->buff_apply_action->trigger_buff( p()->buffs.ritual_pit_lord );
                 make_event( sim, 1_ms, [ this, adjustment ] { p()->buffs.ritual_pit_lord->extend_duration( p(), adjustment ); } );
               }
               break;
@@ -296,7 +296,7 @@ using namespace helpers;
 
       if ( affliction() && active_2pc( TWW2 ) && triggers.jackpot_affliction )
       {
-        bool success = p()->buffs.jackpot_affliction->trigger();
+        bool success = p()->buff_apply_action->trigger_buff( p()->buffs.jackpot_affliction );
 
         if ( success )
         {
@@ -309,16 +309,7 @@ using namespace helpers;
       {
         if ( p()->jackpot_demonology_rng->trigger() )
         {
-          auto dogs = p()->warlock_pet_list.greater_dreadstalkers.spawn( p()->tier.greater_dreadstalker->duration(), 1u );
-
-          for ( auto d : dogs )
-          {
-            if ( d->is_active() && p()->talents.dread_calling.ok() && !d->buffs.dread_calling->check() )
-              d->buffs.dread_calling->trigger( 1, p()->buffs.dread_calling->check_stack_value() );
-          }
-
-          p()->procs.jackpot_demonology->occur();
-          p()->buffs.dread_calling->expire();
+          p()->pet_summon_actions.greater_dreadstalker->execute();
         }
       }
 
@@ -349,7 +340,7 @@ using namespace helpers;
           p()->procs.jackpot_destruction->occur();
 
           if ( active_4pc( TWW2 ) )
-            p()->buffs.jackpot_destruction->trigger();
+            p()->buff_apply_action->trigger_buff( p()->buffs.jackpot_destruction );
         }
       }
     }
@@ -360,7 +351,7 @@ using namespace helpers;
 
       if ( affliction() && triggers.ravenous_afflictions && d->state->result == RESULT_CRIT && p()->ravenous_afflictions_rng->trigger() )
       {
-        p()->buffs.nightfall->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.nightfall );
         p()->procs.ravenous_afflictions->occur();
       }
 
@@ -1033,10 +1024,10 @@ using namespace helpers;
           p()->proc_actions.wicked_reaping->execute_on_target( target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          td( target )->debuffs_shared_fate->trigger();
+          p()->buff_apply_action->trigger_buff( td( target )->debuffs_shared_fate );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls.setting_value ) )
-          p()->feast_of_souls_gain();;
+          p()->feast_of_souls_gain();
       }
 
       if ( time_to_execute == 0_ms )
@@ -1071,7 +1062,7 @@ using namespace helpers;
           if ( crescendo_check( p(), s->target ) && rng().roll( p()->talents.tormented_crescendo->effectN( 1 ).percent() ) )
           {
             p()->procs.tormented_crescendo->occur();
-            p()->buffs.tormented_crescendo->trigger();
+            p()->buff_apply_action->trigger_buff( p()->buffs.tormented_crescendo );
           }
         }
 
@@ -1437,7 +1428,7 @@ using namespace helpers;
 
       if ( affliction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && rng().roll( p()->rng_settings.seeds_of_their_demise.setting_value ) )
       {
-        p()->buffs.tormented_crescendo->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.tormented_crescendo );
         p()->procs.seeds_of_their_demise->occur();
         seeds_triggered = true;
       }
@@ -1558,7 +1549,7 @@ using namespace helpers;
     wicked_reaping_t( warlock_t* p )
       : warlock_spell_t( "Wicked Reaping", p, p->hero.wicked_reaping_dmg )
     {
-      background = dual = true;
+      harmful = background = dual = true;
 
       affected_by.master_demonologist_dd = demonology();
 
@@ -1992,7 +1983,7 @@ using namespace helpers;
 
       if ( p()->agony_accumulator >= 1 )
       {
-        p()->resource_gain( RESOURCE_SOUL_SHARD, 1.0, p()->gains.agony );
+        p()->energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, p()->warlock_base.agony_energize->effectN( 1 ).base_value() / 10.0, p()->gains.agony );
         p()->agony_accumulator -= 1.0;
       }
 
@@ -2209,7 +2200,7 @@ using namespace helpers;
           p()->proc_actions.wicked_reaping->execute_on_target( target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          td( target )->debuffs_shared_fate->trigger();
+          p()->buff_apply_action->trigger_buff( td( target )->debuffs_shared_fate );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls.setting_value ) )
           p()->feast_of_souls_gain();
@@ -2231,7 +2222,7 @@ using namespace helpers;
           if ( crescendo_check( p(), d->target ) && rng().roll( p()->talents.tormented_crescendo->effectN( 2 ).percent() ) )
           {
             p()->procs.tormented_crescendo->occur();
-            p()->buffs.tormented_crescendo->trigger();
+            p()->buff_apply_action->trigger_buff( p()->buffs.tormented_crescendo );
           }
         }
 
@@ -2319,14 +2310,14 @@ using namespace helpers;
         warlock_spell_t::impact( s );
 
         if ( p()->talents.infirmity.ok() && !td( s->target )->debuffs_infirmity->check() )
-          td( s->target )->debuffs_infirmity->trigger();
+          p()->buff_apply_action->trigger_buff( td( s->target )->debuffs_infirmity );
       }
     };
 
     phantom_singularity_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Phantom Singularity", p, p->talents.phantom_singularity, options_str )
     {
-      callbacks = false;
+      callbacks = true;
       hasted_ticks = true;
       tick_action = new phantom_singularity_tick_t( p );
 
@@ -2345,7 +2336,7 @@ using namespace helpers;
       warlock_spell_t::impact( s );
 
       if ( p()->talents.infirmity.ok() )
-        td( s->target )->debuffs_infirmity->trigger();
+        p()->buff_apply_action->trigger_buff( td( s->target )->debuffs_infirmity );
     }
 
     void last_tick( dot_t* d ) override
@@ -2387,7 +2378,7 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       if ( soul_harvester() && p()->hero.sataiels_volition.ok() )
-        p()->buffs.nightfall->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.nightfall );
     }
 
     void impact( action_state_t* s ) override
@@ -2436,7 +2427,7 @@ using namespace helpers;
 
       if ( active_2pc( TWW2 ) )
       {
-        p()->buffs.jackpot_affliction->execute();
+        p()->buff_apply_action->execute_buff( p()->buffs.jackpot_affliction );
         p()->buffs.jackpot_affliction->predict();
         p()->procs.jackpot_affliction->occur();
         helpers::trigger_jackpot_ua( p() );
@@ -2496,7 +2487,7 @@ using namespace helpers;
       if ( soul_harvester() && p()->hero.shadow_of_death.ok() )
       {
         p()->resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
-        p()->buffs.succulent_soul->trigger( as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ) );
+        p()->buff_apply_action->trigger_buff( p()->buffs.succulent_soul, as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ) );
       }
     }
 
@@ -2819,7 +2810,7 @@ using namespace helpers;
       {
         if ( p()->talents.spiteful_reconstitution.ok() && rng().roll( p()->rng_settings.spiteful_reconstitution.setting_value ) )
         {
-          p()->warlock_pet_list.wild_imps.spawn( 1u );
+          p()->pet_summon_actions.wild_imp->execute();
           p()->procs.spiteful_reconstitution->occur();
         }
 
@@ -2857,7 +2848,7 @@ using namespace helpers;
           p()->proc_actions.wicked_reaping->execute_on_target( target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          td( target )->debuffs_shared_fate->trigger();
+          p()->buff_apply_action->trigger_buff( td( target )->debuffs_shared_fate );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls.setting_value ) )
           p()->feast_of_souls_gain();
@@ -2901,7 +2892,7 @@ using namespace helpers;
       {
         aoe = -1;
         background = dual = true;
-        callbacks = false;
+        callbacks = true;
 
         affected_by.wicked_maw = p->talents.shadowtouched.ok(); // 2024-08-01: Despite what is listed in spell data, Wicked Maw seems to only work with Shadowtouched now for Implosion
 
@@ -3076,6 +3067,33 @@ using namespace helpers;
     }
   };
 
+  struct call_greater_dreadstalker_t : public warlock_spell_t
+  {
+    call_greater_dreadstalker_t( warlock_t* p )
+      : warlock_spell_t( "Call Greater Dreadstalker", p, p->tier.greater_dreadstalker )
+    {
+      may_crit = may_miss = false;
+      background = dual = true;
+      harmful = true;
+    }
+
+    void execute() override
+    {
+      warlock_spell_t::execute();
+
+      auto dogs = p()->warlock_pet_list.greater_dreadstalkers.spawn( p()->tier.greater_dreadstalker->duration(), 1u );
+
+      for ( auto d : dogs )
+      {
+        if ( d->is_active() && p()->talents.dread_calling.ok() && !d->buffs.dread_calling->check() )
+          d->buffs.dread_calling->trigger( 1, p()->buffs.dread_calling->check_stack_value() );
+      }
+
+      p()->procs.jackpot_demonology->occur();
+      p()->buffs.dread_calling->expire();
+    }
+  };
+
   struct bilescourge_bombers_t : public warlock_spell_t
   {
     struct bilescourge_bombers_tick_t : public warlock_spell_t
@@ -3201,7 +3219,7 @@ using namespace helpers;
       if ( is_precombat )
       {
         p()->buffs.power_siphon->trigger( 2, p()->talents.power_siphon_buff->duration() );
-        p()->buffs.demonic_core->trigger( 2, p()->talents.demonic_core_buff->duration() );
+        p()->buff_apply_action->trigger_buff( p()->buffs.demonic_core, 2, p()->talents.demonic_core_buff->duration() );
         
         return;
       }
@@ -3241,7 +3259,7 @@ using namespace helpers;
       while ( !imps.empty() )
       {
         p()->buffs.power_siphon->trigger();
-        p()->buffs.demonic_core->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.demonic_core );
         pets::demonology::wild_imp_pet_t* imp = imps.front();
         imps.erase( imps.begin() );
         imp->power_siphon = true;
@@ -3268,16 +3286,7 @@ using namespace helpers;
 
       if ( active_2pc( TWW2 ) )
       {
-        auto dogs = p()->warlock_pet_list.greater_dreadstalkers.spawn( p()->tier.greater_dreadstalker->duration(), 1u );
-
-        for ( auto d : dogs )
-        {
-          if ( d->is_active() && p()->talents.dread_calling.ok() && !d->buffs.dread_calling->check() )
-            d->buffs.dread_calling->trigger( 1, p()->buffs.dread_calling->check_stack_value() );
-        }
-
-        p()->procs.jackpot_demonology->occur();
-        p()->buffs.dread_calling->expire();
+        p()->pet_summon_actions.greater_dreadstalker->execute();
       }
       
       // Last tested 2021-07-13
@@ -3329,7 +3338,7 @@ using namespace helpers;
       p()->buffs.tyrant->trigger();
 
       if ( p()->hero.abyssal_dominion.ok() )
-        p()->buffs.abyssal_dominion->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.abyssal_dominion );
 
       if ( p()->buffs.dreadstalkers->check() )
         p()->buffs.dreadstalkers->extend_duration( p(), extension_time );
@@ -3361,7 +3370,7 @@ using namespace helpers;
       if ( soul_harvester() && p()->hero.shadow_of_death.ok() )
       {
         p()->resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
-        p()->buffs.succulent_soul->trigger( as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ) );
+        p()->buff_apply_action->trigger_buff( p()->buffs.succulent_soul, as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ) );
       }
     }
   };
@@ -3391,6 +3400,7 @@ using namespace helpers;
       : warlock_spell_t( "Summon Vilefiend", p, p->talents.summon_vilefiend, options_str )
     {
       harmful = may_crit = false;
+      callbacks = false;
 
       triggers.diabolic_ritual = p->hero.diabolic_ritual.ok();
     }
@@ -3404,12 +3414,100 @@ using namespace helpers;
     }
   };
 
+  struct summon_wild_imp_t : public warlock_spell_t
+  {
+    summon_wild_imp_t( warlock_t* p )
+      : warlock_spell_t( "Wild Imp", p, p->warlock_base.wild_imp )
+    {
+      may_crit = may_miss = false;
+      background = dual = true;
+      harmful = true;
+    }
+
+    void execute() override
+    {
+      warlock_spell_t::execute();
+
+      p()->warlock_pet_list.wild_imps.spawn();
+    }
+  };
+
+  struct summon_inner_demons_wild_imp_t : public warlock_spell_t
+  {
+    summon_inner_demons_wild_imp_t( warlock_t* p )
+      : warlock_spell_t( "Wild Imp (Inner Demons)", p, p->talents.inner_demons_wild_imp )
+    {
+      may_crit = may_miss = false;
+      background = dual = true;
+      harmful = true;
+    }
+
+    void execute() override
+    {
+      warlock_spell_t::execute();
+
+      p()->warlock_pet_list.wild_imps.spawn( s_data->duration(), s_data->effectN( 1 ).base_value() );
+    }
+  };
+  
+  struct summon_overlord_t : public warlock_spell_t
+  {
+    summon_overlord_t( warlock_t* p )
+      : warlock_spell_t( "Summon Overlord", p, p->hero.summon_overlord )
+    {
+      harmful = may_crit = may_miss = false;
+      background = dual = true;
+    }
+
+    void execute() override
+    {
+      warlock_spell_t::execute();
+
+      p()->warlock_pet_list.overlords.spawn();
+    }
+  };
+
+  struct summon_mother_of_chaos_t : public warlock_spell_t
+  {
+    summon_mother_of_chaos_t( warlock_t* p )
+      : warlock_spell_t( "Summon Mother of Chaos", p, p->hero.summon_mother )
+    {
+      harmful = may_crit = may_miss = false;
+      background = dual = true;
+    }
+
+    void execute() override
+    {
+      warlock_spell_t::execute();
+
+      p()->warlock_pet_list.mothers.spawn();
+    }
+  };
+
+  struct summon_pit_lord_t : public warlock_spell_t
+  {
+    summon_pit_lord_t( warlock_t* p )
+      : warlock_spell_t( "Summon Pit Lord", p, p->hero.summon_pit_lord )
+    {
+      harmful = may_crit = may_miss = false;
+      background = dual = true;
+    }
+
+    void execute() override
+    {
+      warlock_spell_t::execute();
+
+      p()->warlock_pet_list.pit_lords.spawn();
+    }
+  };
+
   struct guillotine_t : public warlock_spell_t
   {
     guillotine_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Guillotine", p, p->talents.guillotine, options_str )
     {
-      may_crit = false;
+      harmful = may_crit = false;
+      callbacks = false;
       internal_cooldown = p->get_cooldown( "felstorm_icd" );
     }
 
@@ -3460,11 +3558,16 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       if ( p()->talents.impending_doom.ok() )
-        p()->warlock_pet_list.wild_imps.spawn( as<int>( p()->talents.impending_doom->effectN( 2 ).base_value() ) );
+      {
+        for ( int i = 0; i < as<const int>( p()->talents.impending_doom->effectN( 2 ).base_value() ); i++ )
+        {
+          p()->pet_summon_actions.wild_imp->execute();
+        }
+      }
 
       if ( p()->talents.doom_eternal.ok() && p()->min_version_check( VERSION_11_1_0 ) )
       {
-        bool success = p()->buffs.demonic_core->trigger( 1, buff_t::DEFAULT_VALUE(), p()->talents.doom_eternal->effectN( 1 ).percent() );
+        bool success = p()->buff_apply_action->trigger_buff( p()->buffs.demonic_core, 1, buff_t::DEFAULT_VALUE(), p()->talents.doom_eternal->effectN( 1 ).percent() );
 
         if ( success )
           p()->procs.doom_eternal->occur();
@@ -3991,7 +4094,7 @@ using namespace helpers;
         warlock_spell_t::impact( s );
 
         if ( p()->talents.pyrogenics.ok() )
-          td( s->target )->debuffs_pyrogenics->trigger();
+          p()->buff_apply_action->trigger_buff( td( s->target )->debuffs_pyrogenics );
       }
 
       double composite_persistent_multiplier( const action_state_t* s ) const override
@@ -4069,7 +4172,7 @@ using namespace helpers;
       warlock_spell_t::impact( s );
 
       if ( p()->talents.pyrogenics.ok() )
-        td( s->target )->debuffs_pyrogenics->trigger();
+        p()->buff_apply_action->trigger_buff( td( s->target )->debuffs_pyrogenics );
     }
   };
 
@@ -4397,6 +4500,7 @@ using namespace helpers;
     {
       may_crit = false;
       resource_current = RESOURCE_SOUL_SHARD; // For Cruelty of Kerxan proccing
+      callbacks = false;
 
       triggers.diabolic_ritual = p->hero.cruelty_of_kerxan.ok();
 
@@ -4409,10 +4513,10 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       if ( p()->talents.crashing_chaos.ok() )
-        p()->buffs.crashing_chaos->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.crashing_chaos );
 
       if ( p()->talents.rain_of_chaos.ok() )
-        p()->buffs.rain_of_chaos->trigger();
+        p()->buff_apply_action->trigger_buff( p()->buffs.rain_of_chaos );
 
       if ( p()->hero.cruelty_of_kerxan.ok() )
       {
@@ -4429,7 +4533,7 @@ using namespace helpers;
         p()->procs.jackpot_destruction->occur();
 
         if ( active_4pc( TWW2 ) )
-          p()->buffs.jackpot_destruction->trigger();
+          p()->buff_apply_action->trigger_buff( p()->buffs.jackpot_destruction );
       }
     }
   };
@@ -4631,6 +4735,7 @@ using namespace helpers;
     {
       triggers.jackpot_demonology = true;
       triggers.jackpot_destruction = true;
+      callbacks = false;
 
       impact_action = new ruination_impact_t( p );
       add_child( impact_action );
@@ -4685,7 +4790,7 @@ using namespace helpers;
       if ( rng().roll( soul_conduit_rng ) )
       {
         pl->sim->print_log( "Soul Conduit proc occurred for Warlock {}, refunding 1.0 soul shards.", pl->name() );
-        pl->resource_gain( RESOURCE_SOUL_SHARD, 1.0, shard_gain );
+        pl->energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, pl->talents.soul_conduit_energize->effectN( 1 ).base_value() / 10.0, shard_gain );
         pl->procs.soul_conduit->occur();
       }
     }
@@ -4730,7 +4835,7 @@ using namespace helpers;
     if ( p->corruption_accumulator >= 1 )
     {
       p->procs.nightfall->occur();
-      p->buffs.nightfall->trigger();
+      p->buff_apply_action->trigger_buff( p->buffs.nightfall );
       p->corruption_accumulator -= 1.0;
     }
   }
@@ -4820,7 +4925,7 @@ using namespace helpers;
   {
     warlock_t* p = static_cast<warlock_t*>( player() );
 
-    p->warlock_pet_list.wild_imps.spawn();
+    p->pet_summon_actions.wild_imp->execute();
 
     // Remove this event from the vector
     auto it = std::find( p->wild_imp_spawns.begin(), p->wild_imp_spawns.end(), this );
@@ -5038,7 +5143,10 @@ using namespace helpers;
       create_affliction_proc_actions();
 
     if ( specialization() == WARLOCK_DEMONOLOGY )
+    {
       create_demonology_proc_actions();
+      create_demonology_pet_summon_actions();
+    }
 
     if ( specialization() == WARLOCK_DESTRUCTION )
       create_destruction_proc_actions();
@@ -5048,6 +5156,10 @@ using namespace helpers;
     create_hellcaller_proc_actions();
 
     create_soul_harvester_proc_actions();
+
+    create_diabolist_pet_summon_actions();
+
+    create_helper_actions();
 
     player_t::create_actions();
   }
@@ -5083,6 +5195,26 @@ using namespace helpers;
     proc_actions.demonic_soul = new demonic_soul_t( this );
     proc_actions.shared_fate = new shared_fate_t( this );
     proc_actions.wicked_reaping = new wicked_reaping_t( this );
+  }
+
+  void warlock_t::create_demonology_pet_summon_actions()
+  {
+    pet_summon_actions.wild_imp = new summon_wild_imp_t( this );
+    pet_summon_actions.inner_demons_wild_imp = new summon_inner_demons_wild_imp_t( this );
+    pet_summon_actions.greater_dreadstalker = new call_greater_dreadstalker_t( this );
+  }
+
+  void warlock_t::create_diabolist_pet_summon_actions()
+  {
+    pet_summon_actions.overlord = new summon_overlord_t( this );
+    pet_summon_actions.mother_of_chaos = new summon_mother_of_chaos_t( this );
+    pet_summon_actions.pit_lord = new summon_pit_lord_t( this );
+  }
+
+  void warlock_t::create_helper_actions()
+  {
+    buff_apply_action = new buff_apply_action_t( "Buff Apply Action", this );
+    energize_action = new energize_action_t( "Energize Action", this );
   }
 
   void warlock_t::init_special_effects()

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -25,6 +25,7 @@ namespace warlock
     // Affliction
     warlock_base.agony = find_class_spell( "Agony" ); // Should be ID 980
     warlock_base.agony_2 = find_spell( 231792 ); // Rank 2, +4 to max stacks
+    warlock_base.agony_energize = find_spell( 17941 );
     warlock_base.xavian_teachings = find_specialization_spell( "Xavian Teachings", WARLOCK_AFFLICTION ); // Instant cast corruption and direct damage. Direct damage is in the base corruption spell on effect 3. Should be ID 317031.
     warlock_base.malefic_rapture = find_specialization_spell( "Malefic Rapture", WARLOCK_AFFLICTION ); // Should be ID 324536
     warlock_base.malefic_rapture_dmg = find_spell( 324540 );
@@ -36,6 +37,7 @@ namespace warlock
     warlock_base.hog_impact = find_spell( 86040 ); // Contains impact damage data
     warlock_base.wild_imp = find_spell( 104317 ); // Contains pet summoning information
     warlock_base.fel_firebolt_2 = find_spell( 334591 ); // 20% cost reduction for Wild Imps
+    warlock_base.infernal_command_buff = find_spell( 387552 ); // Buff of an old talent that still applies but with 0 value
     warlock_base.master_demonologist = find_mastery_spell( WARLOCK_DEMONOLOGY ); // Should be ID 77219
     warlock_base.demonology_warlock = find_specialization_spell( "Demonology Warlock", WARLOCK_DEMONOLOGY ); // Should be ID 137044
 
@@ -71,6 +73,7 @@ namespace warlock
     talents.demonic_tactics = find_talent_spell( talent_tree::CLASS, "Demonic Tactics" ); // Should be ID 452894
 
     talents.soul_conduit = find_talent_spell( talent_tree::CLASS, "Soul Conduit" ); // Should be ID 215941
+    talents.soul_conduit_energize = find_spell( 215942 );
 
     talents.soulburn = find_talent_spell( talent_tree::CLASS, "Soulburn" ); // Should be ID 385899
     talents.soulburn_buff = find_spell( 387626 );
@@ -220,10 +223,12 @@ namespace warlock
     talents.carnivorous_stalkers = find_talent_spell( talent_tree::SPECIALIZATION, "Carnivorous Stalkers" ); // Should be ID 386194
 
     talents.inner_demons = find_talent_spell( talent_tree::SPECIALIZATION, "Inner Demons" ); // Should be ID 267216
+    talents.inner_demons_wild_imp = find_spell( 279910 );
 
     talents.soul_strike = find_talent_spell( talent_tree::SPECIALIZATION, "Soul Strike" ); // Should be ID 428344
     talents.soul_strike_pet = find_spell( 264057 );
     talents.soul_strike_dmg = find_spell( 267964 );
+    talents.soul_strike_energize = find_spell( 270557 );
 
     talents.bilescourge_bombers = find_talent_spell( talent_tree::SPECIALIZATION, "Bilescourge Bombers" ); // Should be ID 267211
     talents.bilescourge_bombers_aoe = find_spell( 267213 );
@@ -616,6 +621,7 @@ namespace warlock
     hero.shared_fate_dmg = find_spell( 450593 );
 
     hero.feast_of_souls = find_talent_spell( talent_tree::HERO, "Feast of Souls" ); // Should be ID 449706
+    hero.feast_of_souls_energize = find_spell( 450752 );
 
     hero.wicked_reaping = find_talent_spell( talent_tree::HERO, "Wicked Reaping" ); // Should be ID 449631
     hero.wicked_reaping_dmg = find_spell( 449826 );
@@ -726,7 +732,7 @@ namespace warlock
                              ->set_tick_time_behavior( buff_tick_time_behavior::UNHASTED )
                              ->set_tick_zero( true )
                              ->set_tick_callback( [ this ]( buff_t*, int, timespan_t ) {
-                               warlock_pet_list.wild_imps.spawn();
+                               pet_summon_actions.inner_demons_wild_imp->execute();
                              } );
 
     buffs.dread_calling = make_buff<buff_t>( this, "dread_calling", talents.dread_calling_buff )
@@ -858,7 +864,7 @@ namespace warlock
                                   {
                                     if ( cur == 0 )
                                     {
-                                      make_event( sim, 0_ms, [ this ] { buffs.art_overlord->trigger(); } );
+                                      make_event( sim, 0_ms, [ this ] { buff_apply_action->trigger_buff( buffs.art_overlord ); } );
                                       diabolic_ritual = 1;
                                     }
                                   } );
@@ -869,7 +875,7 @@ namespace warlock
                                 {
                                   if ( cur == 0 )
                                   {
-                                    make_event( sim, 0_ms, [ this ] { buffs.art_mother->trigger(); } );
+                                    make_event( sim, 0_ms, [ this ] { buff_apply_action->trigger_buff( buffs.art_mother ); } );
                                     diabolic_ritual = 2;
                                   }
                                 } );
@@ -880,7 +886,7 @@ namespace warlock
                                   {
                                     if ( cur == 0 )
                                     {
-                                      make_event( sim, 0_ms, [ this ] { buffs.art_pit_lord->trigger(); } );
+                                      make_event( sim, 0_ms, [ this ] { buff_apply_action->trigger_buff( buffs.art_pit_lord ); } );
                                       diabolic_ritual = 0;
                                     }
                                   } );
@@ -889,7 +895,7 @@ namespace warlock
                              ->set_stack_change_callback( [ this ]( buff_t*, int, int cur )
                                {
                                  if ( cur == 0 )
-                                   warlock_pet_list.overlords.spawn();
+                                   pet_summon_actions.overlord->execute();
                                } );
 
     buffs.art_mother = make_buff( this, "demonic_art_mother_of_chaos", hero.art_mother )
@@ -897,10 +903,10 @@ namespace warlock
                              {
                                if ( cur == 0 )
                                {
-                                 warlock_pet_list.mothers.spawn();
+                                 pet_summon_actions.mother_of_chaos->execute();
 
                                  if ( hero.secrets_of_the_coven.ok() )
-                                      buffs.infernal_bolt->trigger();
+                                   buff_apply_action->trigger_buff( buffs.infernal_bolt );
                                }
                              } );
 
@@ -909,10 +915,10 @@ namespace warlock
                                {
                                  if ( cur == 0 )
                                  {
-                                   warlock_pet_list.pit_lords.spawn();
+                                   pet_summon_actions.pit_lord->execute();
 
                                    if ( hero.ruination.ok() )
-                                     buffs.ruination->trigger();
+                                     buff_apply_action->trigger_buff( buffs.ruination );
                                  }
                                } );
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -47,6 +47,9 @@ void warlock_pet_t::create_buffs()
   buffs.imp_gang_boss = make_buff( this, "imp_gang_boss", o()->talents.imp_gang_boss_buff )
                             ->set_default_value_from_effect( 2 );
 
+  buffs.infernal_command = make_buff( this, "infernal_command", o()->warlock_base.infernal_command_buff )
+                              ->set_default_value( o()->warlock_base.infernal_command_buff->effectN( 1 ).percent() );
+
   buffs.antoran_armaments = make_buff( this, "antoran_armaments", o()->talents.antoran_armaments_buff )
                                 ->set_default_value( o()->talents.antoran_armaments->effectN( 1 ).percent() );
 
@@ -94,6 +97,7 @@ void warlock_pet_t::create_buffs()
 
   // These buffs are needed for operational purposes but serve little to no reporting purpose
   buffs.imp_gang_boss->quiet = true;
+  buffs.infernal_command->quiet = true;
   buffs.demonic_strength->quiet = true;
   buffs.grimoire_of_service->quiet = true;
   buffs.annihilan_training->quiet = true;
@@ -621,7 +625,7 @@ struct felstorm_t : public warlock_pet_melee_attack_t
       warlock_pet_melee_attack_t::impact( s );
 
       if ( applies_fel_sunder )
-        owner_td( s->target )->debuffs_fel_sunder->trigger();
+        p()->o()->buff_apply_action->trigger_buff( owner_td( s->target )->debuffs_fel_sunder ); // this debuff is applied from the player, not the pet
     }
   };
 
@@ -752,7 +756,6 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
 
     soul_cleave = new soul_cleave_t( p );
     add_child( soul_cleave );
-    // TOCHECK: As of 2023-10-16 PTR, Soul Cleave appears to be double-dipping on both Annihilan Training and Antoran Armaments multipliers. Not currently implemented
 
     base_multiplier *= 1.0 + p->o()->talents.fel_invocation->effectN( 1 ).percent();
   }
@@ -762,7 +765,13 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
     warlock_pet_melee_attack_t::execute();
 
     if ( p()->o()->talents.fel_invocation.ok() )
-      p()->o()->resource_gain( RESOURCE_SOUL_SHARD, 1.0, p()->o()->gains.soul_strike );
+    {
+      // Soul Strike soul shard generation only procs trinket and effects with the Demonic Soul talent and when uncapped
+      if ( p()->o()->hero.demonic_soul.ok() && p()->o()->resources.current[ RESOURCE_SOUL_SHARD ] < 5.0 )
+        p()->o()->energize_action->execute_resource_gain( RESOURCE_SOUL_SHARD, p()->o()->talents.soul_strike_energize->effectN( 1 ).base_value() / 10.0, p()->o()->gains.soul_strike );
+      else
+        p()->o()->resource_gain( RESOURCE_SOUL_SHARD, p()->o()->talents.soul_strike_energize->effectN( 1 ).base_value() / 10.0, p()->o()->gains.soul_strike );
+    }
   }
 
   void impact( action_state_t* s ) override
@@ -1004,7 +1013,7 @@ grimoire_felguard_pet_t::grimoire_felguard_pet_t( warlock_t* owner )
    warlock_pet_t::demise();
 
    if ( o()->talents.fiendish_oblation.ok() )
-     o()->buffs.demonic_core->trigger();
+     o()->buff_apply_action->trigger_buff( o()->buffs.demonic_core );
  }
 
  double grimoire_felguard_pet_t::composite_player_multiplier( school_e school ) const
@@ -1089,6 +1098,25 @@ wild_imp_pet_t::wild_imp_pet_t( warlock_t* owner )
 {
   resource_regeneration = regen_type::DISABLED;
   owner_coeff.health = 0.15;
+
+  // 2025-05-30: The Infernal Command buff is applied and faded periodically every approximately 5.25 seconds (with some variance)
+  // In-game testing found this can be modelled fairly closely using a continuous uniform distribution
+  // The current value of this buff is 0, so it does not provide any damage increase
+  // However, it is relevant because applying this buff can procs trinket and effects
+  inf_comm_ev_func = [ this ]() {
+    if ( !is_sleeping() )
+    {
+      if ( buffs.infernal_command->up() )
+        buffs.infernal_command->decrement();
+      else
+        o()->buff_apply_action->trigger_buff( buffs.infernal_command );
+
+      const timespan_t next_tick_mean = inf_comm_period - inf_comm_mdiff;
+      const timespan_t next_tick_time = rng().range( next_tick_mean-inf_comm_period_range, next_tick_mean+inf_comm_period_range );
+      inf_comm_mdiff += next_tick_time - inf_comm_period;
+      inf_comm_ev = make_event( sim, next_tick_time, inf_comm_ev_func );
+    }
+  };
 }
 
 struct fel_firebolt_t : public warlock_pet_spell_t
@@ -1214,6 +1242,11 @@ void wild_imp_pet_t::arise()
     o()->procs.imp_gang_boss->occur();
   }
 
+  // Start Infernal Command buff sequence of events
+  const timespan_t next_tick_time = rng().range( inf_comm_period-inf_comm_period_range, inf_comm_period+inf_comm_period_range );
+  inf_comm_mdiff = next_tick_time - inf_comm_period;
+  inf_comm_ev = make_event( sim, next_tick_time, inf_comm_ev_func );
+
   // Start casting fel firebolts
   firebolt->set_target( o()->target );
   firebolt->schedule_execute();
@@ -1235,7 +1268,7 @@ void wild_imp_pet_t::demise()
       if ( !o()->talents.demoniac.ok() )
         core_chance = 0.0;
 
-      bool success = o()->buffs.demonic_core->trigger( 1, buff_t::DEFAULT_VALUE(), core_chance );
+      bool success = o()->buff_apply_action->trigger_buff( o()->buffs.demonic_core, 1, buff_t::DEFAULT_VALUE(), core_chance );
 
       if ( success )
         o()->procs.demonic_core_imps->occur();
@@ -1243,6 +1276,9 @@ void wild_imp_pet_t::demise()
 
     if ( expiration )
       event_t::cancel( expiration );
+
+    if ( inf_comm_ev )
+      event_t::cancel( inf_comm_ev );
 
     if ( o()->talents.the_expendables.ok() )
       o()->expendables_trigger_helper( this );
@@ -1327,7 +1363,7 @@ struct dreadbite_t : public warlock_pet_melee_attack_t
     warlock_pet_melee_attack_t::impact( s );
 
     if ( p()->o()->talents.wicked_maw.ok() )
-      owner_td( s->target )->debuffs_wicked_maw->trigger();
+      p()->o()->buff_apply_action->trigger_buff( owner_td( s->target )->debuffs_wicked_maw ); // this debuff is applied from the player, not the pet
   }
 
   double composite_da_multiplier( const action_state_t* s ) const override
@@ -1433,7 +1469,7 @@ void dreadstalker_t::demise()
 
     if ( o()->talents.demoniac.ok() )
     {
-      bool success = o()->buffs.demonic_core->trigger( 1, buff_t::DEFAULT_VALUE(), o()->talents.demonic_core_spell->effectN( 2 ).percent() );
+      bool success = o()->buff_apply_action->trigger_buff( o()->buffs.demonic_core, 1, buff_t::DEFAULT_VALUE(), o()->talents.demonic_core_spell->effectN( 2 ).percent() );
       if ( success )
         o()->procs.demonic_core_dogs->occur();
     }
@@ -1559,7 +1595,7 @@ struct bile_spit_t : public warlock_pet_spell_t
     warlock_pet_spell_t::impact( s );
 
     if ( p()->o()->talents.foul_mouth.ok() )
-      owner_td( s->target )->debuffs_wicked_maw->trigger();
+      p()->o()->buff_apply_action->trigger_buff( owner_td( s->target )->debuffs_wicked_maw ); // this debuff is applied from the player, not the pet
   }
 };
 
@@ -1781,7 +1817,7 @@ void greater_dreadstalker_t::demise()
 {
   if ( !current.sleeping && o()->talents.demoniac.ok() )
   {
-    bool success = o()->buffs.demonic_core->trigger( 1, buff_t::DEFAULT_VALUE(), o()->talents.demonic_core_spell->effectN( 2 ).percent() );
+    bool success = o()->buff_apply_action->trigger_buff( o()->buffs.demonic_core, 1, buff_t::DEFAULT_VALUE(), o()->talents.demonic_core_spell->effectN( 2 ).percent() );
     if ( success )
       o()->procs.demonic_core_big_dogs->occur();
   }
@@ -2323,7 +2359,7 @@ namespace diabolist
       warlock_pet_spell_t::impact( s );
 
       if ( p()->o()->hero.cloven_souls.ok() )
-        owner_td( s->target )->debuffs_cloven_soul->trigger();
+        p()->o()->buff_apply_action->trigger_buff( owner_td( s->target )->debuffs_cloven_soul ); // this debuff is applied from the player, not the pet
     }
   };
 

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -36,6 +36,7 @@ struct warlock_pet_t : public pet_t
     propagate_const<buff_t*> annihilan_training; // Permanent aura when talented, 10% increased damage to all abilities
     propagate_const<buff_t*> dread_calling;
     propagate_const<buff_t*> imp_gang_boss; // Aura applied to some Wild Imps for increased damage (and size)
+    propagate_const<buff_t*> infernal_command; // Aura applied to WIld Imps periodically
     propagate_const<buff_t*> antoran_armaments; // Permanent aura when talented, 20% increased damage to all abilities plus Soul Strike cleave
     propagate_const<buff_t*> the_expendables;
     propagate_const<buff_t*> reign_of_tyranny;
@@ -391,6 +392,11 @@ struct wild_imp_pet_t : public warlock_pet_t
   action_t* firebolt;
   bool power_siphon;
   bool imploded;
+  std::function<void()> inf_comm_ev_func;
+  event_t* inf_comm_ev;
+  timespan_t inf_comm_mdiff;
+  static constexpr timespan_t inf_comm_period = 5250_ms;
+  static constexpr timespan_t inf_comm_period_range = 450_ms;
 
   wild_imp_pet_t( warlock_t* );
   void init_base_stats() override;

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6883,30 +6883,87 @@ void mugs_moxie_jug( special_effect_t& effect )
   auto second_proc = new dbc_proc_callback_t( effect.player, *buff_driver );
 
   auto CT = []( player_t* p, std::string_view n ) { return p->find_talent_spell( talent_tree::CLASS, n ); };
+  auto HT = []( player_t* p, std::string_view n ) { return p->find_talent_spell( talent_tree::HERO, n ); };
   auto ST = []( player_t* p, std::string_view n ) { return p->find_talent_spell( talent_tree::SPECIALIZATION, n ); };
 
   switch ( effect.player->type )
   {
     case WARLOCK:
-      // Pretend everything is triggering soul leech which is triggering the trinket. This is not quite true in practice
-      // though.
-      second_proc->allow_pet_procs = true;
-      buff_driver->proc_flags_ |= PF_PERIODIC | PF_HELPFUL_PERIODIC;
-      buff_driver->proc_flags2_ |= PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL;
+      switch( effect.player->specialization() )
+      {
+        case WARLOCK_DEMONOLOGY:
+        {
+          const bool soul_harvester = HT( effect.player, "Demonic Soul" ).ok();
 
-      effect.player->callbacks.register_callback_trigger_function(
-          buff_driver->driver()->id(), dbc_proc_callback_t::trigger_fn_type::CONDITION,
-          []( const dbc_proc_callback_t*, action_t*, const action_state_t* s ) {
-            if ( s->action->player->type == PLAYER_GUARDIAN || s->action->player->type == PLAYER_PET )
-            {
-              // Allowing every pet to hit it grants far too high of an uptime
-              return s->action->player->rng().roll( 0.1 );
-            }
-            // Dots probably do the same. Probably.
-            if ( s->result_type == result_amount_type::DMG_OVER_TIME )
-              return s->action->player->rng().roll( 0.15 );
-            return true;
-          } );
+          if ( soul_harvester )
+          {
+            buff_driver->proc_flags_ |= PF_PERIODIC | PF_HELPFUL_PERIODIC;
+            buff_driver->proc_flags2_ |= PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL;
+          }
+
+          effect.player->callbacks.register_callback_trigger_function(
+            buff_driver->driver()->id(), dbc_proc_callback_t::trigger_fn_type::CONDITION,
+            [ soul_harvester ]( const dbc_proc_callback_t*, action_t*, const action_state_t* s ) {
+              if ( soul_harvester )
+                return true;  // Soul Harverser allows procs from all player (non-pet) damage (including DoTs and items dmg effects)
+
+              if ( s->proc_type() == PROC1_PERIODIC )
+                return false; // only Soul Harverser allows procs from DoTs
+
+              return true;
+            } );
+          break;
+        }
+        case WARLOCK_DESTRUCTION:
+        {
+          buff_driver->proc_flags_ |= PF_PERIODIC | PF_HELPFUL_PERIODIC;
+          buff_driver->proc_flags2_ |= PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL;
+
+          effect.player->callbacks.register_callback_trigger_function(
+            buff_driver->driver()->id(), dbc_proc_callback_t::trigger_fn_type::CONDITION,
+            []( const dbc_proc_callback_t*, action_t*, const action_state_t* s ) {
+              if ( s->proc_type() == PROC1_PERIODIC )
+              {
+                if ( s->action->id == 157736 || s->action->id == 445474 )
+                  return true;  // Only Immolate DoT (157736) and Wither DoT (445474) allow procs
+
+                return false;
+              }
+              return true;
+            } );
+          break;
+        }
+        case WARLOCK_AFFLICTION:
+        {
+          const bool soul_harvester = HT( effect.player, "Demonic Soul" ).ok();
+          const bool siphon_life = ST( effect.player, "Siphon Life" ).ok();
+
+          const auto tal_seeds_of_their_demise = HT( effect.player, "Seeds of Their Demise" );
+          const bool seeds_demise = tal_seeds_of_their_demise.ok();
+          const double seeds_demise_effectn2 = tal_seeds_of_their_demise->effectN( 2 ).base_value();
+
+          buff_driver->proc_flags_ |= PF_PERIODIC | PF_HELPFUL_PERIODIC;
+          buff_driver->proc_flags2_ |= PF2_PERIODIC_DAMAGE | PF2_PERIODIC_HEAL;
+
+          effect.player->callbacks.register_callback_trigger_function(
+            buff_driver->driver()->id(), dbc_proc_callback_t::trigger_fn_type::CONDITION,
+            [ soul_harvester, siphon_life, seeds_demise, seeds_demise_effectn2 ] ( const dbc_proc_callback_t*, action_t*, const action_state_t* s ) {
+              if ( soul_harvester )
+                return true;  // Soul Harverser allows procs from all player (non-pet) damage (including DoTs and items dmg effects)
+
+              if ( s->proc_type() == PROC1_PERIODIC )
+              {
+                // Wither DoT (445474) only allows procs with Siphon Life talent or with Seeds of Their Demise talent (if it ticks on low HP targets)
+                if ( s->action->id == 445474 && ( siphon_life || ( seeds_demise && s->target->health_percentage() <= seeds_demise_effectn2 ) ) )
+                  return true;
+
+                return false;
+              }
+              return true;
+            } );
+          break;
+        }
+      }
       break;
     case EVOKER:
       // Heals trigger Scarlet, which triggers the trinket. Otherwise burnout procs do. Hooking these would be ideal but


### PR DESCRIPTION
The [Mug's Moxie Jug](https://www.wowhead.com/item=230192/mugs-moxie-jug) trinket presents some [issues](https://github.com/simulationcraft/simc/issues/10116) in Simc. This trinket has two drivers: the [main driver](https://www.wowhead.com/spell=471548/mugs-moxie-jug), which is responsible for processing the buff activation (15sec ICD), and the [secondary driver](https://www.wowhead.com/spell=474376/mugs-moxie-jug), which increases the stacks while the buff is active (750ms ICD). Both effects can be triggered by a multitude of player actions: some healing effects, some damage effects, energize effects, some gain/drop/refresh auras, and even some triggers from periodic hidden auras/spells that don't appear in the combatlog or the logs.

Simc doesn't include the implementation of many of these effects, which causes some issues with the trinket. For the main driver, this isn't a big problem, as it's RPPM-based. In Simc it has been established for main driver that it can be triggered by many casts, damage effects, and healing effects. This should be sufficient for it to trigger periodically based on RPPM, so no major changes are needed. The problem is the secondary driver that increases stacks while the buff is present, which is not RPPM-based and always increases the buff by one stack with any of its activations (is 100% chance, so it is activating all the time with all these effects/spells, as long as they occur after its 750ms ICD). In Simc, many of these effects are not implemented, so the buff doesn't increase stacks as quickly as it does ingame for many specs, and that's the problem.

Commit 46eea16 has attempted to make the secondary driver increase stacks more quickly, including most damage and healing casts and effects. This isn't entirely accurate, but it makes its effectiveness more similar to ingame.

[This pevious discarted PR](https://github.com/simulationcraft/simc/pull/10267) provided more information on the issue and proposed an alternative option for a user to set up an alternative way for the trinket to periodically gain stacks based on a timer. However, it was discarded because it was a workaround that didn't address the root of the problem in the warlock module. Although this issue is more general and may affect other classes, it's best to implement it faithfully in the class modules, and for other classes seem that the difference between sims and ingame results doesn't seem as significant as it is for the warlock (specially the demonology).

Commit 53ce36e was then implemented to try to improve this. Although it is still a large workaround hack, it has been tuned to produce results that are more faithful to the observed ingame results.

---

This new PR aims to provide a faithful implementation of trinket procs for all three warlock specs as suggested. To achieve this, most of the modifications are made to the warlock module, although some specific adjustments to the trinket's warlock settings are also necessary. This should result in a much more faithful implementation of this trinket, and also a better tuning of the warlock module to work properly also with other trinkets/effects/procs.

All warlock spells have been tested ingame to document which ones trigger the trinket's secondary driver and which ones don't. This is then used to determine whether the current Simc implementation behaved correctly. An Excel spreadsheet detailing the results is attached below, along with their behavior in the current Simc implementation and the new implementation after this PR:

[wl_trinket_triggers.xlsx](https://github.com/user-attachments/files/20526662/wl_trinket_triggers.xlsx)

Below we will discuss some of the most relevant things about the Warlock's spells and the trinket's secondary driver procs:
- The gear leech doesn't proc the trinket secondary driver.
- The healing from the [Fel Synergy](https://www.wowhead.com/spell=389367/fel-synergy) talent also doesn't proc.
- The damage dealt to the pet with [Soul Link](https://www.wowhead.com/spell=108415/soul-link) doesn't proc either.
- It was believed that [Soul Leech](https://www.wowhead.com/spell=108366/soul-leech) was continuously triggering the trinket with each aura refresh whenever damage is dealt, but this is not true. It has been tested for both the timed and permanent versions of the aura that the trinket procs can only happen when the warlock or pet gains the buff because they didn't have it, but not when the aura is refreshed. This means that the impact the aura was believed to have on the trinket is actually much smaller than previously thought. This spell isn't implemented in Simc, but as stated, it's not as significant.
- Some other classes/specs have periodic unknown hidden auras that continuously trigger the trinket. In the case of the warlock, there is at least one periodic hidden effect, but it only triggers the main driver (which doesn't matter much because it's PRRM-based) and not the secondary driver.
- Most utility spells trigger the trinket procs, although these aren't implemented in Simc.
- Some buffs applied by the player (either to themselves or to other units like their pets) trigger the trinket procs, although not all.
- All the current warlock spells that directly apply a debuff to the target (by the player) allow procs.
- Actions, spells, buffs/debuffs and damage events from the warlock pets do not trigger the trinket procs. The only exceptions are when pet actions apply debuffs that are actually applied by the player (the logs show that the aura is applied by the player), such as the following:
	- [Cloven Soul](https://www.wowhead.com/spell=434424/cloven-soul)
	- [Wicked Maw](https://www.wowhead.com/spell=270569/wicked-maw)
	- [Fel Sunder](https://www.wowhead.com/spell=387402/fel-sunder)
- Summoning pets doesn't always procs the trinket, it depends on the pet. Summoning main pets does, as well as Dreadstalkers, Tyrant, and Wild Imps from Demonology. However, other pets such as the Infernals, Vilefiend, or the three demons from the Diabolist Hero tree do not.
- When the Soul Harvester hero tree talent is selected (for both Affliction and Demonology), this causes any damage the player deals directly (pets don't count) to trigger the trinket procs. This includes things that don't normally procs, such as DoT damage ticks, melee hits, or trinket-damaging effects.
- Most energize effects (gaining soul shards) trigger the trinket procs, and do so even if the player is soul shard capped. However, some do not, such as the periodic regeneration of Infernals or Overfiends.
	- A special case is the Felguard's [Soul Strike](https://www.wowhead.com/spell=428344/soul-strike) with the [Fel Invocation](https://www.wowhead.com/spell=428351/fel-invocation) talent. Normally, the trinket procs aren't triggered for this energize spell, but with the Soul Harvester tree selected it does, but only if the effect effectively gains a Soul Shard (if the player isn't soul shard capped).
- Normally DoT damage doesn't trigger the trinket secondary driver, although as previously mentioned, this isn't the case for Soul Harvester. There are also other exceptions to this:
	- For the Destruction Warlock, each tick of [Immolate](https://www.wowhead.com/spell=348/immolate) and [Wither](https://www.wowhead.com/spell=445474/wither) procs the trinket. It's difficult to know if this is due to each tick generating a Soul Shard or some other related background effect.
	- For the Affliction Warlock, the [Corruption](https://www.wowhead.com/spell=172/corruption) DoT ticks always trigger procs because this spell only exists for Soul Harvester.
		- [Wither](https://www.wowhead.com/spell=445474/wither) replaces it for Hellcaller. [Wither](https://www.wowhead.com/spell=445474/wither) DoT ticks for Affliction only allow the trinket to proc in one of these two circumstances:
			- With the [Siphon Life](https://www.wowhead.com/spell=452999/siphon-life) talent for all ticks
			- Without the [Siphon Life](https://www.wowhead.com/spell=452999/siphon-life) talent, when the tick is on a target below 20% health, as this triggers the collapse of the stacks. This occurs for all ticks in that HP condition, even if the collapse has already ended and only one stack remains.
- Casting [Rain of Fire](https://www.wowhead.com/spell=5740/rain-of-fire) does trigger the trinket procs, but the damage ticks don't. However, if you have the [Pyrogenics](https://www.wowhead.com/spell=387095/pyrogenics) talent selected, each RoF tick will renew the application of this debuff and this does trigger the trinket procs.
- Finally, it's important to note that in many cases it's very difficult to know if the trinket proc is triggered by a cast, the application of a buff, the application of a debuff, an energize effect, etc., since many of these effects occur simultaneously. In the attached spreadsheet, effects that aren't checked are marked with `X`, as they occur alongside others that already trigger the trinket. In Simc, in most of these cases, the most convenient option for implementation is chosen, which is usually the associated `CAST` spell event.
- Special mention should be made of the [Infernal Command](https://www.wowhead.com/spell=387552/infernal-command) aura, which is a remnant of an old demonology warlock talent that no longer exists. However, the aura still exists ingame, although its value is `0` and therefore the damage increase is `0%`. This aura is relevant because its application triggers the trinket, and it has strange behavior: this aura is periodically applied/removed for each wild imp approximately every 5.25 seconds from its spawn. Since this aura had no effect, it was not implemented in Simc, and its implementation is also added in this PR to allow these procs.

Regarding more specific implementation details in this PR, the following are worth highlighting:
- Normally, the second driver does not trigger DoT damage, but as previously mentioned, there are exceptions. This is managed with a custom callback configuration in the Warlock's trinket settings.
- For the most relevant pet summons that are not direct actions in the current simc implementation, direct summon spell actions have been added, and now these actions are called instead of doing directly a `.spawn()`.
- By default in Simc, buffs/debuffs and energize effects do not trigger trinkets, and to do so, they must be wrapped in an action. This can be done in several ways. The way we chose was to use a dummy helper action (`buff_apply_action`) for applying relevant buffs/debuffs and another dummy helper action (`energize_action`) for the relevant energize effects. This has been done so that it's only necessary to replace the current line that triggers the buff/energize with a very similar one that wraps the buff/energize trigger into the action. Other alternatives were, for example, creating a single global dummy action and executing it after each buff/energize in a new line, which would somewhat "decouple" the effect from the action and be more error-prone; or creating a new separate action for each buff/energize effect that required it, which would be very verbose and add confusing duplicate actions to the spells. I guess another valid alternative would be to create our own `warlock_buff_t` derived from `buff_t` where some additional parameter indicates whether it has an associated action. So, if you think any of these or some other approach is preferable to the one implemented, please feel free to comment.

The changes have been thoroughly tested and debugged, and they appear to be working correctly, producing the results shown in the attached spreadsheet. This PR includes a considerable number of changes, so additional reviews are always welcome. Let me know if you have any thoughts, comments, or suggestions.