### PR TITLE
[Warlock] Adjustments and fixes to Havoc, Succulent Soul, Feast of Souls, Malefic Rapture, Shared Fate, and others

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -16,7 +16,6 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
 {
   // Shared
   dots_drain_life = target->get_dot( "drain_life", &p );
-  dots_drain_life_aoe = target->get_dot( "drain_life_aoe", &p );
 
   // Affliction
   dots_corruption = target->get_dot( "corruption", &p );
@@ -135,18 +134,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
   // Soul Harvester
   dots_soul_anathema = target->get_dot( "soul_anathema", &p );
 
-  debuffs_shared_fate = make_buff( *this, "shared_fate", p.hero.shared_fate_debuff )
-                            ->set_tick_zero( false )
-                            ->set_tick_time_behavior( buff_tick_time_behavior::HASTED )
-                            ->set_tick_behavior( buff_tick_behavior::REFRESH )
-                            ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC )
-                            ->set_partial_tick( true )
-                            ->set_period( p.hero.shared_fate_debuff->effectN( 1 ).period() )
-                            ->set_tick_callback( [ this, target ]( buff_t* b, int, timespan_t actual_tick_time )
-                              {
-                                helpers::set_shared_fate_tick_factor( &warlock, actual_tick_time.total_seconds() / b->tick_time().total_seconds() );
-                                warlock.proc_actions.shared_fate->execute_on_target( target );
-                              } );
+  dots_shared_fate = target->get_dot( "shared_fate", &p );
 
   target->register_on_demise_callback( &p, [ this ]( player_t* ) { target_demise(); } );
 }
@@ -197,34 +185,31 @@ void warlock_td_t::target_demise()
 
   if ( warlock.hero.demonic_soul.ok() && warlock.hero.shared_fate.ok() )
   {
-    for ( player_t* t : warlock.sim->target_non_sleeping_list )
-    {
-      auto tdata = warlock.get_target_data( t );
+    warlock.sim->print_log( "Player {} demised. Warlock {} triggers Shared Fate on all targets in range.", target->name(), warlock.name() );
 
-      if ( !tdata )
-        continue;
-
-      if ( tdata == this )
-        continue;
-
-      warlock.sim->print_log( "Player {} demised. Warlock {} triggers Shared Fate on {}.", target->name(), warlock.name(), t->name() );
-
-      tdata->debuffs_shared_fate->trigger();
-
-      break;
-    }
+    warlock.proc_actions.shared_fate->execute();
   }
 
-  if ( warlock.hero.demonic_soul.ok() && warlock.hero.feast_of_souls.ok() && warlock.rng().roll( warlock.rng_settings.feast_of_souls.setting_value ) )
+  if ( warlock.hero.demonic_soul.ok() && warlock.hero.feast_of_souls.ok() )
   {
-    warlock.sim->print_log( "Player {} demised. Warlock {} triggers Feast of Souls.", target->name(), warlock.name() );
+    double chance = 0.0;
+    if ( warlock.specialization() == WARLOCK_AFFLICTION )
+      chance = warlock.rng_settings.feast_of_souls_aff.setting_value;
+    if ( warlock.specialization() == WARLOCK_DEMONOLOGY )
+      chance = warlock.rng_settings.feast_of_souls_demo.setting_value;
 
-    warlock.feast_of_souls_gain();
+    if ( warlock.rng().roll( chance ) )
+    {
+      warlock.sim->print_log( "Player {} demised. Warlock {} triggers Feast of Souls.", target->name(), warlock.name() );
+
+      warlock.feast_of_souls_gain();
+    }
   }
 }
 
 int warlock_td_t::count_affliction_dots() const
 {
+  // NOTE: Shared Fate and Soul Anathema DoTs do not count (they do not affect effects influenced by this count)
   int count = 0;
 
   if ( dots_agony->is_ticking() )
@@ -718,7 +703,8 @@ std::string warlock_t::create_profile( save_e stype )
     profile_str += append_rng_option( rng_settings.mark_of_perotharn );
     profile_str += append_rng_option( rng_settings.succulent_soul_aff );
     profile_str += append_rng_option( rng_settings.succulent_soul_demo );
-    profile_str += append_rng_option( rng_settings.feast_of_souls );
+    profile_str += append_rng_option( rng_settings.feast_of_souls_aff );
+    profile_str += append_rng_option( rng_settings.feast_of_souls_demo );
     profile_str += append_rng_option( rng_settings.umbral_lattice );
     profile_str += append_rng_option( rng_settings.empowered_legion_strike );
   }
@@ -752,7 +738,8 @@ void warlock_t::copy_from( player_t* source )
   rng_settings.mark_of_perotharn = p->rng_settings.mark_of_perotharn;
   rng_settings.succulent_soul_aff = p->rng_settings.succulent_soul_aff;
   rng_settings.succulent_soul_demo = p->rng_settings.succulent_soul_demo;
-  rng_settings.feast_of_souls = p->rng_settings.feast_of_souls;
+  rng_settings.feast_of_souls_aff = p->rng_settings.feast_of_souls_aff;
+  rng_settings.feast_of_souls_demo = p->rng_settings.feast_of_souls_demo;
   rng_settings.umbral_lattice = p->rng_settings.umbral_lattice;
   rng_settings.empowered_legion_strike = p->rng_settings.empowered_legion_strike;
 }
@@ -1021,6 +1008,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
 {
   double actual_amount = player_t::resource_gain( resource_type, amount, source, action );
 
+  // Succulent Soul proc from Demonic Soul talent can only occur from a effective soul shard gain (not overflow)
   if ( resource_type == RESOURCE_SOUL_SHARD && actual_amount > 0.0 && hero.demonic_soul.ok() )
   {
     for ( int i = 0; i < as<int>( actual_amount ); i++ )
@@ -1046,7 +1034,11 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
 
 void warlock_t::feast_of_souls_gain()
 {
-  player_t::resource_gain( RESOURCE_SOUL_SHARD, 1.0, gains.feast_of_souls );
+  // TOCHECK: 2025-08-27 The shard gained from Feast of Souls can also proc another Succulent Soul (bug?)
+  if ( bugs )
+    resource_gain( RESOURCE_SOUL_SHARD, 1.0, gains.feast_of_souls );
+  else
+    player_t::resource_gain( RESOURCE_SOUL_SHARD, 1.0, gains.feast_of_souls );
 
   buffs.succulent_soul->trigger();
   procs.succulent_soul->occur();

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -45,7 +45,6 @@ struct warlock_td_t : public actor_target_data_t
   propagate_const<dot_t*> dots_phantom_singularity;
   propagate_const<dot_t*> dots_unstable_affliction;
   propagate_const<dot_t*> dots_vile_taint;
-  propagate_const<dot_t*> dots_drain_life_aoe; // Soul Rot effect
   propagate_const<dot_t*> dots_soul_rot;
   propagate_const<dot_t*> dots_jackpot_ua; // TWW 11.1 4pc version of Unstable Affliction
 
@@ -77,8 +76,7 @@ struct warlock_td_t : public actor_target_data_t
 
   // Soul Harvester
   propagate_const<dot_t*> dots_soul_anathema;
-
-  propagate_const<buff_t*> debuffs_shared_fate;
+  propagate_const<dot_t*> dots_shared_fate;
 
   double soc_threshold; // Aff - Seed of Corruption counts damage from cross-spec spells such as Drain Life
 
@@ -269,7 +267,7 @@ public:
     player_talent_t improved_malefic_rapture;
 
     player_talent_t oblivion;
-    player_talent_t deaths_embrace; // TOCHECK: Volatile Agony/Perpetual Unstability affected?
+    player_talent_t deaths_embrace; // Volatile Agony and Perpetual Unstability are unaffected by this
     player_talent_t dark_harvest; // Buffs from hitting targets with Soul Rot
     const spell_data_t* dark_harvest_buff;
     player_talent_t ravenous_afflictions;
@@ -323,8 +321,6 @@ public:
     player_talent_t blood_invocation;
     player_talent_t umbral_blaze;
     const spell_data_t* umbral_blaze_dot; // Rolling Periodic DoT with DOT_ROLLING default refresh behavior
-    player_talent_t reign_of_tyranny;
-    const spell_data_t* reign_of_tyranny_buff;
     player_talent_t demonic_calling;
     const spell_data_t* demonic_calling_buff;
     player_talent_t fiendish_oblation;
@@ -554,8 +550,7 @@ public:
     player_talent_t demoniacs_fervor;
 
     player_talent_t shared_fate;
-    const spell_data_t* shared_fate_debuff;
-    const spell_data_t* shared_fate_dmg;
+    const spell_data_t* shared_fate_dot;
     player_talent_t feast_of_souls;
 
     player_talent_t wicked_reaping;
@@ -645,7 +640,6 @@ public:
 
     // Affliction Buffs
     propagate_const<buff_t*> nightfall;
-    propagate_const<buff_t*> soul_rot; // Buff for determining if Drain Life is zero cost and aoe. TODO: After 11.1 goes live, remove old AoE Drain Life code
     propagate_const<buff_t*> tormented_crescendo;
     propagate_const<buff_t*> malign_omen;
     propagate_const<buff_t*> dark_harvest_haste; // One buff in game...
@@ -660,7 +654,7 @@ public:
     propagate_const<buff_t*> inner_demons;
     propagate_const<buff_t*> wild_imps; // Buff for tracking how many Wild Imps are currently out (does NOT include imps waiting to be spawned)
     propagate_const<buff_t*> dreadstalkers; // Buff for tracking number of Dreadstalkers currently out
-    propagate_const<buff_t*> vilefiend; // Buff for tracking if Vilefiend is currently out
+    propagate_const<buff_t*> vilefiend; // Buff for tracking number of Vilefiends currently out
     propagate_const<buff_t*> tyrant; // Buff for tracking if Demonic Tyrant is currently out
     propagate_const<buff_t*> grimoire_felguard; // Buff for tracking if GFG pet is currently out
     propagate_const<buff_t*> dread_calling;
@@ -836,9 +830,10 @@ public:
     rng_setting_t mark_of_perotharn = { 0.15, 0.15, "mark_of_perotharn" };
 
     // Soul Harvester
-    rng_setting_t succulent_soul_aff = { 0.20, 0.20, "succulent_soul_aff" };
+    rng_setting_t succulent_soul_aff = { 0.22, 0.22, "succulent_soul_aff" };
     rng_setting_t succulent_soul_demo = { 0.15, 0.15, "succulent_soul_demo" };
-    rng_setting_t feast_of_souls = { 0.125, 0.125, "feast_of_souls" };
+    rng_setting_t feast_of_souls_aff = { 0.15, 0.15, "feast_of_souls" };
+    rng_setting_t feast_of_souls_demo = { 0.0975, 0.0975, "feast_of_souls" };
   } rng_settings;
 
   int initial_soul_shards;
@@ -1004,7 +999,5 @@ namespace helpers
   void trigger_blackened_soul( warlock_t* p, bool malevolence );
 
   void trigger_jackpot_ua( warlock_t* p );
-
-  void set_shared_fate_tick_factor( warlock_t* p, double f );
 }
 }  // namespace warlock

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -698,7 +698,7 @@ using namespace helpers;
 
       if ( destruction() && affected_by.havoc )
       {
-        // TOCHECK: 2025-08-16 Currently Gloom of Nathreza talent is bugged for Destruction and does not work
+        // TOCHECK: 2025-08-27 Currently Gloom of Nathreza talent is bugged for Destruction and does not work
         base_aoe_multiplier *= p()->talents.havoc_debuff->effectN( 1 ).percent() + ( !p()->bugs ? p()->hero.gloom_of_nathreza->effectN( 2 ).percent() : 0.0 );
         p()->havoc_spells.push_back( this );
       }
@@ -834,29 +834,9 @@ using namespace helpers;
 
   struct drain_life_t : public warlock_spell_t
   {
-
-    // Note: Soul Rot (Affliction talent) turns Drain Life into a multi-target channeled spell. Nothing else in simc behaves this way and
-    // we currently do not have core support for it. Applying this dot to the secondary targets should cover most of the behavior, although
-    // it will be unable to handle the case where primary channel target dies (in-game, this appears to force-swap primary target to another
-    // target currently affected by Drain Life if possible).
-    struct drain_life_dot_t : public warlock_spell_t
-    {
-      drain_life_dot_t( warlock_t* p )
-        : warlock_spell_t( "Drain Life (AoE)", p, p->warlock_base.drain_life )
-      { dual = background = true; }
-
-      double cost_per_tick( resource_e ) const override
-      { return 0.0; }
-    };
-    
-    drain_life_dot_t* aoe_dot;
-
     drain_life_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Drain Life", p, p->warlock_base.drain_life, options_str )
     {
-      aoe_dot = new drain_life_dot_t( p );
-      add_child( aoe_dot );
-
       channeled = true;
     }
 
@@ -864,51 +844,7 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      if ( p()->talents.soul_rot.ok() && p()->buffs.soul_rot->check() )
-      {
-        const auto& tl = target_list();
-
-        for ( auto& t : tl )
-        {
-          // Don't apply AoE version to primary target
-          if ( t == target )
-            continue;
-
-          if ( td( t )->dots_soul_rot->is_ticking() )
-            aoe_dot->execute_on_target( t );
-        }
-      }
-
       p()->buffs.soulburn->expire();
-    }
-
-    double cost_per_tick( resource_e r ) const override
-    {
-      if ( r == RESOURCE_MANA && p()->buffs.soul_rot->check() )
-        return 0.0;
-
-      return warlock_spell_t::cost_per_tick( r );
-    }
-
-    void last_tick( dot_t* d ) override
-    {
-      bool early_cancel = d->remains() > 0_ms;
-
-      warlock_spell_t::last_tick( d );
-
-      // If this is the end of the channel, the AoE DoTs will expire correctly
-      // Otherwise, we need to cancel them on the spot
-      if ( p()->talents.soul_rot.ok() && early_cancel )
-      {
-        const auto& tl = target_list();
-
-        for ( auto& t : tl )
-        {
-          auto data = td( t );
-          if ( data->dots_drain_life_aoe->is_ticking() )
-            data->dots_drain_life_aoe->cancel();
-        }
-      }
     }
   };
 
@@ -973,7 +909,8 @@ using namespace helpers;
       base_dd_multiplier *= 1.0 + p->talents.siphon_life->effectN( 1 ).percent();
       base_dd_multiplier *= 1.0 + p->talents.kindled_malice->effectN( 2 ).percent();
 
-      affected_by.deaths_embrace = p->talents.deaths_embrace.ok();
+      // 2025-08-27: Death's Embrace talent is not applying to the Corruption (direct damage) spell (bug)
+      affected_by.deaths_embrace = p->bugs ? false : p->talents.deaths_embrace.ok();
     }
 
     dot_t* get_dot( player_t* t ) override
@@ -1055,10 +992,10 @@ using namespace helpers;
           p()->proc_actions.wicked_reaping->execute_on_target( target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          td( target )->debuffs_shared_fate->trigger();
+          p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls.setting_value ) )
-          p()->feast_of_souls_gain();;
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_aff.setting_value ) )
+          p()->feast_of_souls_gain();
       }
 
       if ( time_to_execute == 0_ms )
@@ -1589,8 +1526,9 @@ using namespace helpers;
     {
       background = dual = true;
 
-      affected_by.potent_afflictions_td = affliction(); // Note: Technically Soul Anathema is on a separate effect from the others.
-      affected_by.master_demonologist_dd = demonology();
+      // Affected by Demonology/Affliction mastery
+      affected_by.master_demonologist_dd = demonology();  
+      affected_by.potent_afflictions_td = affliction();   // Note: Technically Soul Anathema is on a separate effect from the others.
 
       base_td_multiplier *= 1.0 + p->hero.quietus->effectN( 1 ).percent();
       base_tick_time *= 1.0 + p->hero.quietus->effectN( 2 ).percent();
@@ -1610,6 +1548,7 @@ using namespace helpers;
     {
       background = dual = true;
 
+      // Affected by Demonology mastery, but not by Affliction mastery
       affected_by.master_demonologist_dd = demonology(); // Note: Technically Demonic Soul is on a separate effect from the others.
       affected_by.shadowtouched = false; // Note: We set this to false because we will handle it in the overridden 'composite_target_multiplier' function
 
@@ -1648,24 +1587,13 @@ using namespace helpers;
 
   struct shared_fate_t : public warlock_spell_t
   {
-    double tick_factor;
-
     shared_fate_t( warlock_t* p )
-      : warlock_spell_t( "Shared Fate", p, p->hero.shared_fate_dmg )
+      : warlock_spell_t( "Shared Fate", p, p->hero.shared_fate_dot )
     {
+      aoe = -1; // DoT is applied in AoE
       background = dual = true;
-      aoe = -1;
-      reduced_aoe_targets = p->hero.shared_fate->effectN( 1 ).base_value();
-      tick_factor = 1.0;
-    }
 
-    double composite_da_multiplier( const action_state_t* s ) const override
-    {
-      double m = warlock_spell_t::composite_da_multiplier( s );
-
-      m *= tick_factor;
-
-      return m;
+      // Unaffected by Affliction/Demonology mastery
     }
   };
 
@@ -1678,6 +1606,7 @@ using namespace helpers;
     {
       background = dual = true;
 
+      // Affected by Demonology mastery, but not by Affliction mastery
       affected_by.master_demonologist_dd = demonology();
       affected_by.shadowtouched = false; // Note: We set this to false because we will handle it in the overridden 'composite_target_multiplier' function
 
@@ -1735,8 +1664,8 @@ using namespace helpers;
       {
         double m = warlock_spell_t::composite_da_multiplier( s );
 
-        //In-game a stack gets consumed before MT hits, doing it like this is easier
-        if ( soul_harvester() && p()->buffs.succulent_soul->check() > 1 )
+        // TOCHECK: 2025-08-27 In-game a stack gets consumed before MT hits (bug), doing it like this is easier
+        if ( soul_harvester() && p()->buffs.succulent_soul->check() > ( p()->bugs ? 1 : 0 ) )
           m *= 1.0 + p()->hero.succulent_soul->effectN( 2 ).percent();
 
         return m;
@@ -1897,9 +1826,6 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      if ( p()->talents.malign_omen.ok() && p()->buffs.malign_omen->check() )
-        p()->buffs.soul_rot->extend_duration( p(), timespan_t::from_seconds( p()->talents.malign_omen_buff->effectN( 2 ).base_value() ) );
-
       if ( active_4pc( TWW1 ) )
       {
         bool success = p()->buffs.umbral_lattice->trigger();
@@ -1914,9 +1840,9 @@ using namespace helpers;
 
     void impact( action_state_t* s ) override
     {
-      warlock_spell_t::impact( s );
-
       debug_cast<malefic_rapture_damage_t*>( impact_action )->target_count = as<int>( s->n_targets );
+
+      warlock_spell_t::impact( s );
 
       if ( soul_harvester() && p()->buffs.succulent_soul->check() )
       {
@@ -2321,10 +2247,10 @@ using namespace helpers;
     void snapshot_state( action_state_t* s, result_amount_type rt ) override
     {
       //11.1 onward, nightfall has not buffed hc ds dmg
-      double mul = p()->bugs && hellcaller() ? 0 : p()->talents.nightfall_buff->effectN( 2 ).percent() + p()->hero.necrolyte_teachings->effectN( 1 ).percent();
+      double mul = ( p()->bugs && hellcaller() ) ? 0.0 : ( p()->talents.nightfall_buff->effectN( 2 ).percent() + p()->hero.necrolyte_teachings->effectN( 1 ).percent() );
 
-      debug_cast<drain_soul_state_t*>( s )->tick_time_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? p()->talents.nightfall_buff->effectN( 3 ).percent() : 0 );
-      debug_cast<drain_soul_state_t*>( s )->td_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? mul : 0 );
+      debug_cast<drain_soul_state_t*>( s )->tick_time_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? p()->talents.nightfall_buff->effectN( 3 ).percent() : 0.0 );
+      debug_cast<drain_soul_state_t*>( s )->td_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? mul : 0.0 );
       warlock_spell_t::snapshot_state( s, rt );
     }
 
@@ -2357,9 +2283,9 @@ using namespace helpers;
           p()->proc_actions.wicked_reaping->execute_on_target( target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          td( target )->debuffs_shared_fate->trigger();
+          p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls.setting_value ) )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_aff.setting_value ) )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -2630,8 +2556,6 @@ using namespace helpers;
       timespan_t darkglare_extension = timespan_t::from_seconds( p()->talents.summon_darkglare->effectN( 2 ).base_value() );
 
       darkglare_extension_helper( darkglare_extension );
-
-      p()->buffs.soul_rot->extend_duration( p(), darkglare_extension ); // This dummy buff is active while Soul Rot is ticking
     }
 
     void darkglare_extension_helper( timespan_t darkglare_extension )
@@ -2670,16 +2594,21 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      if ( !p()->min_version_check( VERSION_11_1_0 ) )
-        p()->buffs.soul_rot->trigger();
-
       if ( p()->talents.malign_omen.ok() )
         p()->buffs.malign_omen->trigger( as<int>( p()->talents.malign_omen->effectN( 2 ).base_value() ) );
 
       if ( soul_harvester() && p()->hero.shadow_of_death.ok() )
       {
-        p()->resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
+        // TOCHECK: 2025-08-27 The shards gained by Shadow of Death can also proc another Succulent Soul each (bug?)
+        if ( p()->bugs )
+          p()->resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
+        else
+          p()->player_t::resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
+
         p()->buffs.succulent_soul->trigger( as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ) );
+        for ( int i = 0; i < as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ); i++)
+          p()->procs.succulent_soul->occur();
+
         if ( p()->sets->has_set_bonus( HERO_SOUL_HARVESTER, TWW3, B2 ) && p()->tier.rampaging_demonic_soul->ok() )
         {
           p()->warlock_pet_list.demonic_souls.spawn( p()->tier.rampaging_demonic_soul->duration() );
@@ -3034,7 +2963,7 @@ using namespace helpers;
       if ( p()->talents.dread_calling.ok() )
         p()->buffs.dread_calling->trigger( shards_used );
 
-      if ( p()->talents.doom.ok() && p()->min_version_check( VERSION_11_1_0 ) )
+      if ( p()->talents.doom.ok() )
       {
         for ( const auto t : p()->sim->target_non_sleeping_list )
         {
@@ -3184,15 +3113,6 @@ using namespace helpers;
           if ( active_pet->pet_type == PET_FELGUARD )
             debug_cast<pets::demonology::felguard_pet_t*>( active_pet )->hatred_proc->execute_on_target( execute_state->target );
         }
-
-        if ( p()->talents.doom.ok() && !p()->min_version_check( VERSION_11_1_0 ) )
-        {
-          for ( const auto t : p()->sim->target_non_sleeping_list )
-          {
-            if ( td( t )->debuffs_doom->check() )
-              td( t )->debuffs_doom->extend_duration( p(), -p()->talents.doom->effectN( 1 ).time_value() - p()->talents.doom_eternal->effectN( 1 ).time_value() );
-          }
-        }
       }
       else
       {
@@ -3211,9 +3131,9 @@ using namespace helpers;
           p()->proc_actions.wicked_reaping->execute_on_target( target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          td( target )->debuffs_shared_fate->trigger();
+          p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls.setting_value ) )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_demo.setting_value ) )
           p()->feast_of_souls_gain();
       }
 
@@ -3647,8 +3567,7 @@ using namespace helpers;
       timespan_t extension_time = p()->talents.demonic_power_buff->effectN( 3 ).time_value();
 
       int wild_imp_counter = 0;
-      int demon_counter = 0;
-      int imp_cap = as<int>( p()->talents.summon_demonic_tyrant->effectN( 3 ).base_value() + p()->talents.reign_of_tyranny->effectN( 1 ).base_value() );
+      int imp_cap = as<int>( p()->talents.summon_demonic_tyrant->effectN( 3 ).base_value() );
 
       for ( auto& pet : p()->pet_list )
       {
@@ -3672,7 +3591,6 @@ using namespace helpers;
 
           lock_pet->buffs.demonic_power->trigger();
           wild_imp_counter++;
-          demon_counter++;
         }
         else if ( pet_type == PET_DREADSTALKER || pet_type == PET_VILEFIEND || pet_type == PET_SERVICE_FELGUARD || pet_type == PET_FELGUARD )
         {
@@ -3680,7 +3598,6 @@ using namespace helpers;
             lock_pet->expiration->reschedule_time = lock_pet->expiration->time + extension_time;
 
           lock_pet->buffs.demonic_power->trigger();
-          demon_counter++;
         }
       }
 
@@ -3698,15 +3615,6 @@ using namespace helpers;
       if ( p()->buffs.vilefiend->check() )
         p()->buffs.vilefiend->extend_duration( p(), extension_time );
 
-      if ( p()->talents.reign_of_tyranny.ok() )
-      {
-        for ( auto t : tyrants )
-        {
-          if ( t->is_active() )
-            t->buffs.reign_of_tyranny->trigger( demon_counter );
-        }
-      }
-
       if ( p()->hero.cruelty_of_kerxan.ok() )
       {
         timespan_t reduction = -p()->hero.cruelty_of_kerxan->effectN( 1 ).time_value();
@@ -3718,9 +3626,17 @@ using namespace helpers;
 
       if ( soul_harvester() && p()->hero.shadow_of_death.ok() )
       {
-        p()->resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
+        // TOCHECK: 2025-08-27 The shards gained by Shadow of Death can also proc another Succulent Soul each (bug?)
+        if ( p()->bugs )
+          p()->resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
+        else
+          p()->player_t::resource_gain( RESOURCE_SOUL_SHARD, p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0, p()->gains.shadow_of_death );
+
         p()->buffs.succulent_soul->trigger( as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ) );
-        if( p()->sets->has_set_bonus( HERO_SOUL_HARVESTER, TWW3, B2 ) && p()->tier.rampaging_demonic_soul->ok() )
+        for ( int i = 0; i < as<int>( p()->hero.shadow_of_death_energize->effectN( 1 ).base_value() / 10.0 ); i++)
+          p()->procs.succulent_soul->occur();
+
+        if ( p()->sets->has_set_bonus( HERO_SOUL_HARVESTER, TWW3, B2 ) && p()->tier.rampaging_demonic_soul->ok() )
         {
           p()->warlock_pet_list.demonic_souls.spawn( p()->tier.rampaging_demonic_soul->duration() );
         }
@@ -3761,7 +3677,7 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
       
-      p()->buffs.vilefiend->trigger();
+      p()->buffs.vilefiend->trigger( -1, 1.0 ); // Set value to 1.0 to allow Houndmasters Gambit talent to apply
       p()->warlock_pet_list.vilefiends.spawn( p()->talents.summon_vilefiend->duration() );
     }
   };
@@ -3824,7 +3740,7 @@ using namespace helpers;
       if ( p()->talents.impending_doom.ok() )
         p()->warlock_pet_list.wild_imps.spawn( as<int>( p()->talents.impending_doom->effectN( 2 ).base_value() ) );
 
-      if ( p()->talents.doom_eternal.ok() && p()->min_version_check( VERSION_11_1_0 ) )
+      if ( p()->talents.doom_eternal.ok() )
       {
         bool success = p()->buffs.demonic_core->trigger( 1, buff_t::DEFAULT_VALUE(), p()->talents.doom_eternal->effectN( 1 ).percent() );
 
@@ -3943,6 +3859,18 @@ using namespace helpers;
       base_dd_multiplier *= 1.0 + p->talents.sargerei_technique->effectN( 2 ).percent();
     }
 
+    void init() override
+    {
+      spell_t::init();
+
+      if ( affected_by.havoc )
+      {
+        // NOTE: The FnB talent adds its bonus damage to Incinerate Havoc (regardless of havoc target range)
+        base_aoe_multiplier *= p()->talents.havoc_debuff->effectN( 1 ).percent() + ( !p()->bugs ? p()->hero.gloom_of_nathreza->effectN( 2 ).percent() : 0.0 ) + p()->talents.fire_and_brimstone->effectN( 1 ).percent();
+        p()->havoc_spells.push_back( this );
+      }
+    }
+
     bool ready() override
     {
       if ( diabolist() && p()->executing != this && p()->buffs.infernal_bolt->check() )
@@ -3981,8 +3909,14 @@ using namespace helpers;
     {
       warlock_spell_t::impact( s );
 
+      // TOCHECK: 2025-08-27 Incinerate Havoc crit impacts don't give extra shards (bug?), and only 1 extra shard with Diabolic Embers
       if ( s->result == RESULT_CRIT )
-        p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_crits );
+      {
+        if ( !p()->bugs || s->chain_target == 0 )
+          p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_crits );
+        else if ( p()->talents.diabolic_embers.ok() )
+          p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.incinerate_crits );
+      }
     }
 
     double action_multiplier() const override
@@ -4159,10 +4093,12 @@ using namespace helpers;
       }
     };
 
+    double havoc_rancora_mod_value;
     internal_combustion_t* internal_combustion;
 
     chaos_bolt_t( warlock_t* p, util::string_view options_str )
-      : warlock_spell_t( "Chaos Bolt", p, p->warlock_base.chaos_bolt, options_str )
+      : warlock_spell_t( "Chaos Bolt", p, p->warlock_base.chaos_bolt, options_str ),
+      havoc_rancora_mod_value( 0.8 )
     {
       affected_by.chaotic_energies = true;
       affected_by.havoc = true;
@@ -4175,6 +4111,8 @@ using namespace helpers;
       triggers.jackpot_destruction = true;
 
       base_dd_multiplier *= 1.0 + p->talents.improved_chaos_bolt->effectN( 1 ).percent();
+
+      havoc_rancora_mod_value /= p->talents.havoc_debuff->effectN( 1 ).percent() + ( !p->bugs ? p->hero.gloom_of_nathreza->effectN( 2 ).percent() : 0.0 );
 
       if ( p->talents.internal_combustion.ok() )
       {
@@ -4282,7 +4220,15 @@ using namespace helpers;
       if ( p()->sets->has_set_bonus( HERO_DIABOLIST, TWW3, B2 ) )
         p()->buffs.demonic_oculus->trigger();
 
+      // NOTE: 2025-08-27 Rancora Empowered Havoc spells deals 80% of the original damage (bug?)
+      const double prev_base_aoe_multiplier = base_aoe_multiplier;
+      const bool rancora_empowered = pre_execute_state && debug_cast<chaos_bolt_state_t*>( pre_execute_state )->rancora_empowered;
+      if ( p()->bugs && diabolist() && affected_by.touch_of_rancora && affected_by.havoc && rancora_empowered )
+        base_aoe_multiplier *= havoc_rancora_mod_value;
+
       warlock_spell_t::execute();
+
+      base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
 
       // 2022-10-15: Backdraft is not consumed for Ritual of Ruin empowered casts, but IS hasted by it
       if ( !p()->buffs.ritual_of_ruin->check() )
@@ -4565,8 +4511,11 @@ using namespace helpers;
 
   struct shadowburn_t : public warlock_spell_t
   {
+    double havoc_rancora_mod_value;
+
     shadowburn_t( warlock_t* p, util::string_view options_str )
-      : warlock_spell_t( "Shadowburn", p, p->talents.shadowburn, options_str )
+      : warlock_spell_t( "Shadowburn", p, p->talents.shadowburn, options_str ),
+      havoc_rancora_mod_value( 0.8 )
     {
       cooldown->hasted = true;
       
@@ -4580,6 +4529,8 @@ using namespace helpers;
       triggers.jackpot_destruction = true;
 
       base_dd_multiplier *= 1.0 + p->talents.blistering_atrophy->effectN( 1 ).percent();
+
+      havoc_rancora_mod_value /= p->talents.havoc_debuff->effectN( 1 ).percent() + ( !p->bugs ? p->hero.gloom_of_nathreza->effectN( 2 ).percent() : 0.0 );
     }
 
     void impact( action_state_t* s ) override
@@ -4604,7 +4555,15 @@ using namespace helpers;
       if ( p()->sets->has_set_bonus( HERO_DIABOLIST, TWW3, B2 ) )
         p()->buffs.demonic_oculus->trigger();
 
+      // NOTE: 2025-08-27 Rancora Empowered Havoc spells deals 80% of the original damage (bug?)
+      const double prev_base_aoe_multiplier = base_aoe_multiplier;
+      const bool rancora_empowered = p()->buffs.art_overlord->check() || p()->buffs.art_mother->check() || p()->buffs.art_pit_lord->check();
+      if ( p()->bugs && diabolist() && affected_by.touch_of_rancora && affected_by.havoc && rancora_empowered )
+        base_aoe_multiplier *= havoc_rancora_mod_value;
+
       warlock_spell_t::execute();
+
+      base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
 
       p()->buffs.conflagration_of_chaos_sb->expire();
 
@@ -4945,6 +4904,8 @@ using namespace helpers;
   
   struct infernal_bolt_t : public warlock_spell_t
   {
+    const double havoc_mod_value = 1.0;
+
     infernal_bolt_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Infernal Bolt", p, p->hero.infernal_bolt, options_str )
     {
@@ -4971,6 +4932,18 @@ using namespace helpers;
       {
        base_dd_multiplier *= 1.0 + p->talents.sargerei_technique->effectN( 2 ).percent();
        base_dd_multiplier *= 1.0 + p->talents.sargerei_technique->effectN( 1 ).percent(); //  Sargerei Technique Appears to Double dip for Infernal Bolt due to Demo modifier
+      }
+    }
+
+    void init() override
+    {
+      spell_t::init();
+
+      if ( destruction() && affected_by.havoc )
+      {
+        // NOTE: 2025-08-27 Infernal Bolt Havoc deals 100% of the original damage (bug?)
+        base_aoe_multiplier *= p()->bugs ? havoc_mod_value : ( p()->talents.havoc_debuff->effectN( 1 ).percent() + ( !p()->bugs ? p()->hero.gloom_of_nathreza->effectN( 2 ).percent() : 0.0 ) );
+        p()->havoc_spells.push_back( this );
       }
     }
 
@@ -5361,9 +5334,6 @@ using namespace helpers;
         return;
     }
   }
-
-  void helpers::set_shared_fate_tick_factor( warlock_t* p, double f )
-  { debug_cast<shared_fate_t*>( p->proc_actions.shared_fate )->tick_factor = f; }
 
   // Event for spawning Wild Imps for Demonology
   imp_delay_event_t::imp_delay_event_t( warlock_t* p, double delay, double exp ) : player_event_t( *p, timespan_t::from_millis( delay ) )

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -263,9 +263,6 @@ namespace warlock
     talents.umbral_blaze = find_talent_spell( talent_tree::SPECIALIZATION, "Umbral Blaze" ); // Should be ID 405798
     talents.umbral_blaze_dot = find_spell( 405802 );
 
-    talents.reign_of_tyranny = find_talent_spell( talent_tree::SPECIALIZATION, "Reign of Tyranny" ); // Should be ID 427684
-    talents.reign_of_tyranny_buff = find_spell( 427687 );
-
     talents.demonic_calling = find_talent_spell( talent_tree::SPECIALIZATION, "Demonic Calling" ); // Should be ID 205145
     talents.demonic_calling_buff = find_spell( 205146 );
 
@@ -620,8 +617,7 @@ namespace warlock
     hero.demoniacs_fervor = find_talent_spell( talent_tree::HERO, "Demoniac's Fervor" ); // Should be ID 449629
 
     hero.shared_fate = find_talent_spell( talent_tree::HERO, "Shared Fate" ); // Should be ID 449704
-    hero.shared_fate_debuff = find_spell( 450591 );
-    hero.shared_fate_dmg = find_spell( 450593 );
+    hero.shared_fate_dot = find_spell( 450591 );
 
     hero.feast_of_souls = find_talent_spell( talent_tree::HERO, "Feast of Souls" ); // Should be ID 449706
 
@@ -674,9 +670,6 @@ namespace warlock
 
     // Affliction buffs
     create_buffs_affliction();
-
-    buffs.soul_rot = make_buff( this, "soul_rot", talents.soul_rot)
-                         ->set_cooldown( 0_ms );
 
     buffs.malign_omen = make_buff( this, "malign_omen", talents.malign_omen_buff )
                             ->set_default_value( talents.malign_omen_buff->effectN( 1 ).percent() );
@@ -1362,7 +1355,8 @@ namespace warlock
     add_rng_option( rng_settings.mark_of_perotharn );
     add_rng_option( rng_settings.succulent_soul_aff );
     add_rng_option( rng_settings.succulent_soul_demo );
-    add_rng_option( rng_settings.feast_of_souls );
+    add_rng_option( rng_settings.feast_of_souls_aff );
+    add_rng_option( rng_settings.feast_of_souls_demo );
     add_rng_option( rng_settings.umbral_lattice );
     add_rng_option( rng_settings.empowered_legion_strike );
   }

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -53,9 +53,6 @@ void warlock_pet_t::create_buffs()
   buffs.the_expendables = make_buff( this, "the_expendables", o()->talents.the_expendables_buff )
                               ->set_default_value_from_effect( 1 );
 
-  buffs.reign_of_tyranny = make_buff( this, "reign_of_tyranny", o()->talents.reign_of_tyranny_buff )
-                               ->set_default_value_from_effect( 1 );
-
   buffs.fiendish_wrath = make_buff( this, "fiendish_wrath", o()->talents.fiendish_wrath_buff )
                              ->set_default_value_from_effect( 1 );
 
@@ -1301,7 +1298,7 @@ struct dreadbite_t : public warlock_pet_melee_attack_t
     if ( p->o()->talents.dreadlash.ok() )
     {
       aoe = -1;
-      reduced_aoe_targets = 5; // TOCHECK: Is this removed in TWW?
+      reduced_aoe_targets = 5; // TOCHECK regularly: 2025-08-27 This still applies in TWW
       radius = 8.0;
 
       base_dd_multiplier *= 1.0 + p->o()->talents.dreadlash->effectN( 1 ).percent();
@@ -1448,7 +1445,8 @@ double dreadstalker_t::composite_player_multiplier( school_e school ) const
 {
   double m = warlock_pet_t::composite_player_multiplier( school );
 
-  if ( o()->talents.the_houndmasters_gambit.ok() && o()->buffs.vilefiend->check() )
+  // TOCHECK: 2025-08-27 The Houndmasters Gambit talent cannot be applied by the second Vilefiend (bug?)
+  if ( o()->talents.the_houndmasters_gambit.ok() && ( bugs ? o()->buffs.vilefiend->check_value() : o()->buffs.vilefiend->check() ) )
     m *= 1.0 + o()->talents.houndmasters_aura->effectN( 1 ).percent();
 
   return m;
@@ -1650,9 +1648,9 @@ void vilefiend_t::arise()
 
 void vilefiend_t::demise()
 {
-  if ( !current.sleeping )  
-    o()->buffs.vilefiend->decrement();
-  
+  if ( !current.sleeping )
+    o()->buffs.vilefiend->decrement( 1, 0.0 ); // Set value to 0.0 to prevent Houndmasters Gambit talent from being applied by the 2nd Vilefiend
+
   warlock_simple_pet_t::demise();
 }
 
@@ -1695,8 +1693,6 @@ action_t* demonic_tyrant_t::create_action( util::string_view name, util::string_
 double demonic_tyrant_t::composite_player_multiplier( school_e school ) const
 {
   double m = warlock_pet_t::composite_player_multiplier( school );
-
-  m *= 1.0 + buffs.reign_of_tyranny->check_stack_value();
 
   m *= 1.0 + o()->hero.abyssal_dominion->effectN( 1 ).percent();
 
@@ -1780,7 +1776,7 @@ void greater_dreadstalker_t::arise()
 {
   warlock_pet_t::arise();
 
-  vilefiend_present_on_summon = o()->buffs.vilefiend->check();
+  vilefiend_present_on_summon = bugs ? o()->buffs.vilefiend->check_value() : o()->buffs.vilefiend->check();
 
   dreadbite_executes = 1;
 
@@ -1803,9 +1799,10 @@ double greater_dreadstalker_t::composite_player_multiplier( school_e school ) co
 {
   double m = warlock_pet_t::composite_player_multiplier( school );
 
-  // 2025-03-28: Houndmasters Gambit talent is only applied to Greater Dreadstalkers if Vilefiend is present on summon
+  // 2025-08-27: Houndmasters Gambit talent is only applied to Greater Dreadstalkers if Vilefiend is present on summon
   // Unlike normal Dreadstalkers, summoning Vilefiend when Greater Dreadstalkers are present does not apply the Houndmasters Gambit talent (maybe a bug?)
-  if ( ( vilefiend_present_on_summon || !bugs ) && o()->talents.the_houndmasters_gambit.ok() && o()->buffs.vilefiend->check() )
+  // TOCHECK: 2025-08-27 The Houndmasters Gambit talent cannot be applied by the second Vilefiend (bug?)
+  if ( ( vilefiend_present_on_summon || !bugs ) && o()->talents.the_houndmasters_gambit.ok() && ( bugs ? o()->buffs.vilefiend->check_value() : o()->buffs.vilefiend->check() ) )
     m *= 1.0 + o()->talents.houndmasters_aura->effectN( 1 ).percent();
 
   m *= buffs.demonic_hunger->check_value();

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -38,7 +38,6 @@ struct warlock_pet_t : public pet_t
     propagate_const<buff_t*> imp_gang_boss; // Aura applied to some Wild Imps for increased damage (and size)
     propagate_const<buff_t*> antoran_armaments; // Permanent aura when talented, 20% increased damage to all abilities plus Soul Strike cleave
     propagate_const<buff_t*> the_expendables;
-    propagate_const<buff_t*> reign_of_tyranny;
     propagate_const<buff_t*> fiendish_wrath; // Guillotine talent buff, causes AoE melee attacks and prevents Felstorm
     propagate_const<buff_t*> demonic_inspiration; // Haste buff triggered by filling a Soul Shard
     propagate_const<buff_t*> wrathful_minion; // Damage buff triggered by filling a Soul Shard


### PR DESCRIPTION
This PR includes several modifications to the warlock module, fixing some features and making some other changes detailed below.

Some ingame bugs have been included in simc. These may be fixed by Blizzard in the future, in which case they will also need to be modified in simc. These bugs can be disabled with the `bugs=0` parameter in simc.

**AFFLICTION:**
- After testing, it has been determined that the [Succulent Soul](https://www.wowhead.com/spell=449793/succulent-soul) average proc rate for Affliction is closer to 22% than the previous 20% default value in the code:
  - Logs: https://www.warcraftlogs.com/reports/qRYjnLak28rBW63G?fight=1&type=resources&source=1&spell=107 & https://www.warcraftlogs.com/reports/Nw3t67AqnR8xyvQB?fight=last&type=resources&source=1&spell=107
  - Although this proc is implemented as a flat % chance, the data collected indicates that it's very possible that it uses some other type of the rng commonly used in wow (rppm, accumulator, etc.). We're still working on figuring out what that might be, so in the meantime we're simply adjusting its average to the observed one and hope to be able to correctly figure out and implement its correct rng-type in the future.
- After testing, it has been determined that the [Feast of Souls](https://www.wowhead.com/spell=449706/feast-of-souls) average proc rate for Affliction is closer to 15% than the previous 12.5% default value in the code:
  - Logs: https://www.warcraftlogs.com/reports/YgVAcjbG6m8FLKtM?fight=last&type=resources&source=1&spell=107 & https://www.warcraftlogs.com/reports/Q4V8kYHZg3LKJNh9?fight=2&type=resources&source=1&spell=107 & https://www.warcraftlogs.com/reports/Q4V8kYHZg3LKJNh9?fight=3&type=resources&source=1&spell=107
- In what appears to be an ingame bug, the shard gained from [Feast of Souls](https://www.wowhead.com/spell=449706/feast-of-souls) can also proc another [Succulent Soul](https://www.wowhead.com/spell=449793/succulent-soul). This behavior has been translated to simc.
- [Deaths Embrace](https://www.wowhead.com/spell=453189/deaths-embrace) talent is not applying to the [Corruption (direct damage)](https://www.wowhead.com/spell=172/corruption) spell (ingame bug)
- In simc, the number of [Malefic Rapture](https://www.wowhead.com/spell=324536/malefic-rapture) targets considered for the [Cull the Weak](https://www.wowhead.com/spell=453056/cull-the-weak) talent's damage increase was incorrectly the number of targets of the previous [Malefic Rapture](https://www.wowhead.com/spell=324536/malefic-rapture) spell cast, not the current one. This has been fixed.
- Succulent Souls generated by [Shadow of Death](https://www.wowhead.com/spell=449638/shadow-of-death) now count toward the final proc count.

**DEMONOLOGY:**
- After testing, it has been determined that the [Succulent Soul](https://www.wowhead.com/spell=449793/succulent-soul) average proc rate for Demonology is 15%, the same that the current default value in the code. No changes are needed:
  - Logs: https://www.warcraftlogs.com/reports/rdn3TbZvYg6Az8q7?fight=last&type=resources&source=1&spell=107 & https://www.warcraftlogs.com/reports/cZTPWHALw34yNkQJ?fight=last&type=resources&source=1&spell=107
- After testing, it has been determined that the [Feast of Souls](https://www.wowhead.com/spell=449706/feast-of-souls) average proc rate for Demonology is closer to 9.75% than the previous 12.5% default value in the code:
  - Logs: https://www.warcraftlogs.com/reports/AnX4zK8Zta9fgrJ6?fight=2&type=resources&source=1&spell=107
- Since the Vilefiend's CD was reduced in Patch 11.2, it is now possible for two of them to be active simultaneously. The [Houndmaster's Gambit](https://www.wowhead.com/spell=455572/the-houndmasters-gambit) talent (increases Dreadstalker damage by 50% while the Vilefiend is active) appears to be suffering from an ingame bug due to this: if a second Vilefiend is summoned while the first is active, the second Vilefiend becomes unable to apply/maintain this damage boost buff on Dreadstalkers. This behavior has been translated to the simc code.
- Cleanup: code related to the [Reign of Tyranny](https://www.wowhead.com/spell=427684/reign-of-tyranny) talent has been removed since it has been removed from game in patch 11.2.
- Cleanup: code related to legacy (pre-patch 11.1) behaviors of the [Doom](https://www.wowhead.com/spell=460551/doom) and [Doom Eternal](https://www.wowhead.com/spell=455585/doom-eternal) talents has been removed.

**DESTRUCTION:**
- [Incinerate](https://www.wowhead.com/spell=29722/incinerate) now hits the [Havoc](https://www.wowhead.com/spell=80240/havoc) target for 85% (60% + 25%) of the original damage if the player has the [Fire and Brimstone](https://www.wowhead.com/spell=196408/fire-and-brimstone) talent, as is the case ingame.
- [Incinerate](https://www.wowhead.com/spell=29722/incinerate)'s critical hits on [Havoc](https://www.wowhead.com/spell=80240/havoc) targets now grant no additional shards, and only one additional shard with the [Diabolic Embers](https://www.wowhead.com/spell=387173/diabolic-embers) talent (like the ingame behavior).
- The [Chaos Bolt](https://www.wowhead.com/spell=116858/chaos-bolt) and [Shadowburn](https://www.wowhead.com/spell=17877/shadowburn) spells now deal 80% damage to the [Havoc](https://www.wowhead.com/spell=80240/havoc) target (up from 60%) when empowered by [Touch of Rancora](https://www.wowhead.com/spell=429893/touch-of-rancora?spellModifier=137046), as is the case ingame.
- The [Infernal Bolt](https://www.wowhead.com/spell=434506/infernal-bolt) diabolist spell now deals 100% damage to the [Havoc](https://www.wowhead.com/spell=80240/havoc) target (up from 60%), as is the case ingame.

**COMMON:**
- Several adjustments have been made to the soul harvester's [Shared Fate](https://www.wowhead.com/spell=449704/shared-fate) spell. It appears to have previously been a single-target debuff that ticked in AoE, but this was changed at some point to an AoE DoT (a DoT applied in AoE to every target in range), so the necessary changes have been made to simc to make it work as it does now ingame. The spell that deals damage is now different ([450591](https://www.wowhead.com/spell=450591/shared-fate) instead of [450593](https://www.wowhead.com/spell=450593/shared-fate)), and it no longer benefits from some passives like the previous one did. Additionally, no reduction is applied beyond N targets (previously sqrt reduction beyond 8 targets).
- Cleanup: as suggested in a comment in the code, the old `AoE Drain Life` code has been removed, as this feature was removed from the game in patch 11.1.
- Minor: some comments have been added/modified for extra useful info (or after testing a `//TOCHECK`).