### PR TITLE
[Shaman] Suppress a Conversion Warning

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -6623,7 +6623,7 @@ struct chained_base_t : public shaman_spell_t
         auto new_idx = i;
         do
         {
-          new_idx = rng().range( 1U, tl.size() );
+          new_idx = rng().range<size_t>( 1U, tl.size() );
         } while ( new_idx == i );
 
         sim->print_debug( "{} randomized {} target, target={} (idx={}), new_pos={}",


### PR DESCRIPTION
Fixes a type conversion warning caused by it incorrectly using `rng().range` on `double,double` assumed types due to the inputs not matching by forcing it to use it for size_t, which then converts implicitly without any precision loss fine.
Shouldn't cause any issues but I haven't confirmed if behaviour is altered (negatively or positively)