### PR TITLE
[Rogue] Initial implementations of TWW3 Trickster and Fatebound sets, and PTR Killing Spree

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -502,6 +502,8 @@ public:
     damage_buff_t* tww2_outlaw_2pc;
     damage_buff_t* tww2_subtlety_2pc;
 
+    buff_t* tww3_trickster_4pc;
+
   } buffs;
 
   // Cooldowns
@@ -1082,7 +1084,7 @@ public:
       player_talent_t destiny_defined;  // TODO: Outlaw also gets the poison proc rate the text says is for assa? Verify in-game.
       player_talent_t double_jeopardy;  // TODO: Double jeopardy + edge case stealth break overlap bug
 
-      player_talent_t fateful_ending;   // TODO: Add tertiary stats
+      player_talent_t fateful_ending;
 
     } fatebound;
 
@@ -1183,6 +1185,11 @@ public:
     const spell_data_t* tww2_outlaw_4pc;
     const spell_data_t* tww2_subtlety_2pc;
     const spell_data_t* tww2_subtlety_4pc;
+
+    const spell_data_t* tww3_fatebound_2pc;
+    const spell_data_t* tww3_fatebound_4pc;
+    const spell_data_t* tww3_trickster_2pc;
+    const spell_data_t* tww3_trickster_4pc;
   } set_bonuses;
 
   // Options
@@ -3684,7 +3691,25 @@ struct adrenaline_rush_t : public rogue_spell_t
         p()->buffs.double_jeopardy->expire();
         execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
       }
+      if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+      {
+        execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      }
     }
+  }
+
+  void update_ready( timespan_t cd_duration ) override
+  {
+    if ( p()->set_bonuses.tww3_fatebound_4pc->ok() && p()->buffs.fatebound_lucky_coin->check() )
+    {
+      if ( cd_duration < 0_ms )
+      {
+        cd_duration = cooldown->duration;
+      }
+      cd_duration += p()->set_bonuses.tww3_fatebound_4pc->effectN( 1 ).time_value();
+    }
+
+    rogue_spell_t::update_ready( cd_duration );
   }
 };
 
@@ -4396,7 +4421,25 @@ struct deathmark_t : public rogue_attack_t
         p()->buffs.double_jeopardy->expire();
         execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
       }
+      if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+      {
+        execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      }
     }
+  }
+
+  void update_ready( timespan_t cd_duration ) override
+  {
+    if ( p()->set_bonuses.tww3_fatebound_4pc->ok() && p()->buffs.fatebound_lucky_coin->check() )
+    {
+      if ( cd_duration < 0_ms )
+      {
+        cd_duration = cooldown->duration;
+      }
+      cd_duration += p()->set_bonuses.tww3_fatebound_4pc->effectN( 2 ).time_value();
+    }
+
+    rogue_attack_t::update_ready( cd_duration );
   }
 };
 
@@ -4915,14 +4958,61 @@ struct ghostly_strike_t : public rogue_attack_t
   {
   }
 
+  double action_multiplier() const override
+  {
+    double m = rogue_attack_t::action_multiplier();
+
+    if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+    {
+      m *= 1.0 + p()->set_bonuses.tww3_fatebound_2pc->effectN( 1 ).percent();
+    }
+
+    return m;
+  }
+
   void impact( action_state_t* state ) override
   {
     rogue_attack_t::impact( state );
 
     if ( result_is_hit( state->result ) )
     {
-      td( state->target )->debuffs.ghostly_strike->trigger();
+      timespan_t duration = data().duration();
+      if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+      {
+        duration += p()->set_bonuses.tww3_fatebound_2pc->effectN( 4 ).time_value();
+      }
+      td( state->target )->debuffs.ghostly_strike->trigger( duration );
     }
+  }
+
+  void execute() override
+  {
+    rogue_attack_t::execute();
+
+    if ( p()->talent.fatebound.edge_case->ok() && p()->set_bonuses.tww3_fatebound_2pc->ok() )
+    {
+      execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      if ( p()->talent.fatebound.double_jeopardy->ok() && p()->buffs.double_jeopardy->check() )
+      {
+        p()->buffs.double_jeopardy->expire();
+        execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      }
+    }
+  }
+
+  void update_ready( timespan_t cd_duration ) override
+  {
+    if ( p()->set_bonuses.tww3_fatebound_4pc->ok() && p()->buffs.fatebound_lucky_coin->check() )
+    {
+      if ( cd_duration < 0_ms )
+      {
+        cd_duration = cooldown->duration;
+      }
+      cd_duration += p()->set_bonuses.tww3_fatebound_4pc->effectN( 3 ).time_value();
+    }
+
+    rogue_attack_t::update_ready( cd_duration );
   }
 
   bool procs_main_gauche() const override
@@ -5129,10 +5219,74 @@ struct kingsbane_t : public rogue_attack_t
   {
   }
 
+  double action_multiplier() const override
+  {
+    double m = rogue_attack_t::action_multiplier();
+
+    if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+    {
+      m *= 1.0 + p()->set_bonuses.tww3_fatebound_2pc->effectN( 2 ).percent();
+    }
+
+    return m;
+  }
+
+  timespan_t composite_dot_duration( const action_state_t* s ) const override
+  {
+    timespan_t duration = rogue_attack_t::composite_dot_duration( s );
+    if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+    {
+      duration += p()->set_bonuses.tww3_fatebound_2pc->effectN( 5 ).time_value();
+    }
+    return duration;
+  }
+
+  double composite_persistent_multiplier( const action_state_t* state ) const override
+  {
+    double m = rogue_attack_t::composite_persistent_multiplier( state );
+
+    if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
+    {
+      m *= 1.0 + p()->set_bonuses.tww3_fatebound_2pc->effectN( 3 ).percent();
+    }
+
+    return m;
+  }
+
+  void execute() override
+  {
+    rogue_attack_t::execute();
+
+    if ( p()->talent.fatebound.edge_case->ok() && p()->set_bonuses.tww3_fatebound_2pc->ok() )
+    {
+      execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      if ( p()->talent.fatebound.double_jeopardy->ok() && p()->buffs.double_jeopardy->check() )
+      {
+        p()->buffs.double_jeopardy->expire();
+        execute_fatebound_coinflip( execute_state, fatebound_t::coinflip_e::EDGE );
+      }
+    }
+  }
+
   void last_tick( dot_t* d ) override
   {
     rogue_attack_t::last_tick( d );
     p()->buffs.kingsbane->expire();
+  }
+
+  void update_ready( timespan_t cd_duration ) override
+  {
+    if ( p()->set_bonuses.tww3_fatebound_4pc->ok() && p()->buffs.fatebound_lucky_coin->check() )
+    {
+      if ( cd_duration < 0_ms )
+      {
+        cd_duration = cooldown->duration;
+      }
+      cd_duration += p()->set_bonuses.tww3_fatebound_4pc->effectN( 4 ).time_value();
+    }
+
+    rogue_attack_t::update_ready( cd_duration );
   }
 };
 
@@ -7207,6 +7361,18 @@ struct unseen_blade_t : public rogue_attack_t
   {
   }
 
+  double action_multiplier() const override
+  {
+    double m = rogue_attack_t::action_multiplier();
+
+    if ( p()->set_bonuses.tww3_trickster_2pc->ok() )
+    {
+      m *= 1.0 + p()->set_bonuses.tww3_trickster_2pc->effectN( 1 ).percent();
+    }
+
+    return m;
+  }
+
   void execute() override
   {
     rogue_attack_t::execute();
@@ -7433,7 +7599,25 @@ struct coup_de_grace_t : public rogue_attack_t
     trigger_count_the_odds( execute_state, p()->procs.count_the_odds_coup_de_grace );
     trigger_tww2_set_bonus_removal();
 
+    if ( p()->set_bonuses.tww3_trickster_4pc->ok() )
+    {
+      if ( p()->buffs.tww3_trickster_4pc->check() ) 
+      {
+        p()->buffs.tww3_trickster_4pc->expire();
     p()->buffs.escalating_blade->expire();
+  }
+      else
+      {
+        // 5s timer to recast Coup de Grace starts ~1 second into the cast
+        make_event( *p()->sim, 1_s, [ this ] {
+          p()->buffs.tww3_trickster_4pc->trigger();
+        } );
+      }
+    }
+    else 
+    {
+      p()->buffs.escalating_blade->expire();
+    }
   }
 
   bool ready() override
@@ -9544,6 +9728,14 @@ void actions::rogue_action_t<Base>::trigger_unseen_blade( const action_state_t* 
     p()->buffs.unseen_blade_cd->trigger();
 
   p()->cooldowns.unseen_blade_icd->start();
+
+  if ( p()->set_bonuses.tww3_trickster_2pc->ok() )
+  {
+    if ( this->rng().roll( p()->set_bonuses.tww3_trickster_2pc->effectN( 2 ).percent() ) )
+    {
+      p()->buffs.unseen_blade_cd->expire();
+    }
+  }
 }
 
 template <typename Base>
@@ -11404,6 +11596,11 @@ void rogue_t::init_spells()
 
   spec.tww2_assassination_4pc_buff = set_bonuses.tww2_assassination_4pc->ok() ? find_spell( 1219264 ) : spell_data_t::not_found();
 
+  set_bonuses.tww3_fatebound_2pc = sets->set( HERO_FATEBOUND, TWW3, B2 );
+  set_bonuses.tww3_fatebound_4pc = sets->set( HERO_FATEBOUND, TWW3, B4 );
+  set_bonuses.tww3_trickster_2pc = sets->set( HERO_TRICKSTER, TWW3, B2 );
+  set_bonuses.tww3_trickster_4pc = sets->set( HERO_TRICKSTER, TWW3, B4 );
+
   // Active Spells ==========================================================
 
   auto_attack = new actions::auto_melee_attack_t( this, "" );
@@ -12023,7 +12220,6 @@ void rogue_t::create_buffs()
   
   buffs.fatebound_lucky_coin = make_buff<stat_buff_t>( this, "fatebound_lucky_coin", spell.fatebound_lucky_coin_buff );
   buffs.fatebound_lucky_coin->set_default_value( spell.fatebound_lucky_coin_buff->effectN( 1 ).percent() );
-  // TODO: lucky coin still has effects for non-primary stat buffs, but definitely only affects primary stat in game
   buffs.fatebound_lucky_coin->set_pct_buff_type( STAT_PCT_BUFF_AGILITY );
   buffs.fatebound_lucky_coin->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
   register_on_combat_state_callback( [ this ]( player_t*, bool in_combat ) {
@@ -12315,6 +12511,13 @@ void rogue_t::create_buffs()
   if ( set_bonuses.tww2_subtlety_2pc->ok() )
   {
     buffs.tww2_subtlety_2pc->set_direct_mod( set_bonuses.tww2_subtlety_2pc->effectN( 1 ).trigger(), 1 );
+  }
+
+  // Buff to expose when Coup de Grace is able to be recasted
+  buffs.tww3_trickster_4pc = make_buff( this, "tww3_trickster_coup_recast", set_bonuses.tww3_trickster_4pc );
+  if ( set_bonuses.tww3_trickster_4pc->ok() )
+  {
+    buffs.tww3_trickster_4pc->set_duration( 5_s );
   }
 }
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -571,6 +571,7 @@ public:
     gain_t* improved_adrenaline_rush;
     gain_t* improved_adrenaline_rush_expiry;
     gain_t* improved_ambush;
+    gain_t* killing_spree;
     gain_t* premeditation;
     gain_t* quick_draw;
     gain_t* ruthlessness;
@@ -735,6 +736,7 @@ public:
     const spell_data_t* improved_adrenaline_rush_energize;
     const spell_data_t* killing_spree_mh_attack;
     const spell_data_t* killing_spree_oh_attack;
+    const spell_data_t* killing_spree_cps;
     const spell_data_t* opportunity_buff;
     const spell_data_t* sinister_strike_extra_attack;
     const spell_data_t* sting_like_a_bee_debuff;
@@ -5114,6 +5116,13 @@ struct killing_spree_tick_t : public rogue_attack_t
     {
       p()->get_target_data( state->target )->debuffs.fazed->trigger();
     }
+
+    // 11.2 PTR -- Resource generation coincides with mainhand hit
+    // This triggers at the zero tick unlike in-game, however the zero tick happens before CPs are consumed anyway
+    if ( p()->is_ptr() && weapon->slot == SLOT_MAIN_HAND )
+    {
+      trigger_combo_point_gain( as<int>( p()->spec.killing_spree_cps->effectN( 1 ).base_value() ), p()->gains.killing_spree );
+    }
   }
 
   bool procs_main_gauche() const override
@@ -5137,7 +5146,8 @@ struct killing_spree_t : public rogue_attack_t
     attack_mh( nullptr ), attack_oh( nullptr )
   {
     channeled = tick_zero = true;
-    interrupt_auto_attack = false;
+    // 11.2 PTR -- Auto attacks are interrupted
+    interrupt_auto_attack = p->is_ptr() ? true : false;
 
     attack_mh = p->get_background_action<killing_spree_tick_t>( "killing_spree_mh", p->spec.killing_spree_mh_attack );
     attack_oh = p->get_background_action<killing_spree_tick_t>( "killing_spree_oh", p->spec.killing_spree_oh_attack );
@@ -5189,8 +5199,9 @@ struct killing_spree_t : public rogue_attack_t
   {
     rogue_attack_t::tick( d );
 
-    attack_mh->execute_on_target( d->target );
-    attack_oh->execute_on_target( d->target );
+    // 11.2 PTR -- Both hits target random enemies
+    attack_mh->execute_on_target( p()->is_ptr() ? *rng().range( sim->target_non_sleeping_list.begin(), sim->target_non_sleeping_list.end() ) : d->target );
+    attack_oh->execute_on_target( p()->is_ptr() ? *rng().range( sim->target_non_sleeping_list.begin(), sim->target_non_sleeping_list.end() ) : d->target );
   }
 
   void last_tick( dot_t* d ) override
@@ -7604,8 +7615,8 @@ struct coup_de_grace_t : public rogue_attack_t
       if ( p()->buffs.tww3_trickster_4pc->check() ) 
       {
         p()->buffs.tww3_trickster_4pc->expire();
-    p()->buffs.escalating_blade->expire();
-  }
+        p()->buffs.escalating_blade->expire();
+      }
       else
       {
         // 5s timer to recast Coup de Grace starts ~1 second into the cast
@@ -11525,8 +11536,10 @@ void rogue_t::init_spells()
   spec.greenskins_wickers_buff = talent.outlaw.greenskins_wickers->ok() ? find_spell( 394131 ) : spell_data_t::not_found();
   spec.hidden_opportunity_extra_attack = talent.outlaw.hidden_opportunity->ok() ? find_spell( 385897 ) : spell_data_t::not_found();
   spec.improved_adrenaline_rush_energize = talent.outlaw.improved_adrenaline_rush->ok() ? find_spell( 395424 ) : spell_data_t::not_found();
+  // TOCHECK -- Killing Spree spell ids could change over 11.2 PTR
   spec.killing_spree_mh_attack = talent.outlaw.killing_spree->ok() ? find_spell( 57841 ) : spell_data_t::not_found();
-  spec.killing_spree_oh_attack = spec.killing_spree_mh_attack->effectN( 1 ).trigger();
+  spec.killing_spree_oh_attack = talent.outlaw.killing_spree->ok() ? find_spell( 57842 ) : spell_data_t::not_found();
+  spec.killing_spree_cps = talent.outlaw.killing_spree->ok() ? find_spell( 1235074 ) : spell_data_t::not_found();
   spec.opportunity_buff = talent.outlaw.opportunity->ok() ? find_spell( 195627 ) : spell_data_t::not_found();
   spec.sinister_strike_extra_attack = talent.outlaw.opportunity->ok() ? find_spell( 197834 ) : spell_data_t::not_found();
   spec.summarily_dispatched_buff = talent.outlaw.summarily_dispatched->ok() ? find_spell( 386868 ) : spell_data_t::not_found();
@@ -11861,6 +11874,7 @@ void rogue_t::init_gains()
   gains.improved_adrenaline_rush        = get_gain( "Improved Adrenaline Rush" );
   gains.improved_adrenaline_rush_expiry = get_gain( "Improved Adrenaline Rush (Expiry)" );
   gains.improved_ambush                 = get_gain( "Improved Ambush" );
+  gains.killing_spree                   = get_gain( "Killing Spree" );
   gains.master_of_shadows               = get_gain( "Master of Shadows" );
   gains.premeditation                   = get_gain( "Premeditation" );
   gains.quick_draw                      = get_gain( "Quick Draw" );

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -5245,10 +5245,12 @@ struct kingsbane_t : public rogue_attack_t
   timespan_t composite_dot_duration( const action_state_t* s ) const override
   {
     timespan_t duration = rogue_attack_t::composite_dot_duration( s );
+
     if ( p()->set_bonuses.tww3_fatebound_2pc->ok() )
     {
       duration += p()->set_bonuses.tww3_fatebound_2pc->effectN( 5 ).time_value();
     }
+
     return duration;
   }
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -12190,15 +12190,12 @@ void rogue_t::create_buffs()
   buffs.fatebound_coin_heads = make_buff<damage_buff_t>( this, "fatebound_coin_heads", spell.fatebound_coin_heads_buff, false );
   if ( spell.fatebound_coin_heads_buff->ok() && spell.fatebound_coin_heads_stacking_buff->ok() )
   {
-    // Combine the 1% per additional stack buff (which we use as the stacking base buff) and 3% from initial stack buff (the fatebound_coin_heads_stacking_buff)
     buffs.fatebound_coin_heads->set_direct_mod( spell.fatebound_coin_heads_buff, 1, spell.fatebound_coin_heads_buff->effectN( 1 ).percent(),
-                                                1.0 + spell.fatebound_coin_heads_stacking_buff->effectN( 1 ).percent() - spell.fatebound_coin_heads_buff->effectN( 1 ).percent() );
+                                                1.0 + spell.fatebound_coin_heads_stacking_buff->effectN( 1 ).percent() );
     buffs.fatebound_coin_heads->set_periodic_mod( spell.fatebound_coin_heads_buff, 2, spell.fatebound_coin_heads_buff->effectN( 2 ).percent(),
-                                                  1.0 + spell.fatebound_coin_heads_stacking_buff->effectN( 2 ).percent() - spell.fatebound_coin_heads_buff->effectN( 2 ).percent() );
-    // TODO: fatebound_coin_heads_stacking_buff modifies fatebound_coin_heads_buff for the periodic and direct damage effects, but has an inline 3% auto attack damage effect
-    //  Are we getting an extra 1% AA damage for free? We may never know. Assuming we don't for now.
+                                                  1.0 + spell.fatebound_coin_heads_stacking_buff->effectN( 2 ).percent() );
     buffs.fatebound_coin_heads->set_auto_attack_mod( spell.fatebound_coin_heads_buff, 5, spell.fatebound_coin_heads_buff->effectN( 5 ).percent(),
-                                                  1.0 + spell.fatebound_coin_heads_stacking_buff->effectN( 3 ).percent() - spell.fatebound_coin_heads_buff->effectN( 5 ).percent() );
+                                                  1.0 + spell.fatebound_coin_heads_stacking_buff->effectN( 3 ).percent() );
   }
   buffs.fatebound_coin_heads
     ->set_stack_change_callback( [this]( buff_t*, int, int new_stacks ) {

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -7619,10 +7619,7 @@ struct coup_de_grace_t : public rogue_attack_t
       }
       else
       {
-        // 5s timer to recast Coup de Grace starts ~1 second into the cast
-        make_event( *p()->sim, 1_s, [ this ] {
-          p()->buffs.tww3_trickster_4pc->trigger();
-        } );
+        p()->buffs.tww3_trickster_4pc->trigger();
       }
     }
     else 
@@ -12531,7 +12528,8 @@ void rogue_t::create_buffs()
   buffs.tww3_trickster_4pc = make_buff( this, "tww3_trickster_coup_recast", set_bonuses.tww3_trickster_4pc );
   if ( set_bonuses.tww3_trickster_4pc->ok() )
   {
-    buffs.tww3_trickster_4pc->set_duration( 5_s );
+    // Buff is active on Coup cast but does not begin counting down until 1.2s into the cast, effectively adding 1.2s to its duration
+    buffs.tww3_trickster_4pc->set_duration( timespan_t::from_seconds( set_bonuses.tww3_trickster_4pc->effectN( 2 ).base_value() ) + 1.2_s );
   }
 }
 


### PR DESCRIPTION
For review-
1. Trickster 4pc is using a custom buff, unsure if it's "the right way", though it can be exposed to the APL like this.

2. Not a million percent confident on editing Kingsbane damage, if it needs both action_multiplier and composite_persistent_multiplier overrides.

3. I tied Killing Spree's combo point generation to the mainhand hits, feels kinda hacky but it does work. This method does cause a combo point to be generated on the zero tick, which does not happen in game, but in simc the zero tick happens before CPs are consumed anyway.

4. Also fixed the initial multiplier for Fatebound Heads buff, I don't think it needs to subtract out the per-stack gain anymore.