### PR TITLE
[Warlock] Nerf to 11.2 Tierset for Diabolist Demonology.

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -4726,7 +4726,7 @@ using namespace helpers;
       // In its own effect on mastery, so just manually applying it here rather than adding the affected_by to warlock_spell_t
       if ( p()->warlock_base.master_demonologist->ok() )
         m *= 1.0 + p()->cache.mastery_value();
-      if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+      if ( p()->specialization() == WARLOCK_DEMONOLOGY )
         m *= 1.0 + p()->sets->set( HERO_DIABOLIST, TWW3, B2 )->effectN( 2 ).percent();
     
       m *= p()->buffs.demonic_oculus->check();

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -4726,8 +4726,11 @@ using namespace helpers;
       // In its own effect on mastery, so just manually applying it here rather than adding the affected_by to warlock_spell_t
       if ( p()->warlock_base.master_demonologist->ok() )
         m *= 1.0 + p()->cache.mastery_value();
-
+      if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+        m *= 1.0 + p()->sets->set( HERO_DIABOLIST, TWW3, B2 )->effectN( 2 ).percent();
+    
       m *= p()->buffs.demonic_oculus->check();
+    
 
       return m;
     }


### PR DESCRIPTION
As of build 11.2.0.62253 Blizzard have added an Effect 2 to https://www.wowhead.com/ptr-2/spell=1236417/warlock-diabolist-11-2-class-set-2pc 

This effect is a -45% damage modifier to the [2] Bonus damage done.