### PR TITLE
[Gear] Incorporeal Warpclaw uses meteor split scaling

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -8834,7 +8834,7 @@ void perfidious_projector( special_effect_t& effect )
 // 1243133 Damage
 void incorporeal_warpclaw( special_effect_t& effect )
 {
-  auto damage         = create_proc_action<generic_aoe_proc_t>( "incorporeal_warpstrike", effect, 1243133 );
+  auto damage         = create_proc_action<generic_aoe_proc_t>( "incorporeal_warpstrike", effect, 1243133, true );
   damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
   damage->base_multiplier *= role_mult( effect );
 


### PR DESCRIPTION
I'd be surprised if any modern item has true split damage anymore

https://www.warcraftlogs.com/reports/v1PMz4xYQXg8rc97?fight=12&type=summary&source=21&pins=2%24Separate%24%23244F4B%24damage%240%240.0.0.Any%24228396384.0.0.Rogue%24true%240.0.0.Any%24false%241243133&view=events

1 target - 1148598
2 target - 746589 * 2, which is 30% more total 

(The Mk II Electro Shocker takes 100% extra dmg)