### PR TITLE
[Gear] Fix per-target crit buff for Cursed Stone Idol

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -8720,7 +8720,7 @@ void cursed_stone_idol( special_effect_t& effect )
       max_inc     = value_spell->effectN( 4 ).average( e );
     }
 
-    void start( int s, double v, timespan_t d ) override
+    void bump( int s, double v ) override
     {
       for ( auto& stat : stats )
       {
@@ -8739,7 +8739,7 @@ void cursed_stone_idol( special_effect_t& effect )
         }
       }
       // Skip stat_buff_t::start since we handle stat gain manually
-      buff_t::start( s, v, d );
+      buff_t::bump( s, v );
     }
   };
 


### PR DESCRIPTION
I believe Cursed Stone Idol needs to use bump instead of start, so the crit buff is updated on execute

Before:
<img width="1053" height="216" alt="image" src="https://github.com/user-attachments/assets/81be9d53-9f6a-4b97-9629-f525e61270e4" />

After:
<img width="1058" height="238" alt="image" src="https://github.com/user-attachments/assets/5097ab58-7754-4bb3-b3ad-a76803e8862a" />
