### PR TITLE
[chrono] Avoid redefining CLOCK_PROCESS_CPUTIME_ID and CLOCK_THREAD_CPUTIME_ID on Windows

### DIFF
--- a/engine/util/chrono.cpp
+++ b/engine/util/chrono.cpp
@@ -26,7 +26,12 @@ namespace
 {
 #if defined(SC_WINDOWS)
 
-enum : int { CLOCK_PROCESS_CPUTIME_ID, CLOCK_THREAD_CPUTIME_ID };
+#ifndef CLOCK_PROCESS_CPUTIME_ID
+constexpr int CLOCK_PROCESS_CPUTIME_ID = 2;
+#endif
+#ifndef CLOCK_THREAD_CPUTIME_ID
+constexpr int CLOCK_THREAD_CPUTIME_ID = 3;
+#endif
 std::chrono::nanoseconds do_clock_gettime( int clock_id )
 {
   FILETIME lpCreationTime, lpExitTime, lpKernelTime, lpUserTime;


### PR DESCRIPTION
On Windows, in some implementations, `CLOCK_PROCESS_CPUTIME_ID` and `CLOCK_THREAD_CPUTIME_ID` may already be defined (usually using `#define`), so when the following is defined in simc `/engine/util/chrono.cpp`:
```cpp
enum: int { CLOCK_PROCESS_CPUTIME_ID, CLOCK_THREAD_CPUTIME_ID };
```
, those names are resolved to constants, and the enum is invalid, thus we get a compilation error. This happens, for example, when trying to compile with MSYS2 on Windows (whether using clang, gcc with ucrt, mingw, or other variants).

The suggestion in this PR is to modify that enum to:
```cpp
#ifndef CLOCK_PROCESS_CPUTIME_ID
constexpr int CLOCK_PROCESS_CPUTIME_ID = 2;
#endif
#ifndef CLOCK_THREAD_CPUTIME_ID
constexpr int CLOCK_THREAD_CPUTIME_ID = 3;
#endif
```

Values `2` and `3` are used here because they are the typical values for these constants in POSIX, but any value can be used, that doesn't matter.

Although I think the proposed option is the most appropriate, there are other options as well:

Another valid alternative would be to modify the names of these constants in this `chrono.cpp` file, something like `enum : int { CLOCK_PROCESS_CPUTIME_ID_INTERNAL, CLOCK_THREAD_CPUTIME_ID_INTERNAL };`.

Another simple, though somewhat incomplete, alternative would be the following:
```cpp
#if !defined(CLOCK_PROCESS_CPUTIME_ID) && !defined(CLOCK_THREAD_CPUTIME_ID)
enum : int { CLOCK_PROCESS_CPUTIME_ID, CLOCK_THREAD_CPUTIME_ID };
#endif
```
This last option has the disadvantage that it doesn't consider cases where one of them is defined and the other isn't (I don't know if this could occur in some implementations).

All of this is only relevant for Windows, since we are within a `#if defined(SC_WINDOWS)`.