### PR TITLE
voidfall building doesnt cause final hour

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -8988,7 +8988,6 @@ struct voidfall_building_buff_t : public demon_hunter_buff_t<buff_t>
     base_t::expire( d );
 
     p()->buff.voidfall_spending->trigger( stacks );
-    p()->buff.voidfall_final_hour->trigger( stacks );
   }
 };
 


### PR DESCRIPTION
voidfall building (1256301) doesnt cause final hour (1256322) when converting to Voidfall spending (1256302)
https://www.warcraftlogs.com/reports/2n4mPKAgX3tZYML8?fight=1&source=5&type=casts&start=1297697&end=1335428&pins=0%24Separate%24%23244F4B%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%2413388199.0.0.DemonHunter%24false%241256322%5E0%24Separate%24%23909049%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%2413388199.0.0.DemonHunter%24false%241256301%5E0%24Separate%24%23a04D8A%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%2413388199.0.0.DemonHunter%24false%241256302&ability=1226019&view=events