### PR TITLE
[Mage] Remove ToTM from affecting Intuition

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -7021,7 +7021,6 @@ struct touch_of_the_magi_t final : public arcane_mage_spell_t
   {
     parse_options( options_str );
     triggers.clearcasting = true;
-    triggers.intuition = true;
 
     if ( data().ok() )
       add_child( p->action.touch_of_the_magi_explosion );


### PR DESCRIPTION
ToTM no longer increments or rolls the random proc chance for Intuition.
https://www.warcraftlogs.com/reports/FhGHXaD3tKjLYyRT?fight=last&type=auras&source=1

Currently checking whether or not they also changed stuff for other spells, seems odd that they just decided to target ToTM specifically.