### PR TITLE
[Player] apply passive effect affecting effects directly to the custom dbc

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1520,17 +1520,7 @@ buff_t* buff_t::apply_affecting_effect( const spelleffect_data_t& effect )
     }
   }
 
-  auto apply_flat_effect_modifier = [ this ]( const spelleffect_data_t& effect ) {
-    assert( default_value_effect_idx > 0 && default_value_effect_idx <= s_data->effect_count() );
-    // Fetch the default multiplier from the current effect to multiply the flat value before applying
-    // Ensures the flat modifier is 'calibrated' to the multiplier used in the default value correctly
-    auto prev = default_value;
-    modify_default_value( effect.base_value() * default_value_effect_multiplier );
-    sim->print_debug( "{} default effect modified by {} to {} (was {})",
-                      *this, effect.base_value() * default_value_effect_multiplier, default_value, prev );
-  };
-
-  auto apply_flat_modifier = [ this, apply_flat_effect_modifier ]( const spelleffect_data_t& effect ) {
+  auto apply_flat_modifier = [ this ]( const spelleffect_data_t& effect ) {
     switch ( effect.misc_value1() )
     {
       case P_DURATION:
@@ -1570,42 +1560,9 @@ buff_t* buff_t::apply_affecting_effect( const spelleffect_data_t& effect )
         sim->print_debug( "{} tick period modified by {} to {}", *this, effect.time_value(), buff_period );
         break;
 
-      case P_EFFECT_1:
-        if ( default_value_effect_idx == 1 )
-          apply_flat_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_2:
-        if ( default_value_effect_idx == 2 )
-          apply_flat_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_3:
-        if ( default_value_effect_idx == 3 )
-          apply_flat_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_4:
-        if ( default_value_effect_idx == 4 )
-          apply_flat_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_5:
-        if ( default_value_effect_idx == 5 )
-          apply_flat_effect_modifier( effect );
-        break;
-
       default:
         break;
     }
-  };
-
-  auto apply_percent_effect_modifier = [ this ]( const spelleffect_data_t& effect ) {
-    assert( default_value_effect_idx > 0 && default_value_effect_idx <= s_data->effect_count() );
-    auto prev = default_value;
-    set_default_value( default_value * ( 1.0 + effect.percent() ), default_value_effect_idx );
-    sim->print_debug( "{} default effect modified by {}% to {} (was {})",
-                      *this, effect.percent(), default_value, prev );
   };
 
   // Applies a modifier from -99 to infinity that controls how fast the buff functions.
@@ -1630,7 +1587,7 @@ buff_t* buff_t::apply_affecting_effect( const spelleffect_data_t& effect )
     return this;
   };
 
-  auto apply_percent_modifier = [ this, apply_percent_effect_modifier ]( const spelleffect_data_t& effect ) {
+  auto apply_percent_modifier = [ this ]( const spelleffect_data_t& effect ) {
     switch ( effect.misc_value1() )
     {
       case P_DURATION:
@@ -1649,31 +1606,6 @@ buff_t* buff_t::apply_affecting_effect( const spelleffect_data_t& effect )
       case P_TICK_TIME:
         set_period( buff_period * ( 1.0 + effect.percent() ) );
         sim->print_debug ( "{} tick time modified by {}%", *this, effect.base_value() );
-        break;
-
-      case P_EFFECT_1:
-        if ( default_value_effect_idx == 1 )
-          apply_percent_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_2:
-        if ( default_value_effect_idx == 2 )
-          apply_percent_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_3:
-        if ( default_value_effect_idx == 3 )
-          apply_percent_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_4:
-        if ( default_value_effect_idx == 4 )
-          apply_percent_effect_modifier( effect );
-        break;
-
-      case P_EFFECT_5:
-        if ( default_value_effect_idx == 5 )
-          apply_percent_effect_modifier( effect );
         break;
 
       default:

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1885,7 +1885,8 @@ struct blackout_kick_t : overwhelming_force_t<charred_passions_t<monk_melee_atta
     if ( tier_tww2_opportunistic_strike )
       cooldown->adjust( -p()->tier.tww2.brm_4pc_opportunistic_strike->effectN( 1 ).time_value() );
 
-    p()->buff.shuffle->trigger( timespan_t::from_seconds( p()->talent.brewmaster.shuffle->effectN( 1 ).base_value() ) );
+    p()->buff.shuffle->trigger(
+      timespan_t::from_seconds( p()->baseline.brewmaster.blackout_kick->effectN( 2 ).base_value() ) );
 
     p()->buff.blackout_combo->trigger();
     p()->buff.flow_of_battle_damage->trigger();
@@ -7540,6 +7541,9 @@ void monk_t::init_spells()
     shared.teachings_of_the_monastery = baseline.mistweaver.teachings_of_the_monastery;
   else
     shared.teachings_of_the_monastery = spell_data_t::not_found();
+
+  // Passives that modify effects
+  register_passive_effect_modifier( talent.brewmaster.high_tolerance );
 }
 
 void monk_t::init_background_actions()
@@ -7730,7 +7734,6 @@ struct debuff_override : stagger_impl::debuff_t<monk_t>
   {
     set_default_value_from_effect_type( A_HASTE_ALL );
     set_pct_buff_type( STAT_PCT_BUFF_HASTE );
-    apply_affecting_aura( player->talent.brewmaster.high_tolerance );
     set_stack_change_callback( [ player ]( buff_t *, int old_, int new_ ) {
       if ( old_ )
         player->buff.training_of_niuzao->expire();

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -434,9 +434,7 @@ struct divine_guidance_damage_t : public paladin_spell_t
   {
     proc = may_crit         = true;
     may_miss                = false;
-    attack_power_mod.direct = ( p->talents.lightsmith.divine_guidance->effectN( 1 ).base_value() +
-                                p->spec.protection_paladin->effectN( 25 ).base_value() ) /
-                              10.0;
+    attack_power_mod.direct = p->talents.lightsmith.divine_guidance->effectN( 1 ).base_value() / 10.0;
     aoe                     = -1;
     split_aoe_damage        = true;
   }
@@ -455,9 +453,7 @@ struct divine_guidance_heal_t : public paladin_heal_t
   {
     proc = may_crit         = true;
     may_miss                = false;
-    attack_power_mod.direct = ( p->talents.lightsmith.divine_guidance->effectN( 1 ).base_value() +
-                                p->spec.protection_paladin->effectN( 25 ).base_value() ) /
-                              10.0;
+    attack_power_mod.direct = p->talents.lightsmith.divine_guidance->effectN( 1 ).base_value() / 10.0;
     aoe                     = 1;
   }
 
@@ -3003,10 +2999,7 @@ public:
       echo->base_aoe_multiplier = base_aoe_multiplier;
       echo->crit_bonus_multiplier = crit_bonus_multiplier;
       echo->triggers_higher_calling = true;
-      // ret spec aura applies +20% to second sunrise effectiveness
-      // temporary fix until register_passive_effect_modifier() is implemented
-      echo->base_multiplier *= p->talents.herald_of_the_sun.second_sunrise->effectN( 2 ).percent() +
-                               p->spec.retribution_paladin_2->effectN( 26 ).percent();
+      echo->base_multiplier *= p->talents.herald_of_the_sun.second_sunrise->effectN( 2 ).percent();
     }
   }
 
@@ -3115,12 +3108,7 @@ public:
         s->chain_target == 0 &&
         p()->cooldowns.second_sunrise_icd->up() )
     {
-      // ret spec aura applies +5% to second sunrise chance
-      // temporary fix until register_passive_effect_modifier() is implemented
-      auto sunrise_chance = p()->talents.herald_of_the_sun.second_sunrise->effectN( 1 ).percent() +
-                            p()->spec.retribution_paladin_2->effectN( 25 ).percent();
-
-      if ( rng().roll( sunrise_chance ) )
+      if ( rng().roll( p()->talents.herald_of_the_sun.second_sunrise->effectN( 1 ).percent() ) )
       {
         p()->cooldowns.second_sunrise_icd->start();
         // TODO(mserrano): verify this delay
@@ -3161,10 +3149,6 @@ shield_of_the_righteous_buff_t::shield_of_the_righteous_buff_t( paladin_t* p )
   } );
   set_refresh_behavior( buff_refresh_behavior::CUSTOM );
   cooldown->duration = 0_ms;  // handled by the ability
-  if ( p->sets->has_set_bonus( PALADIN_PROTECTION, TWW1, B2 ) )
-  {
-    apply_affecting_aura( p->sets->set( PALADIN_PROTECTION, TWW1, B2 ) );
-  }
 }
 
 void shield_of_the_righteous_buff_t::expire_override( int expiration_stacks, timespan_t remaining_duration )
@@ -3663,11 +3647,6 @@ paladin_td_t::paladin_td_t( player_t* target, paladin_t* paladin ) : actor_targe
                                  ->set_default_value_from_effect( 1 )
                                  ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
 
-  if (paladin->specialization() == PALADIN_PROTECTION)
-  {
-    debuff.judgment->apply_affecting_aura( paladin->spec.protection_paladin );
-  }
-
   debuff.judgment_of_light     = make_buff( *this, "judgment_of_light", paladin->find_spell( 196941 ) );
 
   debuff.final_reckoning       = make_buff( *this, "final_reckoning", paladin->talents.final_reckoning )
@@ -4136,10 +4115,6 @@ void paladin_t::create_buffs()
 
   buffs.blessing_of_dawn =
       make_buff( this, "blessing_of_dawn", find_spell( 385127 ) )->set_default_value_from_effect( 1 );
-  if ( specialization() == PALADIN_RETRIBUTION )
-  {
-    buffs.blessing_of_dawn->apply_affecting_aura( spec.retribution_paladin );
-  }
   buffs.blessing_of_dusk = make_buff( this, "blessing_of_dusk", find_spell( 385126 ) );
   buffs.faiths_armor     = make_buff( this, "faiths_armor", find_spell( 379017 ) )
                            ->set_default_value_from_effect( 1 )
@@ -4264,11 +4239,6 @@ void paladin_t::create_buffs()
   buffs.herald_of_the_sun.gleaming_rays = make_buff( this, "gleaming_rays", spells.herald_of_the_sun.gleaming_rays )
     ->set_duration( bugs ? timespan_t::from_seconds( 30 ) : timespan_t::zero() ) // infinite duration, except it's bugged
     ->set_default_value_from_effect( 1 );
-  if ( specialization() == PALADIN_RETRIBUTION )
-  {
-    buffs.herald_of_the_sun.gleaming_rays->apply_affecting_aura( spec.retribution_paladin );
-    buffs.herald_of_the_sun.gleaming_rays->apply_affecting_aura( spec.retribution_paladin_2 );
-  }
   auto blessing_of_anshe_id = specialization() == PALADIN_RETRIBUTION ? 445206 : 445204;
   buffs.herald_of_the_sun.blessing_of_anshe = make_buff( this, "blessing_of_anshe", find_spell( blessing_of_anshe_id ) );
   buffs.herald_of_the_sun.solar_grace = make_buff( this, "solar_grace", find_spell( 439841 ) )
@@ -4817,6 +4787,12 @@ void paladin_t::init_spells()
   spells.herald_of_the_sun.gleaming_rays = find_spell( 431481 );
   spells.herald_of_the_sun.dawnlight_aoe_metadata = find_spell( 431581 );
   spells.herald_of_the_sun.solar_wrath            = find_spell( 1236972 );
+
+  // Passives that modify effects
+  register_passive_effect_modifier( spec.protection_paladin );
+  register_passive_effect_modifier( spec.retribution_paladin );
+  register_passive_effect_modifier( spec.retribution_paladin_2 );
+  register_passive_effect_modifier( sets->set( PALADIN_PROTECTION, TWW1, B2 ) );
 }
 
 // paladin_t::primary_role ==================================================
@@ -5050,7 +5026,7 @@ double paladin_t::composite_base_armor_multiplier() const
     a *= 1.0 + talents.holy_aegis -> effectN( 1 ).percent();
 
   if ( talents.sanctified_plates->ok() )
-    a *= 1.0 + ( talents.sanctified_plates->effectN( 3 ).percent() * ( 1.0 + spec.protection_paladin->effectN( 20 ).percent() ) );
+    a *= 1.0 + talents.sanctified_plates->effectN( 3 ).percent();
 
   if ( talents.faiths_armor->ok() && buffs.faiths_armor->up() )
     a *= 1.0 + buffs.faiths_armor->default_value;
@@ -5149,9 +5125,6 @@ double paladin_t::composite_bonus_armor() const
   if ( buffs.shield_of_the_righteous->check() )
   {
     double bonus = spells.sotr_buff->effectN( 1 ).percent() * cache.strength();
-
-    if ( specialization() == PALADIN_PROTECTION )
-      bonus *= 1.0 + spec.protection_paladin->effectN( 23 ).percent();
 
     ba += bonus;
   }

--- a/engine/class_modules/paladin/sc_paladin_retribution.cpp
+++ b/engine/class_modules/paladin/sc_paladin_retribution.cpp
@@ -564,12 +564,7 @@ struct divine_storm_t: public holy_power_consumer_t<paladin_melee_attack_t>
 
     if ( p->talents.herald_of_the_sun.second_sunrise->ok() )
     {
-      // ret spec aura applies +20% to second sunrise effectiveness
-      // temporary fix until register_passive_effect_modifier() is implemented
-      auto effectiveness = p->talents.herald_of_the_sun.second_sunrise->effectN( 2 ).percent() +
-                           p->spec.retribution_paladin_2->effectN( 26 ).percent();
-
-      sunrise_echo = new divine_storm_echo_t( p, effectiveness );
+      sunrise_echo = new divine_storm_echo_t( p, p->talents.herald_of_the_sun.second_sunrise->effectN( 2 ).percent() );
       add_child( sunrise_echo );
     }
   }
@@ -597,12 +592,7 @@ struct divine_storm_t: public holy_power_consumer_t<paladin_melee_attack_t>
 
     if ( p->talents.herald_of_the_sun.second_sunrise->ok() )
     {
-      // ret spec aura applies +20% to second sunrise effectiveness
-      // temporary fix until register_passive_effect_modifier() is implemented
-      auto effectiveness = p->talents.herald_of_the_sun.second_sunrise->effectN( 2 ).percent() +
-                           p->spec.retribution_paladin_2->effectN( 26 ).percent();
-
-      sunrise_echo = new divine_storm_echo_t( p, effectiveness * mul );
+      sunrise_echo = new divine_storm_echo_t( p, p->talents.herald_of_the_sun.second_sunrise->effectN( 2 ).percent() * mul );
       add_child( sunrise_echo );
     }
   }
@@ -635,12 +625,7 @@ struct divine_storm_t: public holy_power_consumer_t<paladin_melee_attack_t>
 
     if ( sunrise_echo && p()->cooldowns.second_sunrise_icd->up() )
     {
-      // ret spec aura applies +5% to second sunrise chance
-      // temporary fix until register_passive_effect_modifier() is implemented
-      auto sunrise_chance = p()->talents.herald_of_the_sun.second_sunrise->effectN( 1 ).percent() +
-                            p()->spec.retribution_paladin_2->effectN( 25 ).percent();
-
-      if ( rng().roll( sunrise_chance ) )
+      if ( rng().roll( p()->talents.herald_of_the_sun.second_sunrise->effectN( 1 ).percent() ) )
       {
         p()->cooldowns.second_sunrise_icd->start();
         // TODO(mserrano): validate the correct delay here

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -11888,8 +11888,6 @@ void runeforge::fallen_crusader( special_effect_t& effect )
       target     = p;
       harmful = callbacks = may_crit  = false;
       base_pct_heal                   = data->effectN( 2 ).percent();
-      const spell_data_t* unholy_bond = p->find_talent_spell( talent_tree::CLASS, "Unholy Bond" );
-      base_pct_heal *= 1.0 + unholy_bond->effectN( 2 ).percent();
 
       if ( p->thewarwithin_opts.attuned_to_the_aether )
         base_pct_heal *= 1.0 + p->find_spell( 1242344 )->effectN( 3 ).percent();
@@ -12041,8 +12039,6 @@ void runeforge::sanguination( special_effect_t& effect )
       background                      = true;
       harmful                         = false;
       tick_pct_heal                   = data().effectN( 1 ).percent();
-      const spell_data_t* unholy_bond = p->find_talent_spell( talent_tree::CLASS, "Unholy Bond" );
-      tick_pct_heal *= 1.0 + unholy_bond->effectN( 1 ).percent();
 
       if ( p->thewarwithin_opts.attuned_to_the_aether )
         tick_pct_heal *= 1.0 + p->find_spell( 1242344 )->effectN( 2 ).percent();
@@ -14264,6 +14260,11 @@ void death_knight_t::init_spells()
 
   spell_lookups();
   set_icds();
+
+  // Passives that modify effects
+  register_passive_effect_modifier( talent.unholy_bond );
+  register_passive_effect_modifier( talent.blood.reinforced_bones );
+
   apply_effect_modifying_effects();
 }
 
@@ -14752,8 +14753,7 @@ inline death_knight_td_t::death_knight_td_t( player_t& target, death_knight_t& p
   debuff.razorice = buff_t::find( &target, "razorice", &p );
   if ( debuff.razorice )
   {
-    debuff.razorice->set_default_value_from_effect( 1 )->set_period( 0_ms )->apply_affecting_aura(
-        p.talent.unholy_bond );
+    debuff.razorice->set_default_value_from_effect( 1 )->set_period( 0_ms );
   }
   if ( !debuff.razorice )
   {
@@ -14761,8 +14761,7 @@ inline death_knight_td_t::death_knight_td_t( player_t& target, death_knight_t& p
                                        p.talent.frost.arctic_assault->ok(),
                                    *this, "razorice", p.spell.razorice_debuff )
                           ->set_default_value_from_effect( 1 )
-                          ->set_period( 0_ms )
-                          ->apply_affecting_aura( p.talent.unholy_bond );
+                          ->set_period( 0_ms );
   }
 
   debuff.everfrost =
@@ -14805,16 +14804,13 @@ inline death_knight_td_t::death_knight_td_t( player_t& target, death_knight_t& p
 
   // Apocalypse Death Knight Runeforge Debuffs
   debuff.apocalypse_death = make_debuff( true, *this, "death",
-                                         p.spell.apocalypse_death_debuff )  // Effect not implemented
-                                ->apply_affecting_aura( p.talent.unholy_bond );
+                                         p.spell.apocalypse_death_debuff );  // Effect not implemented
 
   debuff.apocalypse_famine = make_debuff( true, *this, "famine", p.spell.apocalypse_famine_debuff )
-                                 ->set_default_value_from_effect( 1 )
-                                 ->apply_affecting_aura( p.talent.unholy_bond );
+                                 ->set_default_value_from_effect( 1 );
 
   debuff.apocalypse_war = make_debuff( true, *this, "war", p.spell.apocalypse_war_debuff )
-                              ->set_default_value_from_effect( 1 )
-                              ->apply_affecting_aura( p.talent.unholy_bond );
+                              ->set_default_value_from_effect( 1 );
 
   if (p.thewarwithin_opts.attuned_to_the_aether)
   {
@@ -16342,9 +16338,9 @@ void death_knight_action_t<Base>::apply_target_effects()
   parse_target_effects( d_fn( &death_knight_td_t::dots_t::unholy_blight, false ), p()->spell.unholy_blight_dot,
                         p()->talent.unholy.morbidity );
   parse_target_effects( d_fn( &death_knight_td_t::debuffs_t::apocalypse_war ), p()->spell.apocalypse_war_debuff,
-                        p()->talent.unholy_bond, p()->spell.attuned_to_the_aether );
+                        p()->spell.attuned_to_the_aether );
   parse_target_effects( d_fn( &death_knight_td_t::debuffs_t::razorice ), p()->spell.razorice_debuff,
-                        p()->talent.unholy_bond, p()->spell.attuned_to_the_aether );
+                        p()->spell.attuned_to_the_aether );
   parse_target_effects( d_fn( &death_knight_td_t::debuffs_t::brittle ), p()->spell.brittle_debuff );
 
   // Blood
@@ -16386,7 +16382,7 @@ void death_knight_t::parse_player_effects()
   parse_effects( buffs.antimagic_shell, talent.osmosis );
   parse_target_effects( d_fn( &death_knight_td_t::debuffs_t::brittle ), spell.brittle_debuff );
   parse_target_effects( d_fn( &death_knight_td_t::debuffs_t::apocalypse_war ), spell.apocalypse_war_debuff,
-                        talent.unholy_bond, spell.attuned_to_the_aether );
+                        spell.attuned_to_the_aether );
 
   // Blood
   if ( specialization() == DEATH_KNIGHT_BLOOD )
@@ -16402,7 +16398,7 @@ void death_knight_t::parse_player_effects()
     parse_effects( buffs.vampiric_blood, effect_mask_t( true ).disable( 2, 4 ), talent.blood.vampiric_blood,
                    talent.blood.improved_vampiric_blood );
     parse_effects( buffs.sanguine_ground, talent.blood.sanguine_ground );
-    parse_effects( buffs.bone_shield, IGNORE_STACKS, talent.blood.improved_bone_shield, talent.blood.reinforced_bones );
+    parse_effects( buffs.bone_shield, IGNORE_STACKS, talent.blood.improved_bone_shield );
     parse_effects( buffs.perseverance_of_the_ebon_blade );
 
     // Tier Sets
@@ -16489,12 +16485,10 @@ void death_knight_t::apply_affecting_auras( buff_t& buff )
   // Shared
   buff.apply_affecting_aura( talent.antimagic_barrier );
   buff.apply_affecting_aura( talent.osmosis );
-  buff.apply_affecting_aura( talent.unholy_bond );
   if( thewarwithin_opts.attuned_to_the_aether )
     buff.apply_affecting_aura( spell.attuned_to_the_aether );
 
   // Blood
-  buff.apply_affecting_aura( talent.blood.reinforced_bones );
   buff.apply_affecting_aura( talent.blood.improved_vampiric_blood );
   buff.apply_affecting_aura( sets->set( DEATH_KNIGHT_BLOOD, TWW2, B4 ) );
 

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -6847,13 +6847,7 @@ struct regrowth_t final : public trigger_thriving_growth_t<use_dot_list_t<druid_
     double ctm = base_t::composite_target_multiplier( t );
 
     if ( t == player && p()->talent.harmonious_constitution.ok() )
-    {
-      auto hc_mul = p()->talent.harmonious_constitution->effectN( 1 ).percent();
-      if ( p()->specialization() == DRUID_FERAL )
-        hc_mul += p()->spec_spell->effectN( 16 ).percent();
-
-      ctm *= 1.0 + hc_mul;
-    }
+      ctm *= 1.0 + p()->talent.harmonious_constitution->effectN( 1 ).percent();
 
     return ctm;
   }
@@ -11469,6 +11463,15 @@ void druid_t::init_spells()
   mastery.astral_invocation   = find_mastery_spell( DRUID_BALANCE );
 
   eclipse_handler.init();  // initialize this here since we need talent info to properly init
+
+  register_passive_effect_modifier( spec_spell );
+  register_passive_effect_modifier( talent.berserk_unchecked_aggression );
+  register_passive_effect_modifier( talent.boundless_moonlight );
+  register_passive_effect_modifier( talent.master_shapeshifter );
+  register_passive_effect_modifier( talent.oakskin );
+  register_passive_effect_modifier( talent.potent_enchantments );
+  register_passive_effect_modifier( talent.reinforced_fur );
+  register_passive_effect_modifier( talent.the_eternal_moon );
 }
 
 // druid_t::init_items ======================================================
@@ -11756,8 +11759,7 @@ void druid_t::create_buffs()
     make_fallback( talent.survival_instincts.ok() || sets->has_set_bonus( DRUID_GUARDIAN, TWW2, B2 ),
       this, "survival_instincts", find_spell( 61336 ) )
         ->set_cooldown( 0_ms )
-        ->set_default_value( find_effect( find_spell( 50322 ), A_MOD_DAMAGE_PERCENT_TAKEN ).percent() +
-                             find_effect( talent.oakskin, find_spell( 50322 ), A_ADD_FLAT_MODIFIER ).percent() );
+        ->set_default_value( find_effect( find_spell( 50322 ), A_MOD_DAMAGE_PERCENT_TAKEN ).percent() );
 
   // Balance buffs
   buff.astral_communion = make_fallback( talent.astral_communion.ok(), this, "astral_communion", find_spell( 450599 ) );
@@ -15254,7 +15256,7 @@ void druid_t::apply_affecting_auras( action_t& a )
   a.apply_affecting_aura( talent.radiant_moonlight );
   a.apply_affecting_aura( talent.rattle_the_stars );
   a.apply_affecting_aura( talent.twin_moons );
-  a.apply_affecting_aura( talent.whirling_stars, talent.potent_enchantments );
+  a.apply_affecting_aura( talent.whirling_stars );
   a.apply_affecting_aura( talent.wild_surges );
   a.apply_affecting_aura( sets->set( DRUID_BALANCE, TWW1, B2 ) );
 
@@ -15304,11 +15306,11 @@ void druid_t::apply_affecting_auras( action_t& a )
   a.apply_affecting_aura( talent.astral_insight );
   a.apply_affecting_aura( talent.bestial_strength );
   a.apply_affecting_aura( talent.early_spring );
-  a.apply_affecting_aura( talent.empowered_shapeshifting, spec_spell );
+  a.apply_affecting_aura( talent.empowered_shapeshifting );
   a.apply_affecting_aura( talent.groves_inspiration );
   a.apply_affecting_aura( talent.hunt_beneath_the_open_skies );
   a.apply_affecting_aura( talent.lunar_calling );
-  a.apply_affecting_aura( talent.lunar_insight, spec_spell );
+  a.apply_affecting_aura( talent.lunar_insight );
   a.apply_affecting_aura( talent.potent_enchantments );
   a.apply_affecting_aura( talent.resilient_flourishing );
   a.apply_affecting_aura( talent.stellar_command );
@@ -15321,10 +15323,8 @@ void druid_t::apply_affecting_auras( action_t& a )
 void druid_t::apply_affecting_auras( buff_t& b )
 {
   // Class
-  b.apply_affecting_aura( spec_spell );
   b.apply_affecting_aura( talent.forestwalk );
   b.apply_affecting_aura( talent.improved_barkskin );
-  b.apply_affecting_aura( talent.oakskin );
 
   // Balance
   b.apply_affecting_aura( talent.cosmic_rapidity );
@@ -15337,18 +15337,13 @@ void druid_t::apply_affecting_auras( buff_t& b )
 
   // Guardian
   b.apply_affecting_aura( spec.ursine_adept );
-  b.apply_affecting_aura( talent.berserk_unchecked_aggression );
   b.apply_affecting_aura( talent.circle_of_life_and_death_bear );
-  b.apply_affecting_aura( talent.reinforced_fur );
   b.apply_affecting_aura( talent.ursocs_endurance );
 
   // Restoration
-  b.apply_affecting_aura( talent.master_shapeshifter );
   b.apply_affecting_aura( talent.waking_dream->effectN( 1 ).trigger() );
 
   // Hero talents
-  b.apply_affecting_aura( talent.boundless_moonlight );
-  b.apply_affecting_aura( talent.potent_enchantments );
   b.apply_affecting_aura( talent.the_eternal_moon );
 }
 
@@ -15472,10 +15467,8 @@ void druid_t::parse_action_effects( action_t* action )
       bear_mask.enable( 16, 17 );
   }
 
-  _a->parse_effects( buff.berserk_bear, bear_mask, talent.berserk_ravage,
-                     talent.berserk_unchecked_aggression );
-  _a->parse_effects( buff.incarnation_bear, bear_mask, talent.berserk_ravage,
-                     talent.berserk_unchecked_aggression );
+  _a->parse_effects( buff.berserk_bear, bear_mask, talent.berserk_ravage );
+  _a->parse_effects( buff.incarnation_bear, bear_mask, talent.berserk_ravage );
   _a->parse_effects( buff.dream_of_cenarius, effect_mask_t( true ).disable( 5 ), CONSUME_BUFF );
 
   // dot damage is buffed via script so copy da_mult entries to ta_mult
@@ -15586,7 +15579,7 @@ void druid_t::parse_action_target_effects( action_t* action )
   }
 
   _a->parse_target_effects( d_fn( &druid_td_t::dots_t::adaptive_swarm_damage, false ),
-                            spec.adaptive_swarm_damage, spec_spell, affect_list_t( 2 ).add_spell( 285381 ) );
+                            spec.adaptive_swarm_damage, affect_list_t( 2 ).add_spell( 285381 ) );
 
   _a->parse_target_effects( d_fn( &druid_td_t::debuffs_t::sabertooth ),
                             spec.sabertooth, talent.sabertooth->effectN( 2 ).percent() );

--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -2018,10 +2018,7 @@ struct bear_t final : public dire_critter_t
     dire_critter_t::create_buffs();
 
     buffs.bear_summon = make_buff( this, "bear_summon", o()->talents.howl_of_the_pack_leader_bear_buff )
-      ->set_default_value_from_effect( 1 )
-      ->apply_affecting_aura( o()->specs.beast_mastery_hunter )
-      ->apply_affecting_aura( o()->specs.survival_hunter )
-      ->apply_affecting_aura( o()->tier_set.tww_s3_pack_leader_2pc );
+      ->set_default_value_from_effect( 1 );
   }
 
   const bear_td_t* find_target_data( const player_t* target ) const override
@@ -2134,7 +2131,6 @@ struct hunter_main_pet_base_t : public stable_pet_t
       -> set_default_value_from_effect( 1 )
       -> modify_default_value( o() -> tier_set.tww_s1_bm_2pc -> effectN( 1 ).percent() )
       -> apply_affecting_aura( o() -> talents.savagery )
-      -> apply_affecting_aura( o() -> talents.better_together )
       -> add_invalidate( CACHE_AUTO_ATTACK_SPEED );
 
     buffs.thrill_of_the_hunt =
@@ -2766,7 +2762,7 @@ struct kill_command_bm_t: public hunter_pet_attack_t<hunter_main_pet_base_t>
 
     if ( o()->talents.phantom_pain.ok() )
     {
-      phantom_pain.replicate_amount = o()->talents.phantom_pain->effectN( 1 ).percent() + o()->specs.beast_mastery_hunter->effectN( 13 ).percent();
+      phantom_pain.replicate_amount = o()->talents.phantom_pain->effectN( 1 ).percent();
       phantom_pain.max_targets = as<int>( o()->talents.phantom_pain->effectN( 3 ).base_value() );
     }
   }
@@ -3880,7 +3876,7 @@ bool hunter_t::consume_howl_of_the_pack_leader( player_t* target )
   if ( buffs.howl_of_the_pack_leader_wyvern->check() )
   {
     up++;
-    buffs.wyverns_cry->trigger( as<int>( talents.howl_of_the_pack_leader->effectN( 3 ).base_value() + specs.survival_hunter->effectN( 12 ).base_value() ) );
+    buffs.wyverns_cry->trigger( as<int>( talents.howl_of_the_pack_leader->effectN( 3 ).base_value() ) );
     buffs.howl_of_the_pack_leader_wyvern->expire();
     buffs.sharpened_fangs->trigger();
   }
@@ -8616,6 +8612,15 @@ void hunter_t::init_spells()
   cooldowns.banshees_mark->duration = talents.banshees_mark->internal_cooldown();
 
   cooldowns.no_mercy->duration = talents.no_mercy->internal_cooldown();
+
+  // Passives that modify effects
+  register_passive_effect_modifier( specs.beast_mastery_hunter );
+  register_passive_effect_modifier( specs.survival_hunter );
+  register_passive_effect_modifier( talents.aspect_of_the_beast );
+  register_passive_effect_modifier( talents.better_together );
+  register_passive_effect_modifier( talents.unmatched_precision );
+  register_passive_effect_modifier( talents.windrunner_quiver );
+  register_passive_effect_modifier( tier_set.tww_s3_pack_leader_2pc );
 }
 
 void hunter_t::init_base_stats()
@@ -8705,7 +8710,6 @@ void hunter_t::create_buffs()
   buffs.precise_shots = 
     make_buff( this, "precise_shots", talents.precise_shots_buff )
       ->set_default_value_from_effect( 1 )
-      ->apply_affecting_aura( talents.unmatched_precision )
       ->apply_affecting_aura( talents.windrunner_quiver );
 
   buffs.streamline =
@@ -8945,7 +8949,6 @@ void hunter_t::create_buffs()
   buffs.endurance_training =
     make_buff( this, "endurance_training", find_spell( 264662 ) )
       -> set_default_value_from_effect( 2 )
-      -> apply_affecting_aura( talents.aspect_of_the_beast )
       -> set_stack_change_callback(
           []( buff_t* b, int old, int cur ) {
             player_t* p = b -> player;
@@ -8959,13 +8962,11 @@ void hunter_t::create_buffs()
   buffs.pathfinding =
     make_buff( this, "pathfinding", find_spell( 264656 ) )
       -> set_default_value_from_effect( 2 )
-      -> apply_affecting_aura( talents.aspect_of_the_beast )
       -> add_invalidate( CACHE_RUN_SPEED );
 
   buffs.predators_thirst =
     make_buff( this, "predators_thirst", find_spell( 264663 ) )
       -> set_default_value_from_effect( 2 )
-      -> apply_affecting_aura( talents.aspect_of_the_beast )
       -> add_invalidate( CACHE_LEECH );
 
   // Tier Set Bonuses
@@ -9104,8 +9105,7 @@ void hunter_t::create_buffs()
   buffs.the_bell_tolls = 
     make_buff( this, "the_bell_tolls", talents.the_bell_tolls_buff )
       ->set_default_value_from_effect( 1 )
-      ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
-      ->apply_affecting_aura( specs.beast_mastery_hunter );
+      ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
 }
 
 void hunter_t::init_gains()

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -8325,7 +8325,6 @@ struct slice_and_dice_t : public rogue_buff_t
     set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
     add_invalidate( CACHE_AUTO_ATTACK_SPEED );
     set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
-    apply_affecting_aura( p->talent.trickster.thousand_cuts );
 
     if ( p->talent.rogue.recuperator->ok() )
     {
@@ -11860,6 +11859,12 @@ void rogue_t::init_spells()
   {
     active.tww1.ethereal_rampage = get_background_action<actions::ethereal_rampage_t>( "ethereal_rampage" );
   }
+
+  // Passives that modify effects
+  register_passive_effect_modifier( talent.rogue.featherfoot );
+  register_passive_effect_modifier( talent.outlaw.quick_draw );
+  register_passive_effect_modifier( talent.outlaw.take_em_by_surprise );
+  register_passive_effect_modifier( talent.trickster.thousand_cuts );
 }
 
 // rogue_t::init_talents ====================================================
@@ -12096,19 +12101,17 @@ void rogue_t::create_buffs()
 
   buffs.opportunity = make_buff( this, "opportunity", spec.opportunity_buff )
     ->set_default_value_from_effect_type( A_ADD_PCT_MODIFIER, P_GENERIC )
-    ->apply_affecting_aura( talent.outlaw.quick_draw )
     ->apply_affecting_aura( talent.outlaw.fan_the_hammer );
 
   buffs.take_em_by_surprise = make_buff( this, "take_em_by_surprise", spec.take_em_by_surprise_buff )
     ->set_default_value_from_effect_type( A_HASTE_ALL )
     ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
     ->set_duration( timespan_t::from_seconds( talent.outlaw.take_em_by_surprise->effectN( 1 ).base_value() ) )
-    ->apply_affecting_aura( talent.outlaw.take_em_by_surprise ) // Label modifier on talent
+    ->apply_affecting_aura( talent.outlaw.take_em_by_surprise ) // Duration Modifier
     ->apply_affecting_aura( talent.rogue.subterfuge ); // Duration Modifer
   buffs.take_em_by_surprise_aura = make_buff( this, "take_em_by_surprise_aura", spec.take_em_by_surprise_buff )
     ->set_default_value_from_effect_type( A_HASTE_ALL )
     ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
-    ->apply_affecting_aura( talent.outlaw.take_em_by_surprise ) // Label modifier on talent
     ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT )
     ->set_duration( sim->max_time / 2 ) // So it appears in sample sequence table
     ->set_stack_change_callback( [this]( buff_t*, int, int new_ ) {

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12889,6 +12889,11 @@ void shaman_t::init_spells()
   constant.mul_lightning_rod += spec.enhancement_shaman2->effectN( 8 ).percent();
 
   parse_player_effects_t::init_spells();
+
+  // Passive spells that modify effects
+  register_passive_effect_modifier( spec.elemental_shaman );
+  register_passive_effect_modifier( talent.earthshatter );
+  register_passive_effect_modifier( talent.preeminence );
 }
 
 // shaman_t::init_base ======================================================
@@ -14412,22 +14417,16 @@ void shaman_t::create_buffs()
 
   buff.elemental_blast_crit = make_buff<buff_t>( this, "elemental_blast_critical_strike", find_spell( 118522 ) )
     ->set_default_value_from_effect_type(A_MOD_ALL_CRIT_CHANCE)
-    ->apply_affecting_aura(spec.elemental_shaman)
-    ->apply_affecting_aura(talent.earthshatter)
     ->set_pct_buff_type( STAT_PCT_BUFF_CRIT )
     ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
 
   buff.elemental_blast_haste = make_buff<buff_t>( this, "elemental_blast_haste", find_spell( 173183 ) )
     ->set_default_value_from_effect_type(A_HASTE_ALL)
-    ->apply_affecting_aura(spec.elemental_shaman)
-    ->apply_affecting_aura(talent.earthshatter)
     ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
     ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
 
   buff.elemental_blast_mastery = make_buff<buff_t>( this, "elemental_blast_mastery", find_spell( 173184 ) )
     ->set_default_value_from_effect_type(A_MOD_MASTERY_PCT)
-    ->apply_affecting_aura(spec.elemental_shaman)
-    ->apply_affecting_aura(talent.earthshatter)
     ->set_pct_buff_type( STAT_PCT_BUFF_MASTERY )
     ->set_refresh_behavior( buff_refresh_behavior::PANDEMIC );
 
@@ -15116,12 +15115,7 @@ void shaman_t::apply_player_effects()
     .add_affecting_spell( talent.elemental_equilibrium )
     .set_effect_mask( effect_mask_t( true ).disable( 2 ) )
     .build( this );
-  eff::source_eff_builder_t( buff.ascendance )
-    // Elemental spec aura applies -5 penalty to preeminence, thus ascendance only gets 20%
-    // This is a temporary fix until register_passive_effect_modifier() is implemented
-    // .add_affecting_spell( talent.preeminence )
-    .set_value( talent.preeminence->effectN( 2 ).percent() + spec.elemental_shaman->effectN( 26 ).percent() )
-    .build( this );
+  eff::source_eff_builder_t( buff.ascendance ).build( this );
 }
 
 void shaman_t::apply_action_effects( parse_effects_t* a )
@@ -15129,7 +15123,7 @@ void shaman_t::apply_action_effects( parse_effects_t* a )
   // Shared
   eff::source_eff_builder_t( talent.voltaic_surge )
     .add_affecting_spell( spec.enhancement_shaman2 )
-    .add_affecting_spell( spec.elemental_shaman ).build( a );
+    .build( a );
 
   // Enhancement
   eff::source_eff_builder_t( mastery.enhanced_elements )

--- a/engine/dbc/dbc.hpp
+++ b/engine/dbc/dbc.hpp
@@ -101,9 +101,11 @@ std::vector<const spell_data_t*> class_passives( const player_t* );
 
 player_e get_class_from_spec( specialization_e );
 
-// Retuns a list of all effect subtypes affecting the spell through categories
+// Returns a list of all effect subtypes affecting the spell through categories
 util::span<const effect_subtype_t> effect_category_subtypes();
 
+// Defined in sc_spell_data.cpp
+int get_class_spell_family( player_e );
 } // namespace dbc
 
 struct custom_dbc_data_t
@@ -287,7 +289,6 @@ namespace hotfix
   void apply();
   std::string to_str( bool ptr );
 
-  void add_hotfix_spell( spell_data_t* spell, bool ptr = false );
   const spell_data_t* find_spell( const spell_data_t* dbc_spell, bool ptr = false );
   const spelleffect_data_t* find_effect( const spelleffect_data_t* dbc_effect, bool ptr = false );
   const spellpower_data_t* find_power( const spellpower_data_t* dbc_power, bool ptr = false );
@@ -576,6 +577,9 @@ public:
   // Creates a "deep" copy of the current override database
   std::unique_ptr<dbc_override_t> clone() const;
 
+  // Clone a single spell
+  const spell_data_t* clone_spell( const spell_data_t*, bool ptr );
+
   const spell_data_t* find_spell( unsigned, bool ptr = false ) const;
   const spelleffect_data_t* find_effect( unsigned, bool ptr = false ) const;
   const spellpower_data_t* find_power( unsigned, bool ptr = false ) const;
@@ -590,38 +594,49 @@ private:
 
 namespace dbc
 {
-
 // Wrapper for fetching spell data through various spell data variants
 template <typename T>
 const spell_data_t* find_spell( const T* obj, const spell_data_t* spell )
 {
-  if ( const spell_data_t* override_spell = obj->dbc_override->find_spell( spell -> id(), obj -> dbc->ptr ) )
+  auto return_spell = obj->dbc_override->find_spell( spell->id(), obj->dbc->ptr );
+  if ( return_spell )
+    return return_spell;
+
+  if ( !obj->disable_hotfixes )
+    return_spell = hotfix::find_spell( spell, obj->dbc->ptr );
+  else
+    return_spell = spell;
+
+  // always clone matching class spell family
+  if constexpr ( std::is_base_of_v<T, player_t> )
   {
-    return override_spell;
+    if ( return_spell->class_family() == dbc::get_class_spell_family( obj->type ) )
+      return_spell = T::clone_dbc_override_spell( obj, return_spell );
   }
 
-  if ( ! obj -> disable_hotfixes )
-  {
-    return hotfix::find_spell( spell, obj -> dbc->ptr );
-  }
-
-  return spell;
+  return return_spell;
 }
 
 template <typename T>
 const spell_data_t* find_spell( const T* obj, unsigned spell_id )
 {
-  if ( const spell_data_t* override_spell = obj->dbc_override->find_spell( spell_id, obj -> dbc->ptr ) )
+  auto return_spell = obj->dbc_override->find_spell( spell_id, obj->dbc->ptr );
+  if ( return_spell )
+    return return_spell;
+
+  if ( !obj->disable_hotfixes )
+    return_spell = hotfix::find_spell( obj->dbc->spell( spell_id ), obj->dbc->ptr );
+  else
+    return_spell = obj->dbc->spell( spell_id );
+
+  // always clone matching class spell family
+  if constexpr ( std::is_base_of_v<T, player_t> )
   {
-    return override_spell;
+    if ( return_spell->class_family() == dbc::get_class_spell_family( obj->type ) )
+      return_spell = T::clone_dbc_override_spell( obj, return_spell );
   }
 
-  if ( ! obj -> disable_hotfixes )
-  {
-    return hotfix::find_spell( obj -> dbc->spell( spell_id ), obj -> dbc->ptr );
-  }
-
-  return obj -> dbc->spell( spell_id );
+  return return_spell;
 }
 
 template <typename T>
@@ -655,8 +670,6 @@ const spellpower_data_t* find_power( const T* obj, unsigned power_id )
 
   return & obj -> dbc->power( power_id );
 }
-
-
 } // dbc namespace ends
 
 #endif // SC_DBC_HPP

--- a/engine/dbc/sc_data.cpp
+++ b/engine/dbc/sc_data.cpp
@@ -961,5 +961,11 @@ const spellpower_data_t* dbc_override_t::find_power( unsigned power_id, bool ptr
 }
 
 const std::vector<dbc_override_t::override_entry_t>& dbc_override_t::override_entries( bool ptr ) const
-{ return override_entries_[ ptr ]; }
+{
+  return override_entries_[ ptr ];
+}
 
+const spell_data_t* dbc_override_t::clone_spell( const spell_data_t* spell, bool ptr )
+{
+  return override_db_[ ptr ].clone_spell( spell );
+}

--- a/engine/dbc/sc_spell_data.cpp
+++ b/engine/dbc/sc_spell_data.cpp
@@ -1195,3 +1195,13 @@ std::unique_ptr<spell_data_expr_t> spell_data_expr_t::parse( sim_t* sim, util::s
 
   throw std::invalid_argument( "Unable to build expression tree." );
 }
+
+int dbc::get_class_spell_family( player_e type )
+{
+  auto id = util::class_id( type );
+
+  if ( id <= 0 || id >= MAX_CLASS )
+    return -1;
+
+  return _class_info[ id - 1 ].spell_family;
+}

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -15025,9 +15025,9 @@ bool player_t::is_ptr() const
   return maybe_ptr( dbc->ptr );
 }
 
-void player_t::register_passive_effect_modifier( const spell_data_t* modifying_spell, bool allow_non_passive )
+void player_t::register_passive_effect_modifier( const spell_data_t* modifying_spell, bool allow_non_passive ) const
 {
-  if ( !modifying_spell->ok() )
+  if ( !modifying_spell->ok() || range::contains( passive_effect_modifying_spells_, modifying_spell->id() ) )
     return;
 
   // passive spells are not allowed unless allow_non_passive == true
@@ -15037,6 +15037,8 @@ void player_t::register_passive_effect_modifier( const spell_data_t* modifying_s
                 *this, modifying_spell->name_cstr(), modifying_spell->id() );
     return;
   }
+
+  bool success = false;
 
   // go thru all the effects on the modifying spell
   for ( const auto& modifying_eff : modifying_spell->effects() )
@@ -15126,12 +15128,16 @@ void player_t::register_passive_effect_modifier( const spell_data_t* modifying_s
                           final_value );
 
         dbc_override_->register_effect( *dbc, eff_id, "base_value", final_value );
+        success = true;
       }
     }
   }
+
+  if ( success )
+    passive_effect_modifying_spells_.push_back( modifying_spell->id() );
 }
 
-void player_t::register_passive_effect_override( const spelleffect_data_t& effect, double value )
+void player_t::register_passive_effect_override( const spelleffect_data_t& effect, double value ) const
 {
   dbc_override_->register_effect( *dbc, effect.id(), "base_value", value );
 }

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -7574,7 +7574,6 @@ void player_t::regen( timespan_t periodicity )
   }
 }
 
-
 double player_t::get_stat_value(stat_e stat)
 {
   switch (stat)
@@ -15023,5 +15022,121 @@ void sc_format_to( const player_t& player, fmt::format_context::iterator out )
 
 bool player_t::is_ptr() const
 {
-  return maybe_ptr(dbc->ptr);
+  return maybe_ptr( dbc->ptr );
+}
+
+void player_t::register_passive_effect_modifier( const spell_data_t* modifying_spell, bool allow_non_passive )
+{
+  if ( !modifying_spell->ok() )
+    return;
+
+  // passive spells are not allowed unless allow_non_passive == true
+  if ( !allow_non_passive && !modifying_spell->flags( SX_PASSIVE ) )
+  {
+    sim->error( "{} cannot register passive effect modifiers from non-passive spell {} ({}), ignoring.",
+                *this, modifying_spell->name_cstr(), modifying_spell->id() );
+    return;
+  }
+
+  // go thru all the effects on the modifying spell
+  for ( const auto& modifying_eff : modifying_spell->effects() )
+  {
+    // filter out zero value
+    if ( modifying_eff.base_value() == 0.0 )
+      continue;
+
+    // filter out non-effect-modifying effects
+    if ( modifying_eff.type() != E_APPLY_AURA )
+      continue;
+
+    auto sub_type = modifying_eff.subtype();
+
+    if ( sub_type != A_ADD_FLAT_MODIFIER && sub_type != A_ADD_FLAT_LABEL_MODIFIER &&
+         sub_type != A_ADD_PCT_MODIFIER && sub_type != A_ADD_PCT_LABEL_MODIFIER )
+    {
+      continue;
+    }
+
+    // determine effect idx (or all)
+    int idx = 0;
+    switch ( modifying_eff.misc_value1() )
+    {
+      case P_EFFECT_1: idx =  1; break;
+      case P_EFFECT_2: idx =  2; break;
+      case P_EFFECT_3: idx =  3; break;
+      case P_EFFECT_4: idx =  4; break;
+      case P_EFFECT_5: idx =  5; break;
+      case P_EFFECTS:  idx = -1; break;
+      default:         continue;
+    }
+
+    // find all affected spells
+    std::vector<const spell_data_t*> affected_spells;
+
+    if ( sub_type == A_ADD_FLAT_MODIFIER || sub_type == A_ADD_PCT_MODIFIER )
+    {
+      affected_spells = dbc->effect_affects_spells( modifying_spell->class_family(), &modifying_eff );
+    }
+    else if ( sub_type == A_ADD_FLAT_LABEL_MODIFIER || sub_type == A_ADD_PCT_LABEL_MODIFIER )
+    {
+      auto span_ = dbc->spells_by_label( modifying_eff.misc_value2() );
+      affected_spells.assign( span_.begin(), span_.end() );
+    }
+
+    for ( auto spell : affected_spells )
+    {
+      if ( spell->effect_count() < idx )
+      {
+        sim->print_debug( "{} spell {} ({}) only has {} effects, but {} ({}) is trying to modify effect#{}, ignoring.",
+                          *this, spell->name_cstr(), spell->id(), spell->effect_count(), modifying_spell->name_cstr(),
+                          modifying_spell->id(), idx );
+        continue;
+      }
+
+      // grab the override/hotfix variant
+      spell = dbc::find_spell( this, spell );
+
+      // populate all effects in case of P_EFFECTS
+      std::vector<const spelleffect_data_t*> eff_list;
+      if ( idx == -1 )
+        range::for_each( spell->effects(), [ & ]( const auto& e ) { eff_list.push_back( &e ); } );
+      else
+        eff_list.push_back( &spell->effectN( idx ) );
+
+      for ( auto eff : eff_list )
+      {
+        auto eff_id = eff->id();
+        auto [ it, new_ ] = passive_effect_modifers_.insert( { eff_id, { 0, 0, 1.0 } } );
+
+        // cache original value if this is the first modification
+        if ( new_ )
+          it->second.orig = eff->base_value();
+
+        if ( sub_type == A_ADD_FLAT_MODIFIER || sub_type == A_ADD_FLAT_LABEL_MODIFIER )
+          it->second.flat += modifying_eff.base_value();
+        else if ( sub_type == A_ADD_PCT_MODIFIER || sub_type == A_ADD_PCT_LABEL_MODIFIER )
+          it->second.mult *= 1.0 + modifying_eff.percent();
+
+        // recalculate value
+        auto final_value = ( it->second.orig + it->second.flat ) * it->second.mult;
+
+        sim->print_debug( "{} spell {} ({}) eff#{} modifying {} ({}) eff#{} (orig={} flat_add={} pct_mult={} final={})",
+                          *this, modifying_spell->name_cstr(), modifying_spell->id(), modifying_eff.index() + 1,
+                          spell->name_cstr(), spell->id(), idx, it->second.orig, it->second.flat, it->second.mult,
+                          final_value );
+
+        dbc_override_->register_effect( *dbc, eff_id, "base_value", final_value );
+      }
+    }
+  }
+}
+
+void player_t::register_passive_effect_override( const spelleffect_data_t& effect, double value )
+{
+  dbc_override_->register_effect( *dbc, effect.id(), "base_value", value );
+}
+
+const spell_data_t* player_t::clone_dbc_override_spell( const player_t* p, const spell_data_t* s )
+{
+  return p->dbc_override_->clone_spell( s, p->dbc->ptr );
 }

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -967,8 +967,18 @@ private:
 
   /// Per-player custom dbc data
   std::unique_ptr<dbc_override_t> dbc_override_;
+  struct effect_modifier_t { double orig, flat, mult; };
+  std::unordered_map<unsigned, effect_modifier_t> passive_effect_modifers_;
+
+protected:
+  // pass spell_data_t* to apply all P_EFFECT_# effects to indicated effect in affected spells
+  void register_passive_effect_modifier( const spell_data_t*, bool allow_non_passive = false );
+  // directly override the base_value of effects
+  void register_passive_effect_override( const spelleffect_data_t&, double value );
 
 public:
+  static const spell_data_t* clone_dbc_override_spell( const player_t* p, const spell_data_t* s );
+
   player_t( sim_t* sim, player_e type, util::string_view name, race_e race_e );
   ~player_t() override;
 
@@ -1041,7 +1051,6 @@ public:
   timespan_t cooldown_tolerance() const;
   position_e position() const
   { return current.position; }
-
 
   pet_t* cast_pet();
   const pet_t* cast_pet() const;
@@ -1137,7 +1146,6 @@ public:
   int get_action_id( util::string_view name );
   int get_dot_id( util::string_view name );
   cooldown_waste_data_t* get_cooldown_waste_data( const cooldown_t* cd );
-
 
   // Virtual methods
   virtual void invalidate_cache( cache_e c );
@@ -1357,7 +1365,6 @@ public:
   virtual timespan_t available() const;
   virtual action_t* select_action( const action_priority_list_t&, execute_type type = execute_type::FOREGROUND, const action_t* context = nullptr );
   virtual action_t* execute_action();
-
 
   virtual void   regen( timespan_t periodicity = timespan_t::from_seconds( 0.25 ) );
   virtual double resource_gain( resource_e resource_type, double amount, gain_t* source = nullptr,

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -968,15 +968,15 @@ private:
   /// Per-player custom dbc data
   std::unique_ptr<dbc_override_t> dbc_override_;
   struct effect_modifier_t { double orig, flat, mult; };
-  std::unordered_map<unsigned, effect_modifier_t> passive_effect_modifers_;
-
-protected:
-  // pass spell_data_t* to apply all P_EFFECT_# effects to indicated effect in affected spells
-  void register_passive_effect_modifier( const spell_data_t*, bool allow_non_passive = false );
-  // directly override the base_value of effects
-  void register_passive_effect_override( const spelleffect_data_t&, double value );
+  mutable std::unordered_map<unsigned, effect_modifier_t> passive_effect_modifers_;
+  mutable std::vector<unsigned> passive_effect_modifying_spells_;
 
 public:
+  // pass spell_data_t* to apply all P_EFFECT_# effects to indicated effect in affected spells
+  void register_passive_effect_modifier( const spell_data_t*, bool allow_non_passive = false ) const;
+  // directly override the base_value of effects
+  void register_passive_effect_override( const spelleffect_data_t&, double value ) const;
+
   static const spell_data_t* clone_dbc_override_spell( const player_t* p, const spell_data_t* s );
 
   player_t( sim_t* sim, player_e type, util::string_view name, race_e race_e );


### PR DESCRIPTION
`player_t::register_passive_effect_modifier( spell_data[, allow_non_passive] )`
`player_t::register_passive_effect_override( effect_reference, value )`

You can now register spells that modify the effects of other spells via
P_EFFECT_# effect properties. This utilizes the same methods used to apply
talent rank values to the underlying talent spells. All spells of the same
spell family as the player will be cloned during the various `find_spell()`
calls.

While this can be done anytime during player initialization, generally it
should be done inside of player_t::init_spell() to ensure all spec & talent
spell structs in the derived class_player_t have been populated first.

Longer modification chains can be done, with the registration being done
with the deepest spell coming first.

A is modified by B which is modified by C which is modified by D
```
register_passive_effect_modifier( D );
register_passive_effect_modifier( C );
register_passive_effect_modifier( B );
```
Note that registration methods are protected and cannot be accessed from
outside of player_t & derived class_player_t.