### PR TITLE
[Warlock] Update destro apex r1 behavior

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -827,7 +827,7 @@ public:
 
     // Destruction
     rng_setting_t avatar_of_destruction_dr = { 0.30, 0.30, "avatar_of_destruction_dr" }; // TODO: PLACEHOLDER VALUE! Need to calculate ingame the type of RNG and the average RNG
-    rng_setting_t echo_of_sargeras = { 0.25, 0.25, "echo_of_sargeras" }; // TOCHECK: Proc rate not in spell data
+    rng_setting_t echo_of_sargeras = { 0.10, 0.10, "echo_of_sargeras" };
 
     // Diabolist
 

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -3355,6 +3355,13 @@ using namespace helpers;
 
         if ( p()->bugs && p()->talents.diabolic_embers.ok() && s->result == RESULT_CRIT )
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.incinerate_crits );
+
+        if ( p()->talents.embers_of_nihilam_1.ok() && p()->rng().roll( p()->rng_settings.echo_of_sargeras.setting_value ) )
+        {
+          p()->proc_actions.echo_of_sargeras->execute_on_target( s->target );
+          p()->procs.echo_of_sargeras->occur();
+          p()->buffs.vision_of_nihilam->trigger();
+        }
       }
     };
 
@@ -3414,13 +3421,6 @@ using namespace helpers;
         p()->procs.demonfire_infusion_inc->occur();
       }
 
-      if ( p()->talents.embers_of_nihilam_1.ok() && p()->rng().roll( p()->rng_settings.echo_of_sargeras.setting_value ) )
-      {
-        p()->proc_actions.echo_of_sargeras->execute_on_target( target );
-        p()->procs.echo_of_sargeras->occur();
-        p()->buffs.vision_of_nihilam->trigger();
-      }
-
       p()->buffs.backdraft->decrement();
 
       // Chaotic Inferno buff is only consumed by an Incinerate cast that benefits from the effect
@@ -3439,6 +3439,13 @@ using namespace helpers;
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_crits );
         else if ( p()->talents.diabolic_embers.ok() )
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.incinerate_crits );
+      }
+
+      if ( p()->talents.embers_of_nihilam_1.ok() && p()->rng().roll( p()->rng_settings.echo_of_sargeras.setting_value ) )
+      {
+        p()->proc_actions.echo_of_sargeras->execute_on_target( s->target );
+        p()->procs.echo_of_sargeras->occur();
+        p()->buffs.vision_of_nihilam->trigger();
       }
     }
   };


### PR DESCRIPTION
After testing, it turns out that rank 1 of the destro apex talent actually has a per-target 10% proc chance rather than a per-cast 25% proc chance, so updating the default proc rate as well as when the roll occurs.

Need to further validate that FnB doesn't reduce chance with additional targets but initial testing suggests that it doesn't.