### PR TITLE
[Demon Hunter] Fix Doomsayer trigger asymmetric buff expiration

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3170,6 +3170,7 @@ struct doomsayer_trigger_t : public BASE
     }
 
     BASE::p()->buff.doomsayer_in_combat->expire();
+    BASE::p()->buff.doomsayer_out_of_combat->expire();
 
     for ( int i = 0; i < meteors_to_trigger; ++i )
     {


### PR DESCRIPTION
## Summary

The `doomsayer_trigger_t` guard checks both `doomsayer_in_combat` and `doomsayer_out_of_combat` buffs (line 3161), but only expires `doomsayer_in_combat` (line 3172). If the out-of-combat buff were the active one when the trigger fires, it would not be consumed — allowing a double trigger on the next melee attack.

## Fix

Expire both buffs unconditionally after the trigger fires. `buff_t::expire()` is a no-op on inactive buffs, so both calls are always safe.

```cpp
BASE::p()->buff.doomsayer_in_combat->expire();
BASE::p()->buff.doomsayer_out_of_combat->expire();
```

In practice, the combat state callback (lines 9742-9753) normally swaps to `doomsayer_in_combat` before the first attack, so this is a latent correctness fix rather than a commonly triggered bug.
