### PR TITLE
[Warlock] Cunning Cruelty rng and Fatal Echoes rng

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -113,6 +113,7 @@ void warlock_td_t::target_demise()
   if ( !( target->is_enemy() ) )
     return;
 
+  // Warlock gains only one shard at most per enemy that dies with UA, regardless of UA stacks
   if ( dots.unstable_affliction->is_ticking() )
   {
     warlock.sim->print_log( "Player {} demised. Warlock {} gains a shard from Unstable Affliction.", target->name(), warlock.name() );
@@ -335,7 +336,7 @@ double warlock_t::composite_mastery() const
   return m;
 }
 
-double warlock_t::pseudo_random_p_from_c( double c )
+double warlock_t::pseudo_random_p_from_c( double c ) const
 {
   if ( c <= 0 )
     return 0.0;
@@ -354,7 +355,7 @@ double warlock_t::pseudo_random_p_from_c( double c )
   return ( 1 / sum_n_p_proc_on_n );
 }
 
-double warlock_t::pseudo_random_c_from_p( double p )
+double warlock_t::pseudo_random_c_from_p( double p ) const
 {
   if ( p <= 0 )
     return 0.0;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -854,8 +854,10 @@ public:
   real_ppm_t* ravenous_afflictions_rng;
   real_ppm_t* wrath_of_nathreza_rng;
   real_ppm_t* devil_fruit_rng;
+  accumulated_rng_t* cunning_cruelty_rng;
   accumulated_rng_t* shard_instability_ds_rng;
   accumulated_rng_t* shard_instability_sb_rng;
+  accumulated_rng_t* fatal_echoes_rng;
   accumulated_rng_t* succulent_soul_rng;
   accumulated_rng_t* manifested_avarice_rng;
 
@@ -880,8 +882,8 @@ public:
   void parse_player_effects();
   const spell_data_t* conditional_spell_lookup( bool fn, int id );
   void add_rng_option( warlock_t::rng_settings_t::rng_setting_t& );
-  double pseudo_random_p_from_c( double c );
-  double pseudo_random_c_from_p( double p );
+  double pseudo_random_p_from_c( double c ) const;
+  double pseudo_random_c_from_p( double p ) const;
   int get_spawning_imp_count(); // TODO: Decide if still needed
   timespan_t time_to_imps( int count ); // TODO: Decide if still needed
   int active_demon_count( bool include_diabolist = true ) const;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -813,7 +813,7 @@ using namespace helpers;
           p()->procs.shard_instability->occur();
         }
 
-        if ( p()->talents.cunning_cruelty.ok() && rng().roll( p()->rng_settings.cunning_cruelty_sb.setting_value ) )
+        if ( p()->talents.cunning_cruelty.ok() && p()->cunning_cruelty_rng->trigger() )
         {
           p()->procs.shadowbolt_volley->occur();
           volley->execute_on_target( s->target );
@@ -1448,7 +1448,7 @@ using namespace helpers;
       {
         for ( int i = 0; i < stacks; i++ )
         {
-          if ( rng().roll( p()->talents.fatal_echoes->effectN( 1 ).percent() ) )
+          if ( p()->fatal_echoes_rng->trigger() )
           {
             p()->procs.fatal_echoes->occur();
             make_event( sim, 1_ms, [ this, t = d->state->target ] {
@@ -2011,8 +2011,8 @@ using namespace helpers;
           p()->procs.shard_instability->occur();
         }
 
-        // NOTE: 2026-02-20 Malefic Grasp can proc Cunning Cruelty
-        if ( p()->talents.cunning_cruelty.ok() && rng().roll( p()->rng_settings.cunning_cruelty_ds.setting_value ) )
+        // NOTE: 2026-02-20 Malefic Grasp can proc Cunning Cruelty (PRD: 50% nominal rate if SB is used, 25% nominal rate if DS is used)
+        if ( p()->talents.cunning_cruelty.ok() && p()->cunning_cruelty_rng->trigger() )
         {
           p()->procs.shadowbolt_volley->occur();
           volley->execute_on_target( d->target );
@@ -2149,7 +2149,7 @@ using namespace helpers;
           p()->procs.shard_instability->occur();
         }
 
-        if ( p()->talents.cunning_cruelty.ok() && rng().roll( p()->rng_settings.cunning_cruelty_ds.setting_value ) )
+        if ( p()->talents.cunning_cruelty.ok() && p()->cunning_cruelty_rng->trigger() )
         {
           p()->procs.shadowbolt_volley->occur();
           volley->execute_on_target( d->target );
@@ -4859,8 +4859,8 @@ using namespace helpers;
       dot->decrement( 1 );
       assert( ( dot->is_ticking() && dot->current_stack() > 0 ) && "UA stack decrement event should not cancel the DoT" );
 
-      // if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && dot->is_ticking() && dot->current_stack() > 0 && rng().roll( p->talents.fatal_echoes->effectN( 1 ).percent() ) )
-      if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && rng().roll( p->talents.fatal_echoes->effectN( 1 ).percent() ) )
+      // if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && dot->is_ticking() && dot->current_stack() > 0 && p->fatal_echoes_rng->trigger() )
+      if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && p->fatal_echoes_rng->trigger() )
       {
         p->procs.fatal_echoes->occur();
         dot->current_action->set_target( target );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1133,6 +1133,15 @@ namespace warlock
   {
     ravenous_afflictions_rng = get_rppm( "ravenous_afflictions", talents.ravenous_afflictions );
     wrath_of_nathreza_rng = get_rppm( "wrath_of_nathreza", talents.shadow_of_nathreza_3 );
+
+    // Modeling Cunning Cruelty as a pseudo-random distribution (PRD) with a nominal rate of 50% (SB) / 25% (DS) (MG uses DS rate if
+    // selected, SB rate otherwise) which corresponds to PRD constant C = 0.302103025348741965 (SB) / C = 0.084744091852316990 (DS)
+    if ( talents.cunning_cruelty.ok() )
+    {
+      double c_cc = pseudo_random_c_from_p( talents.drain_soul.ok() ? rng_settings.cunning_cruelty_ds.setting_value : rng_settings.cunning_cruelty_sb.setting_value );
+      cunning_cruelty_rng = get_accumulated_rng( "cunning_cruelty", c_cc );
+    }
+
     // Modeling Shard Instability as a pseudo-random distribution (PRD) with a nominal rate of 10% (DS/MG) / 20% (SB),
     // which corresponds to PRD constant C = 0.014745844781072676 (DS/MG) / C = 0.055704042949781852 (SB)
     if ( talents.shard_instability.ok() )
@@ -1141,6 +1150,14 @@ namespace warlock
       shard_instability_ds_rng = get_accumulated_rng( "shard_instability_ds", c_ds );
       double c_sb = pseudo_random_c_from_p( talents.shard_instability->effectN( 2 ).percent() );
       shard_instability_sb_rng = get_accumulated_rng( "shard_instability_sb", c_sb );
+    }
+
+    // Modeling Fatal Echoes as a pseudo-random distribution (PRD) with a nominal
+    // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
+    if ( talents.fatal_echoes.ok() )
+    {
+      double c_fe = pseudo_random_c_from_p( talents.fatal_echoes->effectN( 1 ).percent() );
+      fatal_echoes_rng = get_accumulated_rng( "fatal_echoes", c_fe );
     }
   }
 


### PR DESCRIPTION
After several in-game tests, we included more PRD-type RNGs in the Warlock module.

## Cunning Cruelty

The behavior of the [[Cunning Cruelty]](https://www.wowhead.com/spell=453172/cunning-cruelty) affliction talent proc RNG has been tested. The spell description does not indicate percentages, although in the past, procs of 50% for Shadow Bolt (SB) and 25% for Drain Soul (DS) had been found and these are the current values used in SimC. New tests have confirmed that these average chances are correct, although instead of flat RNG, the proc appears to use an accumulator. In Midnight, the spell Malefic Grasp (MG) was introduced, which occasionally replaces SB/DS for a time. In new tests, we found that MG proc chance is inherited from the spell it replaces, being 25% if Drain Soul is used, and 50% if Shadow Bolt is used.

A total of 16192 events were collected, resulting in 4149 procs. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 50% for Shadow Bolt and a nominal rate of 25% for Drain Soul. Malefic Grasp inherits 50% or 25% depending on the spell it replaces. That corresponds to a PRD constant C = 0.302103025348741965 for the 50% nominal rate of SB, and C = 0.084744091852316990 for the nominal rate 25% of DS.

Logs:
- https://www.warcraftlogs.com/reports/rLBbW16wtjkQ37aN?fight=2&type=damage-done&source=15&ability=453176
- https://www.warcraftlogs.com/reports/2z4ZbCXWLhyvNG6d?fight=1&type=damage-done&source=15&ability=453176
- https://www.warcraftlogs.com/reports/QZtjANVh7DxywKaz?fight=1&source=1&type=damage-done&ability=453176&target=3.1&start=893403&end=15394300&eventstart=14519665
- https://www.warcraftlogs.com/reports/ZKnW6vhLz7RAJy3r?fight=last&source=1&type=damage-done&target=3

As example, this is the histogram for the distance between procs using Drain Soul (sample labeled as "U"):
<img width="490" height="280" alt="hist_sampleU_interproc_1_11" src="https://github.com/user-attachments/assets/6f2218d7-d80e-4320-b1ef-c4d577caef57" />

Other figures comparing our sample vs simulations of this and other rng models:
- ECDF distance between procs:
<img width="510" height="330" alt="compare_ecdf_U_vs_models_using_prd60k" src="https://github.com/user-attachments/assets/350f4af6-730a-45e8-8439-a9db9c99a529" />

- Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="510" height="330" alt="compare_hazard_U_vs_models_using_prd60k" src="https://github.com/user-attachments/assets/33f65451-e85d-4b1c-9699-5ea2e5af24d1" />


## Fatal Echoes

The behavior of the [[Fatal Echoes]](https://www.wowhead.com/spell=1260229/fatal-echoes) affliction talent proc RNG has been tested. The spell description indicates an average rate of 10% and our tests confirm that. A total of 16116 events were collected, resulting in 1601 procs. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 10%. That corresponds to a PRD constant C = 0.014745844781072676.

Logs:
- https://www.warcraftlogs.com/reports/HqxvbaNZ8X2jnpBL?fight=1&type=auras&spells=debuffs&hostility=1&target=1&ability=1259790&pins=2%24Off%24%23244F4B%24auras-gained%24-1%240.0.0.Any%2414256391.0.0.Warlock%24true%240.0.0.Any%24true%241259790%2473
- File with Timestamps of UA applied by Fatal Echoes (procs): [ua_aura_applied-filtered-ts.txt](https://github.com/user-attachments/files/25563795/ua_aura_applied-filtered-ts.txt)
- File with Timestamps of UA debuffs falling (attempt events): [ua_aura_removed-short-ts.txt](https://github.com/user-attachments/files/25563796/ua_aura_removed-short-ts.txt)

Histogram for the distance between procs (sample labeled as "UA"):
<img width="360" height="220" alt="hist_UA_interproc" src="https://github.com/user-attachments/assets/c18740b3-8520-4d89-b2b1-c99d79c22931" />

Other figures comparing our sample vs simulations of this and other rng models:
- ECDF distance between procs:
<img width="360" height="220" alt="ecdf_UA_vs_flat_prd" src="https://github.com/user-attachments/assets/288de5c5-9c36-4d95-9980-f4f625b35252" />

- Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="360" height="220" alt="hazard_UA_vs_flat_prd" src="https://github.com/user-attachments/assets/50ba9221-b49a-4463-ae73-2c807f74f8f5" />

- Tail / survival of the distance between procs (log scale)
<img width="360" height="220" alt="survival_UA_vs_flat_prd_log" src="https://github.com/user-attachments/assets/053dc970-6d47-4c0d-bbd1-342ec602340a" />


## Manifested Avarice (affliction)

In PR https://github.com/simulationcraft/simc/pull/11019 we had already tested Manifested Avarice (Soul Harvester tree) for Demonology, finding that it followed an accumulator RNG model with a nominal PRD of 10%. We have tested that the same model applies to the Affliction spec, using the same nominal PRD rate of 10%.
- Log: https://www.warcraftlogs.com/reports/HqxvbaNZ8X2jnpBL?fight=1&type=summons&source=1&ability=1269042

No changes to the code are necessary because we were already using the changes made for demonology in affliction as well.