### PR TITLE
[Buff] Add option to disable tick effects

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -730,7 +730,7 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     set_tick_time_behavior( buff_tick_time_behavior::HASTED );
   }
 
-  // Refresh behavior can be set during the `set_tick_behavior` call above. If it wasn't, set it now.
+  // Refresh behavior can be set during the `set_period` call above. If it wasn't, set it now.
   if( refresh_behavior == buff_refresh_behavior::NONE )
     set_refresh_behavior( buff_refresh_behavior::NONE );
 

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -193,23 +193,27 @@ struct tick_t : public buff_event_t
     buff->sim->print_debug( "{} {} ticks ({} of {}).",
         *buff->player, *buff, buff->current_tick, total_ticks );
 
-    // Tick callback is called before the aura stack count is altered to ensure
-    // that the buff is always up during the "tick". Last tick detection can be
-    // made through the int arguments passed to the function call.
-    if ( buff->tick_callback )
-    {
-      buff->tick_callback( buff, total_ticks, tick_time );
-    }
 
-    if ( !buff->freeze_stacks )
+    if ( !buff->disable_tick_effects )
     {
-      if ( !buff->reverse )
+      // Tick callback is called before the aura stack count is altered to ensure
+      // that the buff is always up during the "tick". Last tick detection can be
+      // made through the int arguments passed to the function call.
+      if ( buff->tick_callback )
       {
-        buff->bump( current_stacks, current_value );
+        buff->tick_callback( buff, total_ticks, tick_time );
       }
-      else
+
+      if ( !buff->freeze_stacks )
       {
-        buff->decrement( current_stacks, current_value );
+        if ( !buff->reverse )
+        {
+          buff->bump( current_stacks, current_value );
+        }
+        else
+        {
+          buff->decrement( current_stacks, current_value );
+        }
       }
     }
 
@@ -644,6 +648,7 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     base_time_duration_multiplier( 1.0 ),
     dynamic_time_duration_multiplier( 1.0 ),
     constant_behavior( buff_constant_behavior::DEFAULT ),
+    refresh_behavior_overridden( false ),
     allow_precombat( true ),
     current_tick( 0 ),
     buff_period( timespan_t::min() ),
@@ -654,6 +659,7 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     tick_on_application( false ),
     partial_tick( false ),
     freeze_stacks( false ),
+    disable_tick_effects( false ),
     last_start(),
     last_trigger(),
     last_expire(),
@@ -681,8 +687,7 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     start_intervals(),
     trigger_intervals(),
     duration_lengths(),
-    change_regen_rate( false ),
-    refresh_behavior_overridden( false )
+    change_regen_rate( false )
 {
   if ( source )  // Player Buffs
   {
@@ -1135,6 +1140,13 @@ buff_t* buff_t::set_period( timespan_t period )
         case A_PERIODIC_TRIGGER_SPELL:
         {
           buff_period = e.period();
+          if ( !refresh_behavior_overridden && buff_duration() > timespan_t::zero() )
+          {
+            if ( data().flags( spell_attribute::SX_REFRESH_EXTENDS_DURATION ) )
+              set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
+            else
+              set_refresh_behavior( buff_refresh_behavior::TICK );
+          }
           break;
         }
         default:
@@ -1152,6 +1164,12 @@ buff_t* buff_t::set_period( timespan_t period )
 buff_t* buff_t::modify_period( timespan_t duration )
 {
   set_period( buff_period + duration );
+  return this;
+}
+
+buff_t* buff_t::disable_ticking( bool v )
+{
+  disable_tick_effects = v;
   return this;
 }
 

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1117,10 +1117,6 @@ buff_t* buff_t::modify_cooldown( timespan_t duration )
 
 buff_t* buff_t::set_period( timespan_t period )
 {
-  if ( data().ok() && period == timespan_t::zero() )
-    throw sc_initialization_error( fmt::format(
-        "Buff:{} period was set to 0. To disable tick effects use `disable_ticking( true )`", this->name_str ) );
-
   if ( period > timespan_t::zero() )
     buff_period = period;
 

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1117,9 +1117,9 @@ buff_t* buff_t::modify_cooldown( timespan_t duration )
 
 buff_t* buff_t::set_period( timespan_t period )
 {
-  if ( period == timespan_t::zero() && data().ok() )
+  if ( data().ok() && period == timespan_t::zero() )
     throw sc_initialization_error( fmt::format(
-        "Buff:{} period was set to 0. To disable tick effects use `disable_ticking( true )`", name_str ) );
+        "Buff:{} period was set to 0. To disable tick effects use `disable_ticking( true )`", this->name_str ) );
 
   if ( period > timespan_t::zero() )
     buff_period = period;

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1117,10 +1117,13 @@ buff_t* buff_t::modify_cooldown( timespan_t duration )
 
 buff_t* buff_t::set_period( timespan_t period )
 {
-  if ( period >= timespan_t::zero() )
-  {
+  if ( period == timespan_t::zero() && data().ok() )
+    throw sc_initialization_error( fmt::format(
+        "Buff:{} period was set to 0. To disable tick effects use `disable_ticking( true )`", name_str ) );
+
+  if ( period > timespan_t::zero() )
     buff_period = period;
-  }
+
   else
   {
     for ( size_t i = 1; i <= s_data->effect_count(); i++ )

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -648,6 +648,7 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     base_time_duration_multiplier( 1.0 ),
     dynamic_time_duration_multiplier( 1.0 ),
     constant_behavior( buff_constant_behavior::DEFAULT ),
+    refresh_behavior( buff_refresh_behavior::NONE ),
     refresh_behavior_overridden( false ),
     allow_precombat( true ),
     current_tick( 0 ),
@@ -729,7 +730,9 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     set_tick_time_behavior( buff_tick_time_behavior::HASTED );
   }
 
-  set_refresh_behavior( buff_refresh_behavior::NONE );
+  // Refresh behavior can be set during the `set_tick_behavior` call above. If it wasn't, set it now.
+  if( refresh_behavior == buff_refresh_behavior::NONE )
+    set_refresh_behavior( buff_refresh_behavior::NONE );
 
   set_stack_behavior( buff_stack_behavior::DEFAULT );
 

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -178,24 +178,21 @@ struct tick_t : public buff_event_t
   void execute() override
   {
     buff->tick_event = nullptr;
-    buff->current_tick++;
-
-    int total_ticks = buff->expiration.empty()
-      ? -1
-      : buff->current_tick + static_cast<int>( buff->remains() / buff->tick_time() );
-
-    if ( buff->partial_tick &&
-         ( buff->buff_duration().total_millis() % buff->tick_time().total_millis() ) != 0 )
-    {
-      total_ticks++;
-    }
-
-    buff->sim->print_debug( "{} {} ticks ({} of {}).",
-        *buff->player, *buff, buff->current_tick, total_ticks );
-
 
     if ( !buff->disable_tick_effects )
     {
+      buff->current_tick++;
+
+      int total_ticks =
+          buff->expiration.empty() ? -1 : buff->current_tick + static_cast<int>( buff->remains() / buff->tick_time() );
+
+      if ( buff->partial_tick && ( buff->buff_duration().total_millis() % buff->tick_time().total_millis() ) != 0 )
+      {
+        total_ticks++;
+      }
+
+      buff->sim->print_debug( "{} {} ticks ({} of {}).", *buff->player, *buff, buff->current_tick, total_ticks );
+
       // Tick callback is called before the aura stack count is altered to ensure
       // that the buff is always up during the "tick". Last tick detection can be
       // made through the int arguments passed to the function call.
@@ -260,7 +257,7 @@ struct expiration_t : public buff_event_t
       actual_tick_time = sim().current_time() - tick_event->start_time;
     }
 
-    bool can_tick = tick_event &&
+    bool can_tick = tick_event && !buff->disable_tick_effects &&
       ( ( buff->partial_tick && actual_tick_time > 0_ms ) ||
         ( !buff->partial_tick && tick_event->tick_time == actual_tick_time ) );
 
@@ -2450,7 +2447,7 @@ void buff_t::start( int stacks, double value, timespan_t duration )
       tick_event = make_event<tick_t>( *sim, this, period, current_value, reverse ? reverse_stack_reduction : stacks );
     }
 
-    if ( ( tick_zero || ( tick_on_application && before_stacks == 0 ) ) && tick_callback )
+    if ( ( tick_zero || ( tick_on_application && before_stacks == 0 ) ) && tick_callback && !disable_tick_effects )
     {
       tick_callback( this, expiration.empty() ? -1 : static_cast<int>( remains() / period ), 0_ms );
     }
@@ -2522,7 +2519,7 @@ void buff_t::refresh( int stacks, double value, timespan_t duration )
       tick_event = make_event<tick_t>( *sim, this, period, current_value, reverse ? 1 : stacks );
     }
 
-    if ( tick_zero && tick_callback )
+    if ( tick_zero && tick_callback && !disable_tick_effects )
     {
       tick_callback( this, expiration.empty() ? -1 : static_cast<int>( remains() / tick_time() ), timespan_t::zero() );
     }

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -132,6 +132,7 @@ public:
   bool tick_on_application; // Immediately tick when the buff first goes up, but not on refreshes
   bool partial_tick; // Allow non-full duration ticks at the end of the buff period
   bool freeze_stacks; // Do not increment/decrement stack on each tick
+  bool disable_tick_effects;
 
   // tmp data collection
 protected:
@@ -378,6 +379,7 @@ public:
   buff_t* modify_cooldown( timespan_t duration );
   buff_t* set_period( timespan_t );
   buff_t* modify_period( timespan_t );
+  buff_t* disable_ticking( bool v );
   //virtual buff_t* set_chance( double chance );
   buff_t* set_quiet( bool quiet );
   buff_t* add_invalidate( cache_e );

--- a/engine/class_modules/paladin/sc_paladin_protection.cpp
+++ b/engine/class_modules/paladin/sc_paladin_protection.cpp
@@ -40,7 +40,7 @@ namespace paladin {
     // Sentinel starts at max stacks
     set_initial_stack( max_stack() );
 
-    set_period( 0_ms );
+    disable_ticking( true );
 
     // let the ability handle the cooldown
     cooldown->duration = 0_ms;

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -36,8 +36,8 @@ struct power_word_shield_buff_t : public priest_buff_t<absorb_buff_t>
     set_absorb_source( player->get_stats( "power_word_shield" ) );
     set_cooldown( 0_s );
     initial_size = 0;
-    disable_ticking( true );  // TODO: Work out why Power Word: Shield has buff period. Work out why shields ticking refreshes
-                        // them to full value.
+    disable_ticking( true );  // TODO: Work out why Power Word: Shield has buff period. Work out why shields ticking
+                              // refreshes them to full value.
   }
 
   bool trigger( int stacks, double value, double chance, timespan_t duration ) override

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -36,7 +36,7 @@ struct power_word_shield_buff_t : public priest_buff_t<absorb_buff_t>
     set_absorb_source( player->get_stats( "power_word_shield" ) );
     set_cooldown( 0_s );
     initial_size = 0;
-    buff_period = 0_s;  // TODO: Work out why Power Word: Shield has buff period. Work out why shields ticking refreshes
+    disable_ticking( true );  // TODO: Work out why Power Word: Shield has buff period. Work out why shields ticking refreshes
                         // them to full value.
   }
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -14751,7 +14751,7 @@ inline death_knight_td_t::death_knight_td_t( player_t& target, death_knight_t& p
   debuff.razorice = buff_t::find( &target, "razorice", &p );
   if ( debuff.razorice )
   {
-    debuff.razorice->set_default_value_from_effect( 1 )->set_period( 0_ms )->apply_affecting_aura(
+    debuff.razorice->set_default_value_from_effect( 1 )->disable_ticking( true )->apply_affecting_aura(
         p.talent.unholy_bond );
   }
   if ( !debuff.razorice )
@@ -14760,7 +14760,7 @@ inline death_knight_td_t::death_knight_td_t( player_t& target, death_knight_t& p
                                        p.talent.frost.arctic_assault->ok(),
                                    *this, "razorice", p.spell.razorice_debuff )
                           ->set_default_value_from_effect( 1 )
-                          ->set_period( 0_ms )
+                          ->disable_ticking( true )
                           ->apply_affecting_aura( p.talent.unholy_bond );
   }
 
@@ -15404,7 +15404,7 @@ void death_knight_t::create_buffs()
 
   buffs.legion_of_souls =
       make_fallback( talent.unholy.legion_of_souls.ok(), this, "legion_of_souls", talent.unholy.legion_of_souls )
-          ->set_period( 0_ms )
+          ->disable_ticking( true )
           ->set_cooldown( 0_ms );
 
   buffs.unholy_commander = make_fallback( sets->has_set_bonus( DEATH_KNIGHT_UNHOLY, TWW1, B4 ), this,

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -7236,7 +7236,7 @@ struct immolation_aura_buff_t : public demon_hunter_buff_t<buff_t>
     apply_affecting_aura( p->spec.immolation_aura_3 );
     apply_affecting_aura( p->talent.vengeance.agonizing_flames );
     set_tick_behavior( buff_tick_behavior::NONE );
-    buff_period = 0_ms;
+    disable_ticking( true );
 
     set_default_value_from_effect_type( A_MOD_SPEED_ALWAYS );
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -7745,7 +7745,7 @@ demon_hunter_td_t::demon_hunter_td_t( player_t* target, demon_hunter_t& p )
                             ->set_default_value_from_effect( 1 )
                             ->set_refresh_behavior( buff_refresh_behavior::DURATION )
                             ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
-                            ->set_period( 0_ms )
+                            ->disable_ticking( true )
                             ->apply_affecting_aura( p.talent.vengeance.soulcrush );
       break;
     default:
@@ -8087,7 +8087,7 @@ void demon_hunter_t::create_buffs()
                          ->set_default_value( talent.vengeance.painbringer->effectN( 1 ).percent() )
                          ->set_refresh_behavior( buff_refresh_behavior::DURATION )
                          ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
-                         ->set_period( 0_ms );
+                         ->disable_ticking( true );
 
   buff.soul_furnace_damage_amp =
       make_buff( this, "soul_furnace_damage_amp", spec.soul_furnace_damage_amp )->set_default_value_from_effect( 1 );

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -11674,7 +11674,7 @@ void druid_t::create_buffs()
       ->set_cooldown( 0_ms );
   if ( specialization() == DRUID_FERAL )
   {
-    buff.heart_of_the_wild->set_period( 0_ms );
+    buff.heart_of_the_wild->disable_ticking( true );
   }
   else
   {
@@ -12319,7 +12319,7 @@ void druid_t::create_buffs()
 
   buff.root_network = make_fallback( talent.root_network.ok(), this, "root_network", find_spell( 439887 ) )
     // TODO: confirm updating behavior where all stacks are decreased at once then recalibrated on tick
-    ->set_period( 0_ms );
+    ->disable_ticking( true );
 
   buff.ruthless_aggression = make_fallback( talent.ruthless_aggression.ok(),
     this, "ruthless_aggression", find_trigger( talent.ruthless_aggression ).trigger() )

--- a/engine/class_modules/sc_evoker.cpp
+++ b/engine/class_modules/sc_evoker.cpp
@@ -8202,7 +8202,7 @@ struct temporal_wound_buff_t : public evoker_buff_t<buff_t>
   temporal_wound_buff_t( evoker_td_t& td, util::string_view name, const spell_data_t* s )
     : evoker_buff_t<buff_t>( td, name, s ), eon_actions{ false }
   {
-    buff_period = 0_s;
+    disable_ticking( true );
 
     auto temporal_wound_effect      = new special_effect_t( p() );
     temporal_wound_effect->name_str = "temporal_wound_" + p()->name_str;
@@ -8332,7 +8332,7 @@ struct bombardments_buff_t : public evoker_buff_t<buff_t>
              std::max( p()->option.simulate_bombardments_time_between_procs_stddev / 2, 0.033_s ) ),
       bombardments_external_chance( p()->specialization() == EVOKER_DEVASTATION ? 0.875 : 0.925 )
   {
-    buff_period = 0_s;
+    disable_ticking( true );
 
     set_refresh_behavior( buff_refresh_behavior::EXTEND );
     set_tick_behavior( buff_tick_behavior::REFRESH );

--- a/engine/class_modules/sc_evoker.cpp
+++ b/engine/class_modules/sc_evoker.cpp
@@ -8470,7 +8470,7 @@ evoker_td_t::evoker_td_t( player_t* target, evoker_t* evoker )
                                                          evoker->find_spell( 403275 ), evoker->naszuro ? evoker->naszuro->item : nullptr );
   if ( make_unbound_surge )
   {
-    buffs.unbound_surge->set_period( 0_s );
+    buffs.unbound_surge->disable_ticking( true );
 
     switch ( evoker->specialization() )
     {
@@ -8569,7 +8569,7 @@ evoker_td_t::evoker_td_t( player_t* target, evoker_t* evoker )
     debug_cast<stat_buff_t*>( buffs.ebon_might )->set_stat_from_effect( 2, 0 );
 
     buffs.ebon_might->set_cooldown( 0_ms )
-        ->set_period( 0_ms )
+        ->disable_ticking( true )
         ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC )
         ->add_invalidate( CACHE_STR_AGI_INT )
         ->set_stack_change_callback( [ target, evoker ]( buff_t* b, int, int new_ ) {

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -7899,7 +7899,7 @@ hunter_td_t::hunter_td_t( player_t* t, hunter_t* p ) : actor_target_data_t( t, p
 
   debuffs.outland_venom = make_buff( *this, "outland_venom", p->talents.outland_venom_debuff )
     -> set_default_value( p->talents.outland_venom_debuff->effectN( 1 ).percent() )
-    -> set_period( 0_s );
+    -> disable_ticking( true );
 
   debuffs.kill_zone = make_buff( *this, "kill_zone", p->talents.kill_zone_debuff )
     -> set_default_value_from_effect( 2 )
@@ -8773,7 +8773,7 @@ void hunter_t::create_buffs()
   buffs.volley =
     make_buff( this, "volley", talents.volley_data )
       -> set_cooldown( 0_ms )
-      -> set_period( 0_ms ) // disable ticks as an optimization
+      -> disable_ticking( true ) // disable ticks as an optimization
       -> set_refresh_behavior( buff_refresh_behavior::DURATION );
 
   // Beast Mastery Tree

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -8400,7 +8400,7 @@ struct roll_the_bones_t : public buff_t
     rogue( r )
   {
     set_cooldown( timespan_t::zero() );
-    set_period( timespan_t::zero() ); // Disable ticking
+    disable_ticking( true ); // Disable ticking
     set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
 
     buffs = {
@@ -9931,7 +9931,7 @@ rogue_td_t::rogue_td_t( player_t* target, rogue_t* source ) :
   debuffs.flagellation = make_buff( *this, "flagellation", source->spec.flagellation_buff )
     ->set_initial_stack( 1 )
     ->set_refresh_behavior( buff_refresh_behavior::DISABLED )
-    ->set_period( timespan_t::zero() )
+    ->disable_ticking( true )
     ->set_cooldown( timespan_t::zero() );
 
   debuffs.corrupt_the_blood = make_buff( *this, "corrupt_the_blood", source->spell.corrupt_the_blood_damage )
@@ -12070,7 +12070,7 @@ void rogue_t::create_buffs()
   buffs.envenom = make_buff( this, "envenom", spec.envenom )
     ->set_default_value_from_effect_type( A_ADD_FLAT_MODIFIER, P_PROC_CHANCE )
     ->set_duration( timespan_t::min() )
-    ->set_period( timespan_t::zero() )
+    ->disable_ticking( true )
     ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
   if ( talent.assassination.twist_the_knife->ok() )
   {
@@ -12446,7 +12446,7 @@ void rogue_t::create_buffs()
   buffs.flagellation = make_buff( this, "flagellation_buff", spec.flagellation_buff )
     ->set_refresh_behavior( buff_refresh_behavior::DISABLED )
     ->set_cooldown( timespan_t::zero() )
-    ->set_period( timespan_t::zero() )
+    ->disable_ticking( true )
     ->set_default_value_from_effect_type( A_MOD_MASTERY_PCT )
     ->set_pct_buff_type( STAT_PCT_BUFF_MASTERY )
     ->set_stack_change_callback( [this]( buff_t*, int old_, int new_ ) {

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -9510,7 +9510,7 @@ void warrior_t::create_buffs()
 
   buff.bladestorm =
       make_buff( this, "bladestorm", specialization() == WARRIOR_FURY ? find_spell( 46924 ) : talents.arms.bladestorm )
-      ->set_period( timespan_t::zero() )
+      ->disable_ticking( true )
       ->set_cooldown( timespan_t::zero() );
 
   buff.battle_stance = make_buff( this, "battle_stance", talents.warrior.battle_stance )

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -2508,7 +2508,7 @@ void wandering_soul( special_effect_t& effect )
     }
     else
     {
-      buff -> set_period( timespan_t::zero() ); // disable ticking
+      buff -> disable_ticking( true ); // disable ticking
     }
   }
 

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -4871,7 +4871,7 @@ void player_t::create_buffs()
     // Dragonflight Raid Damage Modifier Debuffs
     auto buff_spell      = find_spell( 428402 );
     debuffs.hunters_mark = make_buff( this, "hunters_mark", find_spell( 257284 ) )
-        ->set_period( 0_s )
+        ->disable_ticking( true )
         ->set_default_value( buff_spell->effectN( 1 ).percent() )
         ->set_schools( buff_spell->effectN( 1 ).affected_schools() );
   }

--- a/engine/player/soulbinds.cpp
+++ b/engine/player/soulbinds.cpp
@@ -650,7 +650,7 @@ void thrill_seeker( special_effect_t& effect )
   if ( !counter_buff )
   {
     counter_buff = make_buff( effect.player, "thrill_seeker", effect.player->find_spell( 331939 ) )
-                       ->set_period( 0_ms )
+                       ->disable_ticking( true )
                        ->set_tick_behavior( buff_tick_behavior::NONE )
                        ->set_expire_at_max_stack( true );
   }
@@ -923,7 +923,7 @@ void battlefield_presence( special_effect_t& effect )
     buff = make_buff( effect.player, "battlefield_presence", effect.player->find_spell( 352858 ) )
                ->set_default_value_from_effect_type( A_MOD_DAMAGE_PERCENT_DONE )
                ->add_invalidate( CACHE_PLAYER_DAMAGE_MULTIPLIER )
-               ->set_period( 0_ms );
+               ->disable_ticking( true );
   }
 
   // If the option is not set, adjust stacks every time the target_non_sleeping_list changes
@@ -1172,7 +1172,7 @@ void pointed_courage( special_effect_t& effect )
                ->set_pct_buff_type( STAT_PCT_BUFF_CRIT )
                // TODO: add better handling of allies/enemies nearby mechanic which is checked every tick. tick is
                // disabled for now
-               ->set_period( 0_ms );
+               ->disable_ticking( true );
   }
 
   effect.player->register_combat_begin(
@@ -1925,7 +1925,7 @@ void gnashing_chompers( special_effect_t& effect )
     buff = make_buff( effect.player, "gnashing_chompers", effect.player->find_spell( 324242 ) )
                ->set_default_value_from_effect_type( A_HASTE_ALL )
                ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
-               ->set_period( 0_ms )
+               ->disable_ticking( true )
                ->set_refresh_behavior( buff_refresh_behavior::DURATION );
   }
 

--- a/engine/player/unique_gear_dragonflight.cpp
+++ b/engine/player/unique_gear_dragonflight.cpp
@@ -11027,7 +11027,7 @@ void brilliance( special_effect_t& effect )
       set_default_value_from_effect( 1 );
       set_duration( 0_s );
       set_constant_behavior( buff_constant_behavior::ALWAYS_CONSTANT );
-      set_period( 0_s );
+      disable_ticking( true );
 
       regen_buff = buff_t::find( player, "brilliance" );
 

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -4110,7 +4110,7 @@ void item::chaos_talisman( special_effect_t& effect )
   const spell_data_t* buff_spell = effect.driver() -> effectN( 1 ).trigger();
   effect.custom_buff = make_buff<stat_buff_t>( effect.player, "chaotic_energy", buff_spell, effect.item )
     ->add_stat( effect.player -> convert_hybrid_stat( STAT_STR_AGI ), buff_spell -> effectN( 1 ).average( effect.item ) )
-    ->set_period( timespan_t::zero() ); // disable ticking
+    ->disable_ticking( true ); // disable ticking
 
   new dbc_proc_callback_t( effect.item, effect );
 }

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -3484,7 +3484,7 @@ void bells_of_the_endless_feast( special_effect_t& effect )
     {
       // the debuff spell id seems to also be a driver of some kind giving extra stacks
       return dbc_proc_callback_t::create_debuff( t )
-        ->set_period( 0_ms )
+        ->disable_ticking( true )
         ->set_cooldown( 0_ms );
     }
 
@@ -4057,7 +4057,7 @@ void chains_of_domination( special_effect_t& effect )
     buff_t* create_debuff( player_t* t ) override
     {
       return proc_spell_t::create_debuff( t )
-        ->set_period( 0_ms )
+        ->disable_ticking( true )
         ->set_cooldown( 0_ms )
         ->set_stack_change_callback( [ this ]( buff_t* b, int old_, int new_ ) {
           if ( old_ == 0 && new_ > 0 )

--- a/engine/player/unique_gear_thewarwithin.cpp
+++ b/engine/player/unique_gear_thewarwithin.cpp
@@ -6314,7 +6314,7 @@ void eye_of_kezan( special_effect_t& effect )
     {
       stat_buff = create_buff<stat_buff_t>( e.player, e.player->find_spell( 469889 ) )
                       ->set_stat_from_effect_type( A_MOD_STAT, e.driver()->effectN( 1 ).average( e ) )
-                      ->set_period( 0_ms ); // Disable Ticking on the in combat buff, its not used.
+                      ->disable_ticking( true );
 
       auto out_of_combat_buff =
           create_buff<stat_buff_t>( e.player, "eye_of_kezan_out_of_combat", e.player->find_spell( 469889 ) )
@@ -8917,7 +8917,7 @@ void mind_fracturing_odium( special_effect_t& effect )
                  ->set_stat_from_effect_type( A_MOD_RATING, e.driver()->effectN( 1 ).average( e ) );
 
       stacking = create_buff<buff_t>( e.player, "mindfracturing_odium", e.driver()->effectN( 1 ).trigger() )
-                     ->set_period( 0_ms )  // Handled by the repeating event
+                     ->disable_ticking( true )
                      ->set_expire_callback( [ & ]( buff_t*, int, timespan_t ) {
                        decrementing = false;
                        stat->expire();


### PR DESCRIPTION
still keeps tick_event for buff_refresh::TICK behavior