### PR TITLE
[Warlock] Model Succulent Soul RNG and fix Shadow of Death

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -884,15 +884,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
   {
     for ( int i = 0; i < as<int>( actual_amount ); i++ )
     {
-      double chance = 0.0;
-
-      if ( affliction() )
-        chance = rng_settings.succulent_soul_aff.setting_value;
-
-      if ( demonology() )
-        chance = rng_settings.succulent_soul_demo.setting_value;
-
-      if ( rng().roll( chance ) )
+      if ( ( affliction() || demonology() ) && succulent_soul_rng->trigger() )
       {
         buffs.succulent_soul->trigger();
         procs.succulent_soul->occur();

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -884,7 +884,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
   {
     for ( int i = 0; i < as<int>( actual_amount ); i++ )
     {
-      if ( ( affliction() || demonology() ) && succulent_soul_rng->trigger() )
+      if ( succulent_soul_rng->trigger() )
       {
         buffs.succulent_soul->trigger();
         procs.succulent_soul->occur();

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -856,6 +856,7 @@ public:
   real_ppm_t* devil_fruit_rng;
   accumulated_rng_t* shard_instability_ds_rng;
   accumulated_rng_t* shard_instability_sb_rng;
+  accumulated_rng_t* succulent_soul_rng;
   accumulated_rng_t* manifested_avarice_rng;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -2287,10 +2287,11 @@ using namespace helpers;
       for ( auto t : tl )
         dark_harvest_dmg->execute_on_target( t );
 
-      if ( soul_harvester() && p()->hero.shadow_of_death.ok() )
+      // Shadow of Death gain starts on the second tick
+      if ( soul_harvester() && p()->hero.shadow_of_death.ok() && d->current_tick > 0 )
       {
-        double gain = p()->hero.shadow_of_death->effectN( 2 ).base_value();
         // NOTE: 2026-02-20 The shards gained by Shadow of Death can also proc another Succulent Soul each (bug?)
+        double gain = p()->hero.shadow_of_death->effectN( 2 ).base_value();
         if ( p()->bugs )
           p()->resource_gain( RESOURCE_SOUL_SHARD, gain, p()->gains.shadow_of_death );
         else

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1165,10 +1165,20 @@ namespace warlock
 
   void warlock_t::init_rng_soul_harvester()
   {
+    // Modeling Succulent Soul as a pseudo-random distribution (PRD) with a nominal rate of 22% (aff) / 15% (demo),
+    // which corresponds to PRD constant C = 0.066676403621508090 (aff) / C = 0.032220914373087675 (demo)
+    double c_ss = 0.0;
+    if ( affliction() )
+      c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_aff.setting_value );
+    else if ( demonology() )
+      c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_demo.setting_value );
+
+    succulent_soul_rng = get_accumulated_rng( "succulent_soul", c_ss );
+
     // Modeling Manifested Avarice as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
-    double c = pseudo_random_c_from_p( rng_settings.manifested_avarice.setting_value );
-    manifested_avarice_rng = get_accumulated_rng( "manifested_avarice", c );
+    double c_ma = pseudo_random_c_from_p( rng_settings.manifested_avarice.setting_value );
+    manifested_avarice_rng = get_accumulated_rng( "manifested_avarice", c_ma );
   }
 
   void warlock_t::init_resources( bool force )


### PR DESCRIPTION
## Succulent Soul
The behavior of the [[Succulent Soul]](https://www.wowhead.com/spell=449793/succulent-soul) proc RNG has been tested for demonology. A total of 29951 events were collected, resulting in 4540 procs. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 15%. That corresponds to a PRD constant C = 0.032220914373087675. The tested spec is Demonology. This model will be used for both specs for now (Demo and Aff), pending further adjustments for Affliction if necessary (Aff currently set to nominal rate of 22% (C = 0.066676403621508090) according to the data we had from TWW).
The logs are the following:
- https://www.warcraftlogs.com/reports/GzVt21pXyhMYkHNK?fight=last&type=auras&source=3&ability=449793&target=3&pins=2%24Off%24%23244F4B%24auras-gained%24-1%2410025333.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24449793%2441&eventstart=5408689
- https://www.warcraftlogs.com/reports/PtJRdVj8YM4AvLnH?fight=last&type=auras&source=2&ability=449793&target=2&pins=2%24Off%24%23244F4B%24auras-gained%24-1%2410025333.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24449793%2441&eventstart=38576948
- https://www.warcraftlogs.com/reports/ZABNb7F8qTjPKCy6?fight=last&type=auras&source=2&target=2&ability=449793&pins=2%24Off%24%23244F4B%24auras-gained%24-1%2410025333.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24449793%2441

As example, this is the histogram of the second+third log (27818 events and 4213 procs) for the distance between procs:
<img width="400" height="240" alt="hist_samplePQ_interproc" src="https://github.com/user-attachments/assets/a5ae419b-89c8-4a4b-b0aa-280c2adebf60" />

If we simulate 60000 events for procs using an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 15%, we obtain the following histogram of distance between procs, very similar to the sample:
<img width="400" height="200" alt="hist_prd15_60000_interproc_1_19_bordered" src="https://github.com/user-attachments/assets/70376ee7-1ec0-42b1-ae03-0e807041dadc" />

Other figures comparing our sample (labeled as "PQ") vs the simulation using PRD 15% nominal rate:
- ECDF distance between procs:
<img width="400" height="250" alt="pq_vs_prd15_ecdf_interproc" src="https://github.com/user-attachments/assets/ed670899-7025-4eec-b2e1-25a58f4443ee" />

- Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="400" height="250" alt="pq_vs_prd15_hazard_curve" src="https://github.com/user-attachments/assets/118acdd4-5fa9-4613-8ae0-5b603352953b" />

- Tail / survival of the distance between procs (log scale)
<img width="400" height="250" alt="pq_vs_prd15_survivor_tail" src="https://github.com/user-attachments/assets/d8073139-3f54-4399-85eb-8ecc1ba7247e" />

## Shadow of Death
Fix to the Shadow of Death soul shard gain of Dark Harvest (Aff) to start on the second tick. The first tick deals damage, but does not trigger Shadow of Death.