### PR TITLE
[Core] Adjust max stack behavior for async buffs

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -2180,13 +2180,7 @@ void buff_t::start( int stacks, double value, timespan_t duration )
         return a->remains() < b->remains();
       } );
     }
-    /* TOCHECK: This seems wrong, since bump() already removes expiration events when we are at max stacks
-    if ( check() == before_stacks && stack_behavior == buff_stack_behavior::ASYNCHRONOUS )
-    {
-      event_t::cancel( expiration.front() );
-      expiration.erase( expiration.begin() );
-    }
-    */
+
   }
 
   timespan_t period = tick_time();
@@ -2346,31 +2340,7 @@ void buff_t::bump( int stacks, double value )
       overflow_total += overflow;
       current_stack = max_stack();
 
-      if ( stack_behavior == buff_stack_behavior::ASYNCHRONOUS )
-      {
-        // Can't trigger more than max stack at a time
-        overflow -= std::max( 0, stacks - max_stack() );
 
-        /* Replace the oldest buff with the new one. We do this by cancelling
-        expiration events until their stack count add up to the overflow. */
-        while ( overflow > 0 )
-        {
-          event_t* e     = expiration.front();
-          int exp_stacks = debug_cast<expiration_t*>( e )->stack;
-
-          if ( exp_stacks > overflow )
-          {
-            debug_cast<expiration_t*>( e )->stack -= overflow;
-            break;
-          }
-          else
-          {
-            event_t::cancel( e );
-            expiration.erase( expiration.begin() );
-            overflow -= exp_stacks;
-          }
-        }
-      }
     }
 
     if ( before_stack != current_stack )

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -688,7 +688,8 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     start_intervals(),
     trigger_intervals(),
     duration_lengths(),
-    change_regen_rate( false )
+    change_regen_rate( false ),
+    disable_async_expire_events_removal( false )
 {
   if ( source )  // Player Buffs
   {
@@ -1508,6 +1509,12 @@ buff_t* buff_t::set_allow_precombat( bool b )
 buff_t* buff_t::set_name_reporting( std::string_view n )
 {
   name_str_reporting = n;
+  return this;
+}
+
+buff_t* buff_t::set_disable_async_expire_events_removal( bool b )
+{
+  disable_async_expire_events_removal = b;
   return this;
 }
 
@@ -2340,7 +2347,30 @@ void buff_t::bump( int stacks, double value )
       overflow_total += overflow;
       current_stack = max_stack();
 
+      if ( !disable_async_expire_events_removal && stack_behavior == buff_stack_behavior::ASYNCHRONOUS )
+      {
+        // Can't trigger more than max stack at a time
+        overflow -= std::max( 0, stacks - max_stack() );
 
+        /* Replace the oldest buff with the new one. We do this by cancelling
+        expiration events until their stack count add up to the overflow. */
+        while ( overflow > 0 )
+        {
+          event_t* e     = expiration.front();
+          int exp_stacks = debug_cast<expiration_t*>( e )->stack;
+          if ( exp_stacks > overflow )
+          {
+            debug_cast<expiration_t*>( e )->stack -= overflow;
+            break;
+          }
+          else
+          {
+            event_t::cancel( e );
+            expiration.erase( expiration.begin() );
+            overflow -= exp_stacks;
+          }
+        }
+      }
     }
 
     if ( before_stack != current_stack )

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -362,6 +362,7 @@ public:
   rng::rng_t& rng() const;
 
   bool change_regen_rate;
+  bool disable_async_expire_events_removal;
 
   buff_t* set_chance( double chance );
   buff_t* set_duration( timespan_t duration );
@@ -422,6 +423,8 @@ public:
   buff_t* set_name_reporting( std::string_view );
 
   buff_t* apply_time_rate_modifier( const spell_data_t* spell );
+
+  buff_t* set_disable_async_expire_events_removal( bool b );
 
   friend void sc_format_to( const buff_t&, fmt::format_context::iterator );
 private:

--- a/engine/class_modules/sc_warrior.cpp
+++ b/engine/class_modules/sc_warrior.cpp
@@ -8002,7 +8002,8 @@ void warrior_t::create_buffs()
      ->set_duration( find_spell( 184362 )->duration() );
 
   buff.frenzy = make_buff( this, "frenzy", find_spell(335082) )
-                          ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
+                          ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
+                          ->set_disable_async_expire_events_removal( true );
 
   buff.heroic_leap_movement   = make_buff( this, "heroic_leap_movement" );
   buff.charge_movement        = make_buff( this, "charge_movement" );
@@ -8071,6 +8072,7 @@ void warrior_t::create_buffs()
 
   buff.berserk = make_buff( this, "berserk", find_spell( 1269349) )
                     ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS )
+                    ->set_disable_async_expire_events_removal( true )
                     ->set_trigger_spell( talents.fury.rampaging_berserker_1 );
 
   buff.seeing_red = make_buff( this, "seeing_red", find_spell( 386486 ) );
@@ -8100,6 +8102,7 @@ void warrior_t::create_buffs()
 
   // Slayer
   buff.executioner          = make_buff( this, "executioner", find_spell( 445584 ) )
+                              ->set_disable_async_expire_events_removal( true )
                               ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
   buff.imminent_demise      = make_buff( this, "imminent_demise", find_spell( 445606 ) );
   buff.brutal_finish        = make_buff( this, "brutal_finish", find_spell( 446918 ) );
@@ -8121,6 +8124,7 @@ void warrior_t::create_buffs()
                                         ->set_cooldown( talents.arms.master_of_warfare_1->internal_cooldown() );
 
   buff.master_of_warfare = make_buff( this, "master_of_warfare", spell.master_of_warfare_2_buff )
+                                ->set_disable_async_expire_events_removal( true )
                                 ->set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
 
   // Protection Apex


### PR DESCRIPTION
In every case I have checked in war and dk, it seems like max stack behavior for async changed at some point over the last few years.

Current behavior in game
- If at max stacks, refresh the buff duration
- queue up a decrement event

In this scenario, we have more decrement events, than we have stacks, so we begin to lose stacks faster than expected.