### PR TITLE
[Warlock][Destruction] Aura Double Dip +  Summoner Embrace works on Diabolist Demons.

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2338,9 +2338,12 @@ namespace diabolist
         // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
         if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
-        // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for
-        // Destruction, No reference spell for it in the hotfix located.
-        m *= 1.15;
+        // Destruction Aura Double Dips due to Diabolist Demon spells being whitelisted on effect 1.
+        m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
+        // Destruction Summoners Embrace also Double Dip due to the same fact.
+        // Those two effects together is what made me believe the May 27 buff got applied.
+        if ( p()->o()->o()->talents.summoners_embrace.ok() )
+          m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
       }
 
       return m;
@@ -2416,9 +2419,12 @@ namespace diabolist
         // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
         if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
-        // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for
-        // Destruction, No reference spell for it in the hotfix located.
-        m *= 1.15;
+        // Destruction Aura Double Dips due to Diabolist Demon spells being whitelisted on effect 1.
+        m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
+        // Destruction Summoners Embrace also Double Dip due to the same fact.
+        // Those two effects together is what made me believe the May 27 buff got applied.
+        if ( p()->o()->o()->talents.summoners_embrace.ok() )
+          m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
       }
 
       return m;
@@ -2516,9 +2522,12 @@ namespace diabolist
         // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
         if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
           m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
-        // Buff  from May 27, 2025 Hotfix Increased the damage of Felseeker, Chaos Salvo and Wicked Cleave by 15% for
-        // Destruction, No reference spell for it in the hotfix located.
-        m *= 1.15;
+        // Destruction Aura Double Dips due to Diabolist Demon spells being whitelisted on effect 1.
+        m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
+        // Destruction Summoners Embrace also Double Dip due to the same fact.
+        // Those two effects together is what made me believe the May 27 buff got applied.
+        if ( p()->o()->o()->talents.summoners_embrace.ok() )
+          m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
       }
 
       return m;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2342,7 +2342,7 @@ namespace diabolist
         m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
         // Destruction Summoners Embrace also Double Dip due to the same fact.
         // Those two effects together is what made me believe the May 27 buff got applied.
-        if ( p()->o()->o()->talents.summoners_embrace.ok() )
+        if ( p()->o()->talents.summoners_embrace.ok() )
           m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
       }
 
@@ -2423,7 +2423,7 @@ namespace diabolist
         m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
         // Destruction Summoners Embrace also Double Dip due to the same fact.
         // Those two effects together is what made me believe the May 27 buff got applied.
-        if ( p()->o()->o()->talents.summoners_embrace.ok() )
+        if ( p()->o()->talents.summoners_embrace.ok() )
           m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
       }
 
@@ -2526,7 +2526,7 @@ namespace diabolist
         m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
         // Destruction Summoners Embrace also Double Dip due to the same fact.
         // Those two effects together is what made me believe the May 27 buff got applied.
-        if ( p()->o()->o()->talents.summoners_embrace.ok() )
+        if ( p()->o()->talents.summoners_embrace.ok() )
           m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
       }
 


### PR DESCRIPTION
Swapping the previous 15% damage increase modifier who i previously believed was the cause of the damage difference between sims and in game with  the double dip Txt found. 

11% from Aura effect 1 (Double dipping as aura also already buffs guardian demons) and 3% from Summoners Embrace.