### PR TITLE
[WARLOCK] [DEMONOLOGY][11.2 UPDATE] Update warlock.cpp for Demonology APL UPDATES FOR 11.2

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -249,7 +249,7 @@ void demonology( player_t* p )
   default_->add_action( "call_action_list,name=opener,if=time<variable.first_tyrant_time" );
   default_->add_action( "invoke_external_buff,name=power_infusion,if=variable.imp_despawn&variable.imp_despawn<time+gcd.max*6+cast_time" );
   default_->add_action( "summon_demonic_tyrant,if=variable.imp_despawn&pet.vilefiend.active&pet.dreadstalker.active&(variable.imp_despawn<time+gcd.max*6+cast_time|buff.wild_imps.stack>=9-2*prev_gcd.1.hand_of_guldan)" );
-  default_->add_action( "grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains>=60|cooldown.summon_demonic_tyrant.remains<=15&cooldown.call_dreadstalkers.remains<10" );
+  default_->add_action( "grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<=15&cooldown.call_dreadstalkers.remains<10" );
   default_->add_action( "summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>=25+cast_time|cooldown.summon_demonic_tyrant.remains<=13&cooldown.call_dreadstalkers.remains<10" );
   default_->add_action( "call_dreadstalkers,if=cooldown.summon_demonic_tyrant.remains>=10|cooldown.summon_demonic_tyrant.remains<=10" );
   default_->add_action( "demonbolt,target_if=min:debuff.doom.remains,if=buff.demonic_core.stack>=3-(talent.doom&debuff.doom.down)*2&soul_shard<=3&talent.doom" );

--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -291,8 +291,8 @@ void demonology( player_t* p )
   opener->add_action( "infernal_bolt" );
   opener->add_action( "shadow_bolt,if=soul_shard<5&buff.dreadstalkers.remains&pet.wild_imp.active<3" );
   opener->add_action( "hand_of_guldan,if=soul_shard>=3&pet.wild_imp.active<10" );
+  opener->add_action( "demonbolt,if=buff.demonic_core.react&buff.dreadstalkers.remains&soul_shard<4" );
   opener->add_action( "hand_of_guldan,if=variable.first_tyrant_time<gcd.max+action.summon_demonic_tyrant.cast_time" );
-  opener->add_action( "demonbolt,if=buff.demonic_core.react&buff.dreadstalkers.remains" );
   opener->add_action( "shadow_bolt,if=buff.dreadstalkers.remains" );
 
 

--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -212,16 +212,14 @@ void demonology( player_t* p )
 {
   action_priority_list_t* default_ = p->get_action_priority_list( "default" );
   action_priority_list_t* precombat = p->get_action_priority_list( "precombat" );
-  action_priority_list_t* fight_end = p->get_action_priority_list( "fight_end" );
   action_priority_list_t* items = p->get_action_priority_list( "items" );
   action_priority_list_t* opener = p->get_action_priority_list( "opener" );
   action_priority_list_t* racials = p->get_action_priority_list( "racials" );
-  action_priority_list_t* tyrant = p->get_action_priority_list( "tyrant" );
   action_priority_list_t* variables = p->get_action_priority_list( "variables" );
 
   precombat->add_action( "summon_pet" );
   precombat->add_action( "snapshot_stats" );
-  precombat->add_action( "variable,name=first_tyrant_time,op=set,value=12", "Sets the expected Tyrant Setup on pull to take a total 12 seconds long" );
+  precombat->add_action( "variable,name=first_tyrant_time,op=set,value=15", "Sets the expected Tyrant Setup on pull to take a total 12 seconds long" );
   precombat->add_action( "variable,name=first_tyrant_time,op=add,value=action.grimoire_felguard.execute_time,if=talent.grimoire_felguard.enabled", "Accounts for the execution time of Grimoire Felguard in the setup of Tyrant on Pull" );
   precombat->add_action( "variable,name=first_tyrant_time,op=add,value=action.summon_vilefiend.execute_time,if=talent.summon_vilefiend.enabled", "Accounts for the execution time of Vilefiend in the the setup of Tyrant on Pull" );
   precombat->add_action( "variable,name=first_tyrant_time,op=add,value=gcd.max,if=talent.grimoire_felguard.enabled|talent.summon_vilefiend.enabled", "Accounts for the execution time of both Grimoire Felguard and Vilefiend in the tyrant Setup on Pull" );
@@ -245,47 +243,29 @@ void demonology( player_t* p )
   precombat->add_action( "shadow_bolt" );
 
   default_->add_action( "call_action_list,name=variables" );
-  default_->add_action( "potion,if=buff.tyrant.remains>10" );
+  default_->add_action( "potion,if=pet.demonic_tyrant.active" );
   default_->add_action( "call_action_list,name=racials,if=pet.demonic_tyrant.active|fight_remains<22,use_off_gcd=1" );
   default_->add_action( "call_action_list,name=items,use_off_gcd=1" );
-  default_->add_action( "call_action_list,name=fight_end,if=fight_remains<30" );
   default_->add_action( "call_action_list,name=opener,if=time<variable.first_tyrant_time" );
-  default_->add_action( "call_action_list,name=tyrant,if=cooldown.summon_demonic_tyrant.remains<gcd.max*14" );
-  default_->add_action( "hand_of_guldan,if=active_enemies>3&(pet.greater_dreadstalker.remains&pet.greater_dreadstalker.remains>gcd.max&pet.greater_dreadstalker.remains<gcd.max*3)&cooldown.call_dreadstalkers.remains>gcd.max*3&cooldown.summon_vilefiend.remains>gcd.max*2" );
-  default_->add_action( "call_dreadstalkers,if=cooldown.summon_demonic_tyrant.remains>25|variable.next_tyrant_cd>25" );
-  default_->add_action( "summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>30" );
-  default_->add_action( "demonbolt,target_if=min:debuff.doom.remains,if=buff.demonic_core.react&(!talent.doom|buff.demonic_core.react>1|debuff.doom.remains>10|debuff.doom.down)&(((!talent.fel_invocation|pet.felguard.cooldown.soul_strike.remains>gcd.max*2)&soul_shard<4))&!prev_gcd.1.demonbolt&!variable.pool_cores_for_tyrant" );
-  default_->add_action( "demonbolt,target_if=min:debuff.doom.remains,if=buff.demonic_core.stack>=3-(talent.doom&debuff.doom.down)*2&soul_shard<=3&!variable.pool_cores_for_tyrant" );
-  default_->add_action( "power_siphon,if=buff.demonic_core.stack<3&cooldown.summon_demonic_tyrant.remains>25" );
-  default_->add_action( "demonic_strength,,if=active_enemies>1" );
+  default_->add_action( "invoke_external_buff,name=power_infusion,if=variable.imp_despawn&variable.imp_despawn<time+gcd.max*6+cast_time" );
+  default_->add_action( "summon_demonic_tyrant,if=variable.imp_despawn&pet.vilefiend.active&pet.dreadstalker.active&(variable.imp_despawn<time+gcd.max*6+cast_time|buff.wild_imps.stack>=9-2*prev_gcd.1.hand_of_guldan)" );
+  default_->add_action( "grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains>=60|cooldown.summon_demonic_tyrant.remains<=15&cooldown.call_dreadstalkers.remains<10" );
+  default_->add_action( "summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>=25+cast_time|cooldown.summon_demonic_tyrant.remains<=13&cooldown.call_dreadstalkers.remains<10" );
+  default_->add_action( "call_dreadstalkers,if=cooldown.summon_demonic_tyrant.remains>=10|cooldown.summon_demonic_tyrant.remains<=10" );
+  default_->add_action( "demonbolt,target_if=min:debuff.doom.remains,if=buff.demonic_core.stack>=3-(talent.doom&debuff.doom.down)*2&soul_shard<=3&talent.doom" );
+  default_->add_action( "demonic_strength,if=pet.demonic_tyrant.active&active_enemies>1" );
   default_->add_action( "bilescourge_bombers,if=active_enemies>1" );
-  default_->add_action( "guillotine,if=active_enemies>1&(cooldown.demonic_strength.remains|!talent.demonic_strength)&(!raid_event.adds.exists|raid_event.adds.exists&raid_event.adds.remains>6)" );
-  default_->add_action( "ruination" );
-  default_->add_action( "hand_of_guldan,if=active_enemies>3&active_enemies<8&soul_shard>=2&set_bonus.tww2_4pc&buff.dreadstalkers.up|active_enemies>7&active_enemies<16&soul_shard>=2&set_bonus.tww2_4pc&buff.tyrant.remains>cast_time" );
+  default_->add_action( "hand_of_guldan,if=demonic_art&soul_shard>=3" );
   default_->add_action( "implosion,if=active_enemies>3&set_bonus.tww2_4pc&buff.wild_imps.stack>7&!buff.demonic_core.react&!prev_gcd.1.implosion|!set_bonus.tww2_4pc&active_enemies>2&two_cast_imps>2&!prev_gcd.1.implosion&variable.impl" );
-  default_->add_action( "infernal_bolt,if=soul_shard<3&cooldown.summon_demonic_tyrant.remains>20" );
-  default_->add_action( "demonbolt,if=variable.diabolic_ritual_remains>gcd.max&variable.diabolic_ritual_remains<gcd.max+gcd.max&buff.demonic_core.up&soul_shard<=3" );
-  default_->add_action( "shadow_bolt,if=variable.diabolic_ritual_remains>gcd.max&variable.diabolic_ritual_remains<soul_shard.deficit*cast_time+gcd.max&soul_shard<5" );
-  default_->add_action( "hand_of_guldan,if=((soul_shard>2&(cooldown.call_dreadstalkers.remains>gcd.max*4|buff.demonic_calling.remains-gcd.max>cooldown.call_dreadstalkers.remains)&cooldown.summon_demonic_tyrant.remains>17)|soul_shard=5|soul_shard=4&talent.fel_invocation)&(active_enemies=1)" );
-  default_->add_action( "hand_of_guldan,if=soul_shard>2&!(active_enemies=1)" );
-  default_->add_action( "demonbolt,target_if=(!debuff.doom.up)|active_enemies<4,if=buff.demonic_core.stack>1&((soul_shard<4&!talent.soul_strike|pet.felguard.cooldown.soul_strike.remains>gcd.max*2&talent.fel_invocation)|soul_shard<3)&!variable.pool_cores_for_tyrant" );
-  default_->add_action( "demonbolt,if=buff.demonic_core.react&buff.tyrant.up&soul_shard<3" );
-  default_->add_action( "demonbolt,if=buff.demonic_core.react>1&soul_shard<4" );
+  default_->add_action( "ruination" );
+  default_->add_action( "demonbolt,target_if=(!debuff.doom.up),if=soul_shard<4&buff.demonic_core.stack>=3&talent.doom" );
+  default_->add_action( "demonbolt,if=soul_shard<4&buff.demonic_core.stack>=3&!talent.doom" );
+  default_->add_action( "power_siphon,if=!buff.demonic_core.up" );
+  default_->add_action( "infernal_bolt,if=soul_shard<3" );
+  default_->add_action( "hand_of_guldan,if=soul_shard>=3" );
+  default_->add_action( "demonbolt,if=soul_shard<4&buff.demonic_core.react" );
   default_->add_action( "shadow_bolt" );
   default_->add_action( "infernal_bolt" );
-
-  fight_end->add_action( "grimoire_felguard,if=fight_remains<20" );
-  fight_end->add_action( "Ruination" );
-  fight_end->add_action( "implosion,if=fight_remains<2*gcd.max&!prev_gcd.1.implosion" );
-  fight_end->add_action( "demonbolt,if=fight_remains<gcd.max*2*buff.demonic_core.stack+9&buff.demonic_core.react&(soul_shard<4|fight_remains<buff.demonic_core.stack*gcd.max)" );
-  fight_end->add_action( "call_dreadstalkers,if=fight_remains<20" );
-  fight_end->add_action( "summon_vilefiend,if=fight_remains<20" );
-  fight_end->add_action( "summon_demonic_tyrant,if=fight_remains<20" );
-  fight_end->add_action( "demonic_strength,if=fight_remains<10" );
-  fight_end->add_action( "power_siphon,if=buff.demonic_core.stack<3&fight_remains<20" );
-  fight_end->add_action( "demonbolt,if=fight_remains<gcd.max*2*buff.demonic_core.stack+9&buff.demonic_core.react&(soul_shard<4|fight_remains<buff.demonic_core.stack*gcd.max)" );
-  fight_end->add_action( "hand_of_guldan,if=soul_shard>2&fight_remains<gcd.max*2*buff.demonic_core.stack+9" );
-  fight_end->add_action( "infernal_bolt" );
 
   items->add_action( "use_item,use_off_gcd=1,slot=trinket1,if=variable.trinket_1_buffs&!variable.trinket_1_manual&(!pet.demonic_tyrant.active&trinket.1.cast_time>0|!trinket.1.cast_time>0)&(pet.demonic_tyrant.active|!talent.summon_demonic_tyrant|variable.trinket_priority=2&cooldown.summon_demonic_tyrant.remains>20&!pet.demonic_tyrant.active&trinket.2.cooldown.remains<cooldown.summon_demonic_tyrant.remains+5)&(variable.trinket_2_exclude|!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1&!variable.trinket_2_manual)|variable.trinket_1_buff_duration>=fight_remains" );
   items->add_action( "use_item,use_off_gcd=1,slot=trinket2,if=variable.trinket_2_buffs&!variable.trinket_2_manual&(!pet.demonic_tyrant.active&trinket.2.cast_time>0|!trinket.2.cast_time>0)&(pet.demonic_tyrant.active|!talent.summon_demonic_tyrant|variable.trinket_priority=1&cooldown.summon_demonic_tyrant.remains>20&!pet.demonic_tyrant.active&trinket.1.cooldown.remains<cooldown.summon_demonic_tyrant.remains+5)&(variable.trinket_1_exclude|!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2&!variable.trinket_1_manual)|variable.trinket_2_buff_duration>=fight_remains" );
@@ -301,43 +281,26 @@ void demonology( player_t* p )
   items->add_action( "use_item,use_off_gcd=1,slot=main_hand,name=neural_synapse_enhancer,if=(pet.demonic_tyrant.active|fight_remains<=15|trinket.2.cooldown.remains>cooldown.summon_demonic_tyrant.remains)&variable.trinket_2_buffs" );  
   items->add_action( "use_item,use_off_gcd=1,slot=main_hand,name=neural_synapse_enhancer,if=(pet.demonic_tyrant.active|fight_remains<=15|trinket.1.cooldown.remains>cooldown.summon_demonic_tyrant.remains)&variable.trinket_1_buffs" );
 
+  opener->add_action( "summon_demonic_tyrant,if=buff.wild_imps.stack>=9&buff.dreadstalkers.remains&(buff.vilefiend.up|!talent.summon_vilefiend)&(buff.grimoire_felguard.up|cooldown.grimoire_felguard.remains>30|!talent.grimoire_felguard)" );
   opener->add_action( "grimoire_felguard,if=soul_shard>=5-talent.fel_invocation" );
   opener->add_action( "summon_vilefiend,if=soul_shard=5" );
   opener->add_action( "shadow_bolt,if=soul_shard<5&cooldown.call_dreadstalkers.up" );
   opener->add_action( "call_dreadstalkers,if=soul_shard=5" );
   opener->add_action( "Ruination" );
+  opener->add_action( "hand_of_guldan,if=soul_shard>=3&buff.infernal_bolt.up" );
+  opener->add_action( "infernal_bolt" );
+  opener->add_action( "shadow_bolt,if=soul_shard<5&buff.dreadstalkers.remains&pet.wild_imp.active<3" );
+  opener->add_action( "hand_of_guldan,if=soul_shard>=3&pet.wild_imp.active<10" );
+  opener->add_action( "hand_of_guldan,if=variable.first_tyrant_time<gcd.max+action.summon_demonic_tyrant.cast_time" );
+  opener->add_action( "demonbolt,if=buff.demonic_core.react&buff.dreadstalkers.remains" );
+  opener->add_action( "shadow_bolt,if=buff.dreadstalkers.remains" );
+
 
   racials->add_action( "berserking,use_off_gcd=1" );
   racials->add_action( "blood_fury" );
   racials->add_action( "fireblood" );
   racials->add_action( "ancestral_call" );
 
-  tyrant->add_action( "call_action_list,name=racials,if=variable.imp_despawn&variable.imp_despawn<time+gcd.max*2+action.summon_demonic_tyrant.cast_time&(prev_gcd.1.hand_of_guldan|prev_gcd.1.ruination)&(variable.imp_despawn&variable.imp_despawn<time+gcd.max+action.summon_demonic_tyrant.cast_time|soul_shard<2)" );
-  tyrant->add_action( "potion,if=variable.imp_despawn&variable.imp_despawn<time+gcd.max*2+action.summon_demonic_tyrant.cast_time&(prev_gcd.1.hand_of_guldan|prev_gcd.1.ruination)&(variable.imp_despawn&variable.imp_despawn<time+gcd.max+action.summon_demonic_tyrant.cast_time|soul_shard<2)" );
-  tyrant->add_action( "invoke_external_buff,name=power_infusion,if=variable.imp_despawn&variable.imp_despawn<time+gcd.max*2+action.summon_demonic_tyrant.cast_time&(prev_gcd.1.hand_of_guldan|prev_gcd.1.ruination)&(variable.imp_despawn&variable.imp_despawn<time+gcd.max+action.summon_demonic_tyrant.cast_time|soul_shard<2)" );
-  tyrant->add_action( "summon_demonic_tyrant,if=buff.power_infusion.up" );
-  tyrant->add_action( "power_siphon,if=cooldown.summon_demonic_tyrant.remains<15" );
-  tyrant->add_action( "ruination,if=buff.dreadstalkers.remains>gcd.max+action.summon_demonic_tyrant.cast_time&(soul_shard=5|variable.imp_despawn)" );
-  tyrant->add_action( "infernal_bolt,if=!buff.demonic_core.react&variable.imp_despawn>time+gcd.max*2+action.summon_demonic_tyrant.cast_time&soul_shard<3" );
-  tyrant->add_action( "shadow_bolt,if=prev_gcd.1.call_dreadstalkers&soul_shard<4&buff.demonic_core.react<4" );
-  tyrant->add_action( "shadow_bolt,if=prev_gcd.2.call_dreadstalkers&prev_gcd.1.shadow_bolt&buff.bloodlust.up&soul_shard<5" );
-  tyrant->add_action( "shadow_bolt,if=prev_gcd.1.summon_vilefiend&(buff.demonic_calling.down|prev_gcd.2.grimoire_felguard)" );
-  tyrant->add_action( "shadow_bolt,if=prev_gcd.1.grimoire_felguard&buff.demonic_core.react<3&buff.demonic_calling.remains>gcd.max*3" );
-  tyrant->add_action( "hand_of_guldan,if=variable.imp_despawn>time+gcd.max*2+action.summon_demonic_tyrant.cast_time&!buff.demonic_core.react&buff.demonic_art_pit_lord.up&variable.imp_despawn<time+gcd.max*5+action.summon_demonic_tyrant.cast_time" );
-  tyrant->add_action( "hand_of_guldan,if=variable.imp_despawn>time+gcd.max+action.summon_demonic_tyrant.cast_time&variable.imp_despawn<time+gcd.max*2+action.summon_demonic_tyrant.cast_time&buff.dreadstalkers.remains>gcd.max+action.summon_demonic_tyrant.cast_time&soul_shard>1" );
-  tyrant->add_action( "shadow_bolt,if=!buff.demonic_core.react&variable.imp_despawn>time+gcd.max*2+action.summon_demonic_tyrant.cast_time&variable.imp_despawn<time+gcd.max*4+action.summon_demonic_tyrant.cast_time&soul_shard<3&buff.dreadstalkers.remains>gcd.max*2+action.summon_demonic_tyrant.cast_time" );
-  tyrant->add_action( "grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13+gcd.max&cooldown.summon_vilefiend.remains<gcd.max&cooldown.call_dreadstalkers.remains<gcd.max*3.33&(soul_shard=5-(pet.felguard.cooldown.soul_strike.remains<gcd.max)&talent.fel_invocation|soul_shard=5)" );
-  tyrant->add_action( "summon_vilefiend,if=(buff.grimoire_felguard.up|cooldown.grimoire_felguard.remains>10|!talent.grimoire_felguard)&cooldown.summon_demonic_tyrant.remains<13&cooldown.call_dreadstalkers.remains<gcd.max*2.33&(soul_shard=5|soul_shard=4&(buff.demonic_core.react=4)|buff.grimoire_felguard.up)" );
-  tyrant->add_action( "call_dreadstalkers,if=(!talent.summon_vilefiend|buff.vilefiend.up)&cooldown.summon_demonic_tyrant.remains<10&soul_shard>=(5-(buff.demonic_core.react>=3))|prev_gcd.3.grimoire_felguard" );
-  tyrant->add_action( "summon_demonic_tyrant,if=variable.imp_despawn&variable.imp_despawn<time+gcd.max*2+cast_time|buff.dreadstalkers.up&buff.dreadstalkers.remains<gcd.max*2+cast_time" );
-  tyrant->add_action( "hand_of_guldan,if=(variable.imp_despawn|buff.dreadstalkers.remains)&soul_shard>=3|soul_shard=5" );
-  tyrant->add_action( "infernal_bolt,if=variable.imp_despawn&soul_shard<3" );
-  tyrant->add_action( "demonbolt,target_if=min:debuff.doom.remains,if=variable.imp_despawn&buff.demonic_core.react&soul_shard<4|prev_gcd.1.call_dreadstalkers&soul_shard<4&buff.demonic_core.react=4|buff.demonic_core.react=4&soul_shard<4|buff.demonic_core.react>=2&cooldown.power_siphon.remains<5" );
-  tyrant->add_action( "ruination,if=variable.imp_despawn|soul_shard=5&cooldown.summon_vilefiend.remains>gcd.max*3" );
-  tyrant->add_action( "shadow_bolt" );
-  tyrant->add_action( "infernal_bolt" );
-
-  
   variables->add_action( "variable,name=next_tyrant_cd,op=set,value=cooldown.summon_demonic_tyrant.remains_expected" );
   variables->add_action( "variable,name=in_opener,op=set,value=0,if=pet.demonic_tyrant.active" );
   variables->add_action( "variable,name=imp_despawn,op=set,value=2*spell_haste*6+0.58+time,if=prev_gcd.1.hand_of_guldan&buff.dreadstalkers.up&cooldown.summon_demonic_tyrant.remains<13&variable.imp_despawn=0", "Sets an expected duration of valid Wild Imps on a tyrant Setup for the sake of casting Tyrant before expiration of Imps" );
@@ -348,9 +311,6 @@ void demonology( player_t* p )
   variables->add_action( "variable,name=impl,op=set,value=buff.tyrant.remains<6,if=active_enemies>2+(talent.sacrificed_souls.enabled)&active_enemies<5+(talent.sacrificed_souls.enabled)", "Defines the Viability of Implosion while Tyrant is Up" );
   variables->add_action( "variable,name=impl,op=set,value=buff.tyrant.remains<8,if=active_enemies>4+(talent.sacrificed_souls.enabled)", "Defines the Viability of Implosion while Tyrant is Up" );
   variables->add_action( "variable,name=pool_cores_for_tyrant,op=set,value=cooldown.summon_demonic_tyrant.remains<20&variable.next_tyrant_cd<20&(buff.demonic_core.stack<=2|!buff.demonic_core.up)&cooldown.summon_vilefiend.remains<gcd.max*8&cooldown.call_dreadstalkers.remains<gcd.max*8", "Restricts Demonic Core usage for the sake of having 2 or more Demonic Cores on Tyrant Setup" );
-  variables->add_action( "variable,name=diabolic_ritual_remains,value=buff.diabolic_ritual_mother_of_chaos.remains,if=buff.diabolic_ritual_mother_of_chaos.up" );
-  variables->add_action( "variable,name=diabolic_ritual_remains,value=buff.diabolic_ritual_overlord.remains,if=buff.diabolic_ritual_overlord.up" );
-  variables->add_action( "variable,name=diabolic_ritual_remains,value=buff.diabolic_ritual_pit_lord.remains,if=buff.diabolic_ritual_pit_lord.up" );
 }
 //demonology_apl_end
 


### PR DESCRIPTION
https://mimiron.raidbots.com/simbot/report/vj4X4ZmLUfeGPnSq78xJi1 Diab sanity check https://mimiron.raidbots.com/simbot/report/eixS5qYuRhFbR9zrf44jB2 Diab 5 targets sanity check  https://mimiron.raidbots.com/simbot/report/4B5khbu2Tp65tBBcneZLeu Soul Harvester Sanity Check https://mimiron.raidbots.com/simbot/report/hoxBupMjsrz2z7NYdx8ykV SH 5t sanity check  https://mimiron.raidbots.com/simbot/report/ugAghunfKkgz3SbtgHErht SH with Doom 5t sanity check  https://mimiron.raidbots.com/simbot/report/fxgX5xhNxAMJwwGUP2twg2 Diab with Doom 5t Sanity Check

Smaller APL, removal of ROT, smaller tyrants and stronger non setup-related effects means a lot of the previous things are no longer beneficial.

OBS: Only push PR with 11.2 