### PR TITLE
[Warlock] Affliction apex talent

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -791,9 +791,7 @@ void warlock_t::parse_player_effects()
     // Affliction Mastery
     parse_effects( warlock_base.potent_afflictions ); // 77215
     // Affliction Debuffs/DoTs
-    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.haunt ); // 48181
-    parse_effects( talents.shadow_of_nathreza_2 ); // 1261990
-    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.shadow_of_nathreza_2 ); // 1261990
+    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.haunt, talents.shadow_of_nathreza_2 );
   }
 
   // Demonology

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -781,6 +781,8 @@ void warlock_t::parse_player_effects()
     parse_effects( warlock_base.potent_afflictions ); // 77215
     // Affliction Debuffs/DoTs
     parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.haunt ); // 48181
+    parse_effects( talents.shadow_of_nathreza_2 ); // 1261990
+    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.shadow_of_nathreza_2 ); // 1261990
   }
 
   // Demonology

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -33,6 +33,17 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                         p.haunt_target = ( cur == 0 ) ? nullptr : b->player;
                       } );
 
+  if ( p.talents.shadow_of_nathreza_1.ok() )
+  {
+    debuffs.haunt->set_tick_zero( false )
+        ->set_period( p.talents.haunt->effectN( 5 ).period() )
+        ->set_tick_callback( [ target, &p ]( buff_t*, int, timespan_t ) {
+          p.proc_actions.shadow_of_nathreza->execute_on_target( target );
+          if ( p.talents.shadow_of_nathreza_3.ok() )
+            helpers::trigger_wrath_of_nathreza( &p, target );
+        } );
+  }
+
   // Demonology
   debuffs.doom = make_buff( *this, "doom", p.talents.doom_debuff )
                      ->set_stack_change_callback( [ &p ]( buff_t* b, int, int cur ) {

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -295,9 +295,13 @@ public:
     player_talent_t patient_zero;
     player_talent_t sow_the_seeds;
 
+    // Affliction Apex
     player_talent_t shadow_of_nathreza_1;
     player_talent_t shadow_of_nathreza_2;
     player_talent_t shadow_of_nathreza_3;
+    const spell_data_t* shadow_of_nathreza_dot;
+    const spell_data_t* wrath_of_nathreza; // Trigger missile spell
+    const spell_data_t* wrath_of_nathreza_impact;
 
     // Demonology
     player_talent_t hand_of_guldan;
@@ -610,6 +614,8 @@ public:
     action_t* echo_of_sargeras_cb;
     action_t* echo_of_sargeras_sb;
     action_t* echo_of_sargeras_rof;
+    action_t* shadow_of_nathreza;
+    action_t* wrath_of_nathreza;
   } proc_actions;
 
   struct pet_summons_t
@@ -751,6 +757,7 @@ public:
     proc_t* ravenous_afflictions;
     proc_t* shard_instability;
     proc_t* fatal_echoes;
+    proc_t* wrath_of_nathreza;
 
     // Demonology
     proc_t* demonic_core_dogs;
@@ -836,6 +843,7 @@ public:
   bool normalize_destruction_mastery;
   shuffled_rng_t* rain_of_chaos_rng;
   real_ppm_t* ravenous_afflictions_rng;
+  real_ppm_t* wrath_of_nathreza_rng;
   real_ppm_t* devil_fruit_rng;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );
@@ -1003,5 +1011,7 @@ namespace helpers
   void trigger_blackened_soul( warlock_t* p, bool malevolence );
 
   void trigger_echo_of_sargeras( warlock_t* p, player_t* target, action_t* echo_action, proc_t* proc );
+
+  void trigger_wrath_of_nathreza( warlock_t* p, player_t* target );
 }
 }  // namespace warlock

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -2123,6 +2123,13 @@ using namespace helpers;
           td( p()->haunt_target )->debuffs.haunt->expire();
 
         td( s->target )->debuffs.haunt->trigger();
+
+        if ( p()->talents.shadow_of_nathreza_1.ok() )
+          p()->proc_actions.shadow_of_nathreza->execute_on_target( s->target );
+
+        // TOCHECK: Does Wrath of Nathreza also proc from the initial Haunt hit?
+        if ( p()->talents.shadow_of_nathreza_3.ok() )
+          helpers::trigger_wrath_of_nathreza( p(), s->target );
       }
     }
   };
@@ -2219,6 +2226,52 @@ using namespace helpers;
     {
       target_cache.is_valid = false;
       warlock_spell_t::execute();
+    }
+  };
+
+  struct shadow_of_nathreza_dmg_t : public warlock_spell_t
+  {
+    shadow_of_nathreza_dmg_t( warlock_t* p )
+      : warlock_spell_t( "shadow_of_nathreza", p, p->talents.shadow_of_nathreza_dot )
+    {
+      background = dual = true;
+    }
+  };
+
+  struct shadow_of_nathreza_t : public warlock_spell_t
+  {
+    shadow_of_nathreza_dmg_t* damage;
+
+    shadow_of_nathreza_t( warlock_t* p )
+      : warlock_spell_t( "shadow_of_nathreza_dot", p, spell_data_t::nil() ),
+      damage( new shadow_of_nathreza_dmg_t( p ) )
+    {
+      background = dual = true;
+      dot_duration = p->talents.haunt->duration();
+      base_tick_time = 1_s;
+      hasted_ticks = false; // TOCHECK: Does this scale with haste?
+      add_child( damage );
+    }
+
+    void tick( dot_t* d ) override
+    {
+      warlock_spell_t::tick( d );
+
+      damage->execute_on_target( d->target );
+
+      if ( p()->talents.shadow_of_nathreza_3.ok() )
+        helpers::trigger_wrath_of_nathreza( p(), d->target );
+    }
+  };
+
+  struct wrath_of_nathreza_t : public warlock_spell_t
+  {
+    wrath_of_nathreza_t( warlock_t* p )
+      : warlock_spell_t( "wrath_of_nathreza", p, p->talents.wrath_of_nathreza_impact )
+    {
+      background = dual = true;
+      aoe = -1;
+      reduced_aoe_targets = as<int>( p->talents.wrath_of_nathreza->effectN( 2 ).base_value() );
     }
   };
 
@@ -4635,6 +4688,19 @@ using namespace helpers;
     p->cooldowns.echo_of_sargeras->start();
   }
 
+  void helpers::trigger_wrath_of_nathreza( warlock_t* p, player_t* target )
+  {
+    if ( !p->talents.shadow_of_nathreza_3.ok() )
+      return;
+
+    // TOCHECK: Spell data suggests ~2 RPPM - verify in-game
+    if ( !p->wrath_of_nathreza_rng->trigger() )
+      return;
+
+    p->proc_actions.wrath_of_nathreza->execute_on_target( target );
+    p->procs.wrath_of_nathreza->occur();
+  }
+
   // Event for spawning Wild Imps for Demonology
   imp_delay_event_t::imp_delay_event_t( warlock_t* p, double delay, double exp, int _index ) : player_event_t( *p, timespan_t::from_millis( delay ) )
   {
@@ -4916,6 +4982,11 @@ using namespace helpers;
 
   void warlock_t::create_affliction_proc_actions()
   {
+    if ( talents.shadow_of_nathreza_1.ok() )
+      proc_actions.shadow_of_nathreza = new shadow_of_nathreza_t( this );
+
+    if ( talents.shadow_of_nathreza_3.ok() )
+      proc_actions.wrath_of_nathreza = new wrath_of_nathreza_t( this );
   }
 
   void warlock_t::create_demonology_proc_actions()

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -2124,9 +2124,6 @@ using namespace helpers;
 
         td( s->target )->debuffs.haunt->trigger();
 
-        if ( p()->talents.shadow_of_nathreza_1.ok() )
-          p()->proc_actions.shadow_of_nathreza->execute_on_target( s->target );
-
         // TOCHECK: Does Wrath of Nathreza also proc from the initial Haunt hit?
         if ( p()->talents.shadow_of_nathreza_3.ok() )
           helpers::trigger_wrath_of_nathreza( p(), s->target );
@@ -2235,32 +2232,6 @@ using namespace helpers;
       : warlock_spell_t( "shadow_of_nathreza", p, p->talents.shadow_of_nathreza_dot )
     {
       background = dual = true;
-    }
-  };
-
-  struct shadow_of_nathreza_t : public warlock_spell_t
-  {
-    shadow_of_nathreza_dmg_t* damage;
-
-    shadow_of_nathreza_t( warlock_t* p )
-      : warlock_spell_t( "shadow_of_nathreza_dot", p, spell_data_t::nil() ),
-      damage( new shadow_of_nathreza_dmg_t( p ) )
-    {
-      background = dual = true;
-      dot_duration = p->talents.haunt->duration();
-      base_tick_time = 1_s;
-      hasted_ticks = false; // TOCHECK: Does this scale with haste?
-      add_child( damage );
-    }
-
-    void tick( dot_t* d ) override
-    {
-      warlock_spell_t::tick( d );
-
-      damage->execute_on_target( d->target );
-
-      if ( p()->talents.shadow_of_nathreza_3.ok() )
-        helpers::trigger_wrath_of_nathreza( p(), d->target );
     }
   };
 
@@ -4693,7 +4664,7 @@ using namespace helpers;
     if ( !p->talents.shadow_of_nathreza_3.ok() )
       return;
 
-    // TOCHECK: Spell data suggests ~2 RPPM - verify in-game
+    // TOCHECK: Spell data suggests ~2 RPPM (hasted) - verify in-game
     if ( !p->wrath_of_nathreza_rng->trigger() )
       return;
 
@@ -4983,7 +4954,7 @@ using namespace helpers;
   void warlock_t::create_affliction_proc_actions()
   {
     if ( talents.shadow_of_nathreza_1.ok() )
-      proc_actions.shadow_of_nathreza = new shadow_of_nathreza_t( this );
+      proc_actions.shadow_of_nathreza = new shadow_of_nathreza_dmg_t( this );
 
     if ( talents.shadow_of_nathreza_3.ok() )
       proc_actions.wrath_of_nathreza = new wrath_of_nathreza_t( this );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -182,10 +182,13 @@ namespace warlock
 
     talents.sow_the_seeds = find_talent_spell( talent_tree::SPECIALIZATION, "Sow the Seeds" ); // Should be ID 196226
 
-    // TODO: Not Yet Implemented
+    // Affliction Apex
     talents.shadow_of_nathreza_1 = find_talent_spell( talent_tree::SPECIALIZATION, "Shadow of Nathreza", 1 ); // Should be ID 1261984 (I)
     talents.shadow_of_nathreza_2 = find_talent_spell( talent_tree::SPECIALIZATION, "Shadow of Nathreza", 2 ); // Should be ID 1261990 (II)
     talents.shadow_of_nathreza_3 = find_talent_spell( talent_tree::SPECIALIZATION, "Shadow of Nathreza", 3 ); // Should be ID 1261992 (III)
+    talents.shadow_of_nathreza_dot = conditional_spell_lookup( talents.shadow_of_nathreza_1.ok(), 1262710 );
+    talents.wrath_of_nathreza = conditional_spell_lookup( talents.shadow_of_nathreza_3.ok(), 1262028 );
+    talents.wrath_of_nathreza_impact = conditional_spell_lookup( talents.shadow_of_nathreza_3.ok(), 1278047 );
 
     // Additional Tier Set spell data
     tier.wl_affliction_12_0_class_set_2pc = sets->set( WARLOCK_AFFLICTION, MID1, B2 ); // Should be ID 1264869
@@ -1019,6 +1022,7 @@ namespace warlock
     procs.ravenous_afflictions = get_proc( "ravenous_afflictions" );
     procs.shard_instability = get_proc( "shard_instability" );
     procs.fatal_echoes = get_proc( "fatal_echoes" );
+    procs.wrath_of_nathreza = get_proc( "wrath_of_nathreza" );
   }
 
   void warlock_t::init_procs_demonology()
@@ -1088,6 +1092,7 @@ namespace warlock
   void warlock_t::init_rng_affliction()
   {
     ravenous_afflictions_rng = get_rppm( "ravenous_afflictions", talents.ravenous_afflictions );
+    wrath_of_nathreza_rng = get_rppm( "wrath_of_nathreza", talents.shadow_of_nathreza_3 );
   }
 
   void warlock_t::init_rng_demonology()


### PR DESCRIPTION
Shadow of Nathreza damage is triggered via Haunt's effect 5 (Periodic Trigger Spell every 1s), wired as a set_tick_callback on the Haunt debuff (similar to how Blackened Soul uses set_period + set_tick_callback)

Wrath of Nathreza uses the impact spell (1278047) for damage, not the trigger missile spell (1262028). The trigger spell is still loaded for reduced_aoe_targets data

### //  TOCHECK
- Does Wrath of Nathreza proc from the initial Haunt hit, periodic ticks, or both? (currently can proc from either based on my reading of the talent's wording, but could not get initial Haunt impact to trigger Wrath when testing on training dummies in beta. unsure if that's RNG or if it only triggers on dot ticks... at the same time it shouldn't be a huge change in output given its RPPM driven)
- Wrath of Nathreza RPPM rate: spell data suggests ~2 RPPM (hasted), should verify in-game