### PR TITLE
[Gear] Fix Ranger-Captain's Iridescent Insignia find cooldown

### DIFF
--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -1839,7 +1839,7 @@ void ranger_captains_iridescent_insignia( special_effect_t& effect )
     {
       // Dont find the cooldown til init finished, as it wont exist when this is created.
       effect.player->register_init_finished_callback(
-          [ & ]( player_t* p ) { cooldown = effect.player->find_cooldown( "silverstrike_trick_shot_1260266" ); } );
+          [ & ]( player_t* ) { cooldown = effect.player->find_cooldown( "silverstrike_trick_shot" ); } );
 
       cdr = timespan_t::from_seconds( -effect.player->find_spell( 1260265 )->effectN( 2 ).base_value() );
     }


### PR DESCRIPTION
Small fix to [Fix Ranger-Captain's Iridescent Insignia] trinket to find the correct "silverstrike_trick_shot" cooldown.