### PR TITLE
[Warlock] Implementing ingame bugs and simc fixes to Wither and HoG

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -122,7 +122,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                                  {
                                    // TOCHECK: 2025-08-16 Currently Hellcaller TWW3 B4 (Maintained Withering) tier bonus
                                    // of doing Blackened Soul damage faster is bugged for destruction and does not work
-                                   if ( p.bugs || p.specialization() != WARLOCK_DESTRUCTION )
+                                   if ( !p.bugs || p.specialization() != WARLOCK_DESTRUCTION )
                                    {
                                      period *= 1.0 + p.buffs.maintained_withering->data()
                                                          .effectN( p.specialization() == WARLOCK_AFFLICTION ? 2 : 3 )

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -119,9 +119,16 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                                  timespan_t period = b->buff_period;
 
                                  if ( p.buffs.maintained_withering->check() )
-                                   period *= 1.0 + p.buffs.maintained_withering->data()
-                                                       .effectN( p.specialization() == WARLOCK_AFFLICTION ? 2 : 3 )
-                                                       .percent();
+                                 {
+                                   // TOCHECK: 2025-08-16 Currently Hellcaller TWW3 B4 (Maintained Withering) tier bonus
+                                   // of doing Blackened Soul damage faster is bugged for destruction and does not work
+                                   if ( p.bugs || p.specialization() != WARLOCK_DESTRUCTION )
+                                   {
+                                     period *= 1.0 + p.buffs.maintained_withering->data()
+                                                         .effectN( p.specialization() == WARLOCK_AFFLICTION ? 2 : 3 )
+                                                         .percent();
+                                   }
+                                 }
                                  return period;
                                } );
 
@@ -500,7 +507,7 @@ double warlock_t::composite_mastery() const
 {
   double m = player_t::composite_mastery();
 
-  if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } && talents.master_summoner.ok() )
+  if ( talents.master_summoner.ok() )
     m += talents.master_summoner->effectN( 3 ).base_value();
 
   return m;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -321,8 +321,8 @@ public:
     player_talent_t the_expendables; // Per-pet stacking buff to damage when a Wild Imp expires
     const spell_data_t* the_expendables_buff;
     player_talent_t blood_invocation;
-    player_talent_t umbral_blaze; // TOCHECK: What is the duration behavior on refresh?
-    const spell_data_t* umbral_blaze_dot;
+    player_talent_t umbral_blaze;
+    const spell_data_t* umbral_blaze_dot; // Rolling Periodic DoT with DOT_ROLLING default refresh behavior
     player_talent_t reign_of_tyranny;
     const spell_data_t* reign_of_tyranny_buff;
     player_talent_t demonic_calling;
@@ -535,11 +535,11 @@ public:
     player_talent_t hatefury_rituals;
     player_talent_t bleakheart_tactics;
 
-    player_talent_t mark_of_xavius; // TODO: This is almost certainly bugged and applying to Wither for Affliction
-    player_talent_t seeds_of_their_demise; // TODO: This still has data buffing Blackened Soul
+    player_talent_t mark_of_xavius;
+    player_talent_t seeds_of_their_demise;
     player_talent_t mark_of_perotharn;
 
-    player_talent_t malevolence; // TODO: While buff is active this guarantees Blackened Soul, but this could be leftover from earlier versions
+    player_talent_t malevolence;
     const spell_data_t* malevolence_buff;
     const spell_data_t* malevolence_dmg;
 
@@ -762,7 +762,7 @@ public:
     proc_t* demonic_core_dogs;
     proc_t* demonic_core_imps;
     proc_t* carnivorous_stalkers;
-    proc_t* shadow_invocation; // Bilescourge Bomber proc on most spells
+    proc_t* shadow_invocation; // Bilescourge Bomber proc on Shadowbolt, Demonbolt and HoG Impacts
     proc_t* imp_gang_boss;
     proc_t* spiteful_reconstitution;
     proc_t* umbral_blaze;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -132,8 +132,7 @@ using namespace helpers;
       affected_by.xalans_cruelty_td = data().affected_by( p->hero.xalans_cruelty->effectN( 4 ) );
       affected_by.xalans_cruelty_crit = data().affected_by( p->hero.xalans_cruelty->effectN( 1 ) );
 
-      if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-        affected_by.master_summoner = data().affected_by( p->talents.master_summoner->effectN( 2 ) );
+      affected_by.master_summoner = data().affected_by( p->talents.master_summoner->effectN( 2 ) );
 
       triggers.decimation = p->talents.decimation.ok();
     }
@@ -209,7 +208,8 @@ using namespace helpers;
           if ( destruction() )
             adjustment = -timespan_t::from_seconds( p()->hero.diabolic_ritual->effectN( 2 ).base_value() );
 
-          if ( demonology() && p()->hero.infernal_machine.ok() && p()->warlock_pet_list.demonic_tyrants.n_active_pets() > 0 )
+          // TOCHECK: 2025-08-16 Currently Infernal Machine talent is bugged for Demonology and does not work
+          if ( demonology() && !p()->bugs && p()->hero.infernal_machine.ok() && p()->warlock_pet_list.demonic_tyrants.n_active_pets() > 0 )
             adjustment += -p()->hero.infernal_machine->effectN( 1 ).time_value();
 
           if ( destruction() && p()->hero.infernal_machine.ok() && p()->warlock_pet_list.infernals.n_active_pets() > 0 )
@@ -698,7 +698,8 @@ using namespace helpers;
 
       if ( destruction() && affected_by.havoc )
       {
-        base_aoe_multiplier *= p()->talents.havoc_debuff->effectN( 1 ).percent() + p()->hero.gloom_of_nathreza->effectN( 2 ).percent();
+        // TOCHECK: 2025-08-16 Currently Gloom of Nathreza talent is bugged for Destruction and does not work
+        base_aoe_multiplier *= p()->talents.havoc_debuff->effectN( 1 ).percent() + ( !p()->bugs ? p()->hero.gloom_of_nathreza->effectN( 2 ).percent() : 0.0 );
         p()->havoc_spells.push_back( this );
       }
 
@@ -1342,8 +1343,23 @@ using namespace helpers;
           }
         }
 
+        // Seeds of their Demise collapse conditions must be checked periodically for every Wither tick
+        if ( !td( d->target )->debuffs_blackened_soul->check() )
+        {
+          bool collapse = false;
+          collapse = collapse || ( p()->hero.seeds_of_their_demise.ok() && d->current_stack() > 1 && d->target->health_percentage() <= p()->hero.seeds_of_their_demise->effectN( 2 ).base_value() ) ;
+          collapse = collapse || ( p()->hero.seeds_of_their_demise.ok() && d->current_stack() >= as<int>( p()->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
+          if ( collapse )
+          {
+            td( d->target )->debuffs_blackened_soul->trigger();
+            p()->sim->print_debug( "{} wither stack collapse in {} started (seeds of their demise) (wither tick check). wither_current_stack={}, wither_target_health_percentage={:.2f}%",
+                                   p()->name(), d->target->name(), d->current_stack(), d->target->health_percentage() );
+          }
+        }
+
         if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && rng().roll( p()->rng_settings.mark_of_perotharn.setting_value ) )
         {
+          // Wither stack gain by Mark of Perotharn does not directly trigger collapse in that tick (it will be trigged on the next tick)
           d->increment( 1 );
           p()->procs.mark_of_perotharn->occur();
         }
@@ -1354,8 +1370,26 @@ using namespace helpers;
         double m = warlock_spell_t::composite_crit_damage_bonus_multiplier();
 
         m *= 1.0 + p()->hero.mark_of_perotharn->effectN( 1 ).percent();
+        // Mark of Perotharn is being applied twice in what appears to be a bug
+        m *= 1.0 + ( p()->bugs ? p()->hero.mark_of_perotharn->effectN( 1 ).percent() : 0.0 );
 
         return m;
+      }
+
+      void trigger_dot( action_state_t* s ) override
+      {
+        warlock_spell_t::trigger_dot( s );
+
+        timespan_t duration = composite_dot_duration( s );
+        if ( duration <= timespan_t::zero() )
+          return;
+
+        auto& dot = td( s->target )->dots_wither;
+        // In simc dots increase their stack count when refreshed.
+        // Ingame, however, Wither does not increase stacks on dot refresh.
+        // Therefore, its stack count should be decreased by 1 after refreshing to match ingame behavior.
+        if ( dot->is_ticking() && dot->current_stack() > 1 )
+          dot->decrement( 1 );
       }
     };
 
@@ -1403,6 +1437,7 @@ using namespace helpers;
 
       if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && rng().roll( p()->rng_settings.mark_of_perotharn.setting_value ) )
       {
+        // Wither stack gain by Mark of Perotharn does not directly trigger collapse (it will be trigged on the next Wither tick)
         td( s->target )->dots_wither->increment( 1 );
         p()->procs.mark_of_perotharn->occur();
       }
@@ -1413,6 +1448,8 @@ using namespace helpers;
       double m = warlock_spell_t::composite_crit_damage_bonus_multiplier();
 
       m *= 1.0 + p()->hero.mark_of_perotharn->effectN( 1 ).percent();
+      // TOCHECK: 2025-08-16 Mark of Perotharn is being applied twice in what appears to be a bug
+      m *= 1.0 + ( p()->bugs ? p()->hero.mark_of_perotharn->effectN( 1 ).percent() : 0.0 );
 
       return m;
     }
@@ -1453,17 +1490,32 @@ using namespace helpers;
       return m;
     }
 
+    void execute() override
+    {
+      // Wither stack decrement is done before damage. Relevant for Mark of Xavius talent.
+      // (e.g.) Blackened Soul where 10 to 9 stacks: Mark of Xavius talent bonus damage is calculated on 9 stacks.
+      if ( td( target )->dots_wither->current_stack() > 1 && !p()->buffs.maintained_withering->check() )
+        td( target )->dots_wither->decrement( 1 );
+
+      warlock_spell_t::execute();
+    }
+
     void impact( action_state_t* s ) override
     {
       warlock_spell_t::impact( s );
 
       player_t* tar = s->target;
 
-      if ( td( tar )->dots_wither->current_stack() > 1 && !p()->buffs.maintained_withering->check() )
-        td( tar )->dots_wither->decrement( 1 );
-
       if ( td( tar )->dots_wither->current_stack() <= 1 )
-        make_event( *sim, 0_ms, [ this, tar ] { td( tar )->debuffs_blackened_soul->expire(); } );
+      {
+        make_event( *sim, 0_ms, [ this, tar ] {
+          if ( td( tar )->debuffs_blackened_soul->check() )
+          {
+            td( tar )->debuffs_blackened_soul->expire();
+            p()->sim->print_debug( "{} wither stack collapse in {} ended. wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots_wither->current_stack() );
+          }
+        } );
+      }
 
       bool seeds_triggered = false;
 
@@ -2718,31 +2770,88 @@ using namespace helpers;
 
     struct hog_impact_t : public warlock_spell_t
     {
-      int shards_used;
+      struct hogi_state_t {
+        int shards_used;
+        bool rancora_empowered;
+        int first_hit_random_target;
+        bool allow_umbral_blaze;
+        bool allow_succulent_soul;
+
+        hogi_state_t()
+          : shards_used( 0 ),
+          rancora_empowered( false ),
+          first_hit_random_target( 0 ),
+          allow_umbral_blaze( true ),
+          allow_succulent_soul( true )
+        { }
+      };
+
+      struct hog_impact_state_t : public action_state_t
+      {
+        hogi_state_t state;
+
+        hog_impact_state_t( action_t* action, player_t* target )
+          : action_state_t( action, target ),
+          state()
+        { }
+
+        void initialize() override
+        {
+          action_state_t::initialize();
+          state.shards_used = 0;
+          state.rancora_empowered = false;
+          state.first_hit_random_target = 0;
+          state.allow_umbral_blaze = true;
+          state.allow_succulent_soul = true;
+        }
+
+        std::ostringstream& debug_str( std::ostringstream& s ) override
+        {
+          action_state_t::debug_str( s );
+          s << " shards_used=" << state.shards_used;
+          s << " rancora_empowered=" << state.rancora_empowered;
+          s << " first_hit_random_target=" << state.first_hit_random_target;
+          s << " allow_umbral_blaze=" << state.allow_umbral_blaze;
+          s << " allow_succulent_soul=" << state.allow_succulent_soul;
+          return s;
+        }
+
+        void copy_state( const action_state_t* s ) override
+        {
+          action_state_t::copy_state( s );
+          state = debug_cast<const hog_impact_state_t*>( s )->state;
+        }
+      };
+
       timespan_t meteor_time;
-      bool rancora_empowered;
-      int rancora_random_target;
+      hogi_state_t state;
       umbral_blaze_dot_t* blaze;
 
       hog_impact_t( warlock_t* p )
         : warlock_spell_t( "Hand of Gul'dan (Impact)", p, p->warlock_base.hog_impact ),
-        shards_used( 0 ),
-        meteor_time( 400_ms ),
-        rancora_empowered( false ),
-        rancora_random_target( 0 )
+        meteor_time( 400_ms )
       {
         aoe = -1;
         dual = true;
 
         affected_by.touch_of_rancora = affected_by.touch_of_rancora_casted = p->hero.touch_of_rancora.ok();
 
-        triggers.shadow_invocation = true;
+        triggers.shadow_invocation = true;  // all HoG impacts can proc SI, including the ones from Ruination and Pact of the Imp Mother
 
         if ( p->talents.umbral_blaze.ok() )
         {
           blaze = new umbral_blaze_dot_t( p );
           add_child( blaze );
         }
+      }
+
+      action_state_t* new_state() override
+      { return new hog_impact_state_t( this, target ); }
+
+      void snapshot_state( action_state_t* s, result_amount_type rt ) override
+      {
+        debug_cast<hog_impact_state_t*>( s )->state = state;
+        warlock_spell_t::snapshot_state( s, rt );
       }
 
       timespan_t travel_time() const override
@@ -2752,8 +2861,16 @@ using namespace helpers;
       {
         double m = warlock_spell_t::composite_da_multiplier( s );
 
+        int first_hit_random_target = debug_cast<const hog_impact_state_t*>( s )->state.first_hit_random_target;
+
+        // TOCHECK: 2025-08-16 Due to a bug, Succulent Soul only affects one of the targets hit in AoE
+        bool allow_succulent_soul = debug_cast<const hog_impact_state_t*>( s )->state.allow_succulent_soul;
+        if ( soul_harvester() && allow_succulent_soul && p()->buffs.succulent_soul->check() && ( !p()->bugs || s->chain_target == first_hit_random_target ) )
+          m *= 1.0 + p()->hero.succulent_soul->effectN( 3 ).percent();
+
         // Touch of Rancora only affects one of HoG's hits in AoE (bug?), randomly selected
-        if ( diabolist() && affected_by.touch_of_rancora && rancora_empowered && ( !p()->bugs || s->chain_target == rancora_random_target ) )
+        bool rancora_empowered = debug_cast<const hog_impact_state_t*>( s )->state.rancora_empowered;
+        if ( diabolist() && affected_by.touch_of_rancora && rancora_empowered && ( !p()->bugs || s->chain_target == first_hit_random_target ) )
         {
           // NOTE: Touch of Rancora is a +100% ADDITION to the MULTIPLIER (bug?), we currently believe this must be done at the end of action_multiplier() calculation
           if ( p()->bugs )
@@ -2774,12 +2891,9 @@ using namespace helpers;
 
       void execute() override
       {
-        if ( diabolist() && affected_by.touch_of_rancora && rancora_empowered )
-        {
-          // NOTE: Touch of Rancora only affects one of HoG's hits in AoE (bug?), randomly selected
-          const std::vector<player_t*>& tl = target_list();
-          rancora_random_target = rng().range( as<int>( tl.size() ) );
-        }
+        // NOTE: Some effects only affects one of HoG's hits in AoE (bug?), randomly selected
+        const std::vector<player_t*>& tl = target_list();
+        state.first_hit_random_target = rng().range( as<int>( tl.size() ) );
 
         warlock_spell_t::execute();
       }
@@ -2791,12 +2905,9 @@ using namespace helpers;
         double gloom = 0.0;
 
         if ( p()->hero.gloom_of_nathreza.ok() )
-           gloom = shards_used * p()->hero.gloom_of_nathreza->effectN( 1 ).percent();
+           gloom = state.shards_used * p()->hero.gloom_of_nathreza->effectN( 1 ).percent();
 
-        m *= shards_used * ( 1.0 + gloom );
-
-        if ( soul_harvester() && p()->buffs.succulent_soul->check() )
-          m *= 1.0 + p()->hero.succulent_soul->effectN( 3 ).percent();
+        m *= state.shards_used * ( 1.0 + gloom );
 
         return m;
       }
@@ -2813,13 +2924,13 @@ using namespace helpers;
           // Current behavior: HoG will spawn a meteor on cast finish. Travel time in spell data is 0.7 seconds.
           // However, damage event occurs before spell effect lands, happening 0.4 seconds after cast.
           // Imps then spawn roughly every 0.18 seconds seconds after the damage event.
-          for ( int i = 1; i <= shards_used; i++ )
+          for ( int i = 1; i <= debug_cast<hog_impact_state_t*>( s )->state.shards_used; i++ )
           {
             auto ev = make_event<imp_delay_event_t>( *sim, p(), rng().gauss( 180.0 * i, 25.0 ), 180.0 * i );
             p()->wild_imp_spawns.push_back( ev );
           }
 
-          if ( p()->talents.umbral_blaze.ok() && rng().roll( p()->talents.umbral_blaze->effectN( 1 ).percent() ) )
+          if ( p()->talents.umbral_blaze.ok() && debug_cast<hog_impact_state_t*>( s )->state.allow_umbral_blaze && rng().roll( p()->talents.umbral_blaze->effectN( 1 ).percent() ) )
           {
             blaze->execute_on_target( s->target );
             p()->procs.umbral_blaze->occur();
@@ -2827,7 +2938,9 @@ using namespace helpers;
         }
 
         // We need Demonic Soul to proc on every target, but buff is decremented on impact. Fudge this by 1ms to ensure all targets are hit.
-        if ( soul_harvester() && p()->buffs.succulent_soul->check() )
+        // TOCHECK: 2025-08-16 Due to a bug, Succulent Soul only affects one of the targets hit in AoE
+        // We keep the original buff decrement behavior and handle this bug from 'composite_da_multiplier()'
+        if ( soul_harvester() && debug_cast<hog_impact_state_t*>( s )->state.allow_succulent_soul && p()->buffs.succulent_soul->check() )
         {
           bool primary = ( s->chain_target == 0 );
 
@@ -2892,20 +3005,22 @@ using namespace helpers;
     void execute() override
     {
       int shards_used = as<int>( cost() );
-      impact_spell->shards_used = shards_used;
+      impact_spell->state.shards_used = shards_used;
       if ( pre_execute_state )
       {
         snapshot_state( pre_execute_state, amount_type( pre_execute_state ) );
         // An incoming rancora empowered casted spell will remain empowered even if the Demonic Art buff falls off during cast
-        impact_spell->rancora_empowered = debug_cast<hand_of_guldan_state_t*>( pre_execute_state )->rancora_empowered;
+        impact_spell->state.rancora_empowered = debug_cast<hand_of_guldan_state_t*>( pre_execute_state )->rancora_empowered;
         // Casted spells do not consume any Demonic Art buff if none were active at the start of the cast
         triggers.demonic_art_buff = debug_cast<hand_of_guldan_state_t*>( pre_execute_state )->demonic_art_buffed;
       }
       else
       {
-        impact_spell->rancora_empowered = false;
+        impact_spell->state.rancora_empowered = false;
         triggers.demonic_art_buff = false;
       }
+      impact_spell->state.allow_umbral_blaze = true;
+      impact_spell->state.allow_succulent_soul = true;
 
       warlock_spell_t::execute();
 
@@ -2967,10 +3082,14 @@ using namespace helpers;
 
       if ( p()->talents.pact_of_the_imp_mother.ok() && rng().roll( p()->talents.pact_of_the_imp_mother->effectN( 1 ).percent() ) )
       {
-        make_event( *sim, 0_ms, [ this, t = target ] {
-          impact_spell->rancora_empowered = false;  // Pact of the Imp Mother extra HoG is never rancora empowered
-          impact_spell->execute_on_target( t );
-        } );
+        make_event( *sim, rng().gauss( impact_spell->travel_time(), timespan_t::from_seconds( sim->travel_variance ) ),
+          [ this, t = target, su = impact_spell->state.shards_used ] {
+            impact_spell->state.shards_used = su;
+            impact_spell->state.rancora_empowered = false;    // Pact of the Imp Mother extra HoG is never rancora empowered
+            impact_spell->state.allow_umbral_blaze = false;   // Pact of the Imp Mother extra HoG can't proc umbral blaze
+            impact_spell->state.allow_succulent_soul = false; // Pact of the Imp Mother extra HoG can't benefit from succulent soul
+            impact_spell->execute_on_target( t );
+          } );
         p()->procs.pact_of_the_imp_mother->occur();
       }
     }
@@ -4918,6 +5037,8 @@ using namespace helpers;
   {
     struct ruination_impact_t : public warlock_spell_t
     {
+      hand_of_guldan_t::hog_impact_t* hog_impact_spell;
+
       ruination_impact_t( warlock_t* p )
         : warlock_spell_t( "Ruination (Impact)", p, p->hero.ruination_impact )
       {
@@ -4927,6 +5048,11 @@ using namespace helpers;
 
         affected_by.chaotic_energies = true;
         affected_by.backdraft = true;
+
+        if ( demonology() )
+        {
+          hog_impact_spell = new hand_of_guldan_t::hog_impact_t( p );
+        }
       }
 
       void impact( action_state_t* s ) override
@@ -4937,11 +5063,13 @@ using namespace helpers;
         {
           if ( demonology() )
           {
-            for ( int i = 1; i <= as<int>( p()->hero.ruination_buff->effectN( 2 ).base_value() ); i++ )
-            {
-              auto ev = make_event<imp_delay_event_t>( *sim, p(), rng().gauss( 180.0 * i, 25.0 ), 180.0 * i );
-              p()->wild_imp_spawns.push_back( ev );
-            }
+            make_event( *sim, 0_ms, [ this, t = target ] {
+              hog_impact_spell->state.shards_used = as<int>( p()->hero.ruination_buff->effectN( 2 ).base_value() );
+              hog_impact_spell->state.rancora_empowered = false;      // Ruination HoG impact is never rancora empowered
+              hog_impact_spell->state.allow_umbral_blaze = false;     // Ruination HoG impact can't proc umbral blaze
+              hog_impact_spell->state.allow_succulent_soul = false;   // Ruination HoG impact can't benefit from succulent soul
+              hog_impact_spell->execute_on_target( t );
+            } );
           }
 
           if ( destruction() )
@@ -5178,18 +5306,24 @@ using namespace helpers;
         p->procs.bleakheart_tactics->occur();
       }
 
-      bool collapse = false; // 2024-09-06 Malevolence no longer initiates collapse automatically
-      collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && target->health_percentage() <= p->hero.seeds_of_their_demise->effectN( 2 ).base_value() ) ;
-      collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots_wither->current_stack() >= as<int>( p->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
+      if ( !tdata->debuffs_blackened_soul->check() )
+      {
+        bool collapse = false; // 2024-09-06 Malevolence no longer initiates collapse automatically
+        collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots_wither->current_stack() > 1 && target->health_percentage() <= p->hero.seeds_of_their_demise->effectN( 2 ).base_value() ) ;
+        collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots_wither->current_stack() >= as<int>( p->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
 
-      if ( collapse )
-      {
-        tdata->debuffs_blackened_soul->trigger();
-      }
-      else if ( p->rng().roll( p->rng_settings.blackened_soul.setting_value ) )
-      {
-        tdata->debuffs_blackened_soul->trigger();
-        p->procs.blackened_soul->occur();
+        if ( collapse )
+        {
+          tdata->debuffs_blackened_soul->trigger();
+          p->sim->print_debug( "{} wither stack collapse in {} started (seeds of their demise) (stack gain check). wither_current_stack={}, wither_target_health_percentage={:.2f}%",
+                      p->name(), target->name(), tdata->dots_wither->current_stack(), target->health_percentage() );
+        }
+        else if ( p->rng().roll( p->rng_settings.blackened_soul.setting_value ) )
+        {
+          tdata->debuffs_blackened_soul->trigger();
+          p->procs.blackened_soul->occur();
+          p->sim->print_debug( "{} wither stack collapse in {} started (blackened soul proc)", p->name(), target->name() );
+        }
       }
 
       if ( malevolence )

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -511,13 +511,10 @@ namespace warlock
     tier.demonfire_flurry = find_spell( 1217731 );
 
     // Manaforge omega
-    if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-    {
-      tier.rampaging_demonic_soul = find_spell( 1239689 );
-      tier.demonic_oculus         = find_spell( 1238810 );
-      tier.eye_blast              = find_spell( 1239510 );
-      tier.demonic_intelligence   = find_spell( 1239569 );
-    }
+    tier.rampaging_demonic_soul = find_spell( 1239689 );
+    tier.demonic_oculus         = find_spell( 1238810 );
+    tier.eye_blast              = find_spell( 1239510 );
+    tier.demonic_intelligence   = find_spell( 1239569 );
 
     // Initialize some default values for pet spawners
     warlock_pet_list.infernals.set_default_duration( talents.summon_infernal_main->duration() );
@@ -951,14 +948,11 @@ namespace warlock
 
     buffs.ruination = make_buff( this, "ruination", hero.ruination_buff );
 
-    if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-    {
-      buffs.demonic_oculus = make_buff( this, "demonic_oculus", tier.demonic_oculus );
+    buffs.demonic_oculus = make_buff( this, "demonic_oculus", tier.demonic_oculus );
 
-      buffs.demonic_intelligence = make_buff( this, "demonic_intelligence", tier.demonic_intelligence )
-                                       ->set_pct_buff_type( STAT_PCT_BUFF_INTELLECT )
-                                       ->set_default_value_from_effect_type( A_MOD_TOTAL_STAT_PERCENTAGE );
-    }
+    buffs.demonic_intelligence = make_buff( this, "demonic_intelligence", tier.demonic_intelligence )
+                                      ->set_pct_buff_type( STAT_PCT_BUFF_INTELLECT )
+                                      ->set_default_value_from_effect_type( A_MOD_TOTAL_STAT_PERCENTAGE );
   }
 
   void warlock_t::create_buffs_hellcaller()

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2355,8 +2355,7 @@ namespace diabolist
       if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
       {
         // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
-        if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
         // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
         m *= 1.0 + p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent();
       }
@@ -2364,8 +2363,7 @@ namespace diabolist
       if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
       {
         // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
         // Destruction Aura Double Dips due to Diabolist Demon spells being whitelisted on effect 1.
         m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
         // Destruction Summoners Embrace also Double Dip due to the same fact.
@@ -2436,8 +2434,7 @@ namespace diabolist
       if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
       {
         // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
-        if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
         // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
         m *= 1.0 + p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent();
       }
@@ -2445,8 +2442,7 @@ namespace diabolist
       if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
       {
         // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
         // Destruction Aura Double Dips due to Diabolist Demon spells being whitelisted on effect 1.
         m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
         // Destruction Summoners Embrace also Double Dip due to the same fact.
@@ -2525,9 +2521,8 @@ namespace diabolist
       double m = spell_t::composite_target_multiplier( target );
 
       // TOCHECK: 2025-07-27 Despite what is listed in spell data, Shadowtouched increases the damage of Feelseeker spell from Pit Lord by 25% instead of 20% (bug?)
-      // TODO: After 11.2.0 goes live, remove the wow version check
       if ( p()->o()->talents.shadowtouched.ok() && dbc::has_common_school( spell_t::get_school(), SCHOOL_SHADOW ) && owner_td( target )->debuffs_wicked_maw->check() )
-        m *= 1.0 + ( ( p()->bugs && ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } ) ) ? shadowtouched_value : p()->o()->talents.shadowtouched->effectN( 1 ).percent() );
+        m *= 1.0 + ( ( p()->bugs ) ? shadowtouched_value : p()->o()->talents.shadowtouched->effectN( 1 ).percent() );
 
       return m;
     }
@@ -2539,8 +2534,7 @@ namespace diabolist
       if ( p()->o()->specialization() == WARLOCK_DEMONOLOGY )
       {
         // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
-        if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
         // Wicked Cleave is mistakenly whitelisted on Effect 1 for Demonology Aura, Double Dipping alongside effect 5.
         m *= 1.0 + p()->o()->warlock_base.demonology_warlock->effectN( 1 ).percent();
       }
@@ -2548,8 +2542,7 @@ namespace diabolist
       if ( p()->o()->specialization() == WARLOCK_DESTRUCTION )
       {
         // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
-        if ( sim->dbc->wowv() >= wowv_t{ 11, 2, 0 } )
-          m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
+        m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
         // Destruction Aura Double Dips due to Diabolist Demon spells being whitelisted on effect 1.
         m *= 1.0 + p()->o()->warlock_base.destruction_warlock->effectN( 1 ).percent();
         // Destruction Summoners Embrace also Double Dip due to the same fact.


### PR DESCRIPTION
This PR includes several modifications to the warlock module, fixing some features and making some other changes detailed below.

Some ingame bugs have been included in simc. These may be fixed by Blizzard in the future, in which case they will also need to be modified in simc. These bugs can be disabled with the `bugs=0` parameter in Simc, and a `// TOCHECK` comment has been added in the code implementation of these for easier tracking.

**INGAME BUGS (2025-08-16):**
- Currently the [Hellcaller 4-tier bonus](https://www.wowhead.com/spell=1236414/warlock-hellcaller-11-2-class-set-4pc) is bugged for Destruction: the Blackened Soul should do the damage +15% faster, but this is not being applied. It is working OK for Affliction. 
- [Infernal Machine](https://www.wowhead.com/spell=429917/infernal-machine) talent is bugged for Demonology and does not work. It is working OK for Destruction. 
- [Gloom of Nathreza](https://www.wowhead.com/spell=429899/gloom-of-nathreza) talent is bugged for Destruction and does not work. It is working OK for Demonology. 
- [Mark of Perotharn](https://www.wowhead.com/spell=440045/mark-of-perotharn) talent is being applied twice in what appears to be a bug (resulting in 21% instead of 10%). This happens for both Destruction and Affliction.
- [Succulent Soul](https://www.wowhead.com/spell=449793/succulent-soul) +60% bonus HoG dmg only affects one of the targets hit in AoE for Demonology. It is working OK for Affliction.

**OTHER SIMC CHANGES:**
- Version checks `>=11.2.0` have been removed from the warlock module code, as this version is already live.
- Some `// TODO` comments that no longer apply to the current situation have been removed.
- Refreshing the [Wither](https://www.wowhead.com/spell=445474/wither) DoT no longer increments its stacks.
- The Wither stack decrement is now done just before [Blackened Soul](https://www.wowhead.com/spell=445736/blackened-soul) damage. Relevant for [Mark of Xavius](https://www.wowhead.com/spell=440046/mark-of-xavius) talent. (e.g.) [Blackened Soul](https://www.wowhead.com/spell=445736/blackened-soul) where 10 to 9 stacks: Mark of Xavius talent bonus damage is calculated on 9 stacks.
- Wither stack collapse has been improved:
	- [Wither](https://www.wowhead.com/spell=445474/wither) ticks can now cause collapse if the conditions are met, as is the case ingame.
	- Wither stack gain by [Mark of Perotharn](https://www.wowhead.com/spell=440045/mark-of-perotharn) does not directly trigger collapse in that tick (it will begin collapsing on the next tick).
	- Debug messages have been added to make it easier to identify when a collapse starts and ends.
- The delay for the extra [HoG impact](https://www.wowhead.com/spell=86040/hand-of-guldan) spell triggered by [PotIM](https://www.wowhead.com/spell=387541/pact-of-the-imp-mother) talent proc has been adjusted based on ingame observations.
- Various changes to [Ruination](https://www.wowhead.com/spell=434636/ruination) for Demonology: it now triggers a 3-shard [HoG impact](https://www.wowhead.com/spell=86040/hand-of-guldan), as is the case ingame. In fact, it is this [HoG impact](https://www.wowhead.com/spell=86040/hand-of-guldan) that summons Wild Imps, not [Ruination](https://www.wowhead.com/spell=434636/ruination). The sequence is as follows:
`Ruination[execute] -> 1_sec (travel_time) -> Ruinaion[impact] -> HoG_impact[execute] -> 400_ms (travel_time) -> HoG_impact[impact] -> imps_start_to_spawn`
- The [HoG impact](https://www.wowhead.com/spell=86040/hand-of-guldan) spell is used ingame in three places: regular [HoG](https://www.wowhead.com/spell=105174/hand-of-guldan) casting, [PotIM](https://www.wowhead.com/spell=387541/pact-of-the-imp-mother) proc talent, [Ruination impact](https://www.wowhead.com/spell=434636/ruination). In each case, the spell can behave differently: it may or may not be affected by [Touch of Rancora](https://www.wowhead.com/spell=429893/touch-of-rancora) and/or [Succulent Soul](https://www.wowhead.com/spell=449793/succulent-soul), and it may or may not be able to trigger [Umbral Blaze](https://www.wowhead.com/spell=405802/umbral-blaze). Additionally, its damage varies depending on the number of shards used. Since there are so many modifiers and it is a spell with `travel_time` and executed from several other spells, we decided to create a custom `action_state_t` where all these modifiers can be managed correctly without different executions affecting each other. There were also some bugs related to this that have been fixed in the new implementation using this action_state: [Umbral Blaze](https://www.wowhead.com/spell=405802/umbral-blaze) and [Succulent Soul](https://www.wowhead.com/spell=449793/succulent-soul) were always affecting [PotIM](https://www.wowhead.com/spell=387541/pact-of-the-imp-mother) HoG extra proc (and it shouldn't) and [Ruination](https://www.wowhead.com/spell=434635/ruination) HoG extra proc did not exist.