### PR TITLE
[Warlock] Fixes to Demonic Inspiration, Bile Spit, Felstorm and pet haste inheritance

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -289,7 +289,14 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   sim->register_heartbeat_event_callback( [ this ]( sim_t* ) {
     for ( auto& pet : active_pets )
     {
-      debug_cast<warlock_pet_t*>( pet )->heartbeat_update_event();
+      auto lock_pet = dynamic_cast<warlock_pet_t*>( pet );
+
+      if ( lock_pet == nullptr )
+        continue;
+      if ( lock_pet->is_sleeping() )
+        continue;
+
+      lock_pet->heartbeat_update_event();
     }
   } );
 }

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -258,7 +258,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
     corruption_accumulator( 0.0 ),
     diabolic_ritual( 0 ),
     demonic_art_buff_replaced( false ),
-    active_pets( 0 ),
+    n_active_pets( 0 ),
     warlock_pet_list( this ),
     talents(),
     hero(),
@@ -272,12 +272,12 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
     initial_soul_shards( 3 ),
     default_pet(),
     disable_auto_felstorm( false ),
-    normalize_destruction_mastery( false )
+    normalize_destruction_mastery( false ),
+    demonic_inspiration_double_dip( false )
 {
   cooldowns.haunt = get_cooldown( "haunt" );
   cooldowns.shadowburn = get_cooldown( "shadowburn" );
   cooldowns.soul_fire = get_cooldown( "soul_fire" );
-  cooldowns.dimensional_rift = get_cooldown( "dimensional_rift" );
   cooldowns.felstorm_icd = get_cooldown( "felstorm_icd" );
   cooldowns.blackened_soul = get_cooldown( "blackened_soul_icd" );
   cooldowns.seeds_of_their_demise = get_cooldown( "seeds_of_their_demise_icd" );
@@ -285,6 +285,13 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   resource_regeneration = regen_type::DYNAMIC;
   regen_caches[ CACHE_HASTE ] = true;
   regen_caches[ CACHE_SPELL_HASTE ] = true;
+
+  sim->register_heartbeat_event_callback( [ this ]( sim_t* ) {
+    for ( auto& pet : active_pets )
+    {
+      debug_cast<warlock_pet_t*>( pet )->heartbeat_update_event();
+    }
+  } );
 }
 
 const spell_data_t* warlock_t::conditional_spell_lookup( bool fn, int id )
@@ -499,6 +506,8 @@ std::string warlock_t::create_profile( save_e stype )
       profile_str += "disable_felstorm=" + util::to_string( disable_auto_felstorm ) + "\n";
     if ( normalize_destruction_mastery )
       profile_str += "normalize_destruction_mastery=" + util::to_string( normalize_destruction_mastery ) + "\n";
+    if ( demonic_inspiration_double_dip )
+      profile_str += "demonic_inspiration_double_dip=" + util::to_string( demonic_inspiration_double_dip ) + "\n";
 
     profile_str += append_rng_option( rng_settings.cunning_cruelty_sb );
     profile_str += append_rng_option( rng_settings.cunning_cruelty_ds );
@@ -534,6 +543,7 @@ void warlock_t::copy_from( player_t* source )
   default_pet = p->default_pet;
   disable_auto_felstorm = p->disable_auto_felstorm;
   normalize_destruction_mastery = p->normalize_destruction_mastery;
+  demonic_inspiration_double_dip = p->demonic_inspiration_double_dip;
 
   rng_settings.cunning_cruelty_sb = p->rng_settings.cunning_cruelty_sb;
   rng_settings.cunning_cruelty_ds = p->rng_settings.cunning_cruelty_ds;
@@ -680,7 +690,7 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
   }
   else if ( name_str == "pet_count" )
   {
-    return make_ref_expr( name_str, active_pets );
+    return make_ref_expr( name_str, n_active_pets );
   }
   else if ( name_str == "last_cast_imps" )
   {

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -145,7 +145,7 @@ public:
   int diabolic_ritual; // Used to cycle between the three different Diabolic Ritual buffs
   bool demonic_art_buff_replaced; // Used to not spawn the Demonic Art demon if the buff is replaced by another
 
-  unsigned active_pets;
+  unsigned n_active_pets;
 
   // This should hold any spell data that is guaranteed in the base class or spec, without talents or other external systems required
   struct base_t
@@ -227,6 +227,7 @@ public:
     // Class Tree
 
     player_talent_t demonic_inspiration; // Primary pet attack speed increase
+    const spell_data_t* demonic_inspiration_buff; // This hidden buff is applied to pets/guardians in the first heartbeat update after arise
     player_talent_t demonic_embrace;
     player_talent_t demonic_fortitude;
     player_talent_t wrathful_minion; // Primary pet damage increase
@@ -672,7 +673,6 @@ public:
     propagate_const<cooldown_t*> haunt;
     propagate_const<cooldown_t*> shadowburn;
     propagate_const<cooldown_t*> soul_fire;
-    propagate_const<cooldown_t*> dimensional_rift;
     propagate_const<cooldown_t*> felstorm_icd; // Shared between Felstorm, Demonic Strength, and Guillotine TODO: Actually use this!
     propagate_const<cooldown_t*> blackened_soul; // Internal cooldown on triggering stack increase to Wither
     propagate_const<cooldown_t*> seeds_of_their_demise; // Estimated internal cooldown, a guess at how Blizzard is minimizing lucky streaks
@@ -887,6 +887,7 @@ public:
   std::string default_pet;
   bool disable_auto_felstorm; // For Demonology main pet
   bool normalize_destruction_mastery;
+  bool demonic_inspiration_double_dip; // Enable Demonic Inspiration double dip on main pets
   shuffled_rng_t* rain_of_chaos_rng;
   real_ppm_t* ravenous_afflictions_rng;
   real_ppm_t* jackpot_demonology_rng;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -710,6 +710,17 @@ using namespace helpers;
       : summon_pet_t( n, p )
     { ignore_false_positive = true; }
 
+    void init_finished() override
+    {
+      summon_pet_t::init_finished();
+
+      if ( is_precombat && pet->affected_by.demonic_inspiration )
+        make_event( *sim, 1_ms, [ this ] {  // Delay buff gain until after pet->reset()
+          if ( !pet->buffs.demonic_inspiration->check() )
+            pet->buffs.demonic_inspiration->trigger();
+        } );
+    }
+
     void schedule_execute( action_state_t* s = nullptr ) override
     {
       summon_pet_t::schedule_execute( s );
@@ -3087,7 +3098,7 @@ using namespace helpers;
 
         debug_cast<pets::demonology::felguard_pet_t*>( active_pet )->queue_ds_felstorm();
 
-        internal_cooldown->start( 5_s * p()->composite_spell_haste() );
+        internal_cooldown->start( 5_s * active_pet->composite_spell_cast_speed() );
       }
     }
   };

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -710,17 +710,6 @@ using namespace helpers;
       : summon_pet_t( n, p )
     { ignore_false_positive = true; }
 
-    void init_finished() override
-    {
-      summon_pet_t::init_finished();
-
-      if ( is_precombat && pet->affected_by.demonic_inspiration )
-        make_event( *sim, 1_ms, [ this ] {  // Delay buff gain until after pet->reset()
-          if ( !pet->buffs.demonic_inspiration->check() )
-            pet->buffs.demonic_inspiration->trigger();
-        } );
-    }
-
     void schedule_execute( action_state_t* s = nullptr ) override
     {
       summon_pet_t::schedule_execute( s );
@@ -745,6 +734,9 @@ using namespace helpers;
       summon_pet_t::execute();
 
       p()->warlock_pet_list.active = pet;
+
+      if ( is_precombat && pet->affected_by.demonic_inspiration && !pet->buffs.demonic_inspiration->check() )
+        pet->buffs.demonic_inspiration->trigger();
 
       if ( p()->buffs.grimoire_of_sacrifice->check() )
         p()->buffs.grimoire_of_sacrifice->expire();

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -60,6 +60,7 @@ namespace warlock
     talents.summoners_embrace = find_talent_spell( talent_tree::SPECIALIZATION, "Summoner's Embrace" ); // Should be ID 453105
 
     talents.demonic_inspiration = find_talent_spell( talent_tree::CLASS, "Demonic Inspiration" ); // Should be ID 386858
+    talents.demonic_inspiration_buff = conditional_spell_lookup( talents.demonic_inspiration, 386861 );
 
     talents.demonic_embrace = find_talent_spell( talent_tree::CLASS, "Demonic Embrace" ); // Should be ID 288843
 
@@ -1349,6 +1350,7 @@ namespace warlock
     add_option( opt_string( "default_pet", default_pet ) );
     add_option( opt_bool( "disable_felstorm", disable_auto_felstorm ) );
     add_option( opt_bool( "normalize_destruction_mastery", normalize_destruction_mastery ) );
+    add_option( opt_bool( "demonic_inspiration_double_dip", demonic_inspiration_double_dip ) );
 
     add_rng_option( rng_settings.cunning_cruelty_sb );
     add_rng_option( rng_settings.cunning_cruelty_ds );

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -17,8 +17,8 @@ warlock_pet_t::warlock_pet_t( warlock_t* owner, util::string_view pet_name, pet_
   owner_coeff.sp_from_sp = 1.0;
   owner_coeff.health = 0.5;
 
-  register_on_arise_callback( this, [ owner ]() { owner->active_pets++; } );
-  register_on_demise_callback( this, [ owner ]( const player_t* ) { owner->active_pets--; } );
+  register_on_arise_callback( this, [ owner ]() { owner->n_active_pets++; } );
+  register_on_demise_callback( this, [ owner ]( const player_t* ) { owner->n_active_pets--; } );
 }
 
 warlock_t* warlock_pet_t::o()
@@ -75,6 +75,8 @@ void warlock_pet_t::create_buffs()
                      } );
 
   // All Specs
+  buffs.demonic_inspiration = make_buff( this, "demonic_inspiration", o()->talents.demonic_inspiration_buff )
+                                  ->set_default_value_from_effect( 1 );
 
   // To avoid clogging the buff reports, we silence the pet movement statistics since Implosion uses them regularly
   // and there are a LOT of Wild Imps. We can instead lump them into a single tracking buff on the owner.
@@ -154,6 +156,13 @@ void warlock_pet_t::schedule_ready( timespan_t delta_time, bool waiting )
   pet_t::schedule_ready( delta_time, waiting );
 }
 
+// Stuff that are updated at the heartbeat update interval
+void warlock_pet_t::heartbeat_update_event()
+{
+  if ( affected_by.demonic_inspiration && !buffs.demonic_inspiration->check() )
+    buffs.demonic_inspiration->trigger();
+};
+
 /*
 Felguard had a Haste scaling energy bug that was supposedly fixed once already. Real fix apparently went live
 2019-03-12. Preserving code from resource regen override for now in case of future issues. if ( !o()->dbc.ptr && ( pet_type == PET_FELGUARD ||
@@ -181,8 +190,12 @@ double warlock_pet_t::composite_spell_haste() const
 {
   double m = pet_t::composite_spell_haste();
 
-  if ( is_main_pet &&  o()->talents.demonic_inspiration.ok() )
-    m *= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
+  if ( buffs.demonic_inspiration->check() )
+  {
+    m /= 1.0 + buffs.demonic_inspiration->check_value();
+    if ( is_main_pet && o()->demonic_inspiration_double_dip )
+      m /= 1.0 + buffs.demonic_inspiration->check_value();
+  }
 
   return m;
 }
@@ -191,11 +204,15 @@ double warlock_pet_t::composite_melee_haste() const
 {
   double m = pet_t::composite_melee_haste();
 
-  if ( is_main_pet &&  o()->talents.demonic_inspiration.ok() )
-    m *= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
+  if ( buffs.demonic_inspiration->check() )
+  {
+    m /= 1.0 + buffs.demonic_inspiration->check_value();
+    if ( is_main_pet && o()->demonic_inspiration_double_dip )
+      m /= 1.0 + buffs.demonic_inspiration->check_value();
+  }
 
   if ( buffs.ferocity_of_fharg->check() )
-    m *= 1.0 + o()->talents.flametouched->effectN( 1 ).percent();
+    m /= 1.0 + o()->talents.flametouched->effectN( 1 ).percent();
 
   return m;
 }
@@ -204,8 +221,12 @@ double warlock_pet_t::composite_spell_cast_speed() const
 {
   double m = pet_t::composite_spell_cast_speed();
 
-  if ( is_main_pet &&  o()->talents.demonic_inspiration.ok() )
-      m /= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
+  if ( buffs.demonic_inspiration->check() )
+  {
+    m /= 1.0 + buffs.demonic_inspiration->check_value();
+    if ( is_main_pet && o()->demonic_inspiration_double_dip )
+      m /= 1.0 + buffs.demonic_inspiration->check_value();
+  }
 
   return m;
 }
@@ -214,8 +235,12 @@ double warlock_pet_t::composite_melee_auto_attack_speed() const
 {
   double m = pet_t::composite_melee_auto_attack_speed();
 
-  if ( is_main_pet && o()->talents.demonic_inspiration.ok() )
-    m /= 1.0 + o()->talents.demonic_inspiration->effectN( 1 ).percent();
+  if ( buffs.demonic_inspiration->check() )
+  {
+    m /= 1.0 + buffs.demonic_inspiration->check_value();
+    if ( is_main_pet && o()->demonic_inspiration_double_dip )
+      m /= 1.0 + buffs.demonic_inspiration->check_value();
+  }
 
   if ( buffs.ferocity_of_fharg->check() )
     m /= 1.0 + o()->talents.flametouched->effectN( 1 ).percent();
@@ -278,6 +303,7 @@ felhunter_pet_t::felhunter_pet_t( warlock_t* owner, util::string_view name )
   action_list_str = "shadow_bite";
 
   is_main_pet = true;
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 struct spell_lock_t : public warlock_pet_spell_t
@@ -327,6 +353,7 @@ imp_pet_t::imp_pet_t( warlock_t* owner, util::string_view name )
   owner_coeff.health = 0.45;
 
   is_main_pet = true;
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 action_t* imp_pet_t::create_action( util::string_view name, util::string_view options_str )
@@ -364,6 +391,7 @@ sayaad_pet_t::sayaad_pet_t( warlock_t* owner, util::string_view name )
   action_list_str = "whiplash/lash_of_pain";
 
   is_main_pet = true;
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 void sayaad_pet_t::init_base_stats()
@@ -418,6 +446,7 @@ voidwalker_pet_t::voidwalker_pet_t( warlock_t* owner, util::string_view name )
   action_list_str = "consuming_shadows";
 
   is_main_pet = true;
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 struct consuming_shadows_t : public warlock_pet_spell_t
@@ -482,6 +511,7 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
   owner_coeff.health = 0.75;
 
   is_main_pet = true;
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 struct felguard_melee_t : public warlock_pet_melee_t
@@ -613,6 +643,10 @@ struct felstorm_t : public warlock_pet_melee_attack_t
       internal_cooldown = p->o()->get_cooldown( "felstorm_icd" );
   }
 
+  // NOTE: Although Felstorm is a "melee" attack, its duration/ticks depend on the pet's 'spell_cast_speed' 
+  double composite_haste() const override
+  { return action_t::composite_haste() * player->cache.spell_cast_speed(); }
+
   timespan_t composite_dot_duration( const action_state_t* s ) const override
   { return s->action->tick_time( s ) * 5.0; }
 
@@ -622,7 +656,7 @@ struct felstorm_t : public warlock_pet_melee_attack_t
 
     // New in 10.0.5 - Hardcoded scripted shared cooldowns while one of Felstorm, Demonic Strength, or Guillotine is active
     if ( internal_cooldown )
-      internal_cooldown->start( 5_s * p()->composite_spell_haste() );
+      internal_cooldown->start( 5_s * p()->composite_spell_cast_speed() );
 
     p()->melee_attack->cancel();
   }
@@ -899,6 +933,8 @@ grimoire_felguard_pet_t::grimoire_felguard_pet_t( warlock_t* owner )
   felstorm_cd = get_cooldown( "felstorm" );
 
   owner_coeff.health = 0.75;
+
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 void grimoire_felguard_pet_t::arise()
@@ -989,6 +1025,8 @@ wild_imp_pet_t::wild_imp_pet_t( warlock_t* owner )
 {
   resource_regeneration = regen_type::DISABLED;
   owner_coeff.health = 0.15;
+
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 struct fel_firebolt_t : public warlock_pet_spell_t
@@ -1429,6 +1467,10 @@ struct bile_spit_t : public warlock_pet_spell_t
     return warlock_pet_spell_t::ready();
   }
 
+  // NOTE: Bile Spit spell cast time is not affected by any haste effects
+  double execute_time_pct_multiplier() const override
+  { return 1.0; }
+
   void execute() override
   {
     warlock_pet_spell_t::execute();
@@ -1555,6 +1597,8 @@ demonic_tyrant_t::demonic_tyrant_t( warlock_t* owner, util::string_view name )
 {
   resource_regeneration = regen_type::DISABLED;
   action_list_str += "/demonfire";
+
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 struct demonfire_t : public warlock_pet_spell_t
@@ -1704,6 +1748,8 @@ infernal_t::infernal_t( warlock_t* owner, util::string_view name )
 
   owner_coeff.ap_from_sp = 2.2275;
   owner_coeff.sp_from_sp = 2.2275;
+
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 struct immolation_tick_t : public warlock_pet_spell_t
@@ -1790,6 +1836,8 @@ infernal_roc_t::infernal_roc_t( warlock_t* owner, util::string_view name ) : des
   type                   = RAIN;
   owner_coeff.ap_from_sp = 1.5;
   owner_coeff.sp_from_sp = 1.5;
+
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
 }
 
 /// Infernal Rain of Chaos End
@@ -2110,7 +2158,11 @@ namespace affliction
 
 darkglare_t::darkglare_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_DARKGLARE, true )
-{ action_list_str += "eye_beam"; }
+{
+  action_list_str += "eye_beam";
+
+  affected_by.demonic_inspiration = o()->talents.demonic_inspiration.ok();
+}
 
 struct eye_beam_t : public warlock_pet_spell_t
 {
@@ -2429,6 +2481,8 @@ namespace diabolist
     type = FRAG;
     owner_coeff.ap_from_sp = 1.5 * owner->hero.abyssal_dominion->effectN( 4 ).percent();
     owner_coeff.sp_from_sp = 1.5 * owner->hero.abyssal_dominion->effectN( 4 ).percent();
+
+    affected_by.demonic_inspiration = false;
   }
 
   /// Infernal Fragment End

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -71,6 +71,7 @@ struct warlock_pet_t : public pet_t
 
   struct buffs_t
   {
+    propagate_const<buff_t*> demonic_inspiration; // Hidden buff from talent that gives haste to some demons
     propagate_const<buff_t*> embers;  // Infernal Shard Generation
     propagate_const<buff_t*> demonic_strength; // Talent that buffs Felguard
     propagate_const<buff_t*> grimoire_of_service; // Buff used by Grimoire: Felguard talent
@@ -85,6 +86,11 @@ struct warlock_pet_t : public pet_t
     propagate_const<buff_t*> demonic_hunger; // TWW2 Demonology 2pc buff
     propagate_const<buff_t*> spliced_4pc; // TWW2 Demonology 4pc dummy buff
   } buffs;
+
+  struct affected_by_t
+  {
+    bool demonic_inspiration = false;
+  } affected_by;
 
   bool is_main_pet = false;
   bool melee_on_summon = true; // Set this to false for a pet to prevent t=0 melees. You MUST schedule a new auto attack manually elsewhere in the implementation if this is disabled
@@ -102,6 +108,8 @@ struct warlock_pet_t : public pet_t
   void apply_affecting_auras( action_t& action ) override;
   void arise() override;
   void demise() override;
+
+  virtual void heartbeat_update_event();
 
   target_specific_t<warlock_pet_td_t> target_data;
 


### PR DESCRIPTION
Various adjustments/fixes to the warlock module:
- The pet stat inheritance implemented in simc in `pet_t::update_stats()` has been verified ingame to be correct for warlock pets and guardians, so no changes are needed in this regard. That is, before applying its own pet effects modifiers, the pet inherits separately from its owner the `spell_haste`, the `melee_haste`, the `spell_speed` and the `melee_speed`.
- However, in simc the `composite_spell_haste` and `composite_melee_haste` functions for warlock pets were multiplying instead of dividing. This has been fixed.
- The cast speed of the [Vilefiend](https://www.wowhead.com/spell=264119)'s [Bile Spit](https://www.wowhead.com/spell=267997) spell is always the fixed base of 2 seconds and is not affected by haste.
- The duration and tick rate of the [Felstorm](https://www.wowhead.com/spell=89753) spell from [Felguard](https://www.wowhead.com/spell=30146) and [Grimorie: Felguard](https://www.wowhead.com/spell=111898) is dependent on the pet's `spell_speed`.
- The [Demonic Inspiration](https://www.wowhead.com/spell=386858) talent has several particularities that need to be implemented/fixed in simc:
  - Despite what the tooltip says, this talent also affects some guardians. The list of guardians AFFECTED by this talent is as follows:
    - Grimorie: Felguard
    - Wild Imps (normal and Imp Gang Boss)
    - Tyrant
    - Infernal
    - Infernal (the extra ones from the RoC talent)
    - Darkglare
  - The list of guardians NOT AFFECTED is as follows:
    - Vilefiend (and its fire and shadow variants)
    - Dreadstalker
    - Greater Dreadstalker
    - Doomguard
    - Overfiend
    - Infernal Fragment (from the Abyssal Dominion diabolist hero talent)
    - Diabolic Imp (Destro diabolist Ruin)
    - Rampaging Demonic Soul (Soul Harvester S3 tier)
  - The effect of this talent is applied through a hidden buff that is not applied at the moment the pet is summoned, but rather on the following heartbeat update.
  - This talent sometimes has a double dip effect. This can only occur on main pets, never on guardians. It's not entirely known what causes this effect or how it occurs, but it is relatively common, especially for the demonology spec (although it can actually affect any spec). A new simc option has been created for the warlock `demonic_inspiration_double_dip`, which can be enabled with `demonic_inspiration_double_dip=1` to activate the double dip of this talent on the main pet. At the moment this option is disabled by default, although in the future if more is discovered about how this effect works and how common it is, it's possible that it will be enabled by default for some specs (or it would even be possible to remove this option if it becomes unnecessary).
  