### PR TITLE
[Action] streamline action_ready() for call_action_list & variable

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -4605,6 +4605,11 @@ call_action_list_t::call_action_list_t( player_t* player, util::string_view opti
 
 bool call_action_list_t::action_ready()
 {
+  // TODO: require a valid target for now. possibly change to `target = player` to allow call_action_list evaluation
+  // during dungeon sim downtime
+  if ( target && target->is_sleeping() )
+    return false;
+
   if ( line_cooldown->down() )
     return false;
 

--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -4603,6 +4603,17 @@ call_action_list_t::call_action_list_t( player_t* player, util::string_view opti
   }
 }
 
+bool call_action_list_t::action_ready()
+{
+  if ( line_cooldown->down() )
+    return false;
+
+  if ( if_expr && !if_expr->success() )
+    return false;
+
+  return true;
+}
+
 swap_action_list_t::swap_action_list_t( player_t* player, util::string_view options_str,
                                         util::string_view name ) :
     action_t( ACTION_OTHER, name, player ),

--- a/engine/action/action.hpp
+++ b/engine/action/action.hpp
@@ -1232,6 +1232,7 @@ struct call_action_list_t : public action_t
   action_priority_list_t* alist;
 
   call_action_list_t( player_t*, util::string_view );
+  bool action_ready() override;
   void execute() override
   { assert( 0 ); }
 };

--- a/engine/action/variable.cpp
+++ b/engine/action/variable.cpp
@@ -380,6 +380,17 @@ void variable_t::execute()
   }
 }
 
+bool variable_t::action_ready()
+{
+  if ( line_cooldown->down() )
+    return false;
+
+  if ( if_expr && !if_expr->success() )
+    return false;
+
+  return true;
+}
+
 void cycling_variable_t::execute()
 {
   if (sim->target_non_sleeping_list.size() > 1)

--- a/engine/action/variable.cpp
+++ b/engine/action/variable.cpp
@@ -382,6 +382,9 @@ void variable_t::execute()
 
 bool variable_t::action_ready()
 {
+  if ( !select_target() )
+    return false;
+
   if ( line_cooldown->down() )
     return false;
 

--- a/engine/action/variable.hpp
+++ b/engine/action/variable.hpp
@@ -45,6 +45,8 @@ struct variable_t : public action_t
 
   // Note note note, doesn't do anything that a real action does
   void execute() override;
+
+  bool action_ready() override;
 };
 
 struct cycling_variable_t : public variable_t


### PR DESCRIPTION
Instead of unnecessarily processing the the full action_t::action_ready(), only check for `line_cd` and `if=` to reduce iteration time.