### PR TITLE
[Items] Implement Lightless Lament Heaven's Glaive proc

### DIFF
--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -2278,15 +2278,14 @@ void torments_duality( special_effect_t& effect )
 // 1266592 AoE damage (Cosmic, 8yd radius, triggered by missile)
 void lightless_lament( special_effect_t& effect )
 {
-  auto missile = create_proc_action<generic_proc_t>( "heavens_glaive_missile", effect,
-                                                     effect.trigger() );
-  auto damage  = create_proc_action<generic_aoe_proc_t>( "heavens_glaive", effect,
-                                                          effect.trigger()->effectN( 1 ).trigger() );
+  auto missile = create_proc_action<generic_proc_t>( "heavens_glaive_missile", effect, effect.trigger() );
+  auto damage = create_proc_action<generic_aoe_proc_t>( "heavens_glaive", effect,
+      missile->data().effectN( 1 ).trigger() );
   damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
   damage->base_multiplier *= role_mult( effect );
 
-  missile->dual          = true;
-  missile->stats         = damage->stats;
+  missile->dual = true;
+  missile->stats = damage->stats;
   missile->impact_action = damage;
 
   effect.execute_action = missile;

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -2274,16 +2274,22 @@ void torments_duality( special_effect_t& effect )
 
 // Lightless Lament
 // 1266257 driver (RPPM equip proc)
-// 1266591 missile (intermediate)
-// 1266592 AoE damage (Cosmic, 8yd radius)
+// 1266591 missile (intermediate, triggered by driver)
+// 1266592 AoE damage (Cosmic, 8yd radius, triggered by missile)
 void lightless_lament( special_effect_t& effect )
 {
-  auto damage = create_proc_action<generic_aoe_proc_t>( "heavens_glaive", effect,
-                                                        effect.player->find_spell( 1266592 ) );
+  auto missile = create_proc_action<generic_proc_t>( "heavens_glaive_missile", effect,
+                                                     effect.trigger() );
+  auto damage  = create_proc_action<generic_aoe_proc_t>( "heavens_glaive", effect,
+                                                          effect.trigger()->effectN( 1 ).trigger() );
   damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
   damage->base_multiplier *= role_mult( effect );
 
-  effect.execute_action = damage;
+  missile->dual          = true;
+  missile->stats         = damage->stats;
+  missile->impact_action = damage;
+
+  effect.execute_action = missile;
 
   new dbc_proc_callback_t( effect.player, effect );
 }

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -2284,8 +2284,7 @@ void lightless_lament( special_effect_t& effect )
   damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
   damage->base_multiplier *= role_mult( effect );
 
-  missile->dual = true;
-  missile->stats = damage->stats;
+  missile->add_child( damage );
   missile->impact_action = damage;
 
   effect.execute_action = missile;

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -2271,6 +2271,22 @@ void torments_duality( special_effect_t& effect )
 
   new torments_duality_cb_t( effect );
 }
+
+// Lightless Lament
+// 1266257 driver (RPPM equip proc)
+// 1266591 missile (intermediate)
+// 1266592 AoE damage (Cosmic, 8yd radius)
+void lightless_lament( special_effect_t& effect )
+{
+  auto damage = create_proc_action<generic_aoe_proc_t>( "heavens_glaive", effect,
+                                                        effect.player->find_spell( 1266592 ) );
+  damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect );
+  damage->base_multiplier *= role_mult( effect );
+
+  effect.execute_action = damage;
+
+  new dbc_proc_callback_t( effect.player, effect );
+}
 }  // namespace weapons
 
 namespace armors
@@ -2516,6 +2532,7 @@ void register_special_effects()
   register_special_effect( 1259103, DISABLED_EFFECT); // Wraps of the Cosmic Madness equip driver
   // Weapons
   register_special_effect( { 1253357, 1253359 }, weapons::torments_duality );  // umbral sabre & radiant foil
+  register_special_effect( 1266257, weapons::lightless_lament );
   // Armor
   register_special_effect( 1271211, armors::eternal_voidsong_chain );
   // Sets


### PR DESCRIPTION
## Summary

Lightless Lament's equip proc (Heaven's Glaive, spell 1266257) is silently a no-op. The generic `special_effect_t` system cannot traverse the `E_TRIGGER_MISSILE` (type 32) on the trigger spell, so `usable_proc()` classifies it as `SPECIAL_EFFECT_ACTION_NONE` / `SPECIAL_EFFECT_BUFF_NONE` and disables the effect.

The actual damage is on a grandchild spell two levels deep:

```
1266257 driver (RPPM 3.0, A_PROC_TRIGGER_SPELL, coeff 9.69)
  → 1266591 missile (E_TRIGGER_MISSILE) ← generic system stops here
    → 1266592 damage (E_SCHOOL_DAMAGE, Cosmic, 8yd radius)
```

This adds a custom implementation that bypasses the missile spell, using `generic_aoe_proc_t` with the damage spell (1266592) directly. Damage is sourced from the driver's effect 1 coefficient, with `role_mult` applied.

## Testing

- Verified proc does not fire before the fix (HTML report shows zero Heaven's Glaive damage)
- Verified proc fires after the fix (~271 DPS ST, ~585 DPS at 5 targets)
- Verified AoE split damage scaling: ST hit ~2720, 5-target hit ~1169/target (expected: 2720 × 2.2 / 5 ≈ 1197)
- Verified RPPM: ~23 procs per 300s fight (3.0 base × haste)
- Verified school is Cosmic, radius 8yd