### PR TITLE
[Mage] Enable Fire Mage profiles in MID1_Raid.simc

### DIFF
--- a/profiles/MID1_Raid.simc
+++ b/profiles/MID1_Raid.simc
@@ -34,8 +34,8 @@ MID1_Demon_Hunter_Vengeance_Aldrachi_Reaver.simc
 
 MID1_Mage_Arcane.simc
 MID1_Mage_Arcane_Sunfury.simc
-# MID1_Mage_Fire.simc
-# MID1_Mage_Fire_Frostfire.simc
+MID1_Mage_Fire.simc
+MID1_Mage_Fire_Frostfire.simc
 MID1_Mage_Frost.simc
 MID1_Mage_Frost_Frostfire.simc
 


### PR DESCRIPTION
## Summary

`MID1_Mage_Fire.simc` and `MID1_Mage_Fire_Frostfire.simc` are present in `profiles/MID1/` with complete gear sets, talent strings, consumables, and default APLs (`source=default`), generated from `profiles/generators/MID1/MID1_Generate_Mage.simc`. Both files follow the same pattern as the already-active Arcane and Frost Mage profiles.

This PR uncomments both entries in `MID1_Raid.simc` so they are included in MID1 raid simulations alongside the other active Mage specs.

## Test plan

- [ ] `simc profiles/MID1_Raid.simc` runs without errors
- [ ] Fire Mage (Sunfury) and Fire Mage (Frostfire) DPS results appear in output