### PR TITLE
[Gear] Charged Crystal uses generic split target scaling

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -10753,7 +10753,7 @@ void charged_crystal( special_effect_t& effect )
   effect.proc_flags2_ = PF2_ALL_HIT;
   effect.ppm_         = driver->_rppm;
   effect.execute_action =
-      create_proc_action<generic_aoe_proc_t>( util::tokenize_fn( trigger->name_cstr() ), effect, trigger );
+      create_proc_action<generic_aoe_proc_t>( util::tokenize_fn( trigger->name_cstr() ), effect, trigger, true );
   effect.execute_action->base_dd_min = effect.execute_action->base_dd_max =
       value_spell->effectN( 13 ).average( effect );
   effect.execute_action->base_multiplier *= role_mult( effect.player, effect.player->find_spell( 1241240 ) );


### PR DESCRIPTION
single target:
![image](https://github.com/user-attachments/assets/617da9d2-dcc7-4062-a826-dce435d0c4f6)
six target:
![image](https://github.com/user-attachments/assets/8c673087-ea4e-43b3-a0ee-a2c3d8cb4e34)

The first hit was a 2,651,609 crit, so at 6 targets it should deal about about 2,651,609 * 2.5 / 6 to each target if it crit

Not the greatest example, can get a better one if needed
