### PR TITLE
[Warlock] Destruction apex talent

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -209,6 +209,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   cooldowns.soul_fire = get_cooldown( "soul_fire" );
   cooldowns.summon_doomguard = get_cooldown( "summon_doomguard" );
   cooldowns.felstorm_icd = get_cooldown( "felstorm_icd" );
+  cooldowns.echo_of_sargeras = get_cooldown( "echo_of_sargeras_icd" );
   cooldowns.blackened_soul = get_cooldown( "blackened_soul_icd" );
   cooldowns.seeds_of_their_demise = get_cooldown( "seeds_of_their_demise_icd" );
 

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -461,6 +461,8 @@ public:
     player_talent_t embers_of_nihilam_1;
     player_talent_t embers_of_nihilam_2;
     player_talent_t embers_of_nihilam_3;
+    const spell_data_t* echo_of_sargeras; // Damage spell (1265884)
+    const spell_data_t* vision_of_nihilam; // Crit/Haste buff (1265939)
   } talents;
 
   struct hero_talents_t
@@ -586,6 +588,10 @@ public:
     action_t* diabolic_gaze_2;
     action_t* diabolic_gaze_3;
     action_t* blighted_maw;
+    action_t* echo_of_sargeras;
+    action_t* echo_of_sargeras_cb;
+    action_t* echo_of_sargeras_sb;
+    action_t* echo_of_sargeras_rof;
   } proc_actions;
 
   struct tier_sets_t
@@ -606,6 +612,7 @@ public:
     propagate_const<cooldown_t*> soul_fire;
     propagate_const<cooldown_t*> summon_doomguard;
     propagate_const<cooldown_t*> felstorm_icd;
+    propagate_const<cooldown_t*> echo_of_sargeras; // ICD for Embers of Nihilam rank 4 procs
     propagate_const<cooldown_t*> blackened_soul; // Internal cooldown on triggering stack increase to Wither
     propagate_const<cooldown_t*> seeds_of_their_demise; // Estimated internal cooldown, a guess at how Blizzard is minimizing lucky streaks
   } cooldowns;
@@ -650,6 +657,7 @@ public:
     propagate_const<buff_t*> crashing_chaos;
     propagate_const<buff_t*> alythesss_ire;
     propagate_const<buff_t*> summon_overfiend;
+    propagate_const<buff_t*> vision_of_nihilam;
 
     // Diabolist Buffs
     propagate_const<buff_t*> ritual_overlord;
@@ -737,6 +745,10 @@ public:
     proc_t* demonfire_infusion_inc;
     proc_t* demonfire_infusion_dot;
     proc_t* alythesss_ire;
+    proc_t* echo_of_sargeras;
+    proc_t* echo_of_sargeras_cb;
+    proc_t* echo_of_sargeras_sb;
+    proc_t* echo_of_sargeras_rof;
 
     // Diabolist
 
@@ -772,6 +784,7 @@ public:
 
     // Destruction
     rng_setting_t avatar_of_destruction_dr = { 0.60, 0.60, "avatar_of_destruction_dr" }; // TODO:  Need to calculate ingame the type of RNG and the average RNG
+    rng_setting_t echo_of_sargeras = { 0.25, 0.25, "echo_of_sargeras" }; // TOCHECK: Proc rate not in spell data
 
     // Diabolist
 
@@ -959,5 +972,7 @@ namespace helpers
   void nightfall_updater( warlock_t* p, dot_t* d );
 
   void trigger_blackened_soul( warlock_t* p, bool malevolence );
+
+  void trigger_echo_of_sargeras( warlock_t* p, player_t* target, action_t* echo_action, proc_t* proc );
 }
 }  // namespace warlock

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -3234,6 +3234,13 @@ using namespace helpers;
         p()->procs.demonfire_infusion_inc->occur();
       }
 
+      if ( p()->talents.embers_of_nihilam_1.ok() && p()->rng().roll( p()->rng_settings.echo_of_sargeras.setting_value ) )
+      {
+        p()->proc_actions.echo_of_sargeras->execute_on_target( target );
+        p()->procs.echo_of_sargeras->occur();
+        p()->buffs.vision_of_nihilam->trigger();
+      }
+
       p()->buffs.backdraft->decrement();
 
       // Chaotic Inferno buff is only consumed by an Incinerate cast that benefits from the effect
@@ -3465,6 +3472,9 @@ using namespace helpers;
 
       if ( p()->talents.internal_combustion.ok() && result_is_hit( s->result ) && ( td( s->target )->dots.immolate->is_ticking() || td( s->target )->dots.wither->is_ticking() ) )
         internal_combustion->execute_on_target( s->target );
+
+      if ( p()->talents.embers_of_nihilam_3.ok() && result_is_hit( s->result ) )
+        helpers::trigger_echo_of_sargeras( p(), s->target, p()->proc_actions.echo_of_sargeras_cb, p()->procs.echo_of_sargeras_cb );
     }
 
     void schedule_execute( action_state_t* s ) override
@@ -3751,6 +3761,9 @@ using namespace helpers;
                                         .start_time( sim->current_time() )
                                         .action( p()->proc_actions.rain_of_fire_tick ) );
 
+      if ( p()->talents.embers_of_nihilam_3.ok() )
+        helpers::trigger_echo_of_sargeras( p(), execute_state->target, p()->proc_actions.echo_of_sargeras_rof, p()->procs.echo_of_sargeras_rof );
+
       p()->buffs.crashing_chaos->decrement();
 
       if ( p()->talents.alythesss_ire.ok() )
@@ -3925,6 +3938,9 @@ using namespace helpers;
       if ( result_is_hit( s->result ) )
       {
         td( s->target )->debuffs.shadowburn->trigger();
+
+        if ( p()->talents.embers_of_nihilam_3.ok() )
+          helpers::trigger_echo_of_sargeras( p(), s->target, p()->proc_actions.echo_of_sargeras_sb, p()->procs.echo_of_sargeras_sb );
       }
     }
 
@@ -4180,6 +4196,31 @@ using namespace helpers;
         p()->buffs.summon_overfiend->trigger();
         p()->procs.avatar_of_destruction->occur();
       }
+    }
+  };
+
+  struct echo_of_sargeras_t : public warlock_spell_t
+  {
+    echo_of_sargeras_t( warlock_t* p, util::string_view name = "echo_of_sargeras", double effectiveness = 1.0 )
+      : warlock_spell_t( name, p, p->talents.echo_of_sargeras )
+    {
+      background = dual = true;
+      aoe = -1;
+      reduced_aoe_targets = as<int>( p->talents.echo_of_sargeras->effectN( 3 ).base_value() );
+
+      spell_power_mod.direct = p->talents.echo_of_sargeras->effectN( 1 ).sp_coeff();
+
+      base_dd_multiplier *= effectiveness;
+    }
+
+    double composite_da_multiplier( const action_state_t* s ) const override
+    {
+      double m = warlock_spell_t::composite_da_multiplier( s );
+
+      if ( s->chain_target != 0 )
+        m *= p()->talents.echo_of_sargeras->effectN( 2 ).sp_coeff() / p()->talents.echo_of_sargeras->effectN( 1 ).sp_coeff();
+
+      return m;
     }
   };
 
@@ -4486,6 +4527,38 @@ using namespace helpers;
       p->cooldowns.blackened_soul->start();
   }
 
+  void helpers::trigger_echo_of_sargeras( warlock_t* p, player_t* target, action_t* echo_action, proc_t* proc )
+  {
+    if ( p->cooldowns.echo_of_sargeras->down() )
+      return;
+
+    // If no valid target provided, find a random target with Immolate or Wither ticking
+    if ( !target || target->is_sleeping() )
+    {
+      std::vector<player_t*> candidates;
+
+      for ( const auto t : p->sim->target_non_sleeping_list )
+      {
+        warlock_td_t* tdata = p->get_target_data( t );
+        if ( !tdata )
+          continue;
+
+        if ( tdata->dots.immolate->is_ticking() || tdata->dots.wither->is_ticking() )
+          candidates.push_back( t );
+      }
+
+      if ( candidates.empty() )
+        return;
+
+      target = candidates[ p->rng().range( candidates.size() ) ];
+    }
+
+    echo_action->execute_on_target( target );
+    proc->occur();
+    p->buffs.vision_of_nihilam->trigger();
+    p->cooldowns.echo_of_sargeras->start();
+  }
+
   // Event for spawning Wild Imps for Demonology
   imp_delay_event_t::imp_delay_event_t( warlock_t* p, double delay, double exp, int _index ) : player_event_t( *p, timespan_t::from_millis( delay ) )
   {
@@ -4778,6 +4851,16 @@ using namespace helpers;
   void warlock_t::create_destruction_proc_actions()
   {
     proc_actions.demonfire_infusion = new channel_demonfire_tick_t( this, true );
+
+    if ( talents.embers_of_nihilam_1.ok() )
+      proc_actions.echo_of_sargeras = new echo_of_sargeras_t( this );
+
+    if ( talents.embers_of_nihilam_3.ok() )
+    {
+      proc_actions.echo_of_sargeras_cb = new echo_of_sargeras_t( this, "echo_of_sargeras_cb", talents.embers_of_nihilam_3->effectN( 1 ).percent() );
+      proc_actions.echo_of_sargeras_sb = new echo_of_sargeras_t( this, "echo_of_sargeras_sb", talents.embers_of_nihilam_3->effectN( 2 ).percent() );
+      proc_actions.echo_of_sargeras_rof = new echo_of_sargeras_t( this, "echo_of_sargeras_rof", talents.embers_of_nihilam_3->effectN( 3 ).percent() );
+    }
   }
 
   void warlock_t::create_diabolist_proc_actions()

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -4550,7 +4550,7 @@ using namespace helpers;
       if ( candidates.empty() )
         return;
 
-      target = candidates[ p->rng().range( candidates.size() ) ];
+      target = p->rng().range( candidates );
     }
 
     echo_action->execute_on_target( target );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -453,10 +453,13 @@ namespace warlock
 
     talents.raging_demonfire = find_talent_spell( talent_tree::SPECIALIZATION, "Raging Demonfire" ); // Should be ID 387166
 
-    // TODO: Not Yet Implemented
     talents.embers_of_nihilam_1 = find_talent_spell( talent_tree::SPECIALIZATION, "Embers of Nihilam", 1 ); // Should be ID 1265770 (I)
     talents.embers_of_nihilam_2 = find_talent_spell( talent_tree::SPECIALIZATION, "Embers of Nihilam", 2 ); // Should be ID 1265772 (II)
     talents.embers_of_nihilam_3 = find_talent_spell( talent_tree::SPECIALIZATION, "Embers of Nihilam", 3 ); // Should be ID 1265774 (III)
+    talents.echo_of_sargeras = conditional_spell_lookup( talents.embers_of_nihilam_1.ok(), 1265884 );
+    talents.vision_of_nihilam = conditional_spell_lookup( talents.embers_of_nihilam_2.ok(), 1265939 );
+
+    cooldowns.echo_of_sargeras->duration = talents.embers_of_nihilam_3->internal_cooldown();
 
     // Additional Tier Set spell data
     tier.wl_destruction_12_0_class_set_2pc = sets->set( WARLOCK_DESTRUCTION, MID1, B2 ); // Should be ID 1264873
@@ -765,6 +768,11 @@ namespace warlock
                               ->set_default_value_from_effect( 1 )
                               ->set_chance( talents.alythesss_ire->effectN( 1 ).percent() ); // TODO: Check RNG type
 
+    buffs.vision_of_nihilam = make_buff( this, "vision_of_nihilam", talents.vision_of_nihilam )
+                                  ->set_default_value( talents.embers_of_nihilam_2->effectN( 1 ).percent() )
+                                  ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
+                                  ->set_pct_buff_type( STAT_PCT_BUFF_CRIT );
+
     buffs.summon_overfiend = make_buff( this, "summon_overfiend", talents.overfiend_buff )
                                  ->set_tick_time_behavior( buff_tick_time_behavior::UNHASTED )
                                  ->set_period( talents.overfiend_buff->effectN( 1 ).period() )
@@ -1025,6 +1033,10 @@ namespace warlock
     procs.rain_of_chaos = get_proc( "rain_of_chaos" );
     procs.demonfire_infusion_inc = get_proc( "demonfire_infusion_incinerate" );
     procs.demonfire_infusion_dot = get_proc( "demonfire_infusion_dot" );
+    procs.echo_of_sargeras = get_proc( "echo_of_sargeras" );
+    procs.echo_of_sargeras_cb = get_proc( "echo_of_sargeras_cb" );
+    procs.echo_of_sargeras_sb = get_proc( "echo_of_sargeras_sb" );
+    procs.echo_of_sargeras_rof = get_proc( "echo_of_sargeras_rof" );
   }
 
   void warlock_t::init_procs_diabolist()
@@ -1268,6 +1280,7 @@ namespace warlock
     add_rng_option( rng_settings.feast_of_souls_aff );
     add_rng_option( rng_settings.feast_of_souls_demo );
     add_rng_option( rng_settings.manifested_avarice );
+    add_rng_option( rng_settings.echo_of_sargeras );
   }
 
   void warlock_t::combat_begin()


### PR DESCRIPTION
Initial implementation of Embers of Nihilam apex talent for warlock destruction spec

Needs verification:
- Rank 1 proc rate (Incinerate → Echo of Sargeras) is not in spell data: using 25% placeholder, configurable via rng_settings

Implementation notes:
- Visions of Nihilam (rank 2/3) scaling: spell data auto-scales base_value with talent rank via op=mul, values=(1,2), so .percent() alone gives the correct value (4% at rank 1, 8% at rank 2)
- Rank 4 uses a helper for all affected spells (CB, SB, RoF) to handle the case where there's no target present - even though CB/SB always has a target as of now, figured it was safer for future proofing
- Rank 1 (proc chance, no ICD) and rank 3 (guaranteed, 0.5s ICD) are intentionally independent as they are separate talent effects with different gating mechanics