### PR TITLE
[Vengeance] Fix Untethered Rage rank 2 not modifying Soul Cleave per-fragment damage

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -8152,7 +8152,9 @@ struct soul_cleave_t
     action_state_t* damage_state = damage->get_state();
     damage_state->target         = target;
     damage->snapshot_state( damage_state, result_amount_type::DMG_DIRECT );
-    damage_state->da_multiplier *= 1.0 + ( damage_spell->effectN( 3 ).percent() * fragments_consumed );
+    // Read per-fragment % from parent spell effectN(1), which Untethered Rage (1270448) effect#1 modifies.
+    // The damage sub-spell 228478 effectN(3) has a stale base value (20) that UR2 does not reach.
+    damage_state->da_multiplier *= 1.0 + ( data().effectN( 1 ).percent() * fragments_consumed );
     damage->schedule_execute( damage_state );
     damage->execute_event->reschedule( timespan_t::from_millis( data().effectN( 2 ).misc_value1() ) );
 


### PR DESCRIPTION
Untethered Rage rank 2 (1270448) effect #1 adds +5%/rank to the per-fragment damage bonus for Soul Cleave, Spirit Bomb, and Soul Sunder. The DBC "Add Flat Modifier: Spell Effect 1" targets **parent spell 228477 effectN(1)**, but the Soul Cleave damage calculation reads from **damage sub-spell 228478 effectN(3)** — a different effect that UR2 does not modify.

This means UR2's per-fragment damage bonus is silently ignored for Soul Cleave.

## Evidence

### spell_query output

UR2 targets the parent spell:
```
Untethered Rage (1270448) effect#1: Add Flat Modifier: Spell Effect 1
  Affected Spells: Soul Cleave (228477), Spirit Bomb (247454), Soul Sunder (452436)
```

The parent's effectN(1) shows "Modified By: Untethered Rage":
```
Soul Cleave (228477)
  #1: Dummy — Base Value: 25
      Modified By: Untethered Rage (1270448 effect#1)
```

But the damage sub-spell's effectN(3) does NOT:
```
Soul Cleave (228478)
  #3: Dummy — Base Value: 20
      (no Modified By entry)
```

### Debug sim

With an Apex 2 build (UR rank 2), all Soul Cleave hits show `da_mul=3.045504` consuming 3 fragments. The fragment component is `1 + 0.20 * 3 = 1.60`, consistent with the unmodified 228478 effectN(3) = 20%.

If UR2 were working, it would be `1 + 0.30 * 3 = 1.90` — an 18.75% increase to the fragment bonus portion.

### action-effects init

No UR2-related modifier appears for `soul_cleave_damage`:
```
action-effects: Action 'soul_cleave_damage' (228478) direct damage modified by 20.0% per stack of buff demon_soul
action-effects: Action 'soul_cleave_damage' (228478) direct damage modified by 20.0% per stack of buff metamorphosis
...
(no untethered_rage entry)
```

## Fix

Switch from `damage_spell->effectN(3)` (228478, not UR2-modified) to `data().effectN(1)` (parent 228477, which UR2 does modify).

## Note on base value change

The parent spell effectN(1) base is 25%, while the damage sub-spell effectN(3) base is 20%. This fix changes the non-UR2 base from 20% to 25%. The tooltip references `$228478s3` (20%), but this value diverges from the parent's 25% and is unreachable by UR2's DBC modifier. This may need in-game verification to determine which base value is mechanically correct.

Spirit Bomb has a similar issue — UR2 modifies 247454 effectN(1) but the code uses `da_multiplier *= fragments_consumed` without referencing effectN(1) at all. That's a more involved change and is not included here.