### PR TITLE
[Outlaw] Adjust the assumed reaction lag setting after Killing Spree

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -5095,6 +5095,11 @@ struct killing_spree_t : public rogue_attack_t
     channeled = tick_zero = true;
     interrupt_auto_attack = p->is_ptr(); // 2025-06-28 -- TOCHECK: Auto attacks are now interrupted on PTR
 
+    // Assume we can react to the ending of Killing Spree faster than the 250ms channel_lag setting
+    // through the use of [nochannel] macros, or in some cases reacting to the combo point generation
+    // to cancel early it with another action
+    ability_lag = p->world_lag;
+
     attack_mh = p->get_background_action<killing_spree_tick_t>( "killing_spree_mh", p->spec.killing_spree_mh_attack );
     attack_oh = p->get_background_action<killing_spree_tick_t>( "killing_spree_oh", p->spec.killing_spree_oh_attack );
     add_child( attack_mh );


### PR DESCRIPTION
Overrides channel_lag into world_lag for Killing Spree, similar to how DH's override the same for Eye Beam