### PR TITLE
[Warlock] Manifested Avarize rng and minor Backdraft tweak

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -66,7 +66,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
 
   // Use havoc_debuff where we need the data but don't have the active talent
   debuffs.havoc = make_buff( *this, "havoc", p.talents.havoc_debuff )
-                      ->set_duration( p.talents.mayhem.ok() ? p.talents.mayhem->effectN( 3 ).time_value() : p.talents.havoc->duration() )
+                      ->set_duration( p.talents.mayhem.ok() ? p.talents.mayhem->effectN( 3 ).time_value() + p.talents.improved_havoc->effectN( 1 ).time_value() : p.talents.havoc->duration() )
                       ->set_cooldown( p.talents.mayhem.ok() ? p.talents.mayhem->internal_cooldown() : 0_ms )
                       ->set_chance( p.talents.mayhem.ok() ? p.talents.mayhem->effectN( 1 ).percent() : p.talents.havoc->proc_chance() )
                       ->set_stack_change_callback( [ &p ]( buff_t* b, int, int cur ) {
@@ -189,7 +189,6 @@ int warlock_td_t::count_affliction_dots() const
 
   return count;
 }
-
 
 warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   : parse_player_effects_t( sim, WARLOCK, name, r ),
@@ -334,6 +333,52 @@ double warlock_t::composite_mastery() const
   }
 
   return m;
+}
+
+double warlock_t::pseudo_random_p_from_c( double c )
+{
+  if ( c <= 0 )
+    return 0.0;
+
+  double p_proc_by_n       = 0;
+  double sum_n_p_proc_on_n = 0;
+
+  int max_fails = as<int>( std::ceil( 1 / c ) );
+  for ( int n = 1; n <= max_fails; ++n )
+  {
+    double p_proc_on_n = std::min( 1.0, n * c ) * ( 1 - p_proc_by_n );
+    p_proc_by_n += p_proc_on_n;
+    sum_n_p_proc_on_n += n * p_proc_on_n;
+  }
+
+  return ( 1 / sum_n_p_proc_on_n );
+}
+
+double warlock_t::pseudo_random_c_from_p( double p )
+{
+  if ( p <= 0 )
+    return 0.0;
+
+  double c_upper = p;
+  double c_lower = 0;
+  double c_mid;
+  double p2 = 1;
+  while ( true )
+  {
+    c_mid = ( c_upper + c_lower ) * 0.5;
+    double p1 = pseudo_random_p_from_c( c_mid );
+    if ( std::abs( p1 - p2 ) <= 1e-12 )
+      break;
+
+    if ( p1 > p )
+      c_upper = c_mid;
+    else
+      c_lower = c_mid;
+
+    p2 = p1;
+  }
+
+  return c_mid;
 }
 
 // Used to determine how many Wild Imps are waiting to be spawned from Hand of Guldan
@@ -880,7 +925,7 @@ void warlock_t::summon_dominion_of_argus_pet( dominion_of_argus_pet_e pet )
   // Odds for each pet currently seem to be
   // Jailer: 30%, Sacrolash: 20%, Grand Warlock Alythess: 20%, Inquisitor: 30% (last tested 2026-02-19)
   // More testing required for more accurate rates.
-  // Probably better to do a better weighted random selection than this. 
+  // Probably better to do a better weighted random selection than this.
   if ( pet == DOA_PET_RANDOM )
   {
     const std::array<dominion_of_argus_pet_e, 10> pets = {

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -842,7 +842,7 @@ public:
     rng_setting_t succulent_soul_demo = { 0.15, 0.15, "succulent_soul_demo" };
     rng_setting_t feast_of_souls_aff = { 0.15, 0.15, "feast_of_souls" };
     rng_setting_t feast_of_souls_demo = { 0.0975, 0.0975, "feast_of_souls" };
-    rng_setting_t manifested_avarice = { 0.10, 0.10, "manifested_avarice" }; // TODO: PLACEHOLDER VALUE! Need to calculate ingame the type of RNG and the average RNG
+    rng_setting_t manifested_avarice = { 0.10, 0.10, "manifested_avarice" };
   } rng_settings;
 
   int initial_soul_shards;
@@ -853,6 +853,7 @@ public:
   real_ppm_t* ravenous_afflictions_rng;
   real_ppm_t* wrath_of_nathreza_rng;
   real_ppm_t* devil_fruit_rng;
+  accumulated_rng_t* manifested_avarice_rng;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );
 
@@ -875,6 +876,8 @@ public:
   void parse_player_effects();
   const spell_data_t* conditional_spell_lookup( bool fn, int id );
   void add_rng_option( warlock_t::rng_settings_t::rng_setting_t& );
+  double pseudo_random_p_from_c( double c );
+  double pseudo_random_c_from_p( double p );
   int get_spawning_imp_count(); // TODO: Decide if still needed
   timespan_t time_to_imps( int count ); // TODO: Decide if still needed
   int active_demon_count( bool include_diabolist = true ) const;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1403,9 +1403,8 @@ using namespace helpers;
       {
         p()->buffs.succulent_soul->decrement();
 
-        if ( p()->hero.manifested_avarice.ok() && rng().roll( p()->rng_settings.manifested_avarice.setting_value ) )
+        if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
         {
-          // TODO: Needed some ingame checks. Is it possible to proc a new Demonic Soul spawn while another Demonic Soul is active? What happens in that case? What happens to the buff and the mastery effect in that case? ​​(Does it stack? Does the duration change?)
           p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
           p()->buffs.manifested_demonic_soul->trigger();
           p()->procs.manifested_avarice->occur();
@@ -1733,9 +1732,8 @@ using namespace helpers;
       {
         p()->buffs.succulent_soul->decrement();
 
-        if ( p()->hero.manifested_avarice.ok() && rng().roll( p()->rng_settings.manifested_avarice.setting_value ) )
+        if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
         {
-          // TODO: Needed some ingame checks. Is it possible to proc a new Demonic Soul spawn while another Demonic Soul is active? What happens in that case? What happens to the buff and the mastery effect in that case? ​​(Does it stack? Does the duration change?)
           p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
           p()->buffs.manifested_demonic_soul->trigger();
           p()->procs.manifested_avarice->occur();
@@ -2538,9 +2536,8 @@ using namespace helpers;
           {
             p()->buffs.succulent_soul->decrement();
 
-            if ( p()->hero.manifested_avarice.ok() && rng().roll( p()->rng_settings.manifested_avarice.setting_value ) )
+            if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
             {
-              // TODO: Needed some ingame checks. Is it possible to proc a new Demonic Soul spawn while another Demonic Soul is active? What happens in that case? What happens to the buff and the mastery effect in that case? ​​(Does it stack? Does the duration change?)
               p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
               p()->buffs.manifested_demonic_soul->trigger();
               p()->procs.manifested_avarice->occur();
@@ -3421,7 +3418,10 @@ using namespace helpers;
         p()->procs.demonfire_infusion_inc->occur();
       }
 
-      p()->buffs.backdraft->decrement();
+      // Backdraft is not consumed by an instant Incinerate cast benefiting from Chaotic Inferno
+      // NOTE: To achieve this, the game checks if the player has the Chaotic Inferno buff
+      if ( p()->bugs ? p()->buffs.chaotic_inferno->check() : ( time_to_execute == 0_ms ) )
+        p()->buffs.backdraft->decrement();
 
       // Chaotic Inferno buff is only consumed by an Incinerate cast that benefits from the effect
       if ( time_to_execute == 0_ms )

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -63,7 +63,7 @@ namespace warlock
 
     talents.grimoire_of_sacrifice = find_talent_spell( talent_tree::SPECIALIZATION, "Grimoire of Sacrifice" ); // Aff/Destro only. Should be ID 108503
     talents.grimoire_of_sacrifice_buff = conditional_spell_lookup( talents.grimoire_of_sacrifice.ok(), 196099 ); // Buff data and RPPM
-    talents.grimoire_of_sacrifice_proc = conditional_spell_lookup( talents.grimoire_of_sacrifice.ok(),196100 ); // Damage data
+    talents.grimoire_of_sacrifice_proc = conditional_spell_lookup( talents.grimoire_of_sacrifice.ok(), 196100 ); // Damage data
 
     warlock_t::init_spells_diabolist();
     warlock_t::init_spells_hellcaller();
@@ -1154,6 +1154,10 @@ namespace warlock
 
   void warlock_t::init_rng_soul_harvester()
   {
+    // Modeling Manifested Avarice as a pseudo-random distribution (PRD) with a nominal
+    // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
+    double c = pseudo_random_c_from_p( rng_settings.manifested_avarice.setting_value );
+    manifested_avarice_rng = get_accumulated_rng( "manifested_avarice", c );
   }
 
   void warlock_t::init_resources( bool force )


### PR DESCRIPTION
The behavior of the Manifested Avarice proc RNG has been tested. It appears to use an accumulator (based on the tooltip description, which states that "has an increasing chance"). After approximately 33 hours of logging, a total of 8497 events were collected, resulting in 839 procs. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 10%, corresponding to a PRD constant C = 0.014745844781072676.
The logs are the following:
- https://www.warcraftlogs.com/reports/GzVt21pXyhMYkHNK?fight=last&type=summons&source=3&ability=1269042
- https://www.warcraftlogs.com/reports/PtJRdVj8YM4AvLnH?fight=last&type=summons&ability=1269042&source=2
- https://www.warcraftlogs.com/reports/ZABNb7F8qTjPKCy6?fight=last&type=summons&ability=1269042&source=2
- https://www.warcraftlogs.com/reports/VGRAbtFzY6nvBxgK?fight=1&type=summons&source=1&ability=1269042

The tested spec is Demonology. This model will be used for both specs for now (Demo and Aff), pending further adjustments for Aff if necessary.

Additionally, two changes made by Blizzard to Destruction have been implemented:
- An instant Incinerate from the Chaotic Inferno buff proc no longer consumes a Backdraft stack.
- The Havoc debuff from Mayhem proc is now affected by the Improved Havoc extended duration talent.

EDIT: Manifested Avarice rng also tested for Affliction, and it is the same PRD 10% nominal proc rate. Log: https://www.warcraftlogs.com/reports/HqxvbaNZ8X2jnpBL?fight=1&type=summons&source=1&ability=1269042