### PR TITLE
druid: fix Guardian APL for Midnight talent tree

### DIFF
--- a/ActionPriorityLists/default/druid_guardian.simc
+++ b/ActionPriorityLists/default/druid_guardian.simc
@@ -11,7 +11,7 @@
 # Snapshot raid buffed stats before combat begins and pre-potting is done.
 actions.precombat=snapshot_stats
 # Executed before combat begins. Accepts non-harmful actions only.
-actions.precombat+=/variable,name=If_build,value=1,value_else=0,if=talent.thorns_of_iron.enabled&talent.ursocs_endurance.enabled
+actions.precombat+=/variable,name=If_build,value=0
 actions.precombat+=/heart_of_the_Wild,if=talent.heart_of_the_wild.enabled&!talent.rip.enabled
 actions.precombat+=/cat_form,if=talent.rip.enabled
 actions.precombat+=/prowl,if=talent.rip.enabled
@@ -42,7 +42,7 @@ actions.bear+=/maul,if=buff.ravage.up&active_enemies<2
 actions.bear+=/raze,if=(buff.tooth_and_claw.stack>1|buff.tooth_and_claw.up&buff.tooth_and_claw.remains<1+gcd|buff.vicious_cycle_maul.stack=3)
 actions.bear+=/thrash_bear,if=active_enemies>=5&talent.lunar_calling.enabled
 actions.bear+=/ironfur,target_if=!debuff.tooth_and_claw.up,if=!buff.ironfur.up&rage>50&!cooldown.pause_action.remains&variable.If_build=0&!buff.rage_of_the_sleeper.up|rage>90&variable.If_build=0|!debuff.tooth_and_claw.up&!buff.ironfur.up&rage>50&!cooldown.pause_action.remains&variable.If_build=0&!buff.rage_of_the_sleeper.up
-actions.bear+=/ironfur,if=!buff.ravage.up&((rage>40&variable.If_build=1|rage>90&variable.If_build=1&!talent.fount_of_strength.enabled|rage>110&variable.If_build=1&talent.fount_of_strength.enabled|(buff.incarnation.up|buff.berserk_bear.up)&rage>20&variable.If_build=1&buff.rage_of_the_sleeper.up&talent.rage_of_the_sleeper.enabled))
+actions.bear+=/ironfur,if=!buff.ravage.up&((rage>40&variable.If_build=1|rage>90&variable.If_build=1&!talent.fount_of_strength.enabled|rage>110&variable.If_build=1&talent.fount_of_strength.enabled|(buff.incarnation.up|buff.berserk_bear.up)&rage>20&variable.If_build=1&buff.rage_of_the_sleeper.up))
 actions.bear+=/ironfur,if=!buff.ravage.up&(buff.incarnation.up|buff.berserk_bear.up)&rage>20&variable.If_build=1
 actions.bear+=/ferocious_bite,if=(buff.cat_form.up&buff.feline_potential.up&(buff.incarnation.up|buff.berserk_bear.up)&!dot.rip.refreshable)
 actions.bear+=/rip,if=(buff.cat_form.up&buff.feline_potential.up)

--- a/engine/class_modules/apl/guardian_apl.inc
+++ b/engine/class_modules/apl/guardian_apl.inc
@@ -2,7 +2,7 @@ action_priority_list_t* precombat = get_action_priority_list( "precombat" );
 action_priority_list_t* def = get_action_priority_list( "default" );
 action_priority_list_t* bear = get_action_priority_list( "bear" );
 
-precombat->add_action( "variable,name=If_build,value=1,value_else=0,if=talent.thorns_of_iron.enabled&talent.ursocs_endurance.enabled","Executed before combat begins. Accepts non-harmful actions only." );
+precombat->add_action( "variable,name=If_build,value=0","Executed before combat begins. Accepts non-harmful actions only." );
 precombat->add_action( "heart_of_the_Wild,if=talent.heart_of_the_wild.enabled&!talent.rip.enabled" );
 precombat->add_action( "cat_form,if=talent.rip.enabled" );
 precombat->add_action( "prowl,if=talent.rip.enabled" );
@@ -31,7 +31,7 @@ bear->add_action( "maul,if=buff.ravage.up&active_enemies<2" );
 bear->add_action( "raze,if=(buff.tooth_and_claw.stack>1|buff.tooth_and_claw.up&buff.tooth_and_claw.remains<1+gcd|buff.vicious_cycle_maul.stack=3)" );
 bear->add_action( "thrash_bear,if=active_enemies>=5&talent.lunar_calling.enabled" );
 bear->add_action( "ironfur,target_if=!debuff.tooth_and_claw.up,if=!buff.ironfur.up&rage>50&!cooldown.pause_action.remains&variable.If_build=0&!buff.rage_of_the_sleeper.up|rage>90&variable.If_build=0|!debuff.tooth_and_claw.up&!buff.ironfur.up&rage>50&!cooldown.pause_action.remains&variable.If_build=0&!buff.rage_of_the_sleeper.up" );
-bear->add_action( "ironfur,if=!buff.ravage.up&((rage>40&variable.If_build=1|rage>90&variable.If_build=1&!talent.fount_of_strength.enabled|rage>110&variable.If_build=1&talent.fount_of_strength.enabled|(buff.incarnation.up|buff.berserk_bear.up)&rage>20&variable.If_build=1&buff.rage_of_the_sleeper.up&talent.rage_of_the_sleeper.enabled))" );
+bear->add_action( "ironfur,if=!buff.ravage.up&((rage>40&variable.If_build=1|rage>90&variable.If_build=1&!talent.fount_of_strength.enabled|rage>110&variable.If_build=1&talent.fount_of_strength.enabled|(buff.incarnation.up|buff.berserk_bear.up)&rage>20&variable.If_build=1&buff.rage_of_the_sleeper.up))" );
 bear->add_action( "ironfur,if=!buff.ravage.up&(buff.incarnation.up|buff.berserk_bear.up)&rage>20&variable.If_build=1" );
 bear->add_action( "ferocious_bite,if=(buff.cat_form.up&buff.feline_potential.up&(buff.incarnation.up|buff.berserk_bear.up)&!dot.rip.refreshable)" );
 bear->add_action( "rip,if=(buff.cat_form.up&buff.feline_potential.up)" );


### PR DESCRIPTION
## Summary

The Guardian Druid default APL references three talents that were removed in the Midnight talent tree, causing initialization errors (`exit=30`):

- `thorns_of_iron` — used in `variable.If_build` definition
- `ursocs_endurance` — used in `variable.If_build` definition  
- `rage_of_the_sleeper` — used as a talent check in an ironfur condition (the ability still exists but is no longer a selectable talent node)

## Changes

- **`variable.If_build`**: Set to `0` unconditionally since the two talents that defined it (`thorns_of_iron` + `ursocs_endurance`) no longer exist
- **ironfur condition**: Removed `talent.rage_of_the_sleeper.enabled` check (kept the `buff.rage_of_the_sleeper.up` check which still works)

Both `.simc` source and compiled `.inc` are updated.

## Test plan

- [x] `simc druid=test spec=guardian level=80 load_default_gear=1 load_default_talents=1 default_actions=1 iterations=500` — exits cleanly, ~24K DPS
- [x] No other talent references are broken (verified all 15 remaining talent refs resolve)
- [x] Compiled `.inc` matches `.simc` source