### PR TITLE
[Demon Hunter] Fix Meteoric Rise soul fragment spawning during Fel Devastation

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4114,8 +4114,9 @@ struct fel_devastation_t : public final_breath_trigger_t<demon_hunter_spell_t>
 
     if ( p()->talent.annihilator.meteoric_rise->ok() )
     {
-      int ticks_per_soul_fragment = as<int>( d->num_ticks() / soul_fragments_from_meteoric_rise );
-      if ( d->num_ticks() % ticks_per_soul_fragment == 0 )
+      int expected_before = ( d->current_tick - 1 ) * soul_fragments_from_meteoric_rise / d->num_ticks();
+      int expected_after  = d->current_tick * soul_fragments_from_meteoric_rise / d->num_ticks();
+      if ( expected_after > expected_before )
       {
         p()->spawn_soul_fragment( p()->proc.soul_fragment_from_meteoric_rise, soul_fragment::LESSER );
       }


### PR DESCRIPTION
## Summary

The Meteoric Rise tick callback uses an integer division algorithm that always evaluates to true, spawning a soul fragment on every tick instead of distributing N fragments across M ticks.

With 4 ticks and 3 target fragments: `ticks_per_soul_fragment = 4/3 = 1` (int), `4 % 1 == 0` → always true → 4 fragments instead of 3.

## Fix

Replace with integer boundary crossing that distributes exactly N fragments across M ticks:

```cpp
int expected_before = ( d->current_tick - 1 ) * soul_fragments_from_meteoric_rise / d->num_ticks();
int expected_after  = d->current_tick * soul_fragments_from_meteoric_rise / d->num_ticks();
if ( expected_after > expected_before )
```

Verified: `current_tick` is 1-based (incremented at `dot.cpp:1079` before `tick()` at line 1092), `tick_on_application = false` for Fel Devastation. With 4 ticks/3 fragments: spawns on ticks 2, 3, 4 (total 3). With 6 ticks/3 fragments: spawns on ticks 2, 4, 6 (evenly spaced).
