### PR TITLE
[Havoc] Use spell data ICD for Essence Break proc

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1008,6 +1008,7 @@ public:
     cooldown_t* relentless_onslaught_icd;
     cooldown_t* fel_rush_vengeful_retreat_movement_shared;
     cooldown_t* felblade_vengeful_retreat_movement_shared;
+    target_specific_cooldown_t* essence_break_proc_icd;
 
     // Vengeance
     cooldown_t* demon_spikes;
@@ -6836,7 +6837,6 @@ struct blade_dance_base_t
   {
     timespan_t delay;
     action_t* trail_of_ruin_dot;
-    bool first_attack;
     bool last_attack;
     unsigned glaive_tempest_targets;
 
@@ -6845,7 +6845,6 @@ struct blade_dance_base_t
       : base_t( n, p, s ),
         delay( timespan_t::from_millis( eff.misc_value1() ) ),
         trail_of_ruin_dot( nullptr ),
-        first_attack( false ),
         last_attack( false )
     {
       background = dual      = true;
@@ -6864,9 +6863,14 @@ struct blade_dance_base_t
     {
       base_t::impact( s );
 
-      if ( result_is_hit( s->result ) && td( s->target )->debuffs.essence_break->up() && first_attack )
+      if ( result_is_hit( s->result ) && td( s->target )->debuffs.essence_break->up() )
       {
-        p()->active.essence_break_proc->execute_on_target( target );
+        cooldown_t* tcd = p()->cooldown.essence_break_proc_icd->get_cooldown( s->target );
+        if ( tcd->up() )
+        {
+          p()->active.essence_break_proc->execute_on_target( s->target );
+          tcd->start();
+        }
       }
 
       if ( last_attack )
@@ -6889,7 +6893,6 @@ struct blade_dance_base_t
   {
     timespan_t delay;
     action_t* trail_of_ruin_dot;
-    bool first_attack;
     bool last_attack;
     unsigned glaive_tempest_targets;
 
@@ -6898,7 +6901,6 @@ struct blade_dance_base_t
       : demon_hunter_attack_t( name, p, first_blood_override ? first_blood_override : eff.trigger() ),
         delay( timespan_t::from_millis( eff.misc_value1() ) ),
         trail_of_ruin_dot( nullptr ),
-        first_attack( false ),
         last_attack( false )
     {
       background = dual      = true;
@@ -6913,9 +6915,14 @@ struct blade_dance_base_t
     {
       demon_hunter_attack_t::impact( s );
 
-      if ( result_is_hit( s->result ) && td( s->target )->debuffs.essence_break->up() && first_attack )
+      if ( result_is_hit( s->result ) && td( s->target )->debuffs.essence_break->up() )
       {
-        p()->active.essence_break_proc->execute_on_target( target );
+        cooldown_t* tcd = p()->cooldown.essence_break_proc_icd->get_cooldown( s->target );
+        if ( tcd->up() )
+        {
+          p()->active.essence_break_proc->execute_on_target( s->target );
+          tcd->start();
+        }
       }
 
       if ( last_attack )
@@ -6975,11 +6982,6 @@ struct blade_dance_base_t
       add_child( attack );
     }
 
-    if ( attacks.front() )
-    {
-      attacks.front()->first_attack = true;
-    }
-
     if ( attacks.back() )
     {
       attacks.back()->last_attack = true;
@@ -6996,11 +6998,6 @@ struct blade_dance_base_t
       for ( auto& attack : first_blood_attacks )
       {
         add_child( attack );
-      }
-
-      if ( first_blood_attacks.front() )
-      {
-        first_blood_attacks.front()->first_attack = true;
       }
 
       if ( first_blood_attacks.back() )
@@ -7340,9 +7337,14 @@ struct chaos_strike_base_t
         p()->buff.warblades_hunger->expire();
       }
 
-      if ( !may_refund && result_is_hit( s->result ) && td( s->target )->debuffs.essence_break->up() )
+      if ( result_is_hit( s->result ) && td( s->target )->debuffs.essence_break->up() )
       {
-        p()->active.essence_break_proc->execute_on_target( target );
+        cooldown_t* tcd = p()->cooldown.essence_break_proc_icd->get_cooldown( s->target );
+        if ( tcd->up() )
+        {
+          p()->active.essence_break_proc->execute_on_target( s->target );
+          tcd->start();
+        }
       }
     }
   };
@@ -10829,6 +10831,7 @@ void demon_hunter_t::init_spells()
   spec.demon_blades                     = find_spell( 203555, DEMON_HUNTER_HAVOC );
   spec.demon_blades_damage              = spec.demon_blades->effectN( 1 ).trigger();
   spec.essence_break_debuff             = talent_spell_lookup( talent.havoc.essence_break, 320338 );
+  cooldown.essence_break_proc_icd->base_duration = spec.essence_break_debuff->internal_cooldown();
   spec.eye_beam_damage                  = talent_spell_lookup( talent.havoc.eye_beam, 198030 );
   spec.furious_gaze_buff                = talent_spell_lookup( talent.havoc.furious_gaze, 343312 );
   spec.first_blood_blade_dance_damage   = talent_spell_lookup( talent.havoc.first_blood, 391374 );
@@ -11461,6 +11464,7 @@ void demon_hunter_t::create_cooldowns()
   cooldown.relentless_onslaught_icd                  = get_cooldown( "relentless_onslaught_icd" );
   cooldown.fel_rush_vengeful_retreat_movement_shared = get_cooldown( "fel_rush_vengeful_retreat_movement_shared" );
   cooldown.felblade_vengeful_retreat_movement_shared = get_cooldown( "felblade_vengeful_retreat_movement_shared" );
+  cooldown.essence_break_proc_icd = get_target_specific_cooldown( "essence_break_proc_icd" );
 
   // Vengeance
   cooldown.demon_spikes              = get_cooldown( "demon_spikes" );


### PR DESCRIPTION
## Problem

Essence Break's debuff (spell 320338) has `Internal Cooldown: 1 seconds` in the spell data, but the code ignores it. Instead, it uses structural gates to limit procs:

- Blade Dance / Death Sweep: `first_attack` boolean (only the first of 4 damage events procs)
- Chaos Strike / Annihilation: `!may_refund` (only the main-hand hit procs)

These gates approximate the ICD at low haste, but break down when the GCD drops below 1.0s. In that case, the old code allows consecutive procs less than 1 second apart, which does not match in-game behavior.

## Fix

Replace the structural gates with a `target_specific_cooldown_t` using the spell data's 1s ICD. This is the same pattern used by Rogue's Weaponmaster and Evoker's Bombardments.

Now any damage event from BD/DS/CS/Anni can trigger the proc, as long as the per-target ICD is ready. This lets a later hit in the sequence proc if the first hit lands too early (during ICD), which is what happens in-game.

## Evidence

### Spell data

```
Name             : Essence Break (id=320338)
Internal Cooldown: 1 seconds
Proc Flags       : Yellow Melee Taken, Generic Hostile Spell Taken
```

### In-game log (WCL)

Procs on a single target during one ESSB window, from @aezeor's testing:

| Time | Event | ESSB Proc? | Gap from prev |
|------|-------|-----------|---------------|
| 5.285 | Anni MH | Yes | - |
| 5.583 | Anni OH | No | 0.298s |
| 6.822 | DS hit 1 | Yes | 1.537s |
| 7.021 | DS hit 2 | No | 0.199s |
| 7.332 | DS hit 3 | No | 0.510s |
| 7.755 | DS hit 4 | No | 0.933s |
| 8.156 | Next hit | Yes | 1.334s |

All proc gaps are > 1.0s. DS hit 4 at 0.933s after the last proc is blocked by ICD.
At the same timestamp (7.755), a different target that had not been procced yet does get its ESSB proc, confirming per-target tracking.

### Sim comparison (debug traces, gear_haste_rating=7000, 5 iterations each)

**Old code (first_attack / !may_refund gates):**

```
iter1: 21 procs, 7 windows, 1 ICD violation (min_gap=0.836s)
iter2: 20 procs, 7 windows, 1 ICD violation (min_gap=0.837s)
iter3: 21 procs, 7 windows, 1 ICD violation (min_gap=0.837s)
iter4: 21 procs, 7 windows, 1 ICD violation (min_gap=0.839s)
iter5: 21 procs, 7 windows, 1 ICD violation (min_gap=0.838s)
```

**New code (1.0s per-target ICD from spell data):**

```
iter1: 21 procs, 7 windows, 0 ICD violations (min_gap=1.087s)
iter2: 18 procs, 7 windows, 0 ICD violations (min_gap=1.086s)
iter3: 21 procs, 7 windows, 0 ICD violations (min_gap=1.087s)
iter4: 21 procs, 7 windows, 0 ICD violations (min_gap=1.087s)
iter5: 21 procs, 7 windows, 0 ICD violations (min_gap=1.087s)
```

Old code consistently allows sub-1.0s proc gaps in the first ESSB window of each fight (during Metamorphosis haste). New code respects the ICD across all windows.

cc @aezeor