### PR TITLE
[Warlock][Diabolist] Change Values for Infernal Fragment AP/SP

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2582,8 +2582,8 @@ namespace diabolist
     : destruction::infernal_t( owner, name )
   {
     type = FRAG;
-    owner_coeff.ap_from_sp *= owner->hero.abyssal_dominion->effectN( 4 ).percent();
-    owner_coeff.sp_from_sp *= owner->hero.abyssal_dominion->effectN( 4 ).percent();
+    owner_coeff.ap_from_sp = 1.5 * owner->hero.abyssal_dominion->effectN( 4 ).percent();
+    owner_coeff.sp_from_sp = 1.5 * owner->hero.abyssal_dominion->effectN( 4 ).percent();
   }
 
   /// Infernal Fragment End


### PR DESCRIPTION


Infernal Fragments have not come to benefit of any buffs to main Infernal since it's inception as such the current value of "1.65 x 0.5" is overperforming  and instead should become set to "1.5 x 0.5" who is the original value Infernal had before buffs mid TWW.