### PR TITLE
[DemonHunter] Add Meteoric Fall trigger to Soul Cleave

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -8073,8 +8073,8 @@ struct inner_demon_t : public demon_hunter_spell_t
 
 // Soul Cleave ==============================================================
 
-struct soul_cleave_t : public voidfall_spending_trigger_t<
-                           art_of_the_glaive_trigger_t<art_of_the_glaive_ability::GLAIVE_FLURRY, demon_hunter_attack_t>>
+struct soul_cleave_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
+                           art_of_the_glaive_trigger_t<art_of_the_glaive_ability::GLAIVE_FLURRY, demon_hunter_attack_t>>>
 {
   struct soul_cleave_damage_t : public burning_blades_trigger_t<demon_hunter_attack_t>
   {


### PR DESCRIPTION
## Summary

The Meteoric Fall tooltip (Vengeance) says:

> While at 3 stacks of Voidfall, **Spirit Bomb and Soul Cleave** consumes all 3 to rapidly call down that many meteor strikes.

Spirit Bomb inherits `meteoric_fall_trigger_t` but Soul Cleave does not. Soul Cleave only had `voidfall_spending_trigger_t`, which decrements one stack at a time. At 3 Voidfall stacks, Soul Cleave should consume all 3 and fire 3 rapid meteors, but instead it was only consuming 1.

## Fix

Add `meteoric_fall_trigger_t` to Soul Cleave's inheritance chain, matching the established pattern from `reap_base_t` (Havoc):

```cpp
// Before:
struct soul_cleave_t : public voidfall_spending_trigger_t<
    art_of_the_glaive_trigger_t<...>>

// After:
struct soul_cleave_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
    art_of_the_glaive_trigger_t<...>>>
```

The existing execution order prevents double-dipping: `meteoric_fall_trigger_t::execute()` runs first (via the base chain), expires all Voidfall stacks, then `voidfall_spending_trigger_t::execute()` checks `buff.up()` — which is now false — and skips.

## Impact

Affects Annihilator builds in scenarios where Soul Cleave executes at max Voidfall stacks. In practice this is uncommon since the APL routes Spirit Bomb at 3+ stacks, but the tooltip is explicit that both abilities should trigger Meteoric Fall.