### PR TITLE
[HTML] Ensure safe global locale fallback setup

### DIFF
--- a/engine/report/report_html_sim.cpp
+++ b/engine/report/report_html_sim.cpp
@@ -1170,20 +1170,34 @@ void print_profilesets( std::ostream& out, const profileset::profilesets_t& prof
   out << "</div>";
 }
 
+void set_global_locale( ) {
+  // Set global locale to en-US for consistent number formatting
+  for (const auto& name :
+  {
+    "en_US.UTF-8",
+    "en_US.utf8",
+    "English_United States.65001",
+    "en_US",
+    "en-US",
+    "English_United States.1252",
+    "C"
+  })
+  {
+    try {
+      std::locale::global(std::locale(name));
+      return;
+    } catch (const std::runtime_error&)
+    { }
+  }
+  std::locale::global(std::locale::classic());
+}
+
 /* Main function building the html document and calling subfunctions
  */
 void print_html_( report::sc_html_stream& os, sim_t& sim )
 {
-  // Set global locale to en-US for consistent number formatting
-  try
-  {
-    std::locale::global( std::locale( "en_US.UTF-8" ) );
-  }
-  catch ( const std::runtime_error& )
-  {
-    // backup spelling for CI
-    std::locale::global( std::locale( "en_US.utf8" ) );
-  }
+  // Set global locale formatting
+  set_global_locale();
 
   // Set floating point formatting
   os.precision( sim.report_precision );

--- a/engine/report/report_html_sim.cpp
+++ b/engine/report/report_html_sim.cpp
@@ -1170,9 +1170,10 @@ void print_profilesets( std::ostream& out, const profileset::profilesets_t& prof
   out << "</div>";
 }
 
-void set_global_locale( ) {
+void set_global_locale()
+{
   // Set global locale to en-US for consistent number formatting
-  for (const auto& name :
+  for ( const auto& name :
   {
     "en_US.UTF-8",
     "en_US.utf8",
@@ -1181,15 +1182,17 @@ void set_global_locale( ) {
     "en-US",
     "English_United States.1252",
     "C"
-  })
+  } )
   {
-    try {
-      std::locale::global(std::locale(name));
+    try
+    {
+      std::locale::global( std::locale( name ) );
       return;
-    } catch (const std::runtime_error&)
+    }
+    catch ( const std::runtime_error& )
     { }
   }
-  std::locale::global(std::locale::classic());
+  std::locale::global( std::locale::classic() );
 }
 
 /* Main function building the html document and calling subfunctions


### PR DESCRIPTION
Currently, in some environments, simc may throw an exception during HTML report creation if the locales `en_US.UTF-8` and `en_US.utf8` do not exist.

This PR makes the global locale setup in the HTML report section more robust by adding a fallback mechanism. It tries several common locale names and falls back to `std::locale::classic()` (which should never fail) as a last resort.