### PR TITLE
[Action] parse hasted gcd based on ability flag

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -633,9 +633,22 @@ void action_t::parse_spell_data( const spell_data_t& spell_data )
   trigger_gcd       = spell_data.gcd();
   school            = spell_data.get_school_type();
 
-  // generic (type==none) and spells (type==magic) have hasted gcd by default
-  if ( spell_data.dmg_class() == SPELL_TYPE_NONE || spell_data.dmg_class() == SPELL_TYPE_MAGIC )
-    gcd_type = gcd_haste_type::SPELL_CAST_SPEED;
+  // non-abilities have hasted gcd by default
+  if ( !spell_data.flags( spell_attribute::SX_ABILITY ) && !spell_data.flags( spell_attribute::SX_RANGED_ABILITY ) )
+  {
+    if ( spell_data.dmg_class() == SPELL_TYPE_MELEE || spell_data.dmg_class() == SPELL_TYPE_RANGED )
+    {
+      // 1s gcd melee class abilities don't get hasted
+      if ( spell_data.affected_by_label( 16 ) && trigger_gcd == 1_s )
+        gcd_type = gcd_haste_type::NONE;
+      else
+        gcd_type = gcd_haste_type::ATTACK_HASTE;
+    }
+    else
+    {
+      gcd_type = gcd_haste_type::SPELL_CAST_SPEED;
+    }
+  }
 
   // parse attributes
   suppress_caster_procs       = spell_data.flags( spell_attribute::SX_SUPPRESS_CASTER_PROCS );

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -740,6 +740,8 @@ monk_melee_attack_t::monk_melee_attack_t( monk_t *player, std::string_view name,
   special    = true;
   may_glance = false;
   // Monk melee attacks do not have hasted GCD by default. Exceptions should be explicitly made.
+  // While action_t sets attacks with 1s gcd to be non-hasted, monks use spec auras to lower ability gcds by 500ms which
+  // is applied in init_finished, thus currently we cannot rely on action_t spell data parsing.
   gcd_type = gcd_haste_type::NONE;
 }
 
@@ -3514,7 +3516,6 @@ struct chi_burst_t : monk_spell_t
     parse_options( options_str );
     may_combo_strike       = true;
     trigger_jadefire_stomp = true;
-    gcd_type               = gcd_haste_type::NONE;
 
     stats = damage->stats;
     add_child( heal );
@@ -3912,7 +3913,6 @@ public:
   {
     add_option( opt_bool( "no_bof_hit", no_bof_hit ) );
     parse_options( options_str );
-    gcd_type = gcd_haste_type::NONE;
 
     aoe                 = -1;
     reduced_aoe_targets = 1.0;
@@ -4047,7 +4047,6 @@ struct exploding_keg_t : public monk_spell_t
   {
     parse_options( options_str );
     cast_during_sck = true;
-    gcd_type        = gcd_haste_type::NONE;
     aoe             = -1;
     add_child( p->active_actions.exploding_keg );
   }
@@ -4348,7 +4347,6 @@ struct xuen_spell_t : public monk_spell_t
     cast_during_sck = true;
     // Specifically set for 10.1 class trinket
     harmful  = true;
-    gcd_type = gcd_haste_type::NONE;
   }
 
   void execute() override
@@ -4580,7 +4578,6 @@ struct niuzao_spell_t : public monk_spell_t
     harmful = true;
     // Forcing the minimum GCD to 750 milliseconds
     min_gcd  = timespan_t::from_millis( 750 );
-    gcd_type = gcd_haste_type::SPELL_HASTE;
 
     apply_affecting_aura( p->talent.brewmaster.walk_with_the_ox );
   }
@@ -4634,7 +4631,6 @@ struct chiji_spell_t : public monk_spell_t
     harmful = true;
     // Forcing the minimum GCD to 750 milliseconds
     min_gcd  = timespan_t::from_millis( 750 );
-    gcd_type = gcd_haste_type::SPELL_HASTE;
   }
 
   void execute() override
@@ -4664,7 +4660,6 @@ struct yulon_spell_t : public monk_spell_t
     harmful = true;
     // Forcing the minimum GCD to 750 milliseconds
     min_gcd  = timespan_t::from_millis( 750 );
-    gcd_type = gcd_haste_type::SPELL_HASTE;
   }
 
   void execute() override
@@ -4952,7 +4947,6 @@ struct jadefire_stomp_t : public monk_spell_t
     parse_options( options_str );
     may_combo_strike = true;
     cast_during_sck  = true;
-    gcd_type         = gcd_haste_type::NONE;  // Need to define this manually for some reason
 
     damage = new jadefire_stomp_damage_t( p );
     heal   = new jadefire_stomp_heal_t( p );

--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -2001,8 +2001,6 @@ struct blessing_of_the_seasons_t : public paladin_spell_t
 
     harmful = false;
 
-    hasted_gcd  = true;
-
     cooldown           = p->cooldowns.blessing_of_the_seasons;
   }
 
@@ -2216,7 +2214,6 @@ struct hammer_of_light_t : public holy_power_consumer_t<paladin_melee_attack_t>
     is_hammer_of_light        = true;
     cleave_hammer             = new hammer_of_light_cleave_t( p, options_str );
     background                = !p->talents.templar.lights_guidance->ok();
-    hasted_gcd                = true;
     // This is not set by definition, since cost changes by spec
     resource_current = RESOURCE_HOLY_POWER;
     ret_cost         = data().powerN( 1 ).cost();
@@ -2715,7 +2712,6 @@ struct holy_armaments_t : public paladin_spell_t
   {
     parse_options( options_str );
     harmful            = false;
-    hasted_gcd         = true;
     name_str_reporting = "Holy Armaments";
     if ( p->talents.lightsmith.forewarning->ok() )
       apply_affecting_aura( p->talents.lightsmith.forewarning );

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -1248,7 +1248,6 @@ public:
 
   // haste scaling bools
   bool hasted_cd;
-  bool hasted_gcd;
 
   bool searing_light_disabled;
   bool always_do_capstones;
@@ -1261,7 +1260,6 @@ public:
     : ab( n, p, s ),
       affected_by( affected_by_t() ),
       hasted_cd( false ),
-      hasted_gcd( false ),
       searing_light_disabled( false ),
       always_do_capstones(false),
       clears_judgment( false ),
@@ -1380,17 +1378,6 @@ public:
     if ( hasted_cd )
     {
       ab::cooldown->hasted = hasted_cd;
-    }
-    if ( hasted_gcd )
-    {
-      if ( p()->specialization() == PALADIN_HOLY )
-      {
-        ab::gcd_type = gcd_haste_type::SPELL_HASTE;
-      }
-      else
-      {
-        ab::gcd_type = gcd_haste_type::ATTACK_HASTE;
-      }
     }
   }
 

--- a/engine/class_modules/paladin/sc_paladin_retribution.cpp
+++ b/engine/class_modules/paladin/sc_paladin_retribution.cpp
@@ -283,9 +283,6 @@ struct execution_sentence_t : public paladin_melee_attack_t
     if ( ! ( p->talents.execution_sentence->ok() ) )
       background = true;
 
-    // Spelldata doesn't seem to have this
-    hasted_gcd = true;
-
     // ... this appears to be true for the base damage only,
     // and is not automatically obtained from spell data.
     affected_by.highlords_judgment = true;
@@ -1023,9 +1020,6 @@ struct justicars_vengeance_t : public holy_power_consumer_t<paladin_melee_attack
     holy_power_consumer_t( "justicars_vengeance", p, p->talents.justicars_vengeance )
   {
     parse_options( options_str );
-
-    // Spelldata doesn't have this
-    hasted_gcd = true;
 
     weapon_multiplier = 0; // why is this needed?
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -2241,7 +2241,6 @@ struct power_word_shield_t final : public priest_absorb_t
   {
     parse_options( options_str );
 
-    gcd_type         = gcd_haste_type::SPELL_CAST_SPEED;
     cooldown->hasted = true;
 
     disc_mastery = true;

--- a/engine/class_modules/priest/sc_priest_pets.cpp
+++ b/engine/class_modules/priest/sc_priest_pets.cpp
@@ -550,7 +550,6 @@ struct void_flay_t final : public priest_pet_spell_t
   {
     parse_options( options );
 
-    gcd_type    = gcd_haste_type::SPELL_HASTE;
     trigger_gcd = 1.5_s;
 
     damage_mul           = data().effectN( 2 ).percent();
@@ -1141,8 +1140,6 @@ struct void_spike_t final : public priest_pet_spell_t
     : priest_pet_spell_t( "void_spike", p, p.o().find_spell( 373279 ) )
   {
     parse_options( options );
-
-    gcd_type = gcd_haste_type::SPELL_HASTE;
 
     aoe                        = -1;
     reduced_aoe_targets        = data().effectN( 3 ).base_value();

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -4304,7 +4304,6 @@ struct horseman_pet_t : public death_knight_pet_t
     {
       parse_options( options_str );
       trigger_gcd = 1_s;
-      gcd_type    = gcd_haste_type::ATTACK_HASTE;  // spell is type melee
       harmful     = false;
     }
 
@@ -5018,7 +5017,6 @@ struct death_knight_action_t : public parse_action_effects_t<Base>
   using base_t        = death_knight_action_t<Base>;
 
   propagate_const<gain_t*> gain;
-  bool hasted_gcd;
   double rp_per_tick;
   std::vector<player_effect_t> runic_power_multiplier_effects;
   std::vector<player_effect_t> runic_power_flat_effects;
@@ -5034,7 +5032,6 @@ struct death_knight_action_t : public parse_action_effects_t<Base>
   death_knight_action_t( std::string_view n, death_knight_t* p, const spell_data_t* s = spell_data_t::nil() )
     : action_base_t( n, p, s ),
       gain( nullptr ),
-      hasted_gcd( false ),
       rp_per_tick( 0 ),
       runic_power_multiplier_effects(),
       runic_power_flat_effects(),
@@ -5353,11 +5350,6 @@ struct death_knight_action_t : public parse_action_effects_t<Base>
     if ( base_gcd == 0_ms )
     {
       return 0_ms;
-    }
-
-    if ( hasted_gcd )
-    {
-      base_gcd *= this->composite_haste();
     }
 
     if ( base_gcd < this->min_gcd )

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -5224,8 +5224,6 @@ struct lunar_inspiration_t final : public cp_generator_t
                  p->talent.lunar_inspiration.ok() ? p->find_spell( 155625 ) : spell_data_t::not_found() )
   {
     may_dodge = may_parry = may_block = false;
-    // LI is a spell, but we parent to cp_generator_t to get all the proper cat attack methods.
-    gcd_type = gcd_haste_type::SPELL_CAST_SPEED;
 
     s_data_reporting = p->talent.lunar_inspiration;
     dot_name = "lunar_inspiration";
@@ -5861,7 +5859,6 @@ struct bristling_fur_t final : public bear_attack_t
   DRUID_ABILITY( bristling_fur_t, bear_attack_t, "bristling_fur", p->talent.bristling_fur )
   {
     harmful = false;
-    gcd_type = gcd_haste_type::ATTACK_HASTE;
   }
 
   void execute() override

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -1761,10 +1761,9 @@ public:
     ab::parse_options( options );
     parse_spell_data( s );
 
-    // rogue_t sets base and min GCD to 1s by default but let's also enforce non-hasted GCDs.
-    // Even for rogue abilities that can be considered spells, hasted GCDs seem to be an exception rather than rule.
-    // Those should be set explicitly. (see Vendetta, Shadow Blades, Detection)
-    ab::gcd_type = gcd_haste_type::NONE;
+    // rogue_t sets base and min GCD to 1s by default and action_t sets 1s gcd attacks to non-hasted regardless of
+    // ability flags. There should no longer be a need to explicitly enforced non-hasted GCDs.
+    // ab::gcd_type = gcd_haste_type::NONE;
 
     // Affecting Passive Auras
     // Put ability specific ones here; class/spec wide ones with labels that can effect things like trinkets in rogue_t::apply_affecting_auras.
@@ -4452,7 +4451,6 @@ struct detection_t : public rogue_spell_t
   detection_t( util::string_view name, rogue_t* p, util::string_view options_str = {} ) :
     rogue_spell_t( name, p, p->spell.detection, options_str )
   {
-    gcd_type = gcd_haste_type::ATTACK_HASTE;
     min_gcd = 750_ms; // Force 750ms min gcd because rogue player base has a 1s min.
     harmful = false;
     set_target( p );


### PR DESCRIPTION
Previously we were using spell type to determine hasted gcd, but using the ability flags (SX_ABILITY SX_RANGED_ABILITY) seems to be the correct method used in-game.

Furthermore class abilities with 1s gcd are set to non-hasted to match behavior for rogue/monk/druid abilities (note that monk still requires explicit overrides due to how data parsing is ordered in the module).

The following differences are seen:
```
Player 'havoc' Action 'fel_rush' (195072) lost hasted gcd
Player 'brewmaster' Action 'chi_burst' (123986) gained hasted gcd
Player 'windwalker' Action 'chi_burst' (461404) gained hasted gcd
Player 'windwalker' Action 'invoke_xuen_the_white_tiger' (123904) gained hasted gcd
Player 'elemental' Action 'liquid_magma_totem' (192222) lost hasted gcd
Player 'arms' Action 'demolish' (436358) lost hasted gcd
Player 'protection_war' Action 'demolish' (436358) lost hasted gcd
Player 'blood_blood_beast' Action 'corrupted_blood' (434574) gained hasted gcd
Player 'unholy_blood_beast' Action 'corrupted_blood' (434574) gained hasted gcd
Player 'demonology_vilefiend' Action 'bile_spit' (267997) lost hasted gcd
```