### PR TITLE
[demon_hunter] Reimplement Undying Embers event. Clean up Clang warnings.

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1592,7 +1592,7 @@ struct undying_embers_event_t : public event_t
   action_state_t* state;
 
   undying_embers_event_t( demon_hunter_t* player, action_t* action, action_state_t* state )
-    : event_t( *player, 0_s ), action( action ), state( state )
+    : event_t( *player, timespan_t::min() ), action( action ), state( state )
   {
   }
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1584,6 +1584,36 @@ bool movement_buff_t::trigger( int s, double v, double c, timespan_t d )
   return buff_t::trigger( s, v, c, d );
 }
 
+// Undying Embers Event definition ==========================================
+
+struct undying_embers_event_t : public event_t
+{
+  action_t* action;
+  action_state_t* state;
+
+  undying_embers_event_t( demon_hunter_t* player, action_t* action, action_state_t* state )
+    : event_t( *player ), action( action ), state( state )
+  {
+  }
+
+  ~undying_embers_event_t()
+  {
+    if ( state )
+      action_state_t::release( state );
+  }
+
+  const char* name() const override
+  {
+    return "undying_embers_event";
+  }
+
+  void execute() override
+  {
+    action->trigger_dot( state );
+    action_state_t::release( state );
+  }
+};
+
 // Soul Fragment definition =================================================
 
 struct soul_fragment_t
@@ -5797,8 +5827,6 @@ struct void_buildup_t : public demon_hunter_spell_t
 
 struct soul_immolation_base_t : public demon_hunter_spell_t
 {
-  std::vector<action_state_t*> undying_embers_states;
-
   soul_immolation_base_t( util::string_view n, demon_hunter_t* p, util::string_view o )
     : demon_hunter_spell_t( n, p, p->talent.devourer.soul_immolation, o )
   {
@@ -5845,23 +5873,9 @@ struct soul_immolation_base_t : public demon_hunter_spell_t
       action_state_t* undying_embers_state = get_state();
       undying_embers_state->target         = d->state->target;
       snapshot_state( undying_embers_state, result_amount_type::DMG_OVER_TIME );
-      undying_embers_states.push_back( undying_embers_state );
 
-      make_event( sim, [ &, undying_embers_state, this ]() mutable {
-        trigger_dot( undying_embers_state );
-        range::erase_remove( undying_embers_states, undying_embers_state );
-        action_state_t::release( undying_embers_state );
-      } );
+      make_event<undying_embers_event_t>( *sim, p(), this, undying_embers_state );
     }
-  }
-
-  void reset() override
-  {
-    for ( auto& state : undying_embers_states )
-      if ( state )
-        action_state_t::release( state );
-
-    demon_hunter_spell_t::reset();
   }
 };
 

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3369,7 +3369,7 @@ struct shattered_souls_trigger_t : public BASE
     return BASE::name_str;
   }
 
-  virtual double shattered_souls_chance( action_state_t* s )
+  virtual double shattered_souls_chance( action_state_t* )
   {
     return shattered_souls_base_chance;
   }
@@ -6299,7 +6299,7 @@ struct collapsing_star_t : public demon_hunter_spell_t
       reduced_aoe_targets = p->spec.collapsing_star_spell->effectN( 1 ).base_value();
     }
 
-    double composite_crit_damage_bonus_multiplier() const
+    double composite_crit_damage_bonus_multiplier() const override
     {
       auto cm = base_t::composite_crit_damage_bonus_multiplier();
 
@@ -9111,7 +9111,7 @@ struct collapsing_star_stacking_t : public demon_hunter_buff_t<buff_t>
   {
     set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
 
-    add_stack_change_callback( [ this ]( buff_t* b, int old, int new_ ) {
+    add_stack_change_callback( [ this ]( buff_t*, int old, int new_ ) {
       if ( new_ >= trigger_threshold && old < trigger_threshold )
       {
         this->p()->buff.collapsing_star->trigger();
@@ -12148,8 +12148,8 @@ double demon_hunter_t::fury_state_t::fury_drain_per_second( int stacks ) const
   double drain = base_fury_drain_per_second( stacks );
 
   bool has_reduced_drain = !p()->in_combat || p()->buff.voidrush->check() ||
-                           p()->executing && p()->executing->id == p()->spec.collapsing_star_spell->id() ||
-                           p()->channeling && p()->channeling->id == p()->talent.devourer.void_ray->id();
+                           ( p()->executing && p()->executing->id == p()->spec.collapsing_star_spell->id() ) ||
+                           ( p()->channeling && p()->channeling->id == p()->talent.devourer.void_ray->id() );
 
   if ( has_reduced_drain )
   {
@@ -12218,8 +12218,8 @@ void demon_hunter_t::fury_state_t::drain()
 
   if ( p()->resources.current[ RESOURCE_FURY ] <= 0.0 )
   {
-    bool cannot_end_meta = ( p()->channeling && p()->channeling->id == p()->talent.devourer.void_ray->id() ||
-                             p()->executing && p()->executing->id == p()->talent.devourer.collapsing_star->id() );
+    bool cannot_end_meta = ( p()->channeling && p()->channeling->id == p()->talent.devourer.void_ray->id() ) ||
+                           ( p()->executing && p()->executing->id == p()->talent.devourer.collapsing_star->id() );
 
     if ( !cannot_end_meta )
     {

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1592,7 +1592,7 @@ struct undying_embers_event_t : public event_t
   action_state_t* state;
 
   undying_embers_event_t( demon_hunter_t* player, action_t* action, action_state_t* state )
-    : event_t( *player ), action( action ), state( state )
+    : event_t( *player, 0_s ), action( action ), state( state )
   {
   }
 


### PR DESCRIPTION
- **[demon_hunter] Use custom event for Undying Embers in order to more efficiently clean up action states.**
- **[demon_hunter] Clean up Clang warnings.**
