### PR TITLE
[Vengeance] Fix missing Chaos Brand on Wounded Quarry mark-expiry discharge

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -9481,6 +9481,12 @@ demon_hunter_td_t::demon_hunter_td_t( player_t* target, demon_hunter_t& p )
               {
                 p.sim->print_debug( "{} triggers Wounded Quarry because Reaver's Mark was removed from target {}: {}",
                                     p.name(), p.last_reavers_mark_applied->name(), p.wounded_quarry_accumulator );
+                // Apply Chaos Brand multiplier to match periodic discharge behavior (line ~2874)
+                if ( p.last_reavers_mark_applied->debuffs.chaos_brand &&
+                     p.last_reavers_mark_applied->debuffs.chaos_brand->up() )
+                {
+                  p.wounded_quarry_accumulator *= 1.0 + p.spell.chaos_brand->effectN( 1 ).percent();
+                }
                 p.active.wounded_quarry->execute_on_target( p.last_reavers_mark_applied, p.wounded_quarry_accumulator );
               }
               p.wounded_quarry_accumulator = 0.0;


### PR DESCRIPTION
The periodic Wounded Quarry discharge (1s ICD batched path at `wounded_quarry_accumulator_t::impact()`) applies the Chaos Brand multiplier to the accumulated damage before dispatching. The mark-expiry discharge (in the `reavers_mark` stack change callback) does not — it passes the raw accumulator value through.

This adds the same Chaos Brand check to the expiry path.

## Evidence

Debug sim comparing the two code paths side by side (same sim, same target, chaos_brand active throughout):

| Discharge type | Time | Accumulator | Dispatched | Ratio |
|---|---|---|---|---|
| Periodic (from throw_glaive) | 56.293 | 3006.48 | 3097 | ×1.03 (chaos_brand applied) |
| Expiry (mark removed) | 57.258 | 1797.96 | 1798 | ×1.00 (raw passthrough) |

The periodic path multiplies the accumulator by `1.0 + chaos_brand_percent` before calling `execute_on_target`. The expiry path skips this and dispatches the raw accumulator.

## Code

Periodic path (line ~2874):
```cpp
if ( s->target->debuffs.chaos_brand->up() )
{
  BASE::p()->wounded_quarry_accumulator *= 1.0 + BASE::p()->spell.chaos_brand->effectN( 1 ).percent();
}
BASE::p()->active.wounded_quarry->execute_on_target( ... );
```

Expiry path (line ~9484, before this fix):
```cpp
// No chaos_brand check
p.active.wounded_quarry->execute_on_target( p.last_reavers_mark_applied, p.wounded_quarry_accumulator );
```