### PR TITLE
[Gear] Automatic Footbomb Dispenser uses meteor split scaling

### DIFF
--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -9438,8 +9438,7 @@ void automatic_footbomb_dispenser( special_effect_t& effect )
     automatic_footbomb_dispenser_proxy_buff_t( const special_effect_t& e )
       : buff_t( e.player, "automatic_footbomb_dispenser", e.player->find_spell( 1234025 ) )
     {
-      auto damage = create_proc_action<generic_aoe_proc_t>( "footbomb_to_the_face", e, 1234219 );
-      damage->split_aoe_damage = false;
+      auto damage = create_proc_action<generic_aoe_proc_t>( "footbomb_to_the_face", e, 1234219, true );
       damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 1 ).average( e );
       damage->base_multiplier *= role_mult( e );
 


### PR DESCRIPTION
https://www.warcraftlogs.com/reports/HCQw3TxN7hvrAztb?fight=8&type=damage-done&source=79&ability=1234219&view=events

1 target - 802670
2 target - 521736 * 2
3 target - 431551 * 3
...
9 target - 224766 * 9