### PR TITLE
[WARLOCK] [DIABOLIST] Fix for Diabolist Nerf/Buffs + Double Dip on Demo.

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2322,18 +2322,27 @@ namespace diabolist
 
     double composite_da_multiplier( const action_state_t* s ) const override
     {
-      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
+      double m = warlock_pet_spell_t::composite_da_multiplier( s );  // base value
 
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
-          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5. 
+      if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+      {
+        // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
+        // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+        m *= 1.0 + p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent();
+      }
+
+      if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+      {
+        // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
+        // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for
+        // Destruction, No reference spell for it in the hotfix located.
+        m *= 1.15;
+      }
+
       return m;
-     }
+    }
 
     void impact( action_state_t* s ) override
     {
@@ -2375,20 +2384,30 @@ namespace diabolist
 
       travel_speed = p->o()->hero.chaos_salvo_missile->missile_speed();
     }
+
     double composite_da_multiplier( const action_state_t* s ) const override
     {
-      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
+      double m = warlock_pet_spell_t::composite_da_multiplier( s );  // base value
 
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
-          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Chaos Salvo is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+      if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+      {
+        // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
+        // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+        m *= 1.0 + p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent();
+      }
+
+      if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+      {
+        // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
+        // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for
+        // Destruction, No reference spell for it in the hotfix located.
+        m *= 1.15;
+      }
+
       return m;
-     }
+    }
   };
 
   struct chaos_salvo_t : public warlock_pet_spell_t
@@ -2449,20 +2468,31 @@ namespace diabolist
 
       base_costs[ RESOURCE_ENERGY ] = 0.0;
     }
+
+
     double composite_da_multiplier( const action_state_t* s ) const override
     {
-      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
+      double m = warlock_pet_spell_t::composite_da_multiplier( s );  // base value
 
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-         if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
-          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Felseeker is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+      if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+      {
+        // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
+        // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+        m *= 1.0 + p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent();
+      }
+
+      if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+      {
+        // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
+        // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for
+        // Destruction, No reference spell for it in the hotfix located.
+        m *= 1.15;
+      }
+
       return m;
-     }
+    }
   };
 
   struct felseeker_t : public warlock_pet_spell_t

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2375,6 +2375,20 @@ namespace diabolist
 
       travel_speed = p->o()->hero.chaos_salvo_missile->missile_speed();
     }
+    double composite_da_multiplier( const action_state_t* s ) const override
+    {
+      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
+
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
+          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Chaos Salvo is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+      return m;
+     }
   };
 
   struct chaos_salvo_t : public warlock_pet_spell_t
@@ -2400,21 +2414,6 @@ namespace diabolist
 
       debug_cast<mother_of_chaos_t*>( p() )->salvos--;
     }
-
-    double composite_da_multiplier( const action_state_t* s ) const override
-    {
-      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
-
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
-          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Chaos Salvo is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
-      return m;
-     }
   };
 
   void mother_of_chaos_t::arise()
@@ -2450,6 +2449,20 @@ namespace diabolist
 
       base_costs[ RESOURCE_ENERGY ] = 0.0;
     }
+    double composite_da_multiplier( const action_state_t* s ) const override
+    {
+      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
+
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
+          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
+          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
+         if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
+          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Felseeker is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+      return m;
+     }
   };
 
   struct felseeker_t : public warlock_pet_spell_t
@@ -2477,21 +2490,6 @@ namespace diabolist
 
       debug_cast<pit_lord_t*>( p() )->felseekers--;
     }
-
-    double composite_da_multiplier( const action_state_t* s ) const override
-    {
-      double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
-
-        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
-          m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-         if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
-          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Felseeker is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
-      return m;
-     }
   };
 
   void pit_lord_t::arise()

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2324,13 +2324,15 @@ namespace diabolist
     {
       double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
 
-        if ( p()->specialization() == WARLOCK_DEMONOLOGY )
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->specialization() == WARLOCK_DESTRUCTION )
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->specialization() == WARLOCK_DESTRUCTION )
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
           m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-        return m;
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
+          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5. 
+      return m;
      }
 
     void impact( action_state_t* s ) override
@@ -2403,13 +2405,15 @@ namespace diabolist
     {
       double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
 
-        if ( p()->specialization() == WARLOCK_DEMONOLOGY )
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->specialization() == WARLOCK_DESTRUCTION )
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->specialization() == WARLOCK_DESTRUCTION )
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
           m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-        return m;
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
+          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Chaos Salvo is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+      return m;
      }
   };
 
@@ -2478,13 +2482,15 @@ namespace diabolist
     {
       double m = warlock_pet_spell_t::composite_da_multiplier( s ); // base value
 
-        if ( p()->specialization() == WARLOCK_DEMONOLOGY )
+        if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent(); // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology 
-        if ( p()->specialization() == WARLOCK_DESTRUCTION )
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent(); // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( p()->specialization() == WARLOCK_DESTRUCTION )
+        if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
           m *= 1.15; // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for Destruction, No reference spell for it in the hotfix located.
-        return m;
+         if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY)
+          m *= 1.0 +p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent(); // Felseeker is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
+      return m;
      }
   };
 


### PR DESCRIPTION
The Previous Change didn't seems to be working to reduce/increase damage for diabolist demons respectively for Demonology/Destruction, i hope with this change it should work. 

Alongside this, it's been brought to attention that there is a small divergence in damage between purely nerfing Demonology diabolist by 20% on Demonology and values ingame, digging dipper i found that all 3 spells are whitelisted on https://www.wowhead.com/ptr-2/spell=137044/demonology-warlock Effect 1 while also being buffed by Effect 5 as they count as guardians/pets. 

I would also urge the importance of the PR https://github.com/simulationcraft/simc/pull/10191 for the numbers to match ingame/sims  as right now there is a slighty divergence involving Diabolist Demons Pitlord/Overlord. 


Adding log vs sim https://mimiron.raidbots.com/simbot/report/dkXUsouxoQvBKMB6v2b7hN/simc  https://www.warcraftlogs.com/reports/61RLZQ2VTn8bxYrk?fight=4&type=damage-done&source=2 for the sake of comparing.

you will notice that Sims are higher (as it don't have the 20% nerf) but, Logs will be higher if you purely reduce sims by 20%. 