### PR TITLE
[Assassination] Spam Crimson Tempest

### DIFF
--- a/engine/class_modules/apl/apl_rogue.cpp
+++ b/engine/class_modules/apl/apl_rogue.cpp
@@ -84,7 +84,7 @@ void assassination( player_t* p )
   default_->add_action( "thistle_tea,if=energy.pct<50&fight_remains<10", "Edge-case check to dump thistle tea at the end of fights" );
   default_->add_action( "call_action_list,name=cds", "Cooldown list takes priority" );
   default_->add_action( "call_action_list,name=core_dot", "Maintain dots when possible" );
-  default_->add_action( "call_action_list,name=generate,if=!buff.darkest_night.up&combo_points<5|buff.darkest_night.up&combo_points.deficit>0", "Build combo points until 5, or max with darkest night" );
+  default_->add_action( "call_action_list,name=generate,if=!buff.darkest_night.up&combo_points<5|buff.darkest_night.up&combo_points.deficit>0|(talent.crimson_tempest&spell_targets.fan_of_knives>=5&(active_dot.garrote<spell_targets.fan_of_knives|active_dot.rupture<spell_targets.fan_of_knives))", "Build combo points until 5, max with darkest night, or ignore finishers to spread more bleeds with CT" );
   default_->add_action( "call_action_list,name=spend,if=!buff.darkest_night.up&combo_points>=5|buff.darkest_night.up&combo_points.deficit=0", "If combo point threshold is reached, spend them" );
 
   cds->add_action( "deathmark,if=dot.garrote.ticking&dot.rupture.ticking&cooldown.kingsbane.remains<=2&buff.envenom.up", "Cooldown list  Deathmark if bleeds are active, kingsbane is ready, and we have envenom TODO:check envenom buff requirement when apex talents are fixed" );

--- a/engine/class_modules/apl/rogue/assassination.simc
+++ b/engine/class_modules/apl/rogue/assassination.simc
@@ -20,8 +20,8 @@ actions+=/thistle_tea,if=energy.pct<50&fight_remains<10
 actions+=/call_action_list,name=cds
 # Maintain dots when possible
 actions+=/call_action_list,name=core_dot
-# Build combo points until 5, or max with darkest night
-actions+=/call_action_list,name=generate,if=!buff.darkest_night.up&combo_points<5|buff.darkest_night.up&combo_points.deficit>0
+# Build combo points until 5, max with darkest night, or ignore finishers to spread more bleeds with CT
+actions+=/call_action_list,name=generate,if=!buff.darkest_night.up&combo_points<5|buff.darkest_night.up&combo_points.deficit>0|(talent.crimson_tempest&spell_targets.fan_of_knives>=5&(active_dot.garrote<spell_targets.fan_of_knives|active_dot.rupture<spell_targets.fan_of_knives))
 # If combo point threshold is reached, spend them
 actions+=/call_action_list,name=spend,if=!buff.darkest_night.up&combo_points>=5|buff.darkest_night.up&combo_points.deficit=0
 


### PR DESCRIPTION
In AoE, it is worth ignoring envenom in order to use more crimson tempests and spread bleeds instead, regardless of talent build