### PR TITLE
[Mage] Sunfury Buff Fixes

### DIFF
--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -7079,7 +7079,11 @@ void mage_t::trigger_mana_cascade()
   // This is still tied to the pet despite the other effects (Ashes of Inspiration,
   // Memory of Al'ar) being moved to Arcane Surge/Combustion.
   int stacks = pets.arcane_phoenix && !pets.arcane_phoenix->is_sleeping() && talents.memory_of_alar.ok() ? 2 : 1;
-  buffs.mana_cascade->trigger( stacks );
+
+  if ( specialization() == MAGE_ARCANE )
+    buffs.mana_cascade->trigger( stacks );
+  else
+    buffs.mana_cascade->execute( stacks );
 }
 
 void mage_t::trigger_fired_up()

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2436,6 +2436,13 @@ struct hot_streak_spell_t : public custom_state_spell_t<fire_mage_spell_t, hot_s
 
   void execute() override
   {
+    if ( last_hot_streak )
+    {
+      p()->trigger_fired_up();
+      p()->trigger_spellfire_sphere( MAGE_FIRE );
+      p()->trigger_mana_cascade();
+    }
+
     custom_state_spell_t::execute();
 
     // TODO: When exactly in execute does this trigger the first cinder?
@@ -2451,20 +2458,15 @@ struct hot_streak_spell_t : public custom_state_spell_t<fire_mage_spell_t, hot_s
     {
       p()->buffs.hot_streak->decrement();
       p()->buffs.pyroclasm->trigger();
-      p()->trigger_fired_up();
-
-      p()->trigger_spellfire_sphere( MAGE_FIRE );
-      p()->trigger_mana_cascade();
     }
 
     // TODO: Pyromaniac seems to proc regardless of Hot Streak state
-    // TODO: Check if Pyromaniac can trigger Fired Up and Cinderstorm.
+    // TODO: Check if Pyromaniac can trigger Cinderstorm.
     if ( ( last_hot_streak || p()->bugs ) && p()->cooldowns.pyromaniac->up() && p()->accumulated_rng.pyromaniac->trigger() )
     {
       p()->cooldowns.pyromaniac->start( p()->talents.pyromaniac->internal_cooldown() );
 
-      // TODO: Pyromaniac increments Sphere's BLP (and thus can proc Spheres w/ the cap), 
-      // but it hasn't been tested whether it can roll the random chance.
+      p()->trigger_fired_up();
       p()->trigger_spellfire_sphere( MAGE_FIRE );
       p()->trigger_mana_cascade();
 
@@ -7096,7 +7098,7 @@ void mage_t::trigger_fired_up()
 
   if ( rng().roll( chance ) )
   {
-    buffs.fired_up->trigger();
+    buffs.fired_up->execute();
     cooldowns.fire_blast->adjust( -talents.fired_up_1->effectN( 2 ).time_value(), false, false );
     buffs.combustion->extend_duration( this, talents.fired_up_1->effectN( 3 ).time_value() );
 

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -2461,7 +2461,6 @@ struct hot_streak_spell_t : public custom_state_spell_t<fire_mage_spell_t, hot_s
     }
 
     // TODO: Pyromaniac seems to proc regardless of Hot Streak state
-    // TODO: Check if Pyromaniac can trigger Cinderstorm.
     if ( ( last_hot_streak || p()->bugs ) && p()->cooldowns.pyromaniac->up() && p()->accumulated_rng.pyromaniac->trigger() )
     {
       p()->cooldowns.pyromaniac->start( p()->talents.pyromaniac->internal_cooldown() );

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -7080,10 +7080,7 @@ void mage_t::trigger_mana_cascade()
   // Memory of Al'ar) being moved to Arcane Surge/Combustion.
   int stacks = pets.arcane_phoenix && !pets.arcane_phoenix->is_sleeping() && talents.memory_of_alar.ok() ? 2 : 1;
 
-  if ( specialization() == MAGE_ARCANE )
-    buffs.mana_cascade->trigger( stacks );
-  else
-    buffs.mana_cascade->execute( stacks );
+  buffs.mana_cascade->execute( stacks );
 }
 
 void mage_t::trigger_fired_up()

--- a/engine/class_modules/sc_mage.cpp
+++ b/engine/class_modules/sc_mage.cpp
@@ -7078,7 +7078,6 @@ void mage_t::trigger_mana_cascade()
   // This is still tied to the pet despite the other effects (Ashes of Inspiration,
   // Memory of Al'ar) being moved to Arcane Surge/Combustion.
   int stacks = pets.arcane_phoenix && !pets.arcane_phoenix->is_sleeping() && talents.memory_of_alar.ok() ? 2 : 1;
-
   buffs.mana_cascade->execute( stacks );
 }
 


### PR DESCRIPTION
arcane needs it to be execute()'d because...

prior, in sims:
<img width="714" height="762" alt="image" src="https://github.com/user-attachments/assets/2bd65b85-c9c0-43b4-baa3-add748acac09" />

in-game:
<img width="1517" height="122" alt="image" src="https://github.com/user-attachments/assets/4944440a-492b-4d8d-8350-14a79e8337d0" />


i don't believe cinderstorm can be proc'd from pyromaniac because 8% of pyros is equal (3 off out of 930) to the amount of times cinderstorm was executed -- if pyromaniac had any influence it'd surely differ.
https://www.warcraftlogs.com/reports/9DWzm8Kf4YZgbvrA?fight=1&type=damage-done&source=1
alternatively, i've another file relating to this, but i'd need to provide a lengthier explanation -- just lemme know.
