### PR TITLE
[Warlock] Optimize S3 profiles

### DIFF
--- a/profiles/TWW3_Raid.simc
+++ b/profiles/TWW3_Raid.simc
@@ -58,10 +58,10 @@ TWW3_Priest_Shadow_Archon.simc
 # TWW3_Shaman_Enhancement_Stormbringer.simc
 
 # TWW3_Warlock_Affliction_Soul_Harvester.simc
-# TWW3_Warlock_Affliction.simc
+TWW3_Warlock_Affliction.simc
 # TWW3_Warlock_Demonology_Soul_Harvester.simc
-# TWW3_Warlock_Demonology.simc
-# TWW3_Warlock_Destruction.simc
+TWW3_Warlock_Demonology.simc
+TWW3_Warlock_Destruction.simc
 # TWW3_Warlock_Destruction_Hellcaller.simc
 
 # TWW3_Warrior_Arms.simc

--- a/profiles/generators/TWW3/TWW3_Generate_Warlock.simc
+++ b/profiles/generators/TWW3/TWW3_Generate_Warlock.simc
@@ -27,34 +27,34 @@
 
 # save=TWW3_Warlock_Affliction_Soul_Harvester.simc
 
-# warlock="TWW3_Warlock_Affliction_Hellcaller"
-# spec=affliction
-# level=80
-# race=maghar_orc
-# role=spell
-# position=back
-# professions=alchemy=100/jewelcrafting=100
-# talents=CkQAAAAAAAAAAAAAAAAAAAAAAAzMzMzMjYYYMbzMzwsNAAAgZGzsYmZsMzMzmZMzAAmxCMwsY0YGQmFwyMAAAAAAAAwY2A
-# default_pet=sayaad
+warlock=TWW3_Warlock_Affliction_Hellcaller
+level=80
+race=maghar_orc
+role=spell
+position=back
+professions=alchemy=100/jewelcrafting=100
+spec=affliction
+talents=CkQAAAAAAAAAAAAAAAAAAAAAAAzMzMzMjYWMwsNzMDzyAAAAmZMziZmxyMzMbmxMDAYGLwAziRjZAZWALzAAAAAAAAAjZD
+default_pet=sayaad
 
-# head=spliced_fiendtraders_transcendence,id=229325,bonus_id=12178/1533/12376/1808,gem_id=213743,enchant_id=7933
-# neck=semicharmed_amulet,id=228841,bonus_id=1533/12376/11964/8781,gem_id=213473/213494
-# shoulders=spliced_fiendtraders_loyal_servants,id=229323,bonus_id=11996/12376/1533
-# back=spliced_fiendtraders_shady_cover,id=229320,bonus_id=11996/12376/1533,enchant_id=7409
-# chest=spliced_fiendtraders_surgical_gown,id=229328,bonus_id=12178/1533/12376,enchant_id=7364
-# wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11109/8960/12043/12040/12373/1808/8790,gem_id=213494,enchant_id=7397,crafted_stats=36/32
-# hands=kings_malicious_clutches,id=221108,bonus_id=11996/11964/12376/3176
-# waist=honorbound_retainers_sash,id=221121,bonus_id=11996/11964/1808/12376/3176,gem_id=213494
-# legs=spliced_fiendtraders_skin_tights,id=229324,bonus_id=11996/10356/11961/6652/10255/12376/1533,enchant_id=7534
-# feet=cloudstrider_soles,id=221043,bonus_id=3176/12376/11964,enchant_id=7424
-# finger1=hoop_of_the_blighted,id=221197,bonus_id=11996/11964/8781/12376/3176,gem_id=213494/213494,enchant_id=7346
-# finger2=the_jastor_diamond,id=231265,bonus_id=1533/12376/11964/8781,gem_id=213482/213458,enchant_id=7346
-# trinket1=mugs_moxie_jug,id=230192,bonus_id=11996/11964/12376/1533
-# trinket2=house_of_cards,id=230027,bonus_id=1533/12376/11964
-# main_hand=scalding_queenmakers_shiv,id=221062,bonus_id=11996/11964/12376/3176,enchant_id=7460
-# off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/1485/11300/8960/12373/8792,crafted_stats=32/49
+head=cowl_of_ranching_fate,id=185795,bonus_id=10035/12361/12239/1808,gem_id=213743
+neck=salhadaars_folly,id=242406,bonus_id=1533/12361/12239/8781,gem_id=213470/213491
+shoulder=inquisitors_gaze_of_madnes,id=237698,bonus_id=12675/1533/12361
+back=reshii_wraps,id=235499,bonus_id=9893/12239,enchant_id=7403,gem_id=238042
+chest=inquisitors_robes_of_madness,id=237703,bonus_id=12676/12361/1533,enchant_id=7364
+wrist=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/12053/12050/1485/1808/11109/8960/8791,enchant_id=7397,gem_id=213491,crafted_stats=36/49
+hands=inquisitors_clutches_of_madness,id=237701,bonus_id=12675/1533/12361
+waist=durable_information_securing_container,id=242664,bonus_id=1489/12352/12239,gem_id=213491,titan_disc_id=1236275
+legs=inquisitors_leggings_of_madness,id=237699,bonus_id=12676/1533/12361,enchant_id=7534
+feet=interlopers_silken_striders,id=243305,bonus_id=1533/12361/12239,enchant_id=7424
+finger1=logic_gate_alpha,id=237567,bonus_id=1533/12361/12239/8781,enchant_id=7334,gem_id=213491/213491
+finger2=band_of_the_shattered_soul,id=242405,bonus_id=1533/12361/12239/8781,enchant_id=7346,gem_id=213479/213455
+trinket1=arazs_ritual_forge,id=242402,bonus_id=1533/12361/12239
+trinket2=azhiccaran_parapodia,id=242497,bonus_id=3215/12361/12239
+main_hand=voidglass_kris,id=237728,bonus_id=1533/12361/12239,enchant_id=7445
+off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12053/12050/1485/11300/8960/8795,crafted_stats=36/49
 
-# save=TWW3_Warlock_Affliction.simc
+save=TWW3_Warlock_Affliction.simc
 
 
 # warlock="TWW3_Warlock_Demonology_Soul_Harvester"
@@ -84,62 +84,62 @@
 
 # save=TWW3_Warlock_Demonology_Soul_Harvester.simc
 
-# warlock="TWW3_Warlock_Demonology_Diabolist"
+warlock="TWW3_Warlock_Demonology_Diabolist"
 # source=default
-# spec=demonology
-# level=80
-# race=Orc
-# role=spell
-# position=ranged_back
-# talents=CoQAAAAAAAAAAAAAAAAAAAAAAgxMzMzMjY2MwsNzMDWGAAAAAAAAAAzAGzYYBGYZ0CNswYmZmtxMLmZmZGjZmBjZmBjZAAA
+spec=demonology
+level=80
+race=Orc
+role=spell
+position=ranged_back
+talents=CoQAAAAAAAAAAAAAAAAAAAAAAAmZmZmZEzmBmtZmZY2GAAAAAAAAAAzAGzYYBGYb0CNswMmhtZmZZGzMzYMjhZmxYYmZAAA
 
-# head=spliced_fiendtraders_transcendence,id=229325,bonus_id=11996/1808/12376/1533,gem_id=213743,enchant_id=7933
-# neck=semicharmed_amulet,id=228841,bonus_id=1533/12376/11964/8781,gem_id=213470/213470
-# shoulders=underbosss_tailored_mantle,id=228870,bonus_id=1533/12376/11964
-# back=candlebearers_shroud,id=221109,bonus_id=11996/11964/12376/3176,enchant_id=7409
-# chest=spliced_fiendtraders_surgical_gown,id=229328,bonus_id=12178/1533/12376,enchant_id=7364
-# wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/10222/11144/11307/11109/8960/1530/12373/8795,ilevel=681,gem_id=213470,enchant_id=7397,crafted_stats=36/32
-# hands=spliced_fiendtraders_demonic_grasp,id=229326,bonus_id=12179/1533/12376
-# waist=excavators_safety_belt,id=159226,bonus_id=11365/12376/11964/1808,gem_id=213470
-# legs=spliced_fiendtraders_skin_tights,id=229324,bonus_id=12178/1533/12376,enchant_id=7534
-# feet=cloudstrider_soles,id=221043,bonus_id=3176/12376/11964,enchant_id=7424
-# finger1=miniature_roulette_wheel,id=228843,bonus_id=11996/11964/8781/12376/1533,gem_id=213470/213491,enchant_id=7346,crafted_stats=40/36
-# finger2=the_jastor_diamond,id=231265,bonus_id=1533/12376/11964/8781,gem_id=213485/213458,enchant_id=7346
-# trinket1=house_of_cards,id=230027,bonus_id=1533/12376/11964
-# trinket2=mugs_moxie_jug,id=230192,bonus_id=1533/12376/11964
-# main_hand=scalding_queenmakers_shiv,id=221062,bonus_id=11996/11964/12376/3176,enchant_id=7445
-# off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/11300/8960/1491/12373/8793,ilevel=681,crafted_stats=40/36
+head=cowl_of_ranching_fate,id=185795,bonus_id=10035/12361/12239/1808,gem_id=213743
+neck=chrysalis_of_sundered_souls,id=237568,bonus_id=1533/12361/12239/8781,gem_id=213467/213491
+shoulder=inquisitors_gaze_of_madnes,id=237698,bonus_id=12675/1533/12361
+back=reshii_wraps,id=235499,bonus_id=9893/12239,enchant_id=7403,gem_id=238042
+chest=inquisitors_robes_of_madness,id=237703,bonus_id=12676/12361/1533,enchant_id=7364
+wrist=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/12053/12050/1485/1808/11109/8960/8791,enchant_id=7397,gem_id=213455,crafted_stats=36/49
+hands=inquisitors_clutches_of_madness,id=237701,bonus_id=12675/1533/12361
+waist=forgeweavers_journal_holster,id=237538,bonus_id=1533/12361/12239/1808,gem_id=213455
+legs=inquisitors_leggings_of_madness,id=237699,bonus_id=12676/1533/12361,enchant_id=7534
+feet=interlopers_silken_striders,id=243305,bonus_id=1533/12361/12239,enchant_id=7424
+finger1=logic_gate_alpha,id=237567,bonus_id=1533/12361/12239/8781,enchant_id=7352,gem_id=213455/213485
+finger2=devout_zealots_ring,id=221136,bonus_id=3215/12361/12239/8781,enchant_id=7352,gem_id=213473/213482
+trinket1=azhiccaran_parapodia,id=242497,bonus_id=3215/12361/12239
+trinket2=arazs_ritual_forge,id=242402,bonus_id=1533/12361/12239
+main_hand=voidglass_sovereigns_blade,id=237735,bonus_id=1533/12361/12239,enchant_id=7445
+off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12053/12050/1485/11300/8960/8795,crafted_stats=36/49
 
-# save=TWW3_Warlock_Demonology.simc
+save=TWW3_Warlock_Demonology.simc
 
-# warlock="TWW3_Warlock_Destruction_Diabolist"
-# spec=destruction
-# level=80
-# race=Dwarf
-# role=spell
-# position=ranged_back
-# talents=CsQAAAAAAAAAAAAAAAAAAAAAAghZmZmZEzmhxsZmZY2mFzwMzsY2MWMzAAAAAjZmtlZmlZAjZMsQGYbYhGLYAAAAAAAMjxMAA
-# default_pet=sayaad
+warlock="TWW3_Warlock_Destruction_Diabolist"
+spec=destruction
+level=80
+race=Dwarf
+role=spell
+position=ranged_back
+default_pet=sayaad
+talents=CsQAAAAAAAAAAAAAAAAAAAAAAAmZmZmZEziBmtZmZYWmFzwMzsYGjFzMAAAAwYmZZZmZZGwYGDLkB2GWoxCGAAAAAAAzYMDAA
 
-# head=spliced_fiendtraders_transcendence,id=229325,bonus_id=1527/11996/1808,gem_id=213743
-# neck=semicharmed_amulet,id=228841,bonus_id=8781,gem_id=213473/213479,ilevel=678
-# shoulders=spliced_fiendtraders_loyal_servants,id=229323,bonus_id=1527/11996
-# back=electricians_siphoning_filter,id=234507,bonus_id=1527/11996/11964
-# chest=spliced_fiendtraders_surgical_gown,id=229328,ilevel=678,enchant_id=7364
-# wrists=consecrated_cuffs,id=222815,bonus_id=10421/9633/8902/9627/10222/11144/11307/11109/8960/8791,enchant_id=7397,gem_id=213491,ilevel=675,crafted_stats=36/32
-# hands=mine_rats_handwarmers,id=159231,bonus_id=11359/11996/11964
-# waist=excavators_safety_belt,id=159226,bonus_id=11359/11996/11964/1808,gem_id=213479
-# legs=spliced_fiendtraders_skin_tights,id=229324,bonus_id=11996/10356/11961/6652/1579/10255,ilevel=678,enchant_id=7534
-# feet=hyperthread_boots,id=168964,bonus_id=10067/11996/11964,enchant_id=7421
-# finger1=hoop_of_the_blighted,id=221197,bonus_id=3170/11996/11964/8781,enchant_id=7346,gem_id=213467/213491
-# finger2=the_jastor_diamond,id=231265,bonus_id=8781,enchant_id=7334,gem_id=213458/213482,ilevel=678
-# trinket1=eye_of_kezan,id=230198,ilevel=678
-# trinket2=mugs_moxie_jug,id=230192,bonus_id=1527/11996/11964
-# main_hand=scalding_queenmakers_shiv,id=221062,bonus_id=3170/11996/11964,enchant_id=7460
-# off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12043/12040/1485/8795/11300/8960,crafted_stats=40/36
+head=cowl_of_ranching_fate,id=185795,bonus_id=10035/12361/12239/1808,gem_id=213743
+neck=salhadaars_folly,id=242406,bonus_id=1533/12361/12239/8781,gem_id=213461/213485
+shoulder=inquisitors_gaze_of_madnes,id=237698,bonus_id=12675/1533/12361
+back=reshii_wraps,id=235499,bonus_id=9893/12239,enchant_id=7403,gem_id=238042
+chest=inquisitors_robes_of_madness,id=237703,bonus_id=12676/12361/1533,enchant_id=7364
+wrist=consecrated_cuff,id=222815,bonus_id=10421/9633/8902/12053/12050/1485/1808/11109/8960/8791,enchant_id=7397,gem_id=213473,crafted_stats=36/49
+hands=inquisitors_clutches_of_madness,id=237701,bonus_id=12675/1533/12361
+waist=cord_of_the_dark_word,id=178822,bonus_id=10032/12361/12239/1808,gem_id=213473
+legs=inquisitors_leggings_of_madness,id=237699,bonus_id=12676/1533/12361,enchant_id=7534
+feet=interlopers_silken_striders,id=243305,bonus_id=1533/12361/12239,enchant_id=7424
+finger1=logic_gate_alphaid=237567,bonus_id=1533/12361/12239/8781,enchant_id=7352,gem_id=213473/213494
+finger2=band_of_the_shattered_soul,id=242405,bonus_id=1533/12361/12239/8781,enchant_id=7352,gem_id=213467/213482
+trinket1=azhiccaran_parapodia,id=242497,bonus_id=3215/12361/12239
+trinket2=diamantine_voidcore,id=242392,bonus_id=1533/12361/12239
+main_hand=voidglass_kris,id=237728,bonus_id=1533/12361/12239,enchant_id=7448
+off_hand=vagabonds_torch,id=222566,bonus_id=10421/9633/8902/12053/12050/1485/11300/8960/8795,crafted_stats=36/49
 
 
-# save=TWW3_Warlock_Destruction.simc
+save=TWW3_Warlock_Destruction.simc
 
 # warlock="TWW3_Warlock_Destruction_Hellcaller"
 # spec=destruction


### PR DESCRIPTION
Gems and gear are optimised. Need to double-check trinekts after buffs before merging, but apart from that, they are good to go. 

Destro: https://mimiron.raidbots.com/simbot/report/9t4yAR2i2fiDinvjFKbpqj
Aff: https://mimiron.raidbots.com/simbot/report/rmsinPtpsH358oCRMsyasd
Demo: https://mimiron.raidbots.com/simbot/report/sMQSG1bkKDWTjicgh9fZvd