### PR TITLE
[Warlock] Demonology APL modification for Vilefiend and THG talent

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -248,7 +248,7 @@ void demonology( player_t* p )
   default_->add_action( "hand_of_guldan,if=soul_shard>=3&cooldown.summon_demonic_tyrant.remains_expected<10&pet.dreadstalker.active" );
   default_->add_action( "summon_demonic_tyrant,if=(variable.imp_despawn&pet.vilefiend.active&pet.dreadstalker.active&(variable.imp_despawn<time+gcd.max+cast_time|buff.wild_imps.stack>=9-2*prev_gcd.1.hand_of_guldan))|(buff.grimoire_felguard.remains>cast_time&buff.grimoire_felguard.remains<action.hand_of_guldan.cast_time+cast_time+gcd.max)|(buff.dreadstalkers.remains>cast_time&((buff.dreadstalkers.remains<action.hand_of_guldan.cast_time+cast_time+gcd.max)|(variable.hog_after_ds&(time>10|buff.wild_imps.stack>=9-2*prev_gcd.1.hand_of_guldan))))" );
   default_->add_action( "grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<=15&cooldown.call_dreadstalkers.remains<10" );
-  default_->add_action( "summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>=25+cast_time|cooldown.summon_demonic_tyrant.remains<=13&cooldown.call_dreadstalkers.remains<10" );
+  default_->add_action( "summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>=25+cast_time&(!pet.vilefiend.active&talent.the_houndmasters_gambit|!talent.the_houndmasters_gambit)|cooldown.summon_demonic_tyrant.remains<=13&cooldown.call_dreadstalkers.remains<10" );
   default_->add_action( "call_dreadstalkers,if=cooldown.summon_demonic_tyrant.remains>=10|cooldown.summon_demonic_tyrant.remains<=10" );
   default_->add_action( "call_dreadstalkers,if=buff.grimoire_felguard.up&buff.grimoire_felguard.remains<12+gcd.max+cast_time" );
   default_->add_action( "call_dreadstalkers,if=buff.vilefiend.up&buff.vilefiend.remains<12+gcd.max+cast_time" );


### PR DESCRIPTION
Small modification to WL Demonology APL to wait for the first Vilefiend to expire before summoning the next. This only applies if the player has the [The Houndmaster's Gambit](https://www.wowhead.com/spell=455572/the-houndmasters-gambit) talent selected. This is an improvement in this case of a ~`0.3%-0.6%` (in the image below, `APL0` is the standard default current APL, and `APL2` is the new modified one implemented in this PR):

<img width="886" height="361" alt="imagen" src="https://github.com/user-attachments/assets/6fc921cc-4704-405c-898f-4f6665408fe8" />

This change is due to an ingame bug in that talent that causes the second Vilefiend to not be able to apply the damage bonus, which was implemented in simc in [this PR](https://github.com/simulationcraft/simc/pull/10581):
- `
Since the Vilefiend's CD was reduced in Patch 11.2, it is now possible for two of them to be active simultaneously. The Houndmaster's Gambit talent (increases Dreadstalker damage by 50% while the Vilefiend is active) appears to be suffering from an ingame bug due to this: if a second Vilefiend is summoned while the first is active, the second Vilefiend becomes unable to apply/maintain this damage boost buff on Dreadstalkers.
`

If at some point this is fixed ingame (and translated to simc), this change should also be reverted.