### PR TITLE
[Warlock] Fix Backdraft

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -3408,7 +3408,8 @@ using namespace helpers;
 
       // Backdraft is not consumed by an instant Incinerate cast benefiting from Chaotic Inferno
       // NOTE: To achieve this, the game checks if the player has the Chaotic Inferno buff
-      if ( p()->bugs ? p()->buffs.chaotic_inferno->check() : ( time_to_execute == 0_ms ) )
+      bool consume_backdraft = p()->bugs ? !p()->buffs.chaotic_inferno->check() : ( time_to_execute != 0_ms );
+      if ( consume_backdraft )
         p()->buffs.backdraft->decrement();
 
       // Chaotic Inferno buff is only consumed by an Incinerate cast that benefits from the effect
@@ -3687,6 +3688,8 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
+
+      p()->buffs.backdraft->decrement();
 
       p()->buffs.crashing_chaos->decrement();
 

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -4499,6 +4499,8 @@ using namespace helpers;
 
       p()->buffs.infernal_bolt->decrement();
 
+      p()->buffs.backdraft->decrement();
+
       // NOTE: 2026-02-18 Infernal Bolt benefits from Chaotic Inferno but does not consume the effect (bug?)
       if ( !p()->bugs )
         p()->buffs.chaotic_inferno->decrement();

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -380,7 +380,6 @@ using namespace helpers;
 
       if ( destruction() && triggers.fiendish_cruelty )
       {
-        // TODO: Check if havoc hits and FnB Incinerate hits are affected by fiendish cruelty
         if ( s->result == RESULT_CRIT )
         {
           bool success = p()->buffs.fiendish_cruelty->trigger();
@@ -3304,7 +3303,7 @@ using namespace helpers;
 
         affected_by.chaotic_energies = true;
 
-        triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok(); // TODO: Check if Fiendish Cruelty actually affects FnB's Incinerate and how it affects it
+        triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok();
 
         base_multiplier *= p->talents.fire_and_brimstone->effectN( 1 ).percent();
       }
@@ -4501,8 +4500,8 @@ using namespace helpers;
 
       p()->buffs.backdraft->decrement();
 
-      // NOTE: 2026-02-18 Infernal Bolt benefits from Chaotic Inferno but does not consume the effect (bug?)
-      if ( !p()->bugs )
+      // Chaotic Inferno buff is only consumed by an Infernal Bolt cast that benefits from the effect
+      if ( time_to_execute == 0_ms )
         p()->buffs.chaotic_inferno->decrement();
     }
   };


### PR DESCRIPTION
Fix for Destruction WL Backdraft buff that was never being consumed by Chaos Bolt and Infernal Bolt and almost never by Incinerate.

As reference, the current (2026-02-25) ingame behavior of Backdraft and Chaotic Inferno is the following (replicated in simc with this PR):

- Backdraft:
  - Backdraft is always consumed by Soul Fire.
  - Backdraft is always consumed by Chaos Bolt.
  - Backdraft is always consumed by Incinerate unless you have the Chaotic Inferno buff.
  - Backdraft is always consumed by IB (regardless of whether you have the Chaotic Inferno buff).

- Chaotic Inferno:
  - Chaotic Inferno is consumed by Incinerate if it is instant.
  - Chaotic Inferno is consumed by IB if it is instant.
*Note: It's possible to cast Incinerate/IB right after a Chaos Bolt before the Chaotic Inferno proc activates (so that cast is not instant but you have the Chaotic Inferno buff); but at least in this case, that cast doesn't consume the Chaotic Inferno buff*