### PR TITLE
[Demon Hunter] Fix action state leak in Undying Embers

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6019,7 +6019,10 @@ struct soul_immolation_base_t : public demon_hunter_spell_t
       action_state_t* undying_embers_state = get_state();
       snapshot_state( undying_embers_state, result_amount_type::DMG_OVER_TIME );
 
-      make_event( sim, [ undying_embers_state, this ] { trigger_dot( undying_embers_state ); } );
+      make_event( sim, [ undying_embers_state, this ]() mutable {
+        trigger_dot( undying_embers_state );
+        action_state_t::release( undying_embers_state );
+      } );
     }
   }
 };


### PR DESCRIPTION
The Undying Embers re-trigger in `soul_immolation_base_t::last_tick` calls `get_state()` to allocate an action state, then passes it to `trigger_dot()` inside a `make_event` lambda. `trigger_dot()` copies the state into the dot via `copy_state()` but doesn't consume the source. The release call was missing, so one action state leaked from the pool every time Undying Embers procced.

Every other `get_state()` call in the DH module passes the state to `schedule_execute()`, which takes ownership. This was the only path using `trigger_dot()` directly.

The lambda needs `mutable` because `action_state_t::release()` takes a non-const `T*&` and value-captured pointers are const by default.