### PR TITLE
[Warlock] Model Shard Instability RNG, tweak HoG, fix Dark Harvest and Diabolic Oculi

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -614,6 +614,7 @@ public:
     action_t* diabolic_gaze_1;
     action_t* diabolic_gaze_2;
     action_t* diabolic_gaze_3;
+    action_t* diabolic_oculi;
     action_t* blighted_maw;
     action_t* echo_of_sargeras;
     action_t* echo_of_sargeras_cb;
@@ -853,6 +854,8 @@ public:
   real_ppm_t* ravenous_afflictions_rng;
   real_ppm_t* wrath_of_nathreza_rng;
   real_ppm_t* devil_fruit_rng;
+  accumulated_rng_t* shard_instability_ds_rng;
+  accumulated_rng_t* shard_instability_sb_rng;
   accumulated_rng_t* manifested_avarice_rng;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -808,12 +808,10 @@ using namespace helpers;
 
       if ( result_is_hit( s->result ) )
       {
-        if ( p()->talents.shard_instability.ok() )
+        if ( p()->talents.shard_instability.ok() && p()->shard_instability_sb_rng->trigger() )
         {
-          bool success = p()->buffs.shard_instability->trigger();
-
-          if ( success )
-            p()->procs.shard_instability->occur();
+          p()->buffs.shard_instability->trigger();
+          p()->procs.shard_instability->occur();
         }
 
         if ( p()->talents.cunning_cruelty.ok() && rng().roll( p()->rng_settings.cunning_cruelty_sb.setting_value ) )
@@ -1167,7 +1165,7 @@ using namespace helpers;
 
       if ( affliction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && rng().roll( p()->rng_settings.seeds_of_their_demise.setting_value ) )
       {
-        p()->buffs.shard_instability->trigger( -1, buff_t::DEFAULT_VALUE(), 1.0 );
+        p()->buffs.shard_instability->trigger();
         p()->procs.seeds_of_their_demise->occur();
         seeds_triggered = true;
       }
@@ -2008,12 +2006,10 @@ using namespace helpers;
       if ( result_is_hit( d->state->result ) )
       {
         // NOTE: 2026-02-20 Malefic Grasp can proc Shard Instability
-        if ( p()->talents.shard_instability.ok() )
+        if ( p()->talents.shard_instability.ok() && p()->shard_instability_ds_rng->trigger() )
         {
-          bool success = p()->buffs.shard_instability->trigger();
-
-          if ( success )
-            p()->procs.shard_instability->occur();
+          p()->buffs.shard_instability->trigger();
+          p()->procs.shard_instability->occur();
         }
 
         // NOTE: 2026-02-20 Malefic Grasp can proc Cunning Cruelty
@@ -2148,12 +2144,10 @@ using namespace helpers;
 
       if ( result_is_hit( d->state->result ) )
       {
-        if ( p()->talents.shard_instability.ok() )
+        if ( p()->talents.shard_instability.ok() && p()->shard_instability_ds_rng->trigger() )
         {
-          bool success = p()->buffs.shard_instability->trigger();
-
-          if ( success )
-            p()->procs.shard_instability->occur();
+          p()->buffs.shard_instability->trigger();
+          p()->procs.shard_instability->occur();
         }
 
         if ( p()->talents.cunning_cruelty.ok() && rng().roll( p()->rng_settings.cunning_cruelty_ds.setting_value ) )
@@ -2254,7 +2248,8 @@ using namespace helpers;
       : warlock_spell_t( "Dark Harvest", p, p->talents.dark_harvest, options_str ),
       dark_harvest_dmg( new dark_harvest_dmg_t( p ) )
     {
-      aoe = -1;
+      channeled = true;
+
       add_child( dark_harvest_dmg );
     }
 
@@ -2288,12 +2283,11 @@ using namespace helpers;
     {
       warlock_spell_t::tick( d );
 
-      auto t = d->state->target;
-      if ( td( t )->dots.corruption->is_ticking() || td( t )->dots.wither->is_ticking() || td( t )->dots.agony->is_ticking() || td( t )->dots.unstable_affliction->is_ticking() )
+      const auto& tl = target_list();
+      for ( auto t : tl )
         dark_harvest_dmg->execute_on_target( t );
 
-      // Shadow of Death gain effect is processed only once
-      if ( soul_harvester() && p()->hero.shadow_of_death.ok() && d->state->chain_target == 0 )
+      if ( soul_harvester() && p()->hero.shadow_of_death.ok() )
       {
         double gain = p()->hero.shadow_of_death->effectN( 2 ).base_value();
         // NOTE: 2026-02-20 The shards gained by Shadow of Death can also proc another Succulent Soul each (bug?)
@@ -2380,13 +2374,11 @@ using namespace helpers;
         int shards_used;
         bool rancora_empowered;
         int last_hit_random_target;
-        bool allow_succulent_soul;
 
         hogi_state_t()
           : shards_used( 0 ),
           rancora_empowered( false ),
-          last_hit_random_target( 0 ),
-          allow_succulent_soul( true )
+          last_hit_random_target( 0 )
         { }
       };
 
@@ -2405,7 +2397,6 @@ using namespace helpers;
           state.shards_used = 0;
           state.rancora_empowered = false;
           state.last_hit_random_target = 0;
-          state.allow_succulent_soul = true;
         }
 
         std::ostringstream& debug_str( std::ostringstream& s ) override
@@ -2414,7 +2405,6 @@ using namespace helpers;
           s << " shards_used=" << state.shards_used;
           s << " rancora_empowered=" << state.rancora_empowered;
           s << " last_hit_random_target=" << state.last_hit_random_target;
-          s << " allow_succulent_soul=" << state.allow_succulent_soul;
           return s;
         }
 
@@ -2430,7 +2420,7 @@ using namespace helpers;
 
       hog_impact_t( warlock_t* p )
         : warlock_spell_t( "Hand of Gul'dan (Impact)", p, p->talents.hog_impact ),
-        meteor_time( 400_ms )
+        meteor_time( 20_ms )
       {
         aoe = -1;
         dual = true;
@@ -2517,33 +2507,17 @@ using namespace helpers;
         {
           // NOTE: Old Behavior (pre Midnight):
           //   Wild Imp spawns appear to have been sped up in Shadowlands. Last tested 2021-04-16.
-          //   Current behavior: HoG will spawn a meteor on cast finish. Travel time in spell data is 0.7 seconds.
+          //   HoG will spawn a meteor on cast finish. Travel time in spell data is 0.7 seconds.
           //   However, damage event occurs before spell effect lands, happening 0.4 seconds after cast.
           //   Imps then spawn roughly every 0.18 seconds seconds after the damage event.
-          // NOTE: New Behavior:
+          // NOTE: New Behavior (from Midnight onwards):
           //   Wild Imps spawn on HoG impact almost instantly, with a 1ms delay between them
+          //   The HoG damage event no longer takes 0.4 seconds after cast (only a few milliseconds)
           //   Last tested: 2026-02-20
           for ( int i = 1; i <= debug_cast<hog_impact_state_t*>( s )->state.shards_used; i++ )
           {
             auto ev = make_event<imp_delay_event_t>( *sim, p(), ( 1.0 * i ), ( 1.0 * i ), i - 1 );
             p()->wild_imp_spawns.push_back( ev );
-          }
-        }
-
-        if ( soul_harvester() && debug_cast<hog_impact_state_t*>( s )->state.allow_succulent_soul && p()->buffs.succulent_soul->check() )
-        {
-          if ( s->chain_target == 0 )
-          {
-            p()->buffs.succulent_soul->decrement();
-
-            if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
-            {
-              p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
-              p()->buffs.manifested_demonic_soul->trigger();
-              p()->procs.manifested_avarice->occur();
-            }
-
-            p()->proc_actions.demonic_soul->execute_on_target( s->target );
           }
         }
       }
@@ -2611,7 +2585,6 @@ using namespace helpers;
         impact_spell->state.rancora_empowered = false;
         triggers.demonic_art_buff = false;
       }
-      impact_spell->state.allow_succulent_soul = true;
 
       if ( p()->hero.diabolic_oculi.ok() )
         p()->buffs.demonic_oculi->trigger();
@@ -2631,6 +2604,20 @@ using namespace helpers;
       {
         p()->buffs.demonic_core->trigger();
         p()->procs.demonic_knowledge->occur();
+      }
+
+      if ( soul_harvester() && p()->buffs.succulent_soul->check() )
+      {
+          p()->buffs.succulent_soul->decrement();
+
+          if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
+          {
+            p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
+            p()->buffs.manifested_demonic_soul->trigger();
+            p()->procs.manifested_avarice->occur();
+          }
+
+          p()->proc_actions.demonic_soul->execute_on_target( target );
       }
 
       // TODO: Are these execute, or impact? Check ingame timings to see when these effects are applied
@@ -4534,7 +4521,6 @@ using namespace helpers;
           hog_impact_spell = new hand_of_guldan_t::hog_impact_t( p );
           hog_impact_spell->state.shards_used = as<int>( p->hero.ruination_buff->effectN( 2 ).base_value() );
           hog_impact_spell->state.rancora_empowered = false;    // Ruination HoG impact is never rancora empowered
-          hog_impact_spell->state.allow_succulent_soul = false; // Ruination HoG impact can't benefit from succulent soul
         }
       }
 
@@ -4654,6 +4640,20 @@ using namespace helpers;
       // Excluded (not whitelisted) from many warlock talents/spells (bug?)
 
       background = true;
+    }
+  };
+
+  struct diabolic_oculi_t : public warlock_spell_t
+  {
+    diabolic_oculi_t( warlock_t* p )
+      : warlock_spell_t( "Diabolic Oculi", p, p->hero.diabolic_oculi )
+    {
+      background = dual = true;
+
+      add_child( p->proc_actions.eye_explosion );
+      add_child( p->proc_actions.diabolic_gaze_3 );
+      add_child( p->proc_actions.diabolic_gaze_2 );
+      add_child( p->proc_actions.diabolic_gaze_1 );
     }
   };
 
@@ -5118,6 +5118,7 @@ using namespace helpers;
     proc_actions.diabolic_gaze_1 = new diabolic_gaze_1_t( this );
     proc_actions.diabolic_gaze_2 = new diabolic_gaze_2_t( this );
     proc_actions.diabolic_gaze_3 = new diabolic_gaze_3_t( this );
+    proc_actions.diabolic_oculi = new diabolic_oculi_t( this );
   }
 
   void warlock_t::create_hellcaller_proc_actions()

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -192,7 +192,7 @@ namespace warlock
     talents.contagion = find_talent_spell( talent_tree::SPECIALIZATION, "Contagion" ); // Should be ID 453096
 
     talents.shard_instability = find_talent_spell( talent_tree::SPECIALIZATION, "Shard Instability" ); // Should be ID 1260264
-    talents.shard_instability_buff = conditional_spell_lookup( talents.shard_instability.ok(), 1260269 );
+    talents.shard_instability_buff = conditional_spell_lookup( warlock_base.affliction_warlock->ok(), 1260269 );
 
     talents.niskaran_methods = find_talent_spell( talent_tree::SPECIALIZATION, "Niskaran Methods" ); // Should be ID 1279510
 
@@ -715,8 +715,7 @@ namespace warlock
 
     buffs.darkglare_presence = make_buff( this, "darkglare_presence", talents.darkglare_presence_buff );
 
-    buffs.shard_instability = make_buff( this, "shard_instability", talents.shard_instability_buff )
-                                  ->set_chance( talents.drain_soul.ok() ? talents.shard_instability->effectN( 1 ).percent() : talents.shard_instability->effectN( 2 ).percent() ); // TODO: Check RNG type
+    buffs.shard_instability = make_buff( this, "shard_instability", talents.shard_instability_buff );
 
     buffs.cascading_calamity = make_buff( this, "cascading_calamity", talents.cascading_calamity_buff )
                                    ->set_default_value_from_effect( 1 )
@@ -919,7 +918,9 @@ namespace warlock
     buffs.ruination = make_buff( this, "ruination", hero.ruination_buff );
 
     buffs.demonic_oculi = make_buff( this, "demonic_oculi", hero.demonic_oculi_buff )
-                              ->set_period( 1_s )
+                              ->set_period( hero.demonic_oculi_buff->effectN( 2 ).period() )
+                              ->set_freeze_stacks( true )
+                              ->set_tick_time_behavior( buff_tick_time_behavior::UNHASTED )
                               ->set_tick_callback( [ this ]( buff_t* b, int, timespan_t ) {
                                 if ( hero.looks_that_kill.ok() )
                                 {
@@ -1132,6 +1133,15 @@ namespace warlock
   {
     ravenous_afflictions_rng = get_rppm( "ravenous_afflictions", talents.ravenous_afflictions );
     wrath_of_nathreza_rng = get_rppm( "wrath_of_nathreza", talents.shadow_of_nathreza_3 );
+    // Modeling Shard Instability as a pseudo-random distribution (PRD) with a nominal rate of 10% (DS/MG) / 20% (SB),
+    // which corresponds to PRD constant C = 0.014745844781072676 (DS/MG) / C = 0.055704042949781852 (SB)
+    if ( talents.shard_instability.ok() )
+    {
+      double c_ds = pseudo_random_c_from_p( talents.shard_instability->effectN( 1 ).percent() );
+      shard_instability_ds_rng = get_accumulated_rng( "shard_instability_ds", c_ds );
+      double c_sb = pseudo_random_c_from_p( talents.shard_instability->effectN( 2 ).percent() );
+      shard_instability_sb_rng = get_accumulated_rng( "shard_instability_sb", c_sb );
+    }
   }
 
   void warlock_t::init_rng_demonology()


### PR DESCRIPTION
## Shard Instability
The behavior of the [[Shard Instability]](https://www.wowhead.com/spell=1260264/shard-instability) affliction talent proc RNG has been tested. Although the spell description only indicates the probability percentages, the spell does not appear to use flat RNG but rather an accumulator. A total of 7910 events were collected, resulting in 1480 procs. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 20% for Shadow Bolt and a nominal rate of 10% for Drain Soul and Malefic Grasp (the values ​​indicated in the toollip, except for Malefic Grasp, which although not indicated in tooltip seems to use the Drain Soul 10% value, ​​whether or not you have that talent). That correspons to a PRD constant C = 0.055704042949781852 for the 20% nominal rate SB and C = 0.014745844781072676 for the nominal rate 10% of DS/MG.
The logs are the following:
- https://www.warcraftlogs.com/reports/2z4ZbCXWLhyvNG6d?fight=1&type=auras&source=15&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Unknown%240.0.0.Any%24true%240.0.0.Any%24true%241260269%2441
- https://www.warcraftlogs.com/reports/rLBbW16wtjkQ37aN?fight=2&type=auras&source=15&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Unknown%240.0.0.Any%24true%240.0.0.Any%24true%241260269%2441
- https://www.warcraftlogs.com/reports/pqtHdAPMbJmTvfzQ?fight=1&type=auras&pins=2%24Off%24%23244F4B%24auras-gained%24-1%2414256391.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%241260269%2441&source=1

As example, this is the histogram of the third log (7051 events and 1399 procs), where using SB (20% nominal rate) the following histogram of distance between procs is obtained:
<img width="432" height="258" alt="hist_sampleN_interproc" src="https://github.com/user-attachments/assets/71d25908-69a1-4a84-8f85-43fe0330d2e1" />

If we simulate 20000 events for procs with a 20% flat % chance, we obtain the following histogram of distance between procs, very different from the sample:
<img width="432" height="258" alt="hist_flat20_20000" src="https://github.com/user-attachments/assets/29b4d3db-f21f-4580-b724-d035dc890fd3" />

If we simulate 20000 events for procs using an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 20%, we obtain the following histogram of distance between procs, very similar to the sample:
<img width="432" height="258" alt="hist_prd20_20000" src="https://github.com/user-attachments/assets/cbda948c-62cd-45df-b0bd-0eb0810e30dc" />
## Diabolic Oculi
A bug with Diabolic Oculi that incorrectly increased its stack with each tick pulse has been fixed, and its report has been improved.
## Dark Harvest
Fixed a bug where Dark Harvest was not considered a channeled spell.
## Hand of Gul'dan
The damage event timing for Hand of Gul'dan has been adjusted, as it appears to have been sped up from 400ms to just a few ms in Midnight.
Hand of Gul'dan now consumes Succulent Soul upon cast (execute) instead of on meteor hit impact.