### PR TITLE
[DemonHunter] Fix Untethered Rage to use Seething Anger stack count

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2528,8 +2528,8 @@ public:
     if ( souls_consumed <= 0 || !p()->talent.vengeance.untethered_rage_1->ok() )
       return false;
 
-    // TODO: refine this as needed
-    double chance_to_proc = souls_consumed * 0.0075 * pow( 1.35, p()->buff.seething_anger->up() );
+    // TODO: base chance and growth factor are approximations, no spell data source
+    double chance_to_proc = souls_consumed * 0.0075 * pow( 1.35, p()->buff.seething_anger->stack() );
     if ( ab::rng().roll( chance_to_proc ) )
     {
       p()->buff.seething_anger->expire();


### PR DESCRIPTION
## Summary

Seething Anger stacks up to 99 and its tooltip says it "increases your chance to gain Untethered Rage" per stack. The proc chance formula was using `buff.seething_anger->up()` (returns 0 or 1) instead of `stack()`, so the `pow(1.35, ...)` multiplier only ever evaluated to `1.0` or `1.35` regardless of how many stacks had accumulated.

This meant the bad-luck protection ramp was completely non-functional — 1 stack of Seething Anger gave the same proc chance as 99 stacks.

## Fix

```cpp
// Before:
pow( 1.35, p()->buff.seething_anger->up() )   // up() returns bool: 0 or 1

// After:
pow( 1.35, p()->buff.seething_anger->stack() ) // stack() returns actual count: 0..99
```

## Notes

As far as I can tell, neither the talent spell nor the buff spell contains proc rate values. The tooltip just says "a chance per soul fragment consumed." The growth factor may need tuning, but this fix at least makes the stacking mechanic functional.

With `stack()`, the formula naturally converges toward a guaranteed proc at high stack counts: at ~28 stacks with 5 fragments consumed, the chance exceeds 100%.