### PR TITLE
[Warlock] Don't trigger expendables on diabolist demons/sh tier

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -646,7 +646,7 @@ void warlock_t::expendables_trigger_helper( warlock_pet_t* source )
       continue;
 
     // 2025-03-28: The Expendables talent does not apply to Greater Dreadstalkers (maybe a bug?)
-    if ( lock_pet->pet_type != PET_FELHUNTER || !lock_pet->bugs )
+    if ( ( lock_pet->pet_type != PET_FELHUNTER || !lock_pet->bugs ) && lock_pet->pet_type != PET_WARLOCK_RANDOM )
       lock_pet->buffs.the_expendables->trigger();
   }
 }

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1683,7 +1683,8 @@ using namespace helpers;
       {
         double m = warlock_spell_t::composite_da_multiplier( s );
 
-        if ( soul_harvester() && p()->buffs.succulent_soul->check() )
+        //In-game a stack gets consumed before MT hits, doing it like this is easier
+        if ( soul_harvester() && p()->buffs.succulent_soul->check() > 1 )
           m *= 1.0 + p()->hero.succulent_soul->effectN( 2 ).percent();
 
         return m;
@@ -2264,8 +2265,11 @@ using namespace helpers;
 
     void snapshot_state( action_state_t* s, result_amount_type rt ) override
     {
+      //11.1 onward, nightfall has not buffed hc ds dmg
+      double mul = p()->bugs && hellcaller() ? 0 : p()->talents.nightfall_buff->effectN( 2 ).percent() + p()->hero.necrolyte_teachings->effectN( 1 ).percent();
+
       debug_cast<drain_soul_state_t*>( s )->tick_time_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? p()->talents.nightfall_buff->effectN( 3 ).percent() : 0 );
-      debug_cast<drain_soul_state_t*>( s )->td_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? p()->talents.nightfall_buff->effectN( 2 ).percent() + p()->hero.necrolyte_teachings->effectN( 1 ).percent() : 0 );
+      debug_cast<drain_soul_state_t*>( s )->td_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? mul : 0 );
       warlock_spell_t::snapshot_state( s, rt );
     }
 
@@ -2382,8 +2386,6 @@ using namespace helpers;
 
      std::vector<player_t*>& target_list() const override
     {
-      // Force regen this every time
-      target_cache.is_valid = false;
       auto& tl              = warlock_spell_t::target_list();
       auto original_size    = tl.size();
 
@@ -2411,7 +2413,12 @@ using namespace helpers;
 
       return tl;
     }
-    
+    void execute() override
+    {
+      target_cache.is_valid = false;
+      warlock_spell_t::execute();
+    }
+
     void impact( action_state_t* s ) override
     {
       bool fresh_agony = !td( s->target )->dots_agony->is_ticking();

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -749,7 +749,7 @@ namespace warlock
     buffs.dreadstalkers = make_buff( this, "dreadstalkers" )->set_max_stack( 8 )
                           ->set_duration( talents.call_dreadstalkers_2->duration() );
 
-    buffs.vilefiend = make_buff( this, "vilefiend" )->set_max_stack( 1 )
+    buffs.vilefiend = make_buff( this, "vilefiend" )->set_max_stack( 2 )
                       ->set_duration( talents.summon_vilefiend->duration() );
 
     buffs.tyrant = make_buff( this, "tyrant" )->set_max_stack( 1 )

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1648,8 +1648,16 @@ void vilefiend_t::arise()
   }
 }
 
-action_t* vilefiend_t::create_action( util::string_view name, util::string_view options_str )
+void vilefiend_t::demise()
 {
+  if ( !current.sleeping )  
+    o()->buffs.vilefiend->decrement();
+  
+  warlock_simple_pet_t::demise();
+}
+
+action_t* vilefiend_t::create_action( util::string_view name, util::string_view options_str )
+  {
   if ( name == "bile_spit" )
     return new bile_spit_t( this );
   if ( name == "headbutt" )

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -434,6 +434,7 @@ struct vilefiend_t : public warlock_simple_pet_t
   void init_base_stats() override;
   void create_buffs() override;
   void arise() override;
+  void demise() override;
   action_t* create_action( util::string_view, util::string_view ) override;
   double composite_player_multiplier( school_e ) const override;
 };


### PR DESCRIPTION
Succulent soul doesn't buff mt if at 1 stack, nightfall +dmg doesn't work on hellcaller ds, allow vilefiend to stack to 2 for reporting