### PR TITLE
[Warlock] Bug fixes, spell modifier fixes, and cleanup

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -317,7 +317,7 @@ double warlock_t::composite_player_target_multiplier( player_t* target, school_e
     if ( talents.haunt.ok() )
       m *= 1.0 + td->debuffs.haunt->check_value();
 
-    if ( talents.shadow_embrace.ok() )
+    if ( talents.shadow_embrace.ok() || talents.improved_haunt.ok() )
       m *= 1.0 + td->debuffs.shadow_embrace->check_stack_value();
   }
 
@@ -424,7 +424,7 @@ double warlock_t::composite_player_target_pet_damage_multiplier( player_t* targe
     if ( talents.haunt.ok() && td->debuffs.haunt->check() )
       m *= 1.0 + td->debuffs.haunt->data().effectN( guardian ? 4 : 3 ).percent();
 
-    if ( talents.shadow_embrace.ok() )
+    if ( talents.shadow_embrace.ok() || talents.improved_haunt.ok() )
       m *= 1.0 + td->debuffs.shadow_embrace->check_stack_value();
 
     if ( talents.infirmity.ok() && !guardian )

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -159,7 +159,6 @@ public:
     // Affliction
     const spell_data_t* agony;
     const spell_data_t* agony_2; // Rank 2 still a separate spell (learned automatically). Grants increased max stacks
-    const spell_data_t* xavian_teachings; // Passive granted only to Affliction. Instant cast data in this spell, points to base Corruption spell (172) for the direct damage
     const spell_data_t* malefic_rapture; // This contains an old sp_coeff value, but it is most likely no longer in use
     const spell_data_t* malefic_rapture_dmg;
     const spell_data_t* potent_afflictions; // Affliction Mastery - Increased DoT and Malefic Rapture damage
@@ -402,11 +401,6 @@ public:
     player_talent_t flametouched;
     player_talent_t immutable_hatred;
     const spell_data_t* immutable_hatred_proc;
-    player_talent_t guillotine;
-    const spell_data_t* guillotine_pet;
-    const spell_data_t* fiendish_wrath_buff;
-    const spell_data_t* fiendish_wrath_dmg; // TODO: Multiplier fixes for this
-    const spell_data_t* fel_explosion;
 
     player_talent_t master_summoner;
 
@@ -428,7 +422,6 @@ public:
     const spell_data_t* havoc_debuff; // This is a second copy of the talent data for use in places that are shared by Havoc and Mayhem
     player_talent_t pyrogenics; // Enemies affected by Rain of Fire receive debuff for increased Fire damage
     const spell_data_t* pyrogenics_debuff;
-    player_talent_t inferno;
     player_talent_t cataclysm;
 
     player_talent_t indiscriminate_flames;
@@ -475,6 +468,7 @@ public:
     player_talent_t reverse_entropy;
     const spell_data_t* reverse_entropy_buff;
     player_talent_t internal_combustion;
+    const spell_data_t* internal_combustion_dmg;
     player_talent_t demonfire_mastery;
 
     player_talent_t devastation;
@@ -554,9 +548,9 @@ public:
     player_talent_t ruination; // TODO: Check damage and buff values closer to release, affected_by lists may be on cast spell not damage in data and could be changed later by Blizzard
     const spell_data_t* ruination_buff;
     const spell_data_t* ruination_cast;
-    const spell_data_t* ruination_impact; // TODO: Demonology version appears to include a Hand of Gul'dan when summoning imps. Not currently implemented
+    const spell_data_t* ruination_impact;
     const spell_data_t* diabolic_imp;
-    const spell_data_t* diabolic_bolt; // TODO: Socrethar's Guile?
+    const spell_data_t* diabolic_bolt;
 
     // Hellcaller
     player_talent_t wither;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -956,13 +956,12 @@ using namespace helpers;
       impact_action = periodic;
       add_child( periodic );
 
-      spell_power_mod.direct = 0; // By default, Corruption does not deal instant damage
+      triggers.jackpot_affliction = true;
 
-      if ( !seed_action && p->warlock_base.xavian_teachings->ok() )
+      if ( seed_action )
       {
-        spell_power_mod.direct = data().effectN( 3 ).sp_coeff();
-        base_execute_time *= 1.0 + p->warlock_base.xavian_teachings->effectN( 1 ).percent();
-        triggers.jackpot_affliction = true;
+        spell_power_mod.direct = 0; // Corruption does not deal instant damage when applied from SoC
+        triggers.jackpot_affliction = false; // Corruption does not trigger jackpot (tww2 tier) when applied from SoC
       }
 
       base_dd_multiplier *= 1.0 + p->talents.siphon_life->effectN( 1 ).percent();
@@ -3236,7 +3235,7 @@ using namespace helpers;
         background = dual = true;
         callbacks = false;
 
-        base_dd_multiplier = 1.0 + p->talents.spiteful_reconstitution->effectN( 1 ).percent();
+        base_dd_multiplier *= 1.0 + p->talents.spiteful_reconstitution->effectN( 1 ).percent();
       }
 
       double action_multiplier() const override
@@ -3741,45 +3740,6 @@ using namespace helpers;
     }
   };
 
-  struct guillotine_t : public warlock_spell_t
-  {
-    guillotine_t( warlock_t* p, util::string_view options_str )
-      : warlock_spell_t( "Guillotine", p, p->talents.guillotine, options_str )
-    {
-      may_crit = false;
-      internal_cooldown = p->get_cooldown( "felstorm_icd" );
-    }
-
-    bool ready() override
-    {
-      auto active_pet = p()->warlock_pet_list.active;
-
-      if ( !active_pet )
-        return false;
-
-      if ( active_pet->pet_type != PET_FELGUARD )
-        return false;
-
-      return warlock_spell_t::ready();
-    }
-
-    void execute() override
-    {
-      auto active_pet = p()->warlock_pet_list.active;
-
-      warlock_spell_t::execute();
-
-      if ( active_pet->pet_type == PET_FELGUARD )
-      {
-        active_pet->buffs.fiendish_wrath->trigger();
-
-        debug_cast<pets::demonology::felguard_pet_t*>( active_pet )->felguard_guillotine->execute_on_target( execute_state->target );
-
-        internal_cooldown->start( 6_s );
-      }
-    }
-  };
-
   struct doom_t : public warlock_spell_t
   {
     doom_t( warlock_t* p )
@@ -3877,7 +3837,7 @@ using namespace helpers;
         double c = warlock_spell_t::composite_crit_chance();
 
         if ( p()->talents.indiscriminate_flames.ok() && p()->buffs.backdraft->check() )
-          c += p()->talents.indiscriminate_flames->effectN( 2 ).percent();
+          c += p()->talents.indiscriminate_flames->effectN( 2 ).percent() * p()->buffs.backdraft->check();
 
         return c;
       }
@@ -3992,7 +3952,7 @@ using namespace helpers;
       double c = warlock_spell_t::composite_crit_chance();
 
       if ( p()->talents.indiscriminate_flames.ok() && p()->buffs.backdraft->check() )
-        c += p()->talents.indiscriminate_flames->effectN( 2 ).percent();
+        c += p()->talents.indiscriminate_flames->effectN( 2 ).percent() * p()->buffs.backdraft->check();
 
       return c;
     }
@@ -4074,7 +4034,7 @@ using namespace helpers;
   struct internal_combustion_t : public warlock_spell_t
   {
     internal_combustion_t( warlock_t* p )
-      : warlock_spell_t( "Internal Combustion", p, p->talents.internal_combustion )
+      : warlock_spell_t( "Internal Combustion", p, p->talents.internal_combustion_dmg )
     {
       background = dual = true;
 
@@ -4229,7 +4189,7 @@ using namespace helpers;
         m *= 1.0 + p()->talents.crashing_chaos->effectN( 1 ).percent();
 
       if ( p()->talents.indiscriminate_flames.ok() && p()->buffs.backdraft->check() )
-        m *= 1.0 + p()->talents.indiscriminate_flames->effectN( 1 ).percent();
+        m *= 1.0 + p()->talents.indiscriminate_flames->effectN( 1 ).percent() * p()->buffs.backdraft->check();
 
       return m;
     }
@@ -4428,8 +4388,6 @@ using namespace helpers;
         affected_by.chaos_incarnate = p->talents.chaos_incarnate.ok();
         affected_by.touch_of_rancora = p->hero.touch_of_rancora.ok();
 
-        base_multiplier *= 1.0 + p->talents.inferno->effectN( 2 ).percent();
-
         triggers.decimation = false;
       }
       
@@ -4463,8 +4421,6 @@ using namespace helpers;
       affected_by.touch_of_rancora = p->hero.touch_of_rancora.ok();
 
       triggers.diabolic_ritual = triggers.demonic_art = triggers.demonic_art_buff = p->hero.diabolic_ritual.ok();
-
-      base_costs[ RESOURCE_SOUL_SHARD ] += p->talents.inferno->effectN( 1 ).base_value() / 10.0;
 
       if ( !p->proc_actions.rain_of_fire_tick )
       {
@@ -4952,7 +4908,7 @@ using namespace helpers;
       double c = warlock_spell_t::composite_crit_chance();
 
       if ( p()->talents.indiscriminate_flames.ok() && p()->buffs.backdraft->check() )
-        c += p()->talents.indiscriminate_flames->effectN( 2 ).percent();
+        c += p()->talents.indiscriminate_flames->effectN( 2 ).percent() * p()->buffs.backdraft->check();
 
       return c;
     }
@@ -5047,7 +5003,7 @@ using namespace helpers;
       double c = warlock_spell_t::composite_crit_chance();
 
       if ( p()->talents.indiscriminate_flames.ok() && p()->buffs.backdraft->check() )
-        c += p()->talents.indiscriminate_flames->effectN( 2 ).percent();
+        c += p()->talents.indiscriminate_flames->effectN( 2 ).percent() * p()->buffs.backdraft->check();
 
       return c;
     }
@@ -5086,7 +5042,6 @@ using namespace helpers;
         reduced_aoe_targets = p->hero.ruination_cast->effectN( 2 ).base_value();
 
         affected_by.chaotic_energies = true;
-        affected_by.backdraft = true;
 
         if ( demonology() )
         {
@@ -5554,8 +5509,6 @@ using namespace helpers;
       return new summon_vilefiend_t( this, options_str );
     if ( action_name == "grimoire_felguard" )
       return new grimoire_felguard_t( this, options_str );
-    if ( action_name == "guillotine" )
-      return new guillotine_t( this, options_str );
 
     return nullptr;
   }

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -25,7 +25,6 @@ namespace warlock
     // Affliction
     warlock_base.agony = find_class_spell( "Agony" ); // Should be ID 980
     warlock_base.agony_2 = find_spell( 231792 ); // Rank 2, +4 to max stacks
-    warlock_base.xavian_teachings = find_specialization_spell( "Xavian Teachings", WARLOCK_AFFLICTION ); // Instant cast corruption and direct damage. Direct damage is in the base corruption spell on effect 3. Should be ID 317031.
     warlock_base.malefic_rapture = find_specialization_spell( "Malefic Rapture", WARLOCK_AFFLICTION ); // Should be ID 324536
     warlock_base.malefic_rapture_dmg = find_spell( 324540 );
     warlock_base.potent_afflictions = find_mastery_spell( WARLOCK_AFFLICTION ); // Should be ID 77215
@@ -320,12 +319,6 @@ namespace warlock
     talents.immutable_hatred = find_talent_spell( talent_tree::SPECIALIZATION, "Immutable Hatred" ); // Should be ID 405670
     talents.immutable_hatred_proc = find_spell( 405681 );
 
-    talents.guillotine = find_talent_spell( talent_tree::SPECIALIZATION, "Guillotine" ); // Should be ID 386833
-    talents.guillotine_pet = find_spell( 386542 );
-    talents.fiendish_wrath_buff = find_spell( 386601 );
-    talents.fiendish_wrath_dmg = find_spell( 386702 );
-    talents.fel_explosion = find_spell( 386609 );
-
     talents.master_summoner = find_talent_spell( talent_tree::SPECIALIZATION, "Master Summoner" );  // Should be ID 1240189
 
     // Additional Tier Set spell data
@@ -379,8 +372,6 @@ namespace warlock
 
     talents.pyrogenics = find_talent_spell( talent_tree::SPECIALIZATION, "Pyrogenics" ); // Should be ID 387095
     talents.pyrogenics_debuff = find_spell( 387096 );
-
-    talents.inferno = find_talent_spell(talent_tree::SPECIALIZATION, "Inferno"); // Should be ID 270545
 
     talents.cataclysm = find_talent_spell( talent_tree::SPECIALIZATION, "Cataclysm" ); // Should be ID 152108
 
@@ -443,6 +434,7 @@ namespace warlock
     talents.reverse_entropy_buff = find_spell( 266030 );
 
     talents.internal_combustion = find_talent_spell( talent_tree::SPECIALIZATION, "Internal Combustion" ); // Should be ID 266134
+    talents.internal_combustion_dmg = find_spell( 266136 );
 
     talents.demonfire_mastery = find_talent_spell( talent_tree::SPECIALIZATION, "Demonfire Mastery" ); // Should be ID 456946
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -37,7 +37,7 @@ void warlock_pet_t::create_buffs()
                                ->set_cooldown( 0_ms );
 
   buffs.grimoire_of_service = make_buff( this, "grimoire_of_service", o()->talents.grimoire_of_service )
-                                  ->set_default_value_from_effect( 1 );
+                                  ->set_default_value( o()->talents.grimoire_of_service->effectN( 1 ).percent() + o()->talents.fiendish_oblation->effectN( 1 ).percent() );
 
   buffs.annihilan_training = make_buff( this, "annihilan_training", o()->talents.annihilan_training_buff )
                                  ->set_default_value( o()->talents.annihilan_training_buff->effectN( 1 ).percent() );
@@ -52,9 +52,6 @@ void warlock_pet_t::create_buffs()
 
   buffs.the_expendables = make_buff( this, "the_expendables", o()->talents.the_expendables_buff )
                               ->set_default_value_from_effect( 1 );
-
-  buffs.fiendish_wrath = make_buff( this, "fiendish_wrath", o()->talents.fiendish_wrath_buff )
-                             ->set_default_value_from_effect( 1 );
 
   buffs.demonic_power = make_buff( this, "demonic_power", o()->talents.demonic_power_buff )
                             ->set_default_value_from_effect( 5 );
@@ -197,6 +194,16 @@ double warlock_pet_t::composite_spell_haste() const
   if ( is_main_pet &&  o()->talents.demonic_inspiration.ok() )
     m *= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
 
+  return m;
+}
+
+double warlock_pet_t::composite_melee_haste() const
+{
+  double m = pet_t::composite_melee_haste();
+
+  if ( is_main_pet &&  o()->talents.demonic_inspiration.ok() )
+    m *= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
+
   if ( ( pet_type == PET_DREADSTALKER || pet_type == PET_FELHUNTER ) && o()->talents.flametouched.ok() )
     m *= 1.0 + o()->talents.flametouched->effectN( 1 ).percent();
 
@@ -209,9 +216,6 @@ double warlock_pet_t::composite_spell_cast_speed() const
 
   if ( is_main_pet &&  o()->talents.demonic_inspiration.ok() )
       m /= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
-
-  if ( ( pet_type == PET_DREADSTALKER || pet_type == PET_FELHUNTER ) && o()->talents.flametouched.ok() )
-    m /= 1.0 + o()->talents.flametouched->effectN( 1 ).percent();
 
   return m;
 }
@@ -467,7 +471,6 @@ namespace demonology
 felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_FELGUARD, false ),
     soul_strike( nullptr ),
-    felguard_guillotine( nullptr ),
     hatred_proc( nullptr ),
     demonic_strength_executes( 0 ),
     min_energy_threshold( find_spell( 89751 )->cost( POWER_ENERGY ) ),
@@ -493,46 +496,9 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
 
 struct felguard_melee_t : public warlock_pet_melee_t
 {
-  struct fiendish_wrath_t : public warlock_pet_melee_attack_t
-  {
-    fiendish_wrath_t( warlock_pet_t* p ) : warlock_pet_melee_attack_t( "Fiendish Wrath", p, p->o()->talents.fiendish_wrath_dmg )
-    {
-      weapon_multiplier = 1.0;
-      background = dual = true;
-      aoe = -1;
-    }
-
-    size_t available_targets( std::vector<player_t*>& tl ) const override
-    {
-      warlock_pet_melee_attack_t::available_targets( tl );
-
-      // Does not hit the main target
-      auto it = range::find( tl, target );
-      if ( it != tl.end() )
-      {
-        tl.erase( it );
-      }
-
-      return tl.size();
-    }
-  };
-
-  fiendish_wrath_t* fiendish_wrath;
-
   felguard_melee_t( warlock_pet_t* p, double wm, const char* name = "melee" ) :
     warlock_pet_melee_t ( p, wm, name )
-  {
-    fiendish_wrath = new fiendish_wrath_t( p );
-    add_child( fiendish_wrath );
-  }
-
-  void impact( action_state_t* s ) override
-  {
-    warlock_pet_melee_t::impact( s );
-
-    if ( p()->buffs.fiendish_wrath->check() )
-      fiendish_wrath->execute_on_target( s->target );
-  }
+  { }
 };
 
 struct axe_toss_t : public warlock_pet_spell_t
@@ -757,7 +723,7 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
 
     soul_cleave = new soul_cleave_t( p );
     add_child( soul_cleave );
-    // TOCHECK: As of 2023-10-16 PTR, Soul Cleave appears to be double-dipping on both Annihilan Training and Antoran Armaments multipliers. Not currently implemented
+    // TOCHECK: As of 2023-10-16 PTR, Soul Cleave appears to be double-dipping on both Annihilan Training and Antoran Armaments multipliers (implemented)
 
     base_multiplier *= 1.0 + p->o()->talents.fel_invocation->effectN( 1 ).percent();
   }
@@ -780,45 +746,6 @@ struct soul_strike_t : public warlock_pet_melee_attack_t
     
     if ( p()->o()->talents.antoran_armaments.ok() )
       soul_cleave->execute_on_target( s->target, amount );
-  }
-};
-
-struct fel_explosion_t : public warlock_pet_spell_t
-{
-  fel_explosion_t( warlock_pet_t* p ) : warlock_pet_spell_t( "Fel Explosion", p, p->o()->talents.fel_explosion )
-  {
-    background = dual = true;
-    callbacks = false;
-    aoe = -1;
-  }
-};
-
-struct felguard_guillotine_t : public warlock_pet_spell_t
-{
-  fel_explosion_t* fel_explosion;
-
-  felguard_guillotine_t( warlock_pet_t* p ) : warlock_pet_spell_t( "Guillotine", p, p->o()->talents.guillotine_pet )
-  {
-    background = true;
-    may_miss = may_crit = false;
-    base_tick_time = 1_s;
-
-    fel_explosion = new fel_explosion_t( p );
-  }
-
-  void execute() override
-  {
-    warlock_pet_spell_t::execute();
-
-    make_event<ground_aoe_event_t>( *sim, p(),
-                                ground_aoe_params_t()
-                                    .target( execute_state->target )
-                                    .x( execute_state->target->x_position )
-                                    .y( execute_state->target->y_position )
-                                    .pulse_time( base_tick_time )
-                                    .duration( data().duration() )
-                                    .start_time( sim->current_time() )
-                                    .action( fel_explosion ) );
   }
 };
 
@@ -893,12 +820,8 @@ void felguard_pet_t::init_base_stats()
   owner_coeff.sp_from_sp = 1.4519;
 
   melee_attack->base_dd_multiplier *= 1.42;
-  debug_cast<felguard_melee_t*>( melee_attack )->fiendish_wrath->base_dd_multiplier = melee_attack->base_dd_multiplier;
 
   special_action = new axe_toss_t( this, "" );
-
-  if ( o()->talents.guillotine.ok() )
-    felguard_guillotine = new felguard_guillotine_t( this );
 
   if ( o()->talents.immutable_hatred.ok() )
     hatred_proc = new immutable_hatred_t( this );
@@ -952,15 +875,6 @@ double felguard_pet_t::composite_player_multiplier( school_e school ) const
   return m;
 }
 
-double felguard_pet_t::composite_melee_auto_attack_speed() const
-{
-  double m = warlock_pet_t::composite_melee_auto_attack_speed();
-
-  m /= 1.0 + buffs.fiendish_wrath->check_value();
-
-  return m;
-}
-
 double felguard_pet_t::composite_melee_crit_chance() const
 {
   double m = warlock_pet_t::composite_melee_crit_chance();
@@ -1010,15 +924,6 @@ grimoire_felguard_pet_t::grimoire_felguard_pet_t( warlock_t* owner )
 
    if ( o()->talents.fiendish_oblation.ok() )
      o()->buffs.demonic_core->trigger();
- }
-
- double grimoire_felguard_pet_t::composite_player_multiplier( school_e school ) const
- {
-   double m = warlock_pet_t::composite_player_multiplier( school );
-
-   m *= 1.0 + o()->talents.fiendish_oblation->effectN( 1 ).percent();
-
-   return m;
  }
 
  // TODO: Grimoire: Felguard only does a single Felstorm at most, rendering some of this unnecessary
@@ -1976,6 +1881,15 @@ struct rift_shadow_bolt_t : public warlock_pet_spell_t
       base_dd_multiplier *= 1.0 + p->o()->talents.summoners_embrace->effectN( 1 ).percent();
   }
 
+  double composite_crit_chance() const override
+  {
+    double c = warlock_pet_spell_t::composite_crit_chance();
+
+    c += p()->o()->talents.devastation->effectN( 1 ).percent();
+
+    return c;
+  }
+
   double composite_crit_damage_bonus_multiplier() const override
   {
     double m = warlock_pet_spell_t::composite_crit_damage_bonus_multiplier();
@@ -2059,6 +1973,15 @@ struct chaos_barrage_tick_t : public warlock_pet_spell_t
   
       // Double dips from whitelist+guardian aura
       base_dd_multiplier *= 1.0 + p->o()->talents.summoners_embrace->effectN( 1 ).percent();
+  }
+
+  double composite_crit_chance() const override
+  {
+    double c = warlock_pet_spell_t::composite_crit_chance();
+
+    c += p()->o()->talents.devastation->effectN( 1 ).percent();
+
+    return c;
   }
 
   double composite_crit_damage_bonus_multiplier() const override
@@ -2251,6 +2174,16 @@ struct overfiend_chaos_bolt_t : public warlock_pet_spell_t
     return m;
   }
 
+  double composite_da_multiplier( const action_state_t* s ) const override
+  {
+    double m = warlock_pet_spell_t::composite_da_multiplier( s );
+
+    if ( p()->o()->talents.summoners_embrace.ok() )
+      m *= 1.0 + p()->o()->talents.summoners_embrace->effectN( 1 ).percent();
+
+    return m;
+  }
+
   double action_multiplier() const override
   {
     double m = warlock_pet_spell_t::action_multiplier();
@@ -2356,6 +2289,20 @@ namespace diabolist
       debug_cast<overlord_t*>( p() )->cleaves--;
     }
 
+    double composite_crit_chance() const override
+    {
+      double c = warlock_pet_spell_t::composite_crit_chance();
+
+      // NOTE: Devastation talent (+5% crit) does affect Wicked Cleave spell from Overlord
+      c += p()->o()->talents.devastation->effectN( 1 ).percent();
+
+      return c;
+    }
+
+    // NOTE: Overlord Wicked Cleave crits does not benefit from other crit dmg bonus multipliers (bug?)
+    double composite_crit_damage_bonus_multiplier() const override
+    { return p()->bugs ? 1.0 : ( warlock_pet_spell_t::composite_crit_damage_bonus_multiplier() * ( 1.0 + p()->o()->talents.ruin->effectN( 1 ).percent() ) ); }
+
     double composite_da_multiplier( const action_state_t* s ) const override
     {
       double m = warlock_pet_spell_t::composite_da_multiplier( s );  // base value
@@ -2414,6 +2361,10 @@ namespace diabolist
     return warlock_pet_t::create_action( name, options_str );
   }
 
+  // NOTE: Overlord does not benefit from critical dmg multiplier effects (bug?)
+  double overlord_t::composite_player_critical_damage_multiplier( const action_state_t* s ) const
+  { return bugs ? 1.0 : warlock_pet_t::composite_player_critical_damage_multiplier( s ); }
+
   mother_of_chaos_t::mother_of_chaos_t( warlock_t* owner, util::string_view name )
     : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
   {
@@ -2429,6 +2380,24 @@ namespace diabolist
       aoe = -1;
 
       travel_speed = p->o()->hero.chaos_salvo_missile->missile_speed();
+    }
+
+    double composite_crit_chance() const override
+    {
+      double c = warlock_pet_spell_t::composite_crit_chance();
+
+      c += p()->o()->talents.devastation->effectN( 1 ).percent();
+
+      return c;
+    }
+
+    double composite_crit_damage_bonus_multiplier() const override
+    {
+      double m = warlock_pet_spell_t::composite_crit_damage_bonus_multiplier();
+
+      m *= 1.0 + p()->o()->talents.ruin->effectN( 1 ).percent();
+
+      return m;
     }
 
     double composite_da_multiplier( const action_state_t* s ) const override
@@ -2516,13 +2485,31 @@ namespace diabolist
       base_costs[ RESOURCE_ENERGY ] = 0.0;
     }
 
+    double composite_crit_chance() const override
+    {
+      double c = warlock_pet_spell_t::composite_crit_chance();
+
+      c += p()->o()->talents.devastation->effectN( 1 ).percent();
+
+      return c;
+    }
+
+    double composite_crit_damage_bonus_multiplier() const override
+    {
+      double m = warlock_pet_spell_t::composite_crit_damage_bonus_multiplier();
+
+      m *= 1.0 + p()->o()->talents.ruin->effectN( 1 ).percent();
+
+      return m;
+    }
+
     double composite_target_multiplier( player_t* target ) const override
     {
       double m = spell_t::composite_target_multiplier( target );
 
       // TOCHECK: 2025-07-27 Despite what is listed in spell data, Shadowtouched increases the damage of Feelseeker spell from Pit Lord by 25% instead of 20% (bug?)
       if ( p()->o()->talents.shadowtouched.ok() && dbc::has_common_school( spell_t::get_school(), SCHOOL_SHADOW ) && owner_td( target )->debuffs.wicked_maw->check() )
-        m *= 1.0 + ( ( p()->bugs ) ? shadowtouched_value : p()->o()->talents.shadowtouched->effectN( 1 ).percent() );
+        m *= 1.0 + ( p()->bugs ? shadowtouched_value : p()->o()->talents.shadowtouched->effectN( 1 ).percent() );
 
       return m;
     }
@@ -2628,7 +2615,11 @@ namespace diabolist
   {
     diabolic_bolt_t( warlock_pet_t* p )
       : warlock_pet_spell_t( "Diabolic Bolt", p, p->o()->hero.diabolic_bolt )
-    { base_costs[ RESOURCE_ENERGY ] = 0.0; }
+    {
+      base_costs[ RESOURCE_ENERGY ] = 0.0;
+
+      base_dd_multiplier *= 1.0 + p->o()->talents.socrethars_guile->effectN( 2 ).percent();
+    }
 
     bool ready() override
     {
@@ -2690,6 +2681,8 @@ struct rampaging_demonic_soul_shard_event_t : public event_t
 
 struct soul_swipe_base_t : public warlock_pet_spell_t
 {
+  const double shadowtouched_value = 1.30 / 1.10;
+
   soul_swipe_base_t( std::string_view n, warlock_pet_t* p, const spell_data_t* s ) : warlock_pet_spell_t( n, p, s )
   {
   }
@@ -2714,13 +2707,11 @@ struct soul_swipe_base_t : public warlock_pet_spell_t
 
   double composite_target_multiplier( player_t* target ) const override
   {
-    double m = warlock_pet_spell_t::composite_target_multiplier( target );
+    double m = spell_t::composite_target_multiplier( target );
 
-    if ( p()->o()->talents.shadowtouched.ok() )
-    {
-      if ( owner_td( target )->debuffs.wicked_maw->check() )
-        m *= 1.0 + p()->o()->talents.shadowtouched->effectN( 1 ).percent();
-    }
+    // TOCHECK: 2025-09-23 Despite what is listed in spell data, Shadowtouched increases the damage of Soul Swipe spell from Rampaging Demonic Soul by 18.18% (1.30/1.10) instead of 20% (bug?)
+    if ( p()->o()->talents.shadowtouched.ok() && dbc::has_common_school( spell_t::get_school(), SCHOOL_SHADOW ) && owner_td( target )->debuffs.wicked_maw->check() )
+      m *= 1.0 + ( p()->bugs ? shadowtouched_value : p()->o()->talents.shadowtouched->effectN( 1 ).percent() );
 
     return m;
   }

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -79,7 +79,6 @@ struct warlock_pet_t : public pet_t
     propagate_const<buff_t*> imp_gang_boss; // Aura applied to some Wild Imps for increased damage (and size)
     propagate_const<buff_t*> antoran_armaments; // Permanent aura when talented, 20% increased damage to all abilities plus Soul Strike cleave
     propagate_const<buff_t*> the_expendables;
-    propagate_const<buff_t*> fiendish_wrath; // Guillotine talent buff, causes AoE melee attacks and prevents Felstorm
     propagate_const<buff_t*> demonic_inspiration; // Haste buff triggered by filling a Soul Shard
     propagate_const<buff_t*> wrathful_minion; // Damage buff triggered by filling a Soul Shard
     propagate_const<buff_t*> demonic_power;
@@ -98,6 +97,7 @@ struct warlock_pet_t : public pet_t
   void schedule_ready( timespan_t = 0_ms, bool = false ) override;
   double composite_player_multiplier( school_e ) const override;
   double composite_spell_haste() const override;
+  double composite_melee_haste() const override;
   double composite_spell_cast_speed() const override;
   double composite_melee_auto_attack_speed() const override;
   double composite_player_critical_damage_multiplier( const action_state_t* ) const override;
@@ -415,7 +415,6 @@ namespace demonology
 struct felguard_pet_t : public warlock_pet_t
 {
   action_t* soul_strike;
-  action_t* felguard_guillotine;
   action_t* hatred_proc;
   cooldown_t* felstorm_cd;
   cooldown_t* dstr_cd;
@@ -432,7 +431,6 @@ struct felguard_pet_t : public warlock_pet_t
   timespan_t available() const override;
   void arise() override;
   double composite_player_multiplier( school_e ) const override;
-  double composite_melee_auto_attack_speed() const override;
   double composite_melee_crit_chance() const override;
   double composite_spell_crit_chance() const override;
 
@@ -455,7 +453,6 @@ struct grimoire_felguard_pet_t : public warlock_pet_t
   timespan_t available() const override;
   void arise() override;
   void demise() override;
-  double composite_player_multiplier( school_e ) const override;
 };
 
 struct wild_imp_pet_t : public warlock_pet_t
@@ -615,6 +612,7 @@ namespace diabolist
     overlord_t( warlock_t*, util::string_view = "overlord" );
     void arise() override;
     action_t* create_action( util::string_view, util::string_view ) override;
+    double composite_player_critical_damage_multiplier( const action_state_t* ) const override;
   };
 
   struct mother_of_chaos_t : public warlock_pet_t


### PR DESCRIPTION
Various fixes/changes to the warlock module, including:
- In simc the [Devastation](https://www.wowhead.com/spell=454735) talent is not affecting some spells that it should: Unstable Tear's [Chaos Barrage](https://www.wowhead.com/spell=387984), Shadowy Tear's [Shadow Barrage](https://www.wowhead.com/spell=394237), the Overlord's [Wicked Cleave](https://www.wowhead.com/spell=432120), Mother of Chaos's [Chaos Salvo](https://www.wowhead.com/spell=432596), and Pit Lord's [Felseeker](https://www.wowhead.com/spell=434404). Fixed.
- In simc the [Ruin](https://www.wowhead.com/spell=387103) talent is not affecting Mother of Chaos's [Chaos Salvo](https://www.wowhead.com/spell=432596) and Pitlord's [Felseeker](https://www.wowhead.com/spell=434404) spells and it should. Fixed.
- Translated the ingame behavior of the Overlord's [Wicked Cleave](https://www.wowhead.com/spell=432120) spell to simc: its crits ignore all bonus multipliers and always do x2 damage.
- The [Fiendish Oblation](https://www.wowhead.com/spell=455569) talent is an additive modifier to +125% of the base [Grimoire of Service](https://www.wowhead.com/spell=216187) of [Grimoire: Felguard](https://www.wowhead.com/spell=111898), not multiplicative as implemented in simc. Fixed.
- Fixed the Overfiend's [Chaos Bolt](https://www.wowhead.com/spell=434589) not benefiting from the [Summoner's Embrace](https://www.wowhead.com/spell=453105) talent.
- [Socrethar's Guile](https://www.wowhead.com/spell=405936)'s talent is not affecting Diabolic Imp's [Diabolic Bolt](https://www.wowhead.com/spell=438823) spell.
- The damage bonus that [Shadowtouched](https://www.wowhead.com/spell=453619) grants to [Soul Swipe](https://www.wowhead.com/spell=1239714) from the Rampaging Demonic Soul pet (tier) has been fixed, it's actually +18.1818% (we're not sure where this value comes from, probably 1.3/1.1 somewhere, but it's the value tested ingame) instead of the +44% implemented in simc.
- The [Indiscriminate Flames](https://www.wowhead.com/spell=457114) talent effects (applied via the [Backdraft](https://www.wowhead.com/spell=117828) buff) scale with stacks ingame, so it's reflected the same way in simc.
- Fixed a bug in simc where [Implosion](https://www.wowhead.com/spell=196278) was not correctly receiving some damage modifiers (such as the [demonology spec passive spell](https://www.wowhead.com/spell=137044)).
- Fixed a bug in simc where [Shadow Embrace](https://www.wowhead.com/spell=32388) was not being taken into account if the [Improved Haunt](https://www.wowhead.com/spell=458034) talent was selected but not the [Shadow Embrace](https://www.wowhead.com/spell=32388) talent.
- Added the spellID for the corresponding [Internal Combustion](https://www.wowhead.com/spell=266136) damage.
- Cleanup and minor adjustments to some removed spells:
  - [Xavian Teachings](https://www.wowhead.com/spell=317031) was removed from the game in patch 11.2.0, and its behavior was implemented within [Corruption](https://www.wowhead.com/spell=172) itself.
  - The demonology [Guillotine](https://www.wowhead.com/spell=386833) talent was removed in patch 11.2.0. Related spells also removed: [Fiendish Wrath](https://www.wowhead.com/spell=386601) and [Fel Explosion](https://www.wowhead.com/spell=386609)
  - The [Inferno](https://www.wowhead.com/spell=270545) talent was removed in patch 11.2.0.

Link to 8-hour test in warcraftlogs testing [Devastation](https://www.wowhead.com/spell=454735) and [Ruin](https://www.wowhead.com/spell=387103) talents: https://www.warcraftlogs.com/reports/GQbh92NKqCJRPD8X?fight=1&type=damage-done&source=1
