### PR TITLE
impending apocalypse is delayed

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6472,10 +6472,14 @@ struct collapsing_star_t : public demon_hunter_spell_t
       {
         p()->cooldown.voidblade->adjust( -p()->talent.devourer.voidrush->effectN( 1 ).time_value() );
       }
+    }
 
+    void impact( action_state_t* s ) override
+    {
+      base_t::impact( s );
       if ( p()->talent.devourer.impending_apocalypse->ok() )
       {
-        p()->buff.impending_apocalypse->trigger();
+        make_event( *p()->sim, 1.2_s, [ this ] { p()->buff.impending_apocalypse->trigger(); } );
       }
     }
   };

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6477,7 +6477,7 @@ struct collapsing_star_t : public demon_hunter_spell_t
     void impact( action_state_t* s ) override
     {
       base_t::impact( s );
-      if ( p()->talent.devourer.impending_apocalypse->ok() )
+      if ( p()->talent.devourer.impending_apocalypse->ok() && s->chain_target == 0 )
       {
         make_event( *p()->sim, 1.2_s, [ this ] { p()->buff.impending_apocalypse->trigger(); } );
       }


### PR DESCRIPTION
impending apocalypse buff application is delayed by ~1.2 seconds from the collapsing star hit