### PR TITLE
[player] Fix string temporaries and warnings

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -15638,8 +15638,8 @@ bool player_t::register_passive_effect( const spelleffect_data_t& modifying_eff,
   {
     // check player affecting subtypes
     auto misc_type = modifying_eff.misc_value1();
-    std::string field {};
-    std::string subtype_str {};
+    std::string field{};
+    std::string subtype_str{};
     bitmap_type_e bit_type = BITMAP_NONE;
     resource_e resource_type;
     double flat_val = 0.0;
@@ -15972,9 +15972,11 @@ bool player_t::register_passive_effect( const spelleffect_data_t& modifying_eff,
     // grab the override/hotfix variant
     auto spell = dbc::find_spell( this, spell_ );
 
-    std::string_view field, field2;
-    std::string_view eff_field, eff_field2;
-    std::string_view pow_field;
+    std::string field{};
+    std::string field2{};
+    std::string eff_field{};
+    std::string eff_field2{};
+    std::string pow_field{};
     unsigned field_type   = P_MAX;
     unsigned field_type2  = P_MAX;
     int eff_idx = 0;
@@ -15985,7 +15987,7 @@ bool player_t::register_passive_effect( const spelleffect_data_t& modifying_eff,
     bool is_damage = false;  // only modifies E_SCHOOL_DAMAGE
     bool allow_zero = true;  // modify even if base dbc value is 0
 
-    auto do_debug = [ & ]( std::string_view msg ) {
+    auto do_debug = [ & ]( std::string msg ) {
       std::string _tmp_full_message_tmp_ = fmt::format(
         "{} ({}) eff#{} {} {} ({}) {}", modifying_spell->name_cstr(), modifying_spell->id(), modifying_eff.index() + 1,
         remove ? "reverting" : "modifying", spell->name_cstr(), spell->id(), msg );

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -15458,7 +15458,7 @@ std::string_view get_field_from_type( unsigned type )
   return {};
 }
 
-int get_type_from_field( std::string_view field )
+unsigned get_type_from_field( std::string_view field )
 {
   for ( auto [ t, f ] : field_type_map )
     if ( f == field )
@@ -15522,7 +15522,7 @@ std::array<double, 3> player_t::get_passive_value( const spelleffect_data_t& eff
     return { it->orig, it->flat, it->pct };
 }
 
-double player_t::get_passive_player_value( double base_val, std::string_view field, int misc_type ) const
+double player_t::get_passive_player_value( double base_val, std::string_view field, unsigned misc_type ) const
 {
   assert( !is_pet() || get_owner_or_self() != this );
   if ( is_pet() )
@@ -15597,7 +15597,7 @@ std::vector<const spell_data_t*> player_t::spells_affected_by_passive( const spe
 }
 
 std::pair<player_t::modified_value_t, const player_t::modified_value_t&> player_t::add_passive_effect_modifier(
-  std::vector<player_t::modified_value_t>& modifiers, int id, int field_id,
+  std::vector<player_t::modified_value_t>& modifiers, unsigned id, unsigned field_id,
   double orig_val, double flat_val, double pct_val )
 {
   auto it = range::find_if( modifiers, [ id, field_id ]( const auto& mod ) {
@@ -15975,8 +15975,8 @@ bool player_t::register_passive_effect( const spelleffect_data_t& modifying_eff,
     std::string_view field, field2;
     std::string_view eff_field, eff_field2;
     std::string_view pow_field;
-    int field_type = -1;
-    int field_type2 = -1;
+    unsigned field_type   = P_MAX;
+    unsigned field_type2  = P_MAX;
     int eff_idx = 0;
     unsigned pow_idx_bit = 0U;
     double flat_val = 0.0;

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -982,10 +982,10 @@ private:
   std::unique_ptr<dbc_override_t> dbc_override_;
   struct modified_value_t
   {
-    int id;
-    int field_id;
+    unsigned id;
+    unsigned field_id;
     double orig, flat, pct;
-    modified_value_t( int id, int field_id, double orig, double flat = 0.0, double pct = 1.0 )
+    modified_value_t( unsigned id, unsigned field_id, double orig, double flat = 0.0, double pct = 1.0 )
       : id( id ), field_id( field_id ), orig( orig ), flat( flat ), pct( pct )
     {}
 
@@ -1002,7 +1002,7 @@ private:
   std::vector<std::pair<unsigned, std::vector<int>>> registered_affected_spell_list_;
 
   std::pair<modified_value_t, const modified_value_t&> add_passive_effect_modifier(
-    std::vector<modified_value_t>&, int id, int field_id,
+    std::vector<modified_value_t>&, unsigned id, unsigned field_id,
     double orig_val, double flat_val, double pct_val );
   bool register_passive_effect( const spelleffect_data_t&, bool remove = false );
 
@@ -1030,7 +1030,7 @@ public:
   std::array<double, 3> get_passive_value( const spellpower_data_t&, std::string_view field ) const;
   std::array<double, 3> get_passive_value( const spelleffect_data_t&, std::string_view field ) const;
   // returns modified value, base_val if no modifications exist
-  double get_passive_player_value( double base_val, std::string_view field, int misc_type = 0 ) const;
+  double get_passive_player_value( double base_val, std::string_view field, unsigned misc_type = 0 ) const;
   // clone a spell into the override dbc
   static const spell_data_t* clone_dbc_override_spell( const player_t* p, const spell_data_t* s );
 


### PR DESCRIPTION
- **[player] Fix int signedness to silence warnings.**
- **[player] Fix problematic `std::string_view` temporaries and make sure all strings are defined.**
