### PR TITLE
[DemonHunter] Fix Meteor Shower tick count (10 -> 12)

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6636,9 +6636,9 @@ struct meteor_shower_t : public demon_hunter_spell_t
     ground_aoe_params_t::hasted_with hasted = p()->specialization() == DEMON_HUNTER_DEVOURER
                                                   ? ground_aoe_params_t::SPELL_HASTE
                                                   : ground_aoe_params_t::ATTACK_HASTE;
-    timespan_t duration =
-        timespan_t::from_seconds( as<int>( p()->talent.annihilator.dark_matter->effectN( 1 ).base_value() ) / 2 );
-    timespan_t pulse_time = duration / 10;  // TODO: VERIFY
+    int tick_count = as<int>( p()->talent.annihilator.dark_matter->effectN( 1 ).base_value() );
+    timespan_t duration = timespan_t::from_seconds( tick_count / 2 );
+    timespan_t pulse_time = duration / tick_count;
 
     make_event<ground_aoe_event_t>( *sim, p(),
                                     ground_aoe_params_t()


### PR DESCRIPTION
## Summary

Meteor Shower (Dark Matter proc) creates a ground AoE that currently ticks 10 times over 6 seconds. The tooltip damage formula is `coefficient * 12`, and `effectN(1).base_value()` = 12, both confirming 12 hits over the 6-second duration (0.5s per tick).

The previous code divided `duration / 10` (with a `TODO: VERIFY` comment), producing 0.6s ticks — 10 damage events instead of 12.

## Fix

Derive `tick_count` directly from `dark_matter->effectN(1).base_value()` so both `duration` and `pulse_time` stay in sync:

```cpp
int tick_count = as<int>( ...dark_matter->effectN( 1 ).base_value() );
timespan_t duration = timespan_t::from_seconds( tick_count / 2 );
timespan_t pulse_time = duration / tick_count;
```

## Impact

16.7% more Meteor Shower damage per Dark Matter proc across all Annihilator builds.