### PR TITLE
[Havoc] Fix Glaive Tempest not proccing with First Blood

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6838,7 +6838,6 @@ struct blade_dance_base_t
     action_t* trail_of_ruin_dot;
     bool first_attack;
     bool last_attack;
-    unsigned glaive_tempest_targets;
 
     blade_dance_damage_first_blood_t( util::string_view n, demon_hunter_t* p, const spell_data_t* s,
                                       const spelleffect_data_t& eff )
@@ -6850,7 +6849,6 @@ struct blade_dance_base_t
     {
       background = dual      = true;
       aoe                    = 0;
-      glaive_tempest_targets = as<unsigned>( p->talent.havoc.glaive_tempest->effectN( 2 ).base_value() );
     }
 
     double composite_da_multiplier( const action_state_t* s ) const override
@@ -6876,11 +6874,6 @@ struct blade_dance_base_t
           trail_of_ruin_dot->execute_on_target( s->target );
         }
 
-        if ( p()->talent.havoc.glaive_tempest->ok() && s->n_targets >= glaive_tempest_targets &&
-             p()->resource_available( RESOURCE_FURY, p()->talent.havoc.glaive_tempest->effectN( 1 ).base_value() ) )
-        {
-          p()->active.glaive_tempest->execute_on_target( target );
-        }
       }
     }
   };
@@ -6925,10 +6918,12 @@ struct blade_dance_base_t
           trail_of_ruin_dot->execute_on_target( s->target );
         }
 
-        // if First Blood is talented, GT will be triggered by the FB attack
-        if ( p()->talent.havoc.glaive_tempest->ok() && !p()->talent.havoc.first_blood->ok() &&
-             s->n_targets >= glaive_tempest_targets &&
-             p()->resource_available( RESOURCE_FURY, p()->talent.havoc.glaive_tempest->effectN( 1 ).base_value() ) )
+        // First Blood splits the primary target into a separate single-target hit,
+        // so add 1 to account for it when checking the target threshold.
+        if ( p()->talent.havoc.glaive_tempest->ok() &&
+             s->n_targets + ( p()->talent.havoc.first_blood->ok() ? 1U : 0U ) >= glaive_tempest_targets &&
+             p()->resource_available( RESOURCE_FURY, p()->talent.havoc.glaive_tempest->effectN( 1 ).base_value() ) &&
+             s->chain_target == 0 )
         {
           p()->active.glaive_tempest->execute_on_target( target );
         }


### PR DESCRIPTION
## Summary

Glaive Tempest never procs from Blade Dance when First Blood is talented.

With First Blood, the GT trigger was delegated to `blade_dance_damage_first_blood_t`, but that action is single-target (`aoe = 0`), so `s->n_targets` is always 1 and the >=3 threshold is never met. The AoE path (`blade_dance_damage_t`) skipped the check when First Blood was talented, so neither path ever triggered GT.

## Fix

Based on [Aezeor's approach](https://github.com/Aezeor/simc/commit/201c893c969ad92ddfe331b70e3d211648fc698c):

- Remove the GT check from `blade_dance_damage_first_blood_t` entirely (and its unused `glaive_tempest_targets` member)
- Move the GT check to `blade_dance_damage_t` for all cases. When First Blood is talented, the AoE hit only sees secondaries via `secondary_targets_only()`, so add 1 to `n_targets` to account for FB's primary target rather than mutating the cached threshold
- Add `s->chain_target == 0` guard so GT fires once per Blade Dance, not once per target hit

## Before/After (3 targets, forced Blade Dance APL, 500 iterations)

| | Glaive Tempest Executes | Glaive Tempest Damage | Total DPS |
|---|---|---|---|
| **Before** | 0 | 0 | 6,588,573 |
| **After** | ~4/fight | 38.3M (~9.5% of total) | 6,745,555 (+2.4%) |