### PR TITLE
[player] Provide virtual bool validate_actor()

### DIFF
--- a/engine/class_modules/apl/apl_monk.cpp
+++ b/engine/class_modules/apl/apl_monk.cpp
@@ -850,30 +850,27 @@ void default_apl( monk_t* player )
 // Shared Defaults
 namespace monk
 {
-void monk_t::validate_actor()
+bool monk_t::validate_actor()
 {
   if ( specialization() == MONK_MISTWEAVER && !sim->allow_experimental_specializations )
   {
     if ( !quiet )
       sim->error( "Mistweaver Monk for {} is not currently supported.", *this );
-    quiet = true;
-    return;
+    return false;
   }
 
   if ( main_hand_weapon.type == WEAPON_NONE )
   {
     if ( !quiet )
       sim->error( "{} has no weapon equipped at the Main-Hand slot.", *this );
-    quiet = true;
-    return;
+    return false;
   }
 
   if ( main_hand_weapon.group() == WEAPON_2H && off_hand_weapon.group() == WEAPON_1H )
   {
     if ( !quiet )
       sim->error( "{} both a 1-hand and 2-hand weapon equipped at once.", *this );
-    quiet = true;
-    return;
+    return false;
   }
 
   switch ( specialization() )
@@ -881,18 +878,17 @@ void monk_t::validate_actor()
     case MONK_BREWMASTER:
     case MONK_MISTWEAVER:
     case MONK_WINDWALKER:
-      return;
+      return true;
     default:
       sim->error( "No specialization was selected for {}.", *this );
-      quiet = true;
-      return;
+      return false;
   }
+
+  return false;
 }
 
 void monk_t::init_blizzard_action_list()
 {
-  validate_actor();
-
   action_priority_list_t* default_ = get_action_priority_list( "default" );
 
   switch ( specialization() )
@@ -1026,8 +1022,6 @@ std::string monk_t::default_temporary_enchant() const
 
 void monk_t::init_action_list()
 {
-  validate_actor();
-
   if ( action_list_str.empty() )
   {
     clear_action_priority_lists();

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -1400,7 +1400,7 @@ public:
   std::string default_temporary_enchant() const override;
   void init_action_list() override;
   void init_blizzard_action_list() override;
-  void validate_actor();
+  bool validate_actor() override;
   bool validate_fight_style( fight_style_e style ) const override;
   parsed_assisted_combat_rule_t parse_assisted_combat_rule( const assisted_combat_rule_data_t &rule,
                                                             const assisted_combat_step_data_t &step ) const override;

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -15101,7 +15101,6 @@ void shaman_t::init_action_list()
 {
   if ( quiet )
     return;
-  }
 
   // After error checks, initialize secondary actions for various things
   windfury_mh = new windfury_attack_t( "windfury_attack", this, find_spell( 25504 ), &( main_hand_weapon ) );

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -1897,6 +1897,7 @@ public:
   void init_items() override;
   void init_special_effects() override;
   void init_finished() override;
+  bool validate_actor() override;
   std::string create_profile( save_e ) override;
   void create_special_effects() override;
   action_t* create_proc_action( util::string_view /* name */, const special_effect_t& /* effect */ ) override;
@@ -14370,6 +14371,31 @@ void shaman_t::init_finished()
   apply_player_effects();
 }
 
+bool shaman_t::validate_actor()
+{
+  if ( !( primary_role() == ROLE_ATTACK && specialization() == SHAMAN_ENHANCEMENT ) &&
+       !( primary_role() == ROLE_SPELL && specialization() == SHAMAN_ELEMENTAL ) &&
+       !( primary_role() == ROLE_SPELL && specialization() == SHAMAN_RESTORATION ) )
+  {
+    if ( !quiet )
+      sim->errorf( "Player %s's role (%s) or spec(%s) isn't supported yet.", name(),
+                   util::role_type_string( primary_role() ), util::specialization_string( specialization() ) );
+    return false;
+  }
+
+  // Restoration isn't supported atm
+  if ( !sim->allow_experimental_specializations && specialization() == SHAMAN_RESTORATION &&
+       primary_role() == ROLE_HEAL )
+  {
+    if ( !quiet )
+      sim->errorf( "Restoration Shaman healing for player %s is not currently supported.", name() );
+
+    return false;
+  }
+
+  return true;
+}
+
 // shaman_t::apply_affecting_auras ==========================================
 
 void shaman_t::apply_affecting_auras( action_t& action )
@@ -15073,25 +15099,7 @@ void shaman_t::init_action_list_restoration_dps()
 
 void shaman_t::init_action_list()
 {
-  if ( !( primary_role() == ROLE_ATTACK && specialization() == SHAMAN_ENHANCEMENT ) &&
-       !( primary_role() == ROLE_SPELL && specialization() == SHAMAN_ELEMENTAL ) &&
-       !( primary_role() == ROLE_SPELL && specialization() == SHAMAN_RESTORATION ) )
-  {
-    if ( !quiet )
-      sim->errorf( "Player %s's role (%s) or spec(%s) isn't supported yet.", name(),
-                   util::role_type_string( primary_role() ), util::specialization_string( specialization() ) );
-    quiet = true;
-    return;
-  }
-
-  // Restoration isn't supported atm
-  if ( !sim->allow_experimental_specializations && specialization() == SHAMAN_RESTORATION &&
-       primary_role() == ROLE_HEAL )
-  {
-    if ( !quiet )
-      sim->errorf( "Restoration Shaman healing for player %s is not currently supported.", name() );
-
-    quiet = true;
+  if ( quiet )
     return;
   }
 

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -3826,6 +3826,13 @@ void player_t::init_background_actions()
 
 void player_t::create_actions()
 {
+  // if actor is not valid, set `quiet` and skip the rest of action creation
+  if ( !validate_actor() )
+  {
+    quiet = true;
+    return;
+  }
+
   if( is_player() && !is_enemy() && !is_pet() )
     consumable::create_consumeable_actions( this );
 

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -1114,6 +1114,8 @@ public:
   virtual void validate_sim_options() {}
   virtual bool validate_fight_style( fight_style_e ) const
   { return true; }
+  virtual bool validate_actor()
+  { return true; }
   virtual void init_meta_gem();
   virtual void init_resources( bool force = false );
   virtual std::vector<std::string> get_item_actions();

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2975,7 +2975,7 @@ void sim_t::analyze()
     std::fflush( stdout );
   }
 
-
+  
   assert( iterations > 0 );
 
   // Run core analyze for all actor collected data before proceeding to full analysis. This is to prevent errors from

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -2975,7 +2975,7 @@ void sim_t::analyze()
     std::fflush( stdout );
   }
 
-  
+
   assert( iterations > 0 );
 
   // Run core analyze for all actor collected data before proceeding to full analysis. This is to prevent errors from


### PR DESCRIPTION
- **[player] Create `bool player_t::validate_actor()` to validate whether or not actor initialization should continue.**

Goal is to unify validation strategies and move it all into `player_t::create_action()`
to simplify logic and deduplicate code due to Blizzard Assisted Combat.
