### PR TITLE
[DH] Death sweep thrill timings

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2233,7 +2233,8 @@ struct art_of_the_glaive_trigger_t : public BASE
 
   art_of_the_glaive_trigger_t( util::string_view n, demon_hunter_t* p, const spell_data_t* s, util::string_view o )
     : BASE( n, p, s, o ),
-      // 2024-07-16 -- This is seems to be 700ms for everything but Death Sweep
+      // 2025-07-18 -- Death sweep triggers this with the same delay as other abilities, also proccing the second
+      // art of the glaive buff early before the final hit of death sweep
       thrill_delay( 700_ms )
   {
   }

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2297,8 +2297,9 @@ struct art_of_the_glaive_trigger_t : public BASE
     {
       if ( BASE::p()->talent.aldrachi_reaver.thrill_of_the_fight->ok() )
       {
+        BASE::p()->buff.thrill_of_the_fight_attack_speed->trigger();
+
         make_event( *BASE::p()->sim, thrill_delay, [ this ] {
-          BASE::p()->buff.thrill_of_the_fight_attack_speed->trigger();
           BASE::p()->buff.thrill_of_the_fight_damage->trigger();
         } );
       }
@@ -5436,7 +5437,6 @@ struct death_sweep_t : public blade_dance_base_t
   death_sweep_t( demon_hunter_t* p, util::string_view options_str )
     : blade_dance_base_t( "death_sweep", p, p->spec.death_sweep, options_str, nullptr )
   {
-    thrill_delay                 = timespan_t::from_millis( data().effectN( 5 ).misc_value1() + 1 );
     winning_streak_removal_delay = timespan_t::from_millis( data().effectN( 5 ).misc_value1() + 1 );
 
     if ( attacks.empty() )


### PR DESCRIPTION
Death sweep does not have an extended delay for proccing the thrill damage buff and shares the 700ms with other abilities, also causing the art of the glaive second bonus to expire before the last hit. Also moved the thrill attack speed buff to occur on cast to match in game