### PR TITLE
Workaround for #10033 (casc_extract: "Invalid file length")

### DIFF
--- a/casc_extract/build_cfg.py
+++ b/casc_extract/build_cfg.py
@@ -156,7 +156,7 @@ class BuildCfg(object):
 		# Slight hack to get the configuration file read easily
 		conf_str = '[base]\n' + open(build_cfg_path, 'r').read()
 		conf_str_fp = io.StringIO(conf_str)
-		self.cfg.readfp(conf_str_fp)
+		self.cfg.read_file(conf_str_fp)
 
 		print(f'Wow build: {build_version}')
 

--- a/casc_extract/casc.py
+++ b/casc_extract/casc.py
@@ -432,6 +432,7 @@ class BLTEExtract:
     def extract_data(self, file_key, file_md5sum, data_file_number,
                      data_file_offset, blte_file_size):
         path = os.path.join(self.options.data_dir, 'Data', 'data', f'data.{data_file_number:03d}')
+        file_key_hex = codecs.encode(file_key, 'hex').decode()
 
         if not self.open(path):
             return None
@@ -442,16 +443,20 @@ class BLTEExtract:
         blte_len = struct.unpack('<I', self.fd.read(4))[0]
 
         if blte_len != blte_file_size:
-            self.options.parser.error(
-                f'Invalid file length, expected {blte_file_size} got {blte_len}'
+            # FIXME: some files don't extract?
+            # https://github.com/simulationcraft/simc/issues/10033
+            print(
+                f'Invalid file length, expected {blte_file_size} got '
+                f'{blte_len} (for {file_key_hex})'
             )
+            return None
 
         # Key is apparently in reverse byte order, and only 9 bytes of it are relevant (as in the
         # index structures)
         for idx in range(0, 9):
             if file_key[idx] != key[len(key) - 1 - idx]:
                 self.options.parser.error(
-                    f"Invalid file key for {codecs.encode(file_key, 'hex').decode('utf-8')}, "
+                    f"Invalid file key for {file_key_hex}, "
                     f"got {codecs.encode(key, 'hex').decode('utf-8')}")
 
         # Skip 10 bytes of unknown data

--- a/casc_extract/casc_extract.py
+++ b/casc_extract/casc_extract.py
@@ -33,6 +33,12 @@ parser.add_option( '--locale', action = 'store', dest = 'locale', default = 'en_
 parser.add_option( '--ribbit', action = 'store_true', dest = 'ribbit', default = False, help = 'Use Ribbit for configuration information')
 parser.add_option( '--bgdl', action = 'store_true', dest = 'bgdl', default = False, help = 'Download background downloader files' )
 parser.add_option( '--custom', type='string', dest = 'custom_build', default = None, help = 'Use a custom Build Config')
+parser.add_option(
+	'--continue_on_failure',
+	action='store_true',
+	default=False,
+	help='If any file fails to extract in "batch" or "unpack" mode, continue trying to extract other files',
+)
 
 if __name__ == '__main__':
 	(opts, args) = parser.parse_args()
@@ -108,7 +114,11 @@ if __name__ == '__main__':
 				print('Extracting %s (id=%d) ...' % (file_name, file_data_id))
 
 				if not blte.extract_file(*extract_data):
-					sys.exit(1)
+					print(f'Failed to extract data for {file_name}', file=sys.stderr)
+					if opts.continue_on_failure:
+						continue
+					else:
+						sys.exit(1)
 		else:
 			cdn = casc.CDNIndex(opts)
 			if not cdn.open():
@@ -151,14 +161,21 @@ if __name__ == '__main__':
 				result = blte.extract_buffer_to_file(data, os.path.join(output_path, file_name.replace('\\', '/')))
 				if not result:
 					print('Failed to extract data for %s %s' % (opts.locale, file_name), file=sys.stderr)
-					sys.exit(1)
+					if opts.continue_on_failure:
+						continue
+					else:
+						sys.exit(1)
 
 	elif opts.mode == 'unpack':
 		blte = casc.BLTEExtract(opts)
-		for file in args:
-			print('Extracting %s ...')
-			if not blte.extract_blte_file(file):
-				sys.exit(1)
+		for file_name in args:
+			print(f'Extracting {file_name}...')
+			if not blte.extract_blte_file(file_name):
+				print(f'Failed to extract data for {file_name}', file=sys.stderr)
+				if opts.continue_on_failure:
+					continue
+				else:
+					sys.exit(1)
 
 	elif opts.mode == 'extract':
 		build = None


### PR DESCRIPTION
This works around #10033, but doesn't actually fix the bug:

* Makes `extract_data()` no longer raise an `OptionParser` parsing error when extraction fails, so the error can be handled better.
* Adds a `--continue_on_failure` option to `casc_extract`, which allows `batch` and `unpack` operations to continue even if a single file fails to extract.

This also includes a rebased version of #10032, so that it works with current versions of Python.
