### PR TITLE
[DemonHunter] Implement Broken Spirit effects for Vengeance

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5461,11 +5461,6 @@ struct sigil_of_spite_t : public demon_hunter_spell_t
       demon_hunter_sigil_t::execute();
       p()->spawn_soul_fragment( p()->proc.soul_fragment_from_sigil_of_spite, soul_fragment::LESSER,
                                 soul_fragments_to_spawn );
-
-      if ( p()->talent.aldrachi_reaver.broken_spirit->ok() )
-      {
-        p()->spawn_soul_fragment( p()->proc.soul_fragment_from_broken_spirit, soul_fragment::LESSER );
-      }
     }
   };
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -664,7 +664,7 @@ public:
       player_talent_t evasive_action;  // No Implementation
       player_talent_t unhindered_assault;
       player_talent_t reavers_mark;
-      player_talent_t broken_spirit;  // NYI
+      player_talent_t broken_spirit;
 
       player_talent_t aldrachi_tactics;
       player_talent_t army_unto_oneself;     // No Implementation
@@ -5461,6 +5461,11 @@ struct sigil_of_spite_t : public demon_hunter_spell_t
       demon_hunter_sigil_t::execute();
       p()->spawn_soul_fragment( p()->proc.soul_fragment_from_sigil_of_spite, soul_fragment::LESSER,
                                 soul_fragments_to_spawn );
+
+      if ( p()->talent.aldrachi_reaver.broken_spirit->ok() )
+      {
+        p()->spawn_soul_fragment( p()->proc.soul_fragment_from_broken_spirit, soul_fragment::LESSER );
+      }
     }
   };
 
@@ -8151,6 +8156,12 @@ struct soul_cleave_t : public voidfall_spending_trigger_t<
     damage->execute_event->reschedule( timespan_t::from_millis( data().effectN( 2 ).misc_value1() ) );
 
     trigger_untethered_rage( fragments_consumed );
+
+    if ( p()->talent.aldrachi_reaver.broken_spirit->ok() &&
+         rng().roll( p()->talent.aldrachi_reaver.broken_spirit->effectN( 3 ).percent() ) )
+    {
+      p()->spawn_soul_fragment( p()->proc.soul_fragment_from_broken_spirit, soul_fragment::LESSER );
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Broken Spirit (1272143) has four effects — two per spec. The Havoc effects (The Hunt +1 fragment, Blade Dance/Chaos Strike 15% proc) were already implemented. One Vengeance effect was missing, and the talent was marked `// NYI`.

### Effect 1 — Sigil of Spite +1 fragment (auto-handled)

This effect is a label modifier (`A_ADD_FLAT_LABEL_MODIFIER`) targeting Sigil of Spite effect 3. The `parse_effects` system already applies it at talent initialization — debug output confirms:

```
Broken Spirit (1272143) eff#1 modifying Sigil of Spite (390163) eff#3 by 1 (orig=3 prev=3 now=4)
```

No explicit code needed. The `soul_fragments_to_spawn` field already reads the modified value.

### Effect 3 — Soul Cleave 20% proc (new)

Tooltip: "Soul Cleave has a 20% chance to shatter a Soul Fragment."

This is a Dummy aura that cannot be auto-parsed. Added `rng().roll( broken_spirit->effectN( 3 ).percent() )` in `soul_cleave_t::execute()`, matching the Blade Dance/Chaos Strike pattern (which uses `effectN( 4 )` for the Havoc 15% rate).

## Spell data reference

| Effect | Type                | baseValue | VDH Use                | Havoc Use        | Status        |
| ------ | ------------------- | --------- | ---------------------- | ---------------- | ------------- |
| 1      | Flat Label Modifier | 1         | Sigil of Spite +1 frag | —                | Auto-handled  |
| 2      | Dummy               | 1         | —                      | The Hunt +1 frag | Already coded |
| 3      | Dummy               | 20        | Soul Cleave 20% proc   | —                | **Added**     |
| 4      | Dummy               | 15        | —                      | BD/CS 15% proc   | Already coded |

Also removed the `// NYI` comment from the `broken_spirit` talent declaration since all four effects are now accounted for.
