### PR TITLE
[Devastation] Mass disintegrate target-count bugfix

### DIFF
--- a/engine/class_modules/sc_evoker.cpp
+++ b/engine/class_modules/sc_evoker.cpp
@@ -5635,7 +5635,7 @@ struct disintegrate_t : public essence_spell_t
       int max_targets_ = max_targets();
       max_targets_     = max_targets_ ? max_targets_ : 1;
 
-      auto buff_size = ( std::min( 3, max_targets_ ) - targets_ ) * mass_disint_mult;
+      auto buff_size = ( max_targets_ - targets_ ) * mass_disint_mult;
       buff_size      = buff_size > 0 ? buff_size : 0;
       p()->buff.mass_disintegrate_ticks->trigger( num_ticks, buff_size, -1, buff_duration );
     }


### PR DESCRIPTION
ie:
1 target -> +45% (was 30%)
2 targets -> +30% (was 15%)
3 targets -> +15% (was 0%)
4 targets -> +0% (was -15%)