### PR TITLE
[monk] SEF, CB, CI, MoH 2p fixes

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -5350,70 +5350,72 @@ struct celestial_fortune_t : public monk_heal_t
 
 namespace absorbs
 {
-// ==========================================================================
-// Celestial Brew
-// ==========================================================================
-struct celestial_brew_t : public brew_t<monk_absorb_t>
+struct absorb_brew_t : public brew_t<monk_absorb_t>
 {
-  struct celestial_brew_t_state_t : public action_state_t
-  {
-    celestial_brew_t_state_t( action_t *a, player_t *target ) : action_state_t( a, target )
-    {
-    }
-
-    proc_types2 cast_proc_type2() const override
-    {
-      // Celestial Brew seems to trigger Bron's Call to Action (and possibly other
-      // effects that care about casts).
-      return PROC2_CAST_HEAL;
-    }
-  };
-
-  celestial_brew_t( monk_t *player, util::string_view options_str, std::string_view name,
-                    const spell_data_t *spell_data )
+  absorb_brew_t( monk_t *player, std::string_view options_str, std::string_view name, const spell_data_t *spell_data )
     : brew_t<monk_absorb_t>( player, name, spell_data )
   {
     parse_options( options_str );
-    harmful = may_crit = false;
-    callbacks          = true;
-    cast_during_sck    = true;
+    cast_during_sck = true;
 
     apply_affecting_aura( player->talent.brewmaster.light_brewing );
     apply_affecting_aura( player->talent.master_of_harmony.endless_draught );
-  }
 
-  action_state_t *new_state() override
-  {
-    return new celestial_brew_t_state_t( this, player );
-  }
-
-  double action_multiplier() const override
-  {
-    double am = base_t::action_multiplier();
-
-    am *= 1 + p()->buff.purified_chi->check_stack_value();
-
-    return am;
+    if ( const spelleffect_data_t &effect = player->talent.brewmaster.purified_chi->effectN( 1 ); effect.ok() )
+      add_parse_entry( da_multiplier_effects )
+          .set_buff( player->buff.purified_chi )
+          .set_use_stacks( true )
+          .set_type( parse_flag_e::EXPIRE_BUFF )
+          .set_value( effect.percent() )
+          .set_eff( &effect );
   }
 
   void execute() override
   {
     if ( p()->buff.blackout_combo->up() )
     {
-      p()->buff.purified_chi->trigger( (int)p()->talent.brewmaster.blackout_combo->effectN( 6 ).base_value() );
+      p()->buff.purified_chi->trigger( as<int>( p()->talent.brewmaster.blackout_combo->effectN( 6 ).base_value() ) );
       p()->proc.blackout_combo_celestial_brew->occur();
     }
-
     p()->buff.aspect_of_harmony.trigger_spend();
+
     brew_t<monk_absorb_t>::execute();
 
     p()->buff.blackout_combo->expire();
-    p()->buff.purified_chi->expire();
     p()->buff.pretense_of_instability->trigger();
     p()->active_actions.special_delivery->execute();
+
     if ( p()->sets->has_set_bonus( HERO_MASTER_OF_HARMONY, TWW3, B4 ) )
       p()->tier.tww3.moh_2pc_harmonic_surge_buff->trigger(
           p()->sets->set( HERO_MASTER_OF_HARMONY, TWW3, B4 )->effectN( 1 ).base_value() );
+  }
+};
+
+struct celestial_brew_t : public absorb_brew_t
+{
+  celestial_brew_t( monk_t *player, std::string_view options_str )
+    : absorb_brew_t( player, options_str, "celestial_brew", player->talent.brewmaster.celestial_brew )
+  {
+  }
+};
+
+struct celestial_infusion_t : public absorb_brew_t
+{
+  celestial_infusion_t( monk_t *player, std::string_view options_str )
+    : absorb_brew_t( player, options_str, "celestial_infusion", player->talent.brewmaster.celestial_infusion )
+  {
+  }
+
+  absorb_buff_t *create_buff( const action_state_t *state ) override
+  {
+    buff_t *b = buff_t::find( state->target, name_str, player );
+    if ( b )
+      return debug_cast<buffs::fractional_absorb_t *>( b );
+
+    auto buff = make_buff<buffs::fractional_absorb_t>( p(), name_str, &data() );
+    buff->set_absorb_source( stats );
+
+    return buff;
   }
 };
 }  // namespace absorbs
@@ -6687,11 +6689,11 @@ action_t *monk_t::create_action( util::string_view name, util::string_view optio
   if ( name == "breath_of_fire" )
     return new breath_of_fire_t( this, options_str );
   if ( name == "celestial_brew" && talent.brewmaster.celestial_infusion->ok() )
-    return new celestial_brew_t( this, options_str, "celestial_infusion", talent.brewmaster.celestial_infusion );
+    return new celestial_infusion_t( this, options_str );
   if ( name == "celestial_brew" )
-    return new celestial_brew_t( this, options_str, "celestial_brew", talent.brewmaster.celestial_brew );
+    return new celestial_brew_t( this, options_str );
   if ( name == "celestial_infusion" )
-    return new celestial_brew_t( this, options_str, "celestial_infusion", talent.brewmaster.celestial_infusion );
+    return new celestial_infusion_t( this, options_str );
   if ( name == "exploding_keg" )
     return new exploding_keg_t( this, options_str );
   if ( name == "fortifying_brew" )

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -3602,6 +3602,8 @@ struct black_ox_brew_t : public brew_t<monk_spell_t>
         cooldown->reset( true, 2 );
       if ( key == p()->talent.brewmaster.celestial_brew->id() )
         cooldown->reset( true, 1 );
+      if ( key == p()->talent.brewmaster.celestial_infusion->id() )
+        cooldown->reset( true, 1 );
     }
 
     p()->resource_gain( RESOURCE_ENERGY, p()->talent.brewmaster.black_ox_brew->effectN( 1 ).base_value(),

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1227,6 +1227,9 @@ struct harmonic_surge_t : public monk_spell_t
     impact_t( monk_t *player, std::string_view name, const spell_data_t *spell_data )
       : TBase( player, name, spell_data )
     {
+      TBase::aoe              = -1;
+      TBase::split_aoe_damage = true;
+
       unsigned offset = 0;
 
       if ( spell_data->effectN( 1 ).type() == E_SCHOOL_DAMAGE )

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -5457,14 +5457,15 @@ namespace buffs
 // ==========================================================================
 
 template <typename Base>
-monk_buff_t<Base>::monk_buff_t( monk_t *player, std::string_view name, const spell_data_t *spell_data, const item_t *item )
+monk_buff_t<Base>::monk_buff_t( monk_t *player, std::string_view name, const spell_data_t *spell_data,
+                                const item_t *item )
   : base_t( player, name, spell_data, item )
 {
 }
 
 template <typename Base>
 monk_buff_t<Base>::monk_buff_t( monk_td_t *target_data, std::string_view name, const spell_data_t *spell_data,
-                          const item_t *item )
+                                const item_t *item )
   : base_t( *target_data, name, spell_data, item )
 {
 }
@@ -6338,16 +6339,17 @@ aspect_of_harmony_t::spender_t::tick_t<base_action_t>::tick_t( monk_t *player, s
 {
 }
 
-fractional_absorb_t::fractional_absorb_t( monk_t* player, std::string_view name, const spell_data_t* spell_data )
+fractional_absorb_t::fractional_absorb_t( monk_t *player, std::string_view name, const spell_data_t *spell_data )
   : monk_buff_t<absorb_buff_t>( player, name, spell_data ), absorb_fraction( 1.0 )
-{}
+{
+}
 
-double fractional_absorb_t::consume( double amount, action_state_t* state )
+double fractional_absorb_t::consume( double amount, action_state_t *state )
 {
   return base_t::consume( amount * absorb_fraction, state );
 }
 
-absorb_buff_t* fractional_absorb_t::set_absorb_fraction( double fraction )
+absorb_buff_t *fractional_absorb_t::set_absorb_fraction( double fraction )
 {
   absorb_fraction = fraction;
   return this;
@@ -9417,17 +9419,17 @@ std::unique_ptr<expr_t> monk_t::create_expression( util::string_view name_str )
 {
   auto splits = util::string_split<util::string_view>( name_str, "." );
 
-  if ( splits.size() >= 3 && splits[1] == "celestial_brew" && talent.brewmaster.celestial_infusion->ok() )
+  if ( splits.size() >= 3 && splits[ 1 ] == "celestial_brew" && talent.brewmaster.celestial_infusion->ok() )
   {
-    if ( splits[0] == "cooldown" )
-      return get_cooldown( "celestial_infusion" )->create_expression( splits[2] );
-    if ( splits[0] == "action" )
-      return find_action( "celestial_infusion" )->create_expression( splits[2] );
-    if ( splits[0] == "buff" )
+    if ( splits[ 0 ] == "cooldown" )
+      return get_cooldown( "celestial_infusion" )->create_expression( splits[ 2 ] );
+    if ( splits[ 0 ] == "action" )
+      return find_action( "celestial_infusion" )->create_expression( splits[ 2 ] );
+    if ( splits[ 0 ] == "buff" )
     {
-      buff_t* buff = buff_t::find( this, "celestial_infusion" );
+      buff_t *buff = buff_t::find( this, "celestial_infusion" );
       assert( buff );
-      return buff_t::create_expression( splits[1], splits[2], *buff );
+      return buff_t::create_expression( splits[ 1 ], splits[ 2 ], *buff );
     }
   }
 

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -3367,6 +3367,13 @@ struct slicing_winds_t : public monk_melee_attack_t
       may_combo_strike    = true;
       aoe                 = -1;
       reduced_aoe_targets = player->talent.windwalker.slicing_winds->effectN( 3 ).base_value();
+
+      if ( const spelleffect_data_t &effect = player->talent.windwalker.storm_earth_and_fire->effectN( 1 );
+           effect.ok() )
+        add_parse_entry( da_multiplier_effects )
+            .set_buff( player->buff.storm_earth_and_fire )
+            .set_value( ( 1.0 + effect.percent() ) * 3.0 - 1.0 )
+            .set_eff( &effect );
     }
   };
 
@@ -3484,6 +3491,13 @@ struct chi_burst_t : monk_spell_t
       for ( const auto &effect : spell_data->effects() )
         if ( effect.type() == E_SCHOOL_DAMAGE )
           TBase::ww_mastery = true;
+
+      if ( const spelleffect_data_t &effect = player->talent.windwalker.storm_earth_and_fire->effectN( 1 );
+           effect.ok() )
+        add_parse_entry( TBase::da_multiplier_effects )
+            .set_buff( player->buff.storm_earth_and_fire )
+            .set_value( ( 1.0 + effect.percent() ) * 3.0 - 1.0 )
+            .set_eff( &effect );
     }
   };
 

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -9417,6 +9417,20 @@ std::unique_ptr<expr_t> monk_t::create_expression( util::string_view name_str )
 {
   auto splits = util::string_split<util::string_view>( name_str, "." );
 
+  if ( splits.size() >= 3 && splits[1] == "celestial_brew" && talent.brewmaster.celestial_infusion->ok() )
+  {
+    if ( splits[0] == "cooldown" )
+      return get_cooldown( "celestial_infusion" )->create_expression( splits[2] );
+    if ( splits[0] == "action" )
+      return find_action( "celestial_infusion" )->create_expression( splits[2] );
+    if ( splits[0] == "buff" )
+    {
+      buff_t* buff = buff_t::find( this, "celestial_infusion" );
+      assert( buff );
+      return buff_t::create_expression( splits[1], splits[2], *buff );
+    }
+  }
+
   if ( name_str == "monk.shadopan.energy_accumulator" )
     return make_ref_expr( "monk.shadopan.energy_accumulator", flurry_strikes_energy );
 

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -6335,6 +6335,21 @@ aspect_of_harmony_t::spender_t::tick_t<base_action_t>::tick_t( monk_t *player, s
   : residual_action::residual_periodic_action_t<base_action_t>( player, name, spell_data )
 {
 }
+
+fractional_absorb_t::fractional_absorb_t( monk_t* player, std::string_view name, const spell_data_t* spell_data )
+  : monk_buff_t<absorb_buff_t>( player, name, spell_data ), absorb_fraction( 1.0 )
+{}
+
+double fractional_absorb_t::consume( double amount, action_state_t* state )
+{
+  return base_t::consume( amount * absorb_fraction, state );
+}
+
+absorb_buff_t* fractional_absorb_t::set_absorb_fraction( double fraction )
+{
+  absorb_fraction = fraction;
+  return this;
+}
 }  // namespace buffs
 
 namespace items

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -5454,42 +5454,48 @@ namespace buffs
 // Monk Buffs
 // ==========================================================================
 
-monk_buff_t::monk_buff_t( monk_t *player, std::string_view name, const spell_data_t *spell_data, const item_t *item )
-  : buff_t( player, name, spell_data, item )
+template <typename Base>
+monk_buff_t<Base>::monk_buff_t( monk_t *player, std::string_view name, const spell_data_t *spell_data, const item_t *item )
+  : base_t( player, name, spell_data, item )
 {
 }
 
-monk_buff_t::monk_buff_t( monk_td_t *target_data, std::string_view name, const spell_data_t *spell_data,
+template <typename Base>
+monk_buff_t<Base>::monk_buff_t( monk_td_t *target_data, std::string_view name, const spell_data_t *spell_data,
                           const item_t *item )
-  : buff_t( *target_data, name, spell_data, item )
+  : base_t( *target_data, name, spell_data, item )
 {
 }
 
-monk_td_t &monk_buff_t::get_td( player_t *t )
+template <typename Base>
+monk_td_t &monk_buff_t<Base>::get_td( player_t *t )
 {
-  return *( p().get_target_data( t ) );
+  return *( base_t::p().get_target_data( t ) );
 }
 
-const monk_td_t *monk_buff_t::find_td( player_t *t ) const
+template <typename Base>
+const monk_td_t *monk_buff_t<Base>::find_td( player_t *t ) const
 {
-  return p().find_target_data( t );
+  return base_t::p().find_target_data( t );
 }
 
-monk_t &monk_buff_t::p()
+template <typename Base>
+monk_t &monk_buff_t<Base>::p()
 {
-  return *debug_cast<monk_t *>( buff_t::source );
+  return *debug_cast<monk_t *>( base_t::source );
 }
 
-const monk_t &monk_buff_t::p() const
+template <typename Base>
+const monk_t &monk_buff_t<Base>::p() const
 {
-  return *debug_cast<monk_t *>( buff_t::source );
+  return *debug_cast<monk_t *>( base_t::source );
 }
 
 // ==========================================================================
 // Gift of the Ox
 // ==========================================================================
 gift_of_the_ox_t::gift_of_the_ox_t( monk_t *player )
-  : monk_buff_t( player, "gift_of_the_ox", player->talent.brewmaster.gift_of_the_ox_buff ),
+  : monk_buff_t<>( player, "gift_of_the_ox", player->talent.brewmaster.gift_of_the_ox_buff ),
     player( player ),
     heal_trigger(
         new orb_t( player, "gift_of_the_ox_trigger", player->talent.brewmaster.gift_of_the_ox_heal_trigger ) ),
@@ -5638,7 +5644,7 @@ const char *gift_of_the_ox_t::orb_event_t::name() const
 // Shuffle
 // ==========================================================================
 shuffle_t::shuffle_t( monk_t *player )
-  : monk_buff_t( player, "shuffle", player->talent.brewmaster.shuffle_buff ),
+  : monk_buff_t<>( player, "shuffle", player->talent.brewmaster.shuffle_buff ),
     accumulator( 0_s ),
     max_duration( 3.0 * base_buff_duration )
 {
@@ -5671,7 +5677,7 @@ void shuffle_t::trigger( timespan_t duration )
 // ===============================================================================
 // Fortifying Brew Buff
 // ===============================================================================
-struct fortifying_brew_t : public monk_buff_t
+struct fortifying_brew_t : public monk_buff_t<>
 {
   int health_gain;
   fortifying_brew_t( monk_t *player )
@@ -5710,7 +5716,7 @@ struct fortifying_brew_t : public monk_buff_t
 // ===============================================================================
 // Touch of Karma Buff
 // ===============================================================================
-struct touch_of_karma_buff_t : public monk_buff_t
+struct touch_of_karma_buff_t : public monk_buff_t<>
 {
   touch_of_karma_buff_t( monk_t *p, util::string_view n, const spell_data_t *s ) : monk_buff_t( p, n, s )
   {
@@ -5738,7 +5744,7 @@ struct touch_of_karma_buff_t : public monk_buff_t
 // ===============================================================================
 // Whirling Dragon Punch Buff
 // ===============================================================================
-struct whirling_dragon_punch_buff_t : monk_buff_t
+struct whirling_dragon_punch_buff_t : monk_buff_t<>
 {
   whirling_dragon_punch_buff_t( monk_t *player )
     : monk_buff_t( player, "whirling_dragon_punch", player->talent.windwalker.whirling_dragon_punch_buff )
@@ -5764,7 +5770,7 @@ struct whirling_dragon_punch_buff_t : monk_buff_t
 // ===============================================================================
 // Rushing Jade Wind Buff
 // ===============================================================================
-struct rushing_jade_wind_buff_t : public monk_buff_t
+struct rushing_jade_wind_buff_t : public monk_buff_t<>
 {
   struct tick_action_t : actions::monk_melee_attack_t
   {
@@ -5831,8 +5837,7 @@ struct rushing_jade_wind_buff_t : public monk_buff_t
 // ===============================================================================
 // Invoke Xuen the White Tiger
 // ===============================================================================
-
-struct invoke_xuen_the_white_tiger_buff_t : public monk_buff_t
+struct invoke_xuen_the_white_tiger_buff_t : public monk_buff_t<>
 {
   static void invoke_xuen_callback( buff_t *b, int, timespan_t )
   {
@@ -5895,7 +5900,7 @@ struct invoke_xuen_the_white_tiger_buff_t : public monk_buff_t
 // ===============================================================================
 // Fury of Xuen Stacking Buff
 // ===============================================================================
-struct fury_of_xuen_stacking_buff_t : public monk_buff_t
+struct fury_of_xuen_stacking_buff_t : public monk_buff_t<>
 {
   fury_of_xuen_stacking_buff_t( monk_t *p, util::string_view n, const spell_data_t *s ) : monk_buff_t( p, n, s )
   {
@@ -5910,7 +5915,7 @@ struct fury_of_xuen_stacking_buff_t : public monk_buff_t
 // ===============================================================================
 // Fury of Xuen Haste Buff
 // ===============================================================================
-struct fury_of_xuen_t : public monk_buff_t
+struct fury_of_xuen_t : public monk_buff_t<>
 {
   static void fury_of_xuen_callback( buff_t *b, int, timespan_t )
   {
@@ -5984,7 +5989,7 @@ struct fury_of_xuen_t : public monk_buff_t
 // ===============================================================================
 // Niuzao Rank 2 Purifying Buff
 // ===============================================================================
-struct purifying_buff_t : public monk_buff_t
+struct purifying_buff_t : public monk_buff_t<>
 {
   purifying_buff_t( monk_t *player ) : monk_buff_t( player, "purifying_brew", spell_data_t::nil() )
   {
@@ -6010,8 +6015,7 @@ struct purifying_buff_t : public monk_buff_t
 // three chi orbs that the player can pick up whenever they do not have max
 // Chi. Given we want to provide the chi but apply it slowly if the player is at
 // max chi, then we need to set up so that it triggers on it's own.
-
-struct touch_of_death_ww_buff_t : public monk_buff_t
+struct touch_of_death_ww_buff_t : public monk_buff_t<>
 {
   touch_of_death_ww_buff_t( monk_t *p, util::string_view n, const spell_data_t *s ) : monk_buff_t( p, n, s )
   {
@@ -6043,7 +6047,7 @@ struct touch_of_death_ww_buff_t : public monk_buff_t
 // ===============================================================================
 // Windwalking Buff
 // ===============================================================================
-struct windwalking_driver_t : public monk_buff_t
+struct windwalking_driver_t : public monk_buff_t<>
 {
   double movement_increase;
   windwalking_driver_t( monk_t *p, util::string_view n, const spell_data_t *s )
@@ -7720,10 +7724,10 @@ struct debuff_override : stagger_impl::debuff_t<monk_t>
   }
 };
 
-struct training_of_niuzao_buff : buffs::monk_buff_t
+struct training_of_niuzao_buff : buffs::monk_buff_t<>
 {
   training_of_niuzao_buff( monk_t *player )
-    : buffs::monk_buff_t( player, "training_of_niuzao", player->talent.brewmaster.training_of_niuzao )
+    : buffs::monk_buff_t<>( player, "training_of_niuzao", player->talent.brewmaster.training_of_niuzao )
   {
     set_default_value( 0.0 );
     set_pct_buff_type( STAT_PCT_BUFF_MASTERY );
@@ -7733,7 +7737,7 @@ struct training_of_niuzao_buff : buffs::monk_buff_t
                 timespan_t duration = timespan_t::min() ) override
   {
     double v = p().find_stagger( "Stagger" )->level_index() * data().effectN( 1 ).base_value();
-    return buffs::monk_buff_t::trigger( 1, v, chance, duration );
+    return base_t::trigger( 1, v, chance, duration );
   }
 };
 

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -363,10 +363,10 @@ struct fractional_absorb_t : public monk_buff_t<absorb_buff_t>
 {
   double absorb_fraction;
 
-  fractional_absorb_t( monk_t* player, std::string_view name, const spell_data_t* spell_data );
+  fractional_absorb_t( monk_t *player, std::string_view name, const spell_data_t *spell_data );
 
-  double consume( double amount, action_state_t* state = nullptr ) override;
-  absorb_buff_t* set_absorb_fraction( double fraction );
+  double consume( double amount, action_state_t *state = nullptr ) override;
+  absorb_buff_t *set_absorb_fraction( double fraction );
 };
 }  // namespace buffs
 

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -227,8 +227,11 @@ struct conduit_of_the_celestials_container_t
 
 namespace buffs
 {
-struct monk_buff_t : public buff_t
+template <typename Base = buff_t>
+struct monk_buff_t : public Base
 {
+  using base_t = Base;
+
   monk_buff_t( monk_t *player, std::string_view name, const spell_data_t *spell_data = spell_data_t::nil(),
                const item_t *item = nullptr );
   monk_buff_t( monk_td_t *player, std::string_view name, const spell_data_t *spell_data = spell_data_t::nil(),
@@ -239,7 +242,7 @@ struct monk_buff_t : public buff_t
   const monk_t &p() const;
 };
 
-struct shuffle_t : monk_buff_t
+struct shuffle_t : monk_buff_t<>
 {
   timespan_t accumulator;
   const timespan_t max_duration;
@@ -249,7 +252,7 @@ struct shuffle_t : monk_buff_t
   void trigger( timespan_t duration );
 };
 
-struct gift_of_the_ox_t : monk_buff_t
+struct gift_of_the_ox_t : monk_buff_t<>
 {
   /*
    * TODO:
@@ -308,14 +311,14 @@ private:
 
   bool fallback;
 
-  struct accumulator_t : monk_buff_t
+  struct accumulator_t : monk_buff_t<>
   {
     aspect_of_harmony_t *aspect_of_harmony;
     accumulator_t( monk_t *player, aspect_of_harmony_t *aspect_of_harmony );
     void trigger_with_state( action_state_t *state );
   };
 
-  struct spender_t : monk_buff_t
+  struct spender_t : monk_buff_t<>
   {
     template <class base_action_t>
     struct purified_spirit_t : base_action_t

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -358,6 +358,16 @@ public:
 
   bool heal_ticking();
 };
+
+struct fractional_absorb_t : public monk_buff_t<absorb_buff_t>
+{
+  double absorb_fraction;
+
+  fractional_absorb_t( monk_t* player, std::string_view name, const spell_data_t* spell_data );
+
+  double consume( double amount, action_state_t* state = nullptr ) override;
+  absorb_buff_t* set_absorb_fraction( double fraction );
+};
 }  // namespace buffs
 
 struct monk_td_t : public actor_target_data_t


### PR DESCRIPTION
- **[monk] Fix SEF compensation multiplier for SW and CB.**
- **[monk] Cause MoH 2p damage to split. Note: doesn't change overall damage dealt significantly.**
- **[monk] Allow Black Ox Brew to reset one Celestial Infusion charge.**
- **[monk] Implement templated `monk_buff_t`.**
- **[monk] Implement fractional absorb buff type.**
- **[monk] Reimplement Celestial Brew and Celestial Infusion.**
- **[monk] Allow `celestial_brew` expr to resolve to `celestial_infusion` expr to allow for easier APL construction.**
- **clang-format**
