### PR TITLE
Sync latest WoWDBDefs with dbc_extract formats

### DIFF
--- a/dbc_extract3/formats/12.0.1.65337.json
+++ b/dbc_extract3/formats/12.0.1.65337.json
@@ -1266,9 +1266,9 @@
     "fields": [
       { "data_type": "q", "field": "race_mask" },
       { "data_type": "S", "field": "failure_description_lang" },
-      { "data_type": "H", "field": "class_mask" },
       { "data_type": "H", "field": "min_level" },
-      { "data_type": "i", "field": "max_level" },
+      { "data_type": "H", "field": "max_level" },
+      { "data_type": "i", "field": "class_mask" },
       { "data_type": "I", "field": "skill_logic" },
       { "data_type": "i", "field": "id_language" },
       { "data_type": "B", "field": "min_language" },

--- a/dbc_extract3/formats/12.0.1.65337.json
+++ b/dbc_extract3/formats/12.0.1.65337.json
@@ -251,6 +251,13 @@
       { "data_type": "i", "field": "id_mastery", "elements": 2, "formats": { "cpp": "%6u" }, "ref": "SpellName" }
     ]
   },
+  "CompositeSpellsUIRedirect": {
+    "fields": [
+      { "data_type": "i", "field": "id_parent_spell" },
+      { "data_type": "i", "field": "id_child_spell" },
+      { "data_type": "i", "field": "field_12_0_1_64889_002" }
+    ]
+  },
   "ConditionalContentTuning": {
     "parent": "ContentTuning",
     "fields": [
@@ -2201,6 +2208,14 @@
       { "data_type": "h", "field": "override_height" },
       { "data_type": "b", "field": "flags" },
       { "data_type": "B", "field": "id_ui_canvas" }
+    ]
+  },
+  "UnitCondition": {
+    "fields": [
+      { "data_type": "i", "field": "flags" },
+      { "data_type": "B", "field": "variable" },
+      { "data_type": "B", "field": "op" },
+      { "data_type": "i", "field": "value" }
     ]
   }
 }

--- a/dbc_extract3/formats/12.0.1.65337.json
+++ b/dbc_extract3/formats/12.0.1.65337.json
@@ -1152,9 +1152,9 @@
       { "data_type": "H", "field": "id_map", "ref": "Map" },
       { "data_type": "i", "field": "flags" },
       { "data_type": "i", "field": "unk_2" },
-      { "data_type": "i", "field": "expansion_level" },
-      { "data_type": "I", "field": "unk_1" },
-      { "data_type": "i", "field": "criteria_count", "elements": 3 },
+      { "data_type": "I", "field": "expansion_level" },
+      { "data_type": "i", "field": "unk_1" },
+      { "data_type": "h", "field": "criteria_count", "elements": 3 },
       { "data_type": "i", "field": "id_first_reward_quest" },
       { "data_type": "i", "field": "id_reward_quest" }
     ]

--- a/dbc_extract3/formats/12.0.1.65337.json
+++ b/dbc_extract3/formats/12.0.1.65337.json
@@ -1,25 +1,21 @@
 {
   "Achievement": {
     "fields": [
-      { "data_type": "S", "field": "description" },
       { "data_type": "S", "field": "title" },
-      { "data_type": "S", "field": "reward" },
-      { "data_type": "i", "field": "id" },
-      { "data_type": "h", "field": "id_instance" },
-      { "data_type": "b", "field": "faction" },
-      { "data_type": "i", "field": "supercedes" },
-      { "data_type": "h", "field": "category" },
-      { "data_type": "b", "field": "minimum_criteria" },
-      { "data_type": "b", "field": "points" },
+      { "data_type": "S", "field": "description" },
       { "data_type": "i", "field": "flags" },
+      { "data_type": "S", "field": "reward" },
+      { "data_type": "h", "field": "id_instance" },
+      { "data_type": "h", "field": "supercedes" },
+      { "data_type": "h", "field": "category" },
       { "data_type": "h", "field": "ui_order" },
-      { "data_type": "i", "field": "id_icon_file_data" },
-      { "data_type": "i", "field": "id_reward_item" },
-      { "data_type": "I", "field": "criteria_tree", "ref": "CriteriaTree" },
       { "data_type": "h", "field": "shares_criteria" },
-      { "data_type": "i", "field": "id_covenant" },
-      { "data_type": "i", "field": "hidden_before_display_season" },
-      { "data_type": "i", "field": "legacy_after_time_event" }
+      { "data_type": "H", "field": "criteria_tree", "ref": "CriteriaTree" },
+      { "data_type": "b", "field": "faction" },
+      { "data_type": "b", "field": "points" },
+      { "data_type": "b", "field": "minimum_criteria" },
+      { "data_type": "i", "field": "id" },
+      { "data_type": "i", "field": "id_icon_file_data" }
     ]
   },
   "ArmorLocation": {
@@ -36,11 +32,11 @@
       { "data_type": "S", "field": "f1" },
       { "data_type": "i", "field": "id", "formats": { "cpp": "%2u" } },
       { "data_type": "H", "field": "f2" },
-      { "data_type": "I", "field": "f3" },
-      { "data_type": "I", "field": "unk_1" },
+      { "data_type": "i", "field": "f3" },
+      { "data_type": "i", "field": "unk_1" },
       { "data_type": "i", "field": "f5" },
       { "data_type": "H", "field": "id_spec", "formats": { "cpp": "%3u" }, "ref": "ChrSpecialization" },
-      { "data_type": "B", "field": "f7" },
+      { "data_type": "i", "field": "f7" },
       { "data_type": "B", "field": "f8" },
       { "data_type": "I", "field": "f9" },
       { "data_type": "I", "field": "f10" }
@@ -54,7 +50,7 @@
       { "data_type": "B", "field": "id_artifact", "formats": { "cpp": "%3u" }, "ref": "Artifact" },
       { "data_type": "B", "field": "max_rank", "formats": { "cpp": "%3u" } },
       { "data_type": "i", "field": "index", "formats": { "cpp": "%2u" } },
-      { "data_type": "B", "field": "type", "formats": { "cpp": "%3u" } },
+      { "data_type": "i", "field": "type", "formats": { "cpp": "%3u" } },
       { "data_type": "B", "field": "unk" }
     ]
   },
@@ -150,8 +146,8 @@
     "fields": [
       { "data_type": "i", "field": "unk_28366" },
       { "data_type": "i", "field": "id_power", "ref": "AzeritePower" },
-      { "data_type": "i", "field": "class_id" },
-      { "data_type": "b", "field": "tier" },
+      { "data_type": "b", "field": "class_id" },
+      { "data_type": "B", "field": "tier" },
       { "data_type": "i", "field": "index" }
     ]
   },
@@ -167,7 +163,7 @@
       { "data_type": "q", "field": "race_mask" },
       { "data_type": "b", "field": "id_class", "ref": "ChrClasses" },
       { "data_type": "i", "field": "purpose" },
-      { "data_type": "b", "field": "id_mod" }
+      { "data_type": "B", "field": "id_mod" }
     ]
   },
   "CharacterLoadoutItem": {
@@ -181,7 +177,8 @@
       { "data_type": "S", "field": "name" },
       { "data_type": "S", "field": "shortcut" },
       { "data_type": "i", "field": "flags" },
-      { "data_type": "b", "field": "faction" }
+      { "data_type": "B", "field": "faction" },
+      { "data_type": "i", "field": "ruleset" }
     ]
   },
   "ChrClasses": {
@@ -200,8 +197,8 @@
       { "data_type": "I", "field": "select_screen_file_data_id" },
       { "data_type": "I", "field": "icon_file_data_id" },
       { "data_type": "I", "field": "low_res_screen_file_data_id" },
-      { "data_type": "I", "field": "flags" },
-      { "data_type": "I", "field": "spell_texture_blob_file_data_id" },
+      { "data_type": "i", "field": "flags" },
+      { "data_type": "i", "field": "spell_texture_blob_file_data_id" },
       { "data_type": "I", "field": "role_mask" },
       { "data_type": "I", "field": "armor_type_mask" },
       { "data_type": "i", "field": "unk_1" },
@@ -215,10 +212,10 @@
       { "data_type": "i", "field": "unk_4" },
       { "data_type": "H", "field": "cinematic_sequence_id" },
       { "data_type": "H", "field": "default_spec" },
-      { "data_type": "B", "field": "id" },
+      { "data_type": "b", "field": "id" },
       { "data_type": "B", "field": "has_strength_attack_bonus" },
-      { "data_type": "B", "field": "primary_stat_priority" },
-      { "data_type": "B", "field": "display_power" },
+      { "data_type": "b", "field": "primary_stat_priority" },
+      { "data_type": "b", "field": "display_power" },
       { "data_type": "B", "field": "ranged_attack_power_per_agility" },
       { "data_type": "B", "field": "attack_power_per_agility" },
       { "data_type": "B", "field": "attack_power_per_strength" },
@@ -251,7 +248,7 @@
       { "data_type": "i", "field": "id_icon",    "formats": { "cpp": "%-5u" } },
       { "data_type": "b", "field": "unk_6",      "formats": { } },
       { "data_type": "i", "field": "unk_3",      "formats": { } },
-      { "data_type": "I", "field": "id_mastery", "elements": 2, "formats": { "cpp": "%6u" }, "ref": "SpellName" }
+      { "data_type": "i", "field": "id_mastery", "elements": 2, "formats": { "cpp": "%6u" }, "ref": "SpellName" }
     ]
   },
   "ConditionalContentTuning": {
@@ -272,13 +269,17 @@
       { "data_type": "i", "field": "min_level" },
       { "data_type": "i", "field": "max_level" },
       { "data_type": "i", "field": "lower_bound_semantics" },
-      { "data_type": "i", "field": "upper_bound_semantics" },
+      { "data_type": "f", "field": "upper_bound_semantics" },
       { "data_type": "i", "field": "target_level_delta" },
       { "data_type": "i", "field": "target_level_delta_max" },
       { "data_type": "i", "field": "target_level_min" },
       { "data_type": "i", "field": "target_level_max" },
       { "data_type": "i", "field": "item_level_min" },
-      { "data_type": "f", "field": "quest_xp_mult" }
+      { "data_type": "i", "field": "quest_xp_mult" },
+      { "data_type": "i", "field": "lfg_min_level" },
+      { "data_type": "i", "field": "lfg_max_level" },
+      { "data_type": "i", "field": "i_level" },
+      { "data_type": "f", "field": "xp_mult_quest" }
     ]
   },
   "ContentTuningXExpected": {
@@ -366,7 +367,7 @@
       { "data_type": "I", "field": "parent" },
       { "data_type": "I", "field": "amount" },
       { "data_type": "i", "field": "operator" },
-      { "data_type": "i", "field": "id_criteria" },
+      { "data_type": "I", "field": "id_criteria" },
       { "data_type": "i", "field": "order_index" },
       { "data_type": "i", "field": "flags" }
     ]
@@ -375,7 +376,7 @@
     "fields": [
       { "data_type": "S", "field": "name" },
       { "data_type": "i", "field": "flags" },
-      { "data_type": "i", "field": "id_expansion" },
+      { "data_type": "B", "field": "id_expansion" },
       { "data_type": "i", "field": "id_parent_category" }
     ]
   },
@@ -386,7 +387,7 @@
       { "data_type": "i", "field": "min_amount" },
       { "data_type": "i", "field": "max_amount" },
       { "data_type": "i", "field": "id_container_icon" },
-      { "data_type": "i", "field": "containter_quality" },
+      { "data_type": "b", "field": "containter_quality" },
       { "data_type": "i", "field": "unk_1" }
     ]
   },
@@ -413,13 +414,14 @@
       { "data_type": "f", "field": "unk_18" },
       { "data_type": "B", "field": "unk_19" },
       { "data_type": "i", "field": "id_mcr_currency" },
-      { "data_type": "I", "field": "flags", "elements": 2 }
+      { "data_type": "i", "field": "flags", "elements": 2 }
     ]
   },
   "Curve": {
     "fields": [
-      { "data_type": "B", "field": "type", "formats": { "cpp": "%4u"    } },
-      { "data_type": "B", "field": "flags",     "formats": { "cpp": "%2u"    } }
+      { "data_type": "i", "field": "type", "formats": { "cpp": "%4u"    } },
+      { "data_type": "B", "field": "type" },
+      { "data_type": "i", "field": "flags",     "formats": { "cpp": "%2u"    } }
     ]
   },
   "CurvePoint": {
@@ -427,8 +429,8 @@
       { "data_type": "f", "field": "val", "elements": 2, "formats": { "cpp": "%10.5ff" } },
       { "data_type": "f", "field": "level", "elements": 2, "formats": { "cpp": "%10.5ff" } },
       { "data_type": "i", "field": "id" },
-      { "data_type": "i", "field": "id_distribution", "formats": { "cpp": "%4u"    }, "ref": "Curve" },
-      { "data_type": "B", "field": "curve_index",     "formats": { "cpp": "%2u"    } }
+      { "data_type": "I", "field": "id_distribution", "formats": { "cpp": "%4u"    }, "ref": "Curve" },
+      { "data_type": "I", "field": "curve_index",     "formats": { "cpp": "%2u"    } }
     ]
   },
   "Difficulty": {
@@ -500,7 +502,7 @@
       { "data_type": "i", "field": "id_icon_file_data" },
       { "data_type": "I", "field": "unk_2" },
       { "data_type": "I", "field": "id_garr_ability" },
-      { "data_type": "b", "field": "unk_3" },
+      { "data_type": "i", "field": "unk_3" },
       { "data_type": "i", "field": "unk_4" },
       { "data_type": "i", "field": "id_garr_talent_prereq" },
       { "data_type": "i", "field": "unk_6" },
@@ -511,7 +513,7 @@
   "GarrTalentTree": {
     "fields": [
       { "data_type": "S", "field": "title" },
-      { "data_type": "B", "field": "id_garr_type" },
+      { "data_type": "b", "field": "id_garr_type" },
       { "data_type": "i", "field": "id_class" },
       { "data_type": "b", "field": "max_tiers" },
       { "data_type": "b", "field": "unk_0" },
@@ -520,7 +522,7 @@
       { "data_type": "i", "field": "garr_talent_tree_type" },
       { "data_type": "i", "field": "unk_2" },
       { "data_type": "B", "field": "feature_type" },
-      { "data_type": "b", "field": "feature_rank" },
+      { "data_type": "B", "field": "feature_rank" },
       { "data_type": "i", "field": "unk_4" }
     ]
   },
@@ -549,7 +551,7 @@
   "GemProperties": {
     "fields": [
       { "data_type": "H", "field": "id_enchant", "formats": { "cpp": "%5u"   }, "ref": "SpellItemEnchantment" },
-      { "data_type": "I", "field": "color",      "formats": { "cpp": "%#.8x" } }
+      { "data_type": "i", "field": "color",      "formats": { "cpp": "%#.8x" } }
     ]
   },
   "GlyphProperties": {
@@ -581,7 +583,7 @@
   },
   "ItemSparse": {
     "fields": [
-      { "data_type": "Q", "field": "race_mask", "formats": { "cpp": "%#.16x" } },
+      { "data_type": "q", "field": "race_mask", "formats": { "cpp": "%#.16x" } },
       { "data_type": "S", "field": "desc" },
       { "data_type": "S", "field": "pad2" },
       { "data_type": "S", "field": "pad1" },
@@ -632,7 +634,7 @@
       { "data_type": "H", "field": "req_skill_rank" },
       { "data_type": "H", "field": "req_skill" },
       { "data_type": "H", "field": "ilevel" },
-      { "data_type": "H", "field": "class_mask", "formats": { "cpp": "%#.4x" } },
+      { "data_type": "h", "field": "class_mask", "formats": { "cpp": "%#.4x" } },
       { "data_type": "B", "field": "id_artifact" },
       { "data_type": "B", "field": "spell_weight" },
       { "data_type": "B", "field": "spell_weight_category" },
@@ -744,7 +746,8 @@
       { "data_type": "i", "field": "unk_2" },
       { "data_type": "i", "field": "id_item_bonus_season", "ref": "ItemBonusSeason" },
       { "data_type": "i", "field": "unk_3" },
-      { "data_type": "i", "field": "unk_4" }
+      { "data_type": "i", "field": "unk_4" },
+      { "data_type": "i", "field": "unk_5" }
     ]
   },
   "ItemBonusTree": {
@@ -773,7 +776,7 @@
     "fields": [
       { "data_type": "i", "field": "id_item", "formats": { "cpp": "%6u" }, "ref": "ItemSparse" },
       { "data_type": "i", "field": "id_child", "formats": { "cpp": "%6u" }, "ref": "ItemSparse" },
-      { "data_type": "B", "field": "unk_2" }
+      { "data_type": "i", "field": "unk_2" }
     ]
   },
   "ItemConversion": {
@@ -823,14 +826,14 @@
   },
   "ItemEffect": {
     "fields": [
-      { "data_type": "b", "field": "index", "formats": { "cpp": "%3d" } },
-      { "data_type": "b", "field": "trigger_type", "formats": { "cpp": "%3d" } },
+      { "data_type": "B", "field": "index", "formats": { "cpp": "%3d" } },
+      { "data_type": "B", "field": "trigger_type", "formats": { "cpp": "%3d" } },
       { "data_type": "h", "field": "cooldown_charges" },
       { "data_type": "i", "field": "cooldown_duration", "formats": { "cpp": "%7d" }  },
       { "data_type": "i", "field": "cooldown_group_duration", "formats": { "cpp": "%7d" }  },
-      { "data_type": "h", "field": "cooldown_group", "formats": { "cpp": "%4d" } },
+      { "data_type": "H", "field": "cooldown_group", "formats": { "cpp": "%4d" } },
       { "data_type": "i", "field": "id_spell", "formats": { "cpp": "%6d" }, "ref": "SpellName" },
-      { "data_type": "h", "field": "id_specialization", "ref": "ChrSpecialization" },
+      { "data_type": "H", "field": "id_specialization", "ref": "ChrSpecialization" },
       { "data_type": "i", "field": "unk_8" }
     ]
   },
@@ -845,7 +848,7 @@
       { "data_type": "i", "field": "id_item", "elements": 5, "ref": "ItemSparse" },
       { "data_type": "H", "field": "item_count", "elements": 5 },
       { "data_type": "H", "field": "id_currency", "elements": 5 },
-      { "data_type": "i", "field": "currency_count", "elements": 5 }
+      { "data_type": "I", "field": "currency_count", "elements": 5 }
     ]
   },
   "ItemGroupIlvlScalingEntry": {
@@ -860,16 +863,16 @@
   },
   "ItemLevelSelector": {
     "fields": [
-      { "data_type": "h", "field": "min_item_level" },
-      { "data_type": "h", "field": "id_item_level_selector_quality_set" },
-      { "data_type": "h", "field": "id_azerite_unlock_mapping_set" }
+      { "data_type": "H", "field": "min_item_level" },
+      { "data_type": "H", "field": "id_item_level_selector_quality_set" },
+      { "data_type": "H", "field": "id_azerite_unlock_mapping_set" }
     ]
   },
   "ItemLimitCategory": {
     "fields": [
       { "data_type": "S", "field": "name" },
-      { "data_type": "b", "field": "quantity" },
-      { "data_type": "B", "field": "flags" }
+      { "data_type": "B", "field": "quantity" },
+      { "data_type": "i", "field": "flags" }
     ]
   },
   "ItemModifiedAppearance": {
@@ -879,14 +882,14 @@
       { "data_type": "i", "field": "f3"},
       { "data_type": "i", "field": "id_appearance", "ref": "ItemAppearance" },
       { "data_type": "i", "field": "f5"},
-      { "data_type": "b", "field": "f6"},
+      { "data_type": "B", "field": "f6"},
       { "data_type": "i", "field": "f7"}
     ]
   },
   "ItemNameDescription": {
     "fields": [
       { "data_type": "S", "field": "desc", "formats": { "cpp": "%-45s" } },
-      { "data_type": "I", "field": "flags"                               }
+      { "data_type": "i", "field": "flags"                               }
     ]
   },
   "ItemNameSlotOverride": {
@@ -949,20 +952,21 @@
       { "data_type": "S", "field": "name" },
       { "data_type": "b", "field": "id_class" },
       { "data_type": "f", "field": "price_modifier" },
-      { "data_type": "B", "field": "flags" }
+      { "data_type": "i", "field": "flags" }
     ]
   },
   "ItemSubClass": {
     "fields": [
       { "data_type": "S", "field": "display_name" },
       { "data_type": "S", "field": "verbose_name" },
+      { "data_type": "i", "field": "id" },
       { "data_type": "b", "field": "id_class" },
       { "data_type": "b", "field": "id_sub_class" },
       { "data_type": "B", "field": "auction_house_sort_order" },
       { "data_type": "b", "field": "prerequisite_proficiency" },
-      { "data_type": "H", "field": "flags" },
-      { "data_type": "b", "field": "display_flags" },
-      { "data_type": "B", "field": "weapon_swing_size" },
+      { "data_type": "i", "field": "flags" },
+      { "data_type": "i", "field": "display_flags" },
+      { "data_type": "b", "field": "weapon_swing_size" },
       { "data_type": "b", "field": "postrequisite_proficiency" }
     ]
   },
@@ -975,7 +979,7 @@
     "parent": "ItemLogicalCostGroup",
     "fields": [
       { "data_type": "i", "field": "mask_inv_type" },
-      { "data_type": "B", "field": "flags" },
+      { "data_type": "i", "field": "flags" },
       { "data_type": "i", "field": "id_item_extended_cost", "ref": "ItemExtendedCost" }
     ]
   },
@@ -1011,8 +1015,8 @@
       { "data_type": "H", "field": "first_section_id" },
       { "data_type": "H", "field": "ui_map_id" },
       { "data_type": "I", "field": "map_display_condition_id" },
-      { "data_type": "B", "field": "flags" },
-      { "data_type": "B", "field": "difficulty_mask" }
+      { "data_type": "i", "field": "flags" },
+      { "data_type": "b", "field": "difficulty_mask" }
     ]
   },
   "JournalEncounterCreature": {
@@ -1023,7 +1027,7 @@
       { "data_type": "i", "field": "id" },
       { "data_type": "H", "field": "id_journal_encounter", "ref": "JournalEncounter" },
       { "data_type": "I", "field": "id_creature_display_info" },
-      { "data_type": "i", "field": "id_data_file", "ref": "ManifestInterfaceData" },
+      { "data_type": "I", "field": "id_data_file", "ref": "ManifestInterfaceData" },
       { "data_type": "B", "field": "order_index" },
       { "data_type": "I", "field": "id_ui_model_scene" }
     ]
@@ -1055,14 +1059,14 @@
       { "data_type": "i", "field": "id_ui_model_scene" },
       { "data_type": "i", "field": "id_spell", "ref": "SpellName" },
       { "data_type": "i", "field": "id_icon_file_data" },
-      { "data_type": "H", "field": "flags" },
-      { "data_type": "H", "field": "icon_flags" },
+      { "data_type": "i", "field": "flags" },
+      { "data_type": "i", "field": "icon_flags" },
       { "data_type": "b", "field": "difficulty_mask" }
     ]
   },
   "JournalEncounterXDifficulty": {
     "fields": [
-      { "data_type": "B", "field": "id_difficulty", "ref": "Difficulty" }
+      { "data_type": "h", "field": "id_difficulty", "ref": "Difficulty" }
     ]
   },
   "JournalInstance": {
@@ -1074,7 +1078,7 @@
       { "data_type": "i", "field": "id_button_file_data", "ref": "ManifestInterfaceData" },
       { "data_type": "i", "field": "id_button_small_file_data", "ref": "ManifestInterfaceData" },
       { "data_type": "i", "field": "id_lore_file_data" },
-      { "data_type": "b", "field": "flags" },
+      { "data_type": "i", "field": "flags" },
       { "data_type": "H", "field": "area_id" },
       { "data_type": "H", "field": "unk_9" }
     ]
@@ -1145,11 +1149,14 @@
     "fields": [
       { "data_type": "S", "field": "name" },
       { "data_type": "i", "field": "id" },
-      { "data_type": "i", "field": "id_map", "ref": "Map" },
-      { "data_type": "B", "field": "flags" },
-      { "data_type": "I", "field": "expansion_level" },
+      { "data_type": "H", "field": "id_map", "ref": "Map" },
+      { "data_type": "i", "field": "flags" },
+      { "data_type": "i", "field": "unk_2" },
+      { "data_type": "i", "field": "expansion_level" },
       { "data_type": "I", "field": "unk_1" },
-      { "data_type": "H", "field": "criteria_count", "elements": 3 }
+      { "data_type": "i", "field": "criteria_count", "elements": 3 },
+      { "data_type": "i", "field": "id_first_reward_quest" },
+      { "data_type": "i", "field": "id_reward_quest" }
     ]
   },
   "MapDifficulty": {
@@ -1157,7 +1164,7 @@
     "fields": [
       { "data_type": "S", "field": "message" },
       { "data_type": "i", "field": "id" },
-      { "data_type": "i", "field": "difficulty" },
+      { "data_type": "h", "field": "difficulty" },
       { "data_type": "i", "field": "id_lock" },
       { "data_type": "B", "field": "reset_interval" },
       { "data_type": "i", "field": "max_players" },
@@ -1248,6 +1255,8 @@
   "MythicPlusSeasonRewardLevels": {
     "parent": "MythicPlusSeason",
     "fields": [
+      { "data_type": "i", "field": "id_mythic_plus_season" },
+      { "data_type": "i", "field": "id_activity_tier" },
       { "data_type": "i", "field": "difficulty_level" },
       { "data_type": "i", "field": "weekly_reward_level" },
       { "data_type": "i", "field": "end_of_run_reward_level" }
@@ -1255,11 +1264,11 @@
   },
   "PlayerCondition": {
     "fields": [
-      { "data_type": "Q", "field": "race_mask" },
+      { "data_type": "q", "field": "race_mask" },
       { "data_type": "S", "field": "failure_description_lang" },
-      { "data_type": "i", "field": "class_mask" },
+      { "data_type": "H", "field": "class_mask" },
       { "data_type": "H", "field": "min_level" },
-      { "data_type": "H", "field": "max_level" },
+      { "data_type": "i", "field": "max_level" },
       { "data_type": "I", "field": "skill_logic" },
       { "data_type": "i", "field": "id_language" },
       { "data_type": "B", "field": "min_language" },
@@ -1274,12 +1283,12 @@
       { "data_type": "I", "field": "current_completed_quest_logic" },
       { "data_type": "I", "field": "spell_logic" },
       { "data_type": "I", "field": "item_logic" },
-      { "data_type": "B", "field": "item_flags" },
+      { "data_type": "i", "field": "item_flags" },
       { "data_type": "I", "field": "aura_spell_logic" },
       { "data_type": "H", "field": "id_world_state_expression" },
       { "data_type": "i", "field": "id_weather" },
       { "data_type": "B", "field": "party_status" },
-      { "data_type": "B", "field": "lifetime_max_pvp_rank" },
+      { "data_type": "b", "field": "lifetime_max_pvp_rank" },
       { "data_type": "I", "field": "achievement_logic" },
       { "data_type": "b", "field": "gender" },
       { "data_type": "b", "field": "native_gender" },
@@ -1294,7 +1303,7 @@
       { "data_type": "i", "field": "max_avg_item_level" },
       { "data_type": "H", "field": "min_avg_equipped_item_level" },
       { "data_type": "H", "field": "max_avg_equipped_item_level" },
-      { "data_type": "B", "field": "phase_use_flags" },
+      { "data_type": "i", "field": "phase_use_flags" },
       { "data_type": "H", "field": "id_phase" },
       { "data_type": "I", "field": "id_phase_group" },
       { "data_type": "i", "field": "flags" },
@@ -1303,14 +1312,14 @@
       { "data_type": "I", "field": "id_modifier_tree" },
       { "data_type": "b", "field": "power_type" },
       { "data_type": "B", "field": "power_type_comp" },
-      { "data_type": "B", "field": "power_type_value" },
+      { "data_type": "b", "field": "power_type_value" },
       { "data_type": "i", "field": "weapon_subclass_mask" },
       { "data_type": "B", "field": "max_guild_level" },
       { "data_type": "B", "field": "min_guild_level" },
       { "data_type": "b", "field": "max_expansion_tier" },
       { "data_type": "b", "field": "min_expansion_tier" },
-      { "data_type": "B", "field": "min_pvp_rank" },
-      { "data_type": "B", "field": "max_pvp_rank" },
+      { "data_type": "b", "field": "min_pvp_rank" },
+      { "data_type": "b", "field": "max_pvp_rank" },
       { "data_type": "i", "field": "id_content_tuning" },
       { "data_type": "i", "field": "id_covenant" },
       { "data_type": "I", "field": "unk_56" },
@@ -1329,7 +1338,7 @@
       { "data_type": "I", "field": "time", "elements": 2 },
       { "data_type": "i", "field": "id_aura_spell", "elements": 4 },
       { "data_type": "B", "field": "aura_stacks", "elements": 4 },
-      { "data_type": "H", "field": "achievement", "elements": 4 },
+      { "data_type": "I", "field": "achievement", "elements": 4 },
       { "data_type": "H", "field": "id_area", "elements": 4 },
       { "data_type": "B", "field": "lfg_status", "elements": 4 },
       { "data_type": "B", "field": "lfg_compare", "elements": 4 },
@@ -1339,8 +1348,8 @@
       { "data_type": "I", "field": "quest_kill_monster", "elements": 6 },
       { "data_type": "i", "field": "movement_flags", "elements": 2 },
       { "data_type": "i", "field": "unk_81", "elements": 4 },
-      { "data_type": "h", "field": "unk_82", "elements": 4 },
-      { "data_type": "h", "field": "unk_83", "elements": 4 }
+      { "data_type": "H", "field": "unk_82", "elements": 4 },
+      { "data_type": "H", "field": "unk_83", "elements": 4 }
     ]
   },
   "PowerType": {
@@ -1409,8 +1418,8 @@
   "RewardPack": {
     "fields": [
       { "data_type": "i", "field": "id_char_title" },
-      { "data_type": "i", "field": "money" },
-      { "data_type": "B", "field": "artifact_xp_difficulty" },
+      { "data_type": "I", "field": "money" },
+      { "data_type": "b", "field": "artifact_xp_difficulty" },
       { "data_type": "f", "field": "artifact_xp_multiplier" },
       { "data_type": "B", "field": "id_artifact_xp_category" },
       { "data_type": "I", "field": "id_treasure_picker" }
@@ -1447,7 +1456,7 @@
     "fields": [
       { "data_type": "S", "field": "string" },
       { "data_type": "i", "field": "id" },
-      { "data_type": "b", "field": "flags" }
+      { "data_type": "i", "field": "flags" }
     ]
   },
   "SkillLine": {
@@ -1462,8 +1471,8 @@
       { "data_type": "i", "field": "id_spell_icon_file" },
       { "data_type": "b", "field": "can_link" },
       { "data_type": "I", "field": "id_parent_skill_line" },
-      { "data_type": "I", "field": "parent_tier_index" },
-      { "data_type": "H", "field": "flags" },
+      { "data_type": "i", "field": "parent_tier_index" },
+      { "data_type": "i", "field": "flags" },
       { "data_type": "i", "field": "id_spell_book_spell" },
       { "data_type": "i", "field": "unk_1" },
       { "data_type": "i", "field": "unk_2" }
@@ -1472,14 +1481,14 @@
   "SkillLineAbility": {
     "parent": "SkillLine",
     "fields": [
-      { "data_type": "Q", "field": "mask_race", "formats": { "cpp": "%#.16x" } },
+      { "data_type": "q", "field": "mask_race", "formats": { "cpp": "%#.16x" } },
       { "data_type": "S", "field": "verb" },
       { "data_type": "S", "field": "verb_all" },
       { "data_type": "i", "field": "id" },
       { "data_type": "h", "field": "id_skill", "ref": "SkillLine", "formats": { "cpp": "%4u" } },
       { "data_type": "i", "field": "id_spell", "ref": "SpellName" },
       { "data_type": "h", "field": "req_skill_level" },
-      { "data_type": "I", "field": "mask_class", "formats": { "cpp": "%#.8x" } },
+      { "data_type": "i", "field": "mask_class", "formats": { "cpp": "%#.8x" } },
       { "data_type": "i", "field": "id_replace", "ref": "SpellName" },
       { "data_type": "i", "field": "acquire_method" },
       { "data_type": "h", "field": "max_learn_skill" },
@@ -1511,7 +1520,7 @@
   },
   "SoulbindConduit": {
     "fields": [
-      { "data_type": "i", "field": "type", "formats": { "cpp": "%1u" } },
+      { "data_type": "B", "field": "type", "formats": { "cpp": "%1u" } },
       { "data_type": "i", "field": "id_covenant", "ref": "Covenant" },
       { "data_type": "i", "field": "id_spec_set" },
       { "data_type": "i", "field": "unk_1" }
@@ -1541,7 +1550,7 @@
     "fields": [
       { "data_type": "i", "field": "rank" },
       { "data_type": "i", "field": "item_level" },
-      { "data_type": "i", "field": "unk_1" }
+      { "data_type": "b", "field": "unk_1" }
     ]
   },
   "SpecializationSpells": {
@@ -1551,7 +1560,7 @@
       { "data_type": "i", "field": "id"  },
       { "data_type": "H", "field": "spec_id", "formats": { "cpp": "%4u" }, "ref": "ChrSpecialization" },
       { "data_type": "i", "field": "spell_id", "formats": { "cpp": "%6u" }, "ref": "SpellName" },
-      { "data_type": "I", "field": "replace_spell_id", "formats": { "cpp": "%6u" }, "ref": "SpellName" },
+      { "data_type": "i", "field": "replace_spell_id", "formats": { "cpp": "%6u" }, "ref": "SpellName" },
       { "data_type": "B", "field": "unk_2" }
     ]
   },
@@ -1571,26 +1580,30 @@
     "parent": "SpellName",
     "fields": [
       { "data_type": "h", "field": "difficulty_id" },
-      { "data_type": "h", "field": "stack_amount" },
-      { "data_type": "I", "field": "internal_cooldown" },
-      { "data_type": "b", "field": "proc_chance" },
+      { "data_type": "H", "field": "stack_amount" },
+      { "data_type": "i", "field": "internal_cooldown" },
+      { "data_type": "B", "field": "proc_chance" },
       { "data_type": "i", "field": "proc_charges" },
-      { "data_type": "h", "field": "id_ppm", "ref": "SpellProcsPerMinute" },
-      { "data_type": "I", "field": "proc_flags", "elements": 2 }
+      { "data_type": "H", "field": "id_ppm", "ref": "SpellProcsPerMinute" },
+      { "data_type": "i", "field": "proc_flags", "elements": 2 }
     ]
   },
   "SpellAuraRestrictions": {
     "parent": "SpellName",
     "fields": [
-      { "data_type": "B", "field": "difficulty" },
-      { "data_type": "B", "field": "caster_aura_state" },
-      { "data_type": "B", "field": "target_aura_state" },
-      { "data_type": "B", "field": "exclude_caster_aura_state" },
-      { "data_type": "B", "field": "exclude_target_aura_state" },
+      { "data_type": "h", "field": "difficulty" },
+      { "data_type": "i", "field": "caster_aura_state" },
+      { "data_type": "i", "field": "target_aura_state" },
+      { "data_type": "i", "field": "exclude_caster_aura_state" },
+      { "data_type": "i", "field": "exclude_target_aura_state" },
       { "data_type": "i", "field": "id_caster_aura", "ref": "SpellName" },
       { "data_type": "i", "field": "id_target_aura", "ref": "SpellName" },
       { "data_type": "i", "field": "id_exclude_caster_aura", "ref": "SpellName" },
-      { "data_type": "i", "field": "id_exclude_target_aura", "ref": "SpellName" }
+      { "data_type": "i", "field": "id_exclude_target_aura", "ref": "SpellName" },
+      { "data_type": "h", "field": "caster_aura_type" },
+      { "data_type": "h", "field": "target_aura_type" },
+      { "data_type": "h", "field": "exclude_caster_aura_type" },
+      { "data_type": "h", "field": "exclude_target_aura_type" }
     ]
   },
   "SpellCastTimes": {
@@ -1602,9 +1615,9 @@
   "SpellCastingRequirements": {
     "fields": [
       { "data_type": "i", "field": "id_spell" },
-      { "data_type": "b", "field": "facing_flags" },
-      { "data_type": "h", "field": "id_min_faction" },
-      { "data_type": "b", "field": "min_reputation" },
+      { "data_type": "i", "field": "facing_flags" },
+      { "data_type": "H", "field": "id_min_faction" },
+      { "data_type": "i", "field": "min_reputation" },
       { "data_type": "H", "field": "id_required_area" },
       { "data_type": "B", "field": "required_aura_vision" },
       { "data_type": "H", "field": "required_spell_focus" }
@@ -1637,19 +1650,19 @@
   "SpellClassOptions": {
     "fields": [
       { "data_type": "i", "field": "id_spell", "ref": "SpellName" },
-      { "data_type": "i", "field": "modal_next_spell", "ref": "SpellName" },
+      { "data_type": "I", "field": "modal_next_spell", "ref": "SpellName" },
       { "data_type": "B", "field": "family" },
-      { "data_type": "I", "field": "flags", "elements": 4 }
+      { "data_type": "i", "field": "flags", "elements": 4 }
     ]
   },
   "SpellCooldowns": {
     "parent": "SpellName",
     "fields": [
       { "data_type": "h", "field": "difficulty_id" },
-      { "data_type": "I", "field": "category_cooldown" },
-      { "data_type": "I", "field": "cooldown" },
-      { "data_type": "I", "field": "gcd_cooldown" },
-      { "data_type": "I", "field": "id_buff_spell", "ref": "SpellName" }
+      { "data_type": "i", "field": "category_cooldown" },
+      { "data_type": "i", "field": "cooldown" },
+      { "data_type": "i", "field": "gcd_cooldown" },
+      { "data_type": "i", "field": "id_buff_spell", "ref": "SpellName" }
     ]
   },
   "SpellDescriptionVariables": {
@@ -1670,15 +1683,15 @@
       { "data_type": "h", "field": "sub_type", "formats": { "cpp": "%3u" } },
       { "data_type": "h", "field": "difficulty_id" },
       { "data_type": "i", "field": "index", "formats": { "cpp": "%2u" } },
-      { "data_type": "i", "field": "type", "formats": { "cpp": "%3u" } },
+      { "data_type": "I", "field": "type", "formats": { "cpp": "%3u" } },
       { "data_type": "f", "field": "val_mul" },
-      { "data_type": "I", "field": "attribute" },
-      { "data_type": "I", "field": "amplitude" },
+      { "data_type": "i", "field": "attribute" },
+      { "data_type": "i", "field": "amplitude" },
       { "data_type": "f", "field": "sp_coefficient" },
       { "data_type": "f", "field": "dmg_multiplier" },
       { "data_type": "i", "field": "chain_target", "formats": { "cpp": "%3d" } },
-      { "data_type": "I", "field": "item_type", "ref": "ItemSparse" },
-      { "data_type": "I", "field": "id_mechanic", "ref": "SpellMechanic" },
+      { "data_type": "i", "field": "item_type", "ref": "ItemSparse" },
+      { "data_type": "i", "field": "id_mechanic", "ref": "SpellMechanic" },
       { "data_type": "f", "field": "points_per_combo_points" },
       { "data_type": "f", "field": "unk_1" },
       { "data_type": "f", "field": "real_ppl" },
@@ -1694,29 +1707,29 @@
       { "data_type": "i", "field": "unk_24" },
       { "data_type": "i", "field": "misc_value", "elements": 2 },
       { "data_type": "I", "field": "id_radius", "elements": 2, "ref": "SpellRadius" },
-      { "data_type": "I", "field": "class_mask", "elements": 4 },
-      { "data_type": "H", "field": "implicit_target", "elements": 2 }
+      { "data_type": "i", "field": "class_mask", "elements": 4 },
+      { "data_type": "h", "field": "implicit_target", "elements": 2 }
     ]
   },
   "SpellEffectAutoDescription": {
     "fields": [
       { "data_type": "S", "field": "desc" },
       { "data_type": "S", "field": "tt" },
-      { "data_type": "I", "field": "unk_3" },
+      { "data_type": "i", "field": "unk_3" },
       { "data_type": "i", "field": "unk_4" },
-      { "data_type": "b", "field": "unk_5" },
-      { "data_type": "b", "field": "unk_6" },
+      { "data_type": "B", "field": "unk_5" },
+      { "data_type": "B", "field": "unk_6" },
       { "data_type": "b", "field": "school" },
-      { "data_type": "I", "field": "type" },
+      { "data_type": "i", "field": "type" },
       { "data_type": "i", "field": "sub_type" }
     ]
   },
   "SpellEquippedItems": {
     "fields": [
       { "data_type": "i", "field": "id_spell", "ref": "SpellName" },
-      { "data_type": "B", "field": "item_class", "formats": { "cpp": "%2u" } },
-      { "data_type": "I", "field": "mask_inv_type", "formats": { "cpp": "%#.8x" } },
-      { "data_type": "I", "field": "mask_sub_class", "formats": { "cpp": "%#.8x" } }
+      { "data_type": "i", "field": "item_class", "formats": { "cpp": "%2u" } },
+      { "data_type": "i", "field": "mask_inv_type", "formats": { "cpp": "%#.8x" } },
+      { "data_type": "i", "field": "mask_sub_class", "formats": { "cpp": "%#.8x" } }
     ]
   },
   "SpellFocusObject": {
@@ -1727,10 +1740,10 @@
   "SpellInterrupts": {
     "parent": "SpellName",
     "fields": [
-      { "data_type": "H", "field": "difficulty" },
-      { "data_type": "I", "field": "interrupt_flags" },
-      { "data_type": "I", "field": "aura_interrupt_flags", "elements": 2 },
-      { "data_type": "I", "field": "channel_interrupt_flags", "elements": 2 }
+      { "data_type": "h", "field": "difficulty" },
+      { "data_type": "i", "field": "interrupt_flags" },
+      { "data_type": "i", "field": "aura_interrupt_flags", "elements": 2 },
+      { "data_type": "i", "field": "channel_interrupt_flags", "elements": 2 }
     ]
   },
   "SpellItemEnchantment": {
@@ -1778,7 +1791,7 @@
   },
   "SpellMechanic": {
     "fields": [
-      { "data_type": "I", "field": "mechanic", "formats": { "cpp": "%2u" } }
+      { "data_type": "S", "field": "mechanic", "formats": { "cpp": "%2u" } }
     ]
   },
   "SpellName": {
@@ -1789,7 +1802,7 @@
   "SpellMisc": {
     "parent": "SpellName",
     "fields": [
-      { "data_type": "I", "field": "flags", "elements": 17 },
+      { "data_type": "i", "field": "flags", "elements": 17 },
       { "data_type": "h", "field": "difficulty_id" },
       { "data_type": "H", "field": "id_cast_time", "ref": "SpellCastTimes" },
       { "data_type": "H", "field": "id_duration", "ref": "SpellDuration" },
@@ -1829,13 +1842,13 @@
   "SpellProcsPerMinute": {
     "fields": [
       { "data_type": "f", "field": "ppm" },
-      { "data_type": "B", "field": "flags" }
+      { "data_type": "i", "field": "flags" }
     ]
   },
   "SpellProcsPerMinuteMod": {
     "parent": "SpellProcsPerMinute",
     "fields": [
-      { "data_type": "b", "field": "unk_1" },
+      { "data_type": "i", "field": "unk_1" },
       { "data_type": "i", "field": "id_chr_spec" },
       { "data_type": "f", "field": "coefficient" }
     ]
@@ -1852,7 +1865,7 @@
     "fields": [
       { "data_type": "S", "field": "display_name" },
       { "data_type": "S", "field": "display_name_short" },
-      { "data_type": "B", "field": "flag" },
+      { "data_type": "i", "field": "flag" },
       { "data_type": "f", "field": "min_range", "elements": 2 },
       { "data_type": "f", "field": "max_range", "elements": 2 }
     ]
@@ -1867,9 +1880,9 @@
   "SpellShapeshift": {
     "fields": [
       { "data_type": "i", "field": "id_spell", "ref": "SpellName" },
-      { "data_type": "B", "field": "unk" },
-      { "data_type": "I", "field": "flags_not", "elements": 2 },
-      { "data_type": "I", "field": "flags", "elements": 2, "formats": { "cpp": "%#.8x" } }
+      { "data_type": "b", "field": "unk" },
+      { "data_type": "i", "field": "flags_not", "elements": 2 },
+      { "data_type": "i", "field": "flags", "elements": 2, "formats": { "cpp": "%#.8x" } }
     ]
   },
   "SpellTargetRestrictions": {
@@ -1877,10 +1890,10 @@
     "fields": [
       { "data_type": "h", "field": "difficulty_id" },
       { "data_type": "f", "field": "cone" },
-      { "data_type": "b", "field": "max_affected_targets" },
-      { "data_type": "i", "field": "max_target_level" },
+      { "data_type": "B", "field": "max_affected_targets" },
+      { "data_type": "I", "field": "max_target_level" },
       { "data_type": "h", "field": "unk_4" },
-      { "data_type": "I", "field": "flags" },
+      { "data_type": "i", "field": "flags" },
       { "data_type": "f", "field": "width" }
     ]
   },
@@ -1904,7 +1917,7 @@
     "fields": [
       { "data_type": "S", "field": "desc" },
       { "data_type": "B", "field": "row", "formats": { "cpp": "%3u" } },
-      { "data_type": "B", "field": "flags", "formats": { "cpp": "%3u" } },
+      { "data_type": "i", "field": "flags", "formats": { "cpp": "%3u" } },
       { "data_type": "B", "field": "col", "formats": { "cpp": "%3u" } },
       { "data_type": "H", "field": "unk_4" },
       { "data_type": "b", "field": "class_id" },
@@ -1922,10 +1935,10 @@
     "fields": [
       { "data_type": "S", "field": "name" },
       { "data_type": "S", "field": "horde_name" },
-      { "data_type": "h", "field": "id_parent_trade_skill_category", "ref": "TradeSkillCategory" },
-      { "data_type": "h", "field": "id_skill_line", "ref": "SkillLine" },
+      { "data_type": "H", "field": "id_parent_trade_skill_category", "ref": "TradeSkillCategory" },
+      { "data_type": "H", "field": "id_skill_line", "ref": "SkillLine" },
       { "data_type": "h", "field": "order" },
-      { "data_type": "b", "field": "flags" }
+      { "data_type": "i", "field": "flags" }
     ]
   },
   "TraitCond": {
@@ -2133,7 +2146,7 @@
     "fields": [
       { "data_type": "i", "field": "id_covenant_preview", "ref": "UICovenantPreview" },
       { "data_type": "i", "field": "id_spell", "formats": { "cpp": "%6u" }, "ref": "SpellName" },
-      { "data_type": "b", "field": "ability_type" },
+      { "data_type": "B", "field": "ability_type" },
       { "data_type": "i", "field": "unk" }
     ]
   },
@@ -2161,9 +2174,9 @@
     "fields": [
       { "data_type": "i", "field": "id" },
       { "data_type": "i", "field": "id_icon_file_data" },
-      { "data_type": "h", "field": "width" },
-      { "data_type": "h", "field": "height" },
-      { "data_type": "b", "field": "id_ui_canvas" }
+      { "data_type": "H", "field": "width" },
+      { "data_type": "H", "field": "height" },
+      { "data_type": "B", "field": "id_ui_canvas" }
     ]
   },
   "UiTextureAtlasElement": {

--- a/dbc_extract3/formats/12.0.1.65337.json
+++ b/dbc_extract3/formats/12.0.1.65337.json
@@ -255,7 +255,7 @@
     "fields": [
       { "data_type": "i", "field": "id_parent_spell" },
       { "data_type": "i", "field": "id_child_spell" },
-      { "data_type": "i", "field": "field_12_0_1_64889_002" }
+      { "data_type": "i", "field": "id_unit_condition", "ref": "UnitCondition" }
     ]
   },
   "ConditionalContentTuning": {


### PR DESCRIPTION
All field data types should be lined up which should resolve potential hiccups with hotfixes. Added some more fields that were missing.

I didn't do a thorough check of field names so it's still possible that DBCs that aren't used regularly have mixed up field names.