### PR TITLE
[Mage] Update Fire APL with new FF execute

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -123,7 +123,7 @@ void fire( player_t* p )
   action_priority_list_t* ff_execute = p->get_action_priority_list( "ff_execute" );
   action_priority_list_t* ff_filler = p->get_action_priority_list( "ff_filler" );
   action_priority_list_t* sf_combustion = p->get_action_priority_list( "sf_combustion" );
-  action_priority_list_t* sf_filler = p->get_action_priority_list( "sf_filler" ); 
+  action_priority_list_t* sf_filler = p->get_action_priority_list( "sf_filler" );
 
   precombat->add_action( "arcane_intellect" );
   precombat->add_action( "variable,name=cast_remains_time,value=0.2" );
@@ -160,7 +160,7 @@ void fire( player_t* p )
   ff_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&!buff.hot_streak.react&buff.combustion.down&active_enemies>=variable.ff_combustion_flamestrike" );
   ff_combustion->add_action( "pyroblast,if=buff.pyroclasm.up&!buff.hot_streak.react&buff.combustion.down" );
   ff_combustion->add_action( "fireball,if=buff.combustion.down" );
-  ff_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<8)|(!talent.burnout&buff.combustion.remains>2)" );
+  ff_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<6)|(!talent.burnout&buff.combustion.remains>2)" );
   ff_combustion->add_action( "flamestrike,if=buff.hot_streak.react&active_enemies>=variable.ff_combustion_flamestrike" );
   ff_combustion->add_action( "pyroblast,if=buff.hot_streak.react" );
   ff_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&cast_time>buff.combustion.remains&active_enemies>=variable.ff_combustion_flamestrike" );
@@ -193,7 +193,7 @@ void fire( player_t* p )
   sf_combustion->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.combustion.up&buff.heating_up.react&action.fireball.executing&action.fireball.execute_remains<0.5" );
   sf_combustion->add_action( "flamestrike,if=buff.combustion.down&!buff.hot_streak.react&buff.pyroclasm.up&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "pyroblast,if=buff.combustion.down&!buff.hot_streak.react&buff.pyroclasm.up" );
-  sf_combustion->add_action( "fireball,if=buff.combustion.down" ); 
+  sf_combustion->add_action( "fireball,if=buff.combustion.down" );
   sf_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<8)|(!talent.burnout&buff.combustion.remains>2)" );
   sf_combustion->add_action( "flamestrike,if=buff.hot_streak.react&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&!buff.hot_streak.up&cast_time>buff.combustion.remains&active_enemies>=variable.sf_combustion_flamestrike" );

--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -194,7 +194,7 @@ void fire( player_t* p )
   sf_combustion->add_action( "flamestrike,if=buff.combustion.down&!buff.hot_streak.react&buff.pyroclasm.up&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "pyroblast,if=buff.combustion.down&!buff.hot_streak.react&buff.pyroclasm.up" );
   sf_combustion->add_action( "fireball,if=buff.combustion.down" );
-  sf_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<8)|(!talent.burnout&buff.combustion.remains>2)" );
+  sf_combustion->add_action( "meteor" );
   sf_combustion->add_action( "flamestrike,if=buff.hot_streak.react&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&!buff.hot_streak.up&cast_time>buff.combustion.remains&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "pyroblast,if=buff.hot_streak.react" );

--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -120,9 +120,10 @@ void fire( player_t* p )
   action_priority_list_t* precombat = p->get_action_priority_list( "precombat" );
   action_priority_list_t* cds = p->get_action_priority_list( "cds" );
   action_priority_list_t* ff_combustion = p->get_action_priority_list( "ff_combustion" );
+  action_priority_list_t* ff_execute = p->get_action_priority_list( "ff_execute" );
   action_priority_list_t* ff_filler = p->get_action_priority_list( "ff_filler" );
   action_priority_list_t* sf_combustion = p->get_action_priority_list( "sf_combustion" );
-  action_priority_list_t* sf_filler = p->get_action_priority_list( "sf_filler" );
+  action_priority_list_t* sf_filler = p->get_action_priority_list( "sf_filler" ); 
 
   precombat->add_action( "arcane_intellect" );
   precombat->add_action( "variable,name=cast_remains_time,value=0.2" );
@@ -152,13 +153,14 @@ void fire( player_t* p )
   cds->add_action( "invoke_external_buff,name=power_infusion,if=buff.power_infusion.down&(buff.combustion.remains>6|fight_remains<25)" );
 
   ff_combustion->add_action( "combustion,use_off_gcd=1,use_while_casting=1,if=buff.combustion.down&action.fireball.executing&(action.fireball.execute_remains<variable.cast_remains_time)|action.meteor.in_flight&(action.meteor.in_flight_remains<0.3)|action.pyroblast.executing&(action.pyroblast.execute_remains<variable.cast_remains_time)" );
+  ff_combustion->add_action( "run_action_list,name=ff_execute,if=target.health.pct<=30&active_enemies<variable.ff_combustion_flamestrike+1" );
   ff_combustion->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.combustion.up&!action.fireball.executing&!action.pyroblast.executing&!buff.hot_streak.react&gcd.remains&gcd.remains<gcd.max&(hot_streak_spells_in_flight+buff.heating_up.react)<2" );
   ff_combustion->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.combustion.up&buff.heating_up.react&(action.pyroblast.executing&action.pyroblast.execute_remains<0.5|action.flamestrike.executing&action.flamestrike.execute_remains<0.5)" );
   ff_combustion->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.combustion.up&buff.heating_up.react&action.fireball.executing&action.fireball.execute_remains<0.5" );
   ff_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&!buff.hot_streak.react&buff.combustion.down&active_enemies>=variable.ff_combustion_flamestrike" );
   ff_combustion->add_action( "pyroblast,if=buff.pyroclasm.up&!buff.hot_streak.react&buff.combustion.down" );
   ff_combustion->add_action( "fireball,if=buff.combustion.down" );
-  ff_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<6)|(!talent.burnout&buff.combustion.remains>2)" );
+  ff_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<8)|(!talent.burnout&buff.combustion.remains>2)" );
   ff_combustion->add_action( "flamestrike,if=buff.hot_streak.react&active_enemies>=variable.ff_combustion_flamestrike" );
   ff_combustion->add_action( "pyroblast,if=buff.hot_streak.react" );
   ff_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&cast_time>buff.combustion.remains&active_enemies>=variable.ff_combustion_flamestrike" );
@@ -166,7 +168,17 @@ void fire( player_t* p )
   ff_combustion->add_action( "scorch,if=buff.heat_shimmer.react" );
   ff_combustion->add_action( "fireball" );
 
+  ff_execute->add_action( "combustion,use_off_gcd=1,use_while_casting=1" );
+  ff_execute->add_action( "meteor" );
+  ff_execute->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1" );
+  ff_execute->add_action( "flamestrike,if=buff.hot_streak.react&buff.combustion.up&active_enemies>=variable.ff_combustion_flamestrike" );
+  ff_execute->add_action( "pyroblast,if=buff.hot_streak.react&buff.combustion.up" );
+  ff_execute->add_action( "flamestrike,if=buff.pyroclasm.up&cast_time>buff.combustion.remains&active_enemies>=variable.ff_combustion_flamestrike" );
+  ff_execute->add_action( "pyroblast,if=buff.pyroclasm.up&cast_time>buff.combustion.remains" );
+  ff_execute->add_action( "fireball" );
+
   ff_filler->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.heating_up.react&action.fireball.executing&action.fireball.execute_remains<0.5&cooldown.combustion.remains>variable.pooling_time" );
+  ff_filler->add_action( "run_action_list,name=ff_execute,if=target.health.pct<=30&active_enemies<variable.ff_filler_flamestrike+1" );
   ff_filler->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.heating_up.react&action.pyroblast.executing&action.pyroblast.execute_remains<0.5" );
   ff_filler->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&!buff.hot_streak.react&(hot_streak_spells_in_flight+buff.heating_up.react<2)&gcd.remains<gcd.max&cooldown.combustion.remains>variable.pooling_time" );
   ff_filler->add_action( "meteor" );
@@ -181,8 +193,8 @@ void fire( player_t* p )
   sf_combustion->add_action( "fire_blast,use_off_gcd=1,use_while_casting=1,if=cooldown_react&buff.combustion.up&buff.heating_up.react&action.fireball.executing&action.fireball.execute_remains<0.5" );
   sf_combustion->add_action( "flamestrike,if=buff.combustion.down&!buff.hot_streak.react&buff.pyroclasm.up&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "pyroblast,if=buff.combustion.down&!buff.hot_streak.react&buff.pyroclasm.up" );
-  sf_combustion->add_action( "fireball,if=buff.combustion.down" );
-  sf_combustion->add_action( "meteor" );
+  sf_combustion->add_action( "fireball,if=buff.combustion.down" ); 
+  sf_combustion->add_action( "meteor,if=(talent.burnout&buff.combustion.remains<8)|(!talent.burnout&buff.combustion.remains>2)" );
   sf_combustion->add_action( "flamestrike,if=buff.hot_streak.react&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "flamestrike,if=buff.pyroclasm.up&!buff.hot_streak.up&cast_time>buff.combustion.remains&active_enemies>=variable.sf_combustion_flamestrike" );
   sf_combustion->add_action( "pyroblast,if=buff.hot_streak.react" );


### PR DESCRIPTION
Added execute cases for FF in prepatch.

Tested in ST, 2t, 3t+ to find the point where its no longer worth it. These are added as a switch so it will return to normal rotation 3 or more. Flamestrike (2t) or Hotstreak in Execute Combustion are fairly close but Flamestrike was .8% ahead. Went with it for consistency. 