### PR TITLE
[Warlock] Modeling Warlock RNGs

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -65,6 +65,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                            ->set_default_value( p.talents.shadowburn_2->effectN( 1 ).base_value() / 10 );
 
   // Use havoc_debuff where we need the data but don't have the active talent
+  // Mayhem proc chance follows a Flat % RNG model, but has ICD
   debuffs.havoc = make_buff( *this, "havoc", p.talents.havoc_debuff )
                       ->set_duration( p.talents.mayhem.ok() ? p.talents.mayhem->effectN( 3 ).time_value() + p.talents.improved_havoc->effectN( 1 ).time_value() : p.talents.havoc->duration() )
                       ->set_cooldown( p.talents.mayhem.ok() ? p.talents.mayhem->internal_cooldown() : 0_ms )
@@ -151,13 +152,7 @@ void warlock_td_t::target_demise()
 
   if ( warlock.hero.demonic_soul.ok() && warlock.hero.feast_of_souls.ok() )
   {
-    double chance = 0.0;
-    if ( warlock.affliction() )
-      chance = warlock.rng_settings.feast_of_souls_aff.setting_value;
-    if ( warlock.demonology() )
-      chance = warlock.rng_settings.feast_of_souls_demo.setting_value;
-
-    if ( warlock.rng().roll( chance ) )
+    if ( warlock.feast_of_souls_rng->trigger() )
     {
       warlock.sim->print_log( "Player {} demised. Warlock {} triggers Feast of Souls.", target->name(), warlock.name() );
 
@@ -197,6 +192,8 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
     havoc_spells(),
     agony_accumulator( 0.0 ),
     corruption_accumulator( 0.0 ),
+    alythesss_ire_counter( 0 ),
+    alythesss_ire_trigger( 0 ),
     diabolic_ritual( 0 ),
     demonic_art_buff_replaced( false ),
     n_active_pets( 0 ),
@@ -512,8 +509,12 @@ std::string warlock_t::create_profile( save_e stype )
     profile_str += append_rng_option( rng_settings.cunning_cruelty_ds );
     profile_str += append_rng_option( rng_settings.agony );
     profile_str += append_rng_option( rng_settings.nightfall );
-    profile_str += append_rng_option( rng_settings.avatar_of_destruction_dr );
     profile_str += append_rng_option( rng_settings.spiteful_reconstitution );
+    profile_str += append_rng_option( rng_settings.spiteful_reconstitution_hard_cap );
+    profile_str += append_rng_option( rng_settings.demonic_knowledge_rank1_cards );
+    profile_str += append_rng_option( rng_settings.demonic_knowledge_rank2_cards );
+    profile_str += append_rng_option( rng_settings.alythesss_ire_shift );
+    profile_str += append_rng_option( rng_settings.echo_of_sargeras );
     profile_str += append_rng_option( rng_settings.blackened_soul );
     profile_str += append_rng_option( rng_settings.bleakheart_tactics );
     profile_str += append_rng_option( rng_settings.seeds_of_their_demise );
@@ -522,6 +523,8 @@ std::string warlock_t::create_profile( save_e stype )
     profile_str += append_rng_option( rng_settings.succulent_soul_demo );
     profile_str += append_rng_option( rng_settings.feast_of_souls_aff );
     profile_str += append_rng_option( rng_settings.feast_of_souls_demo );
+    profile_str += append_rng_option( rng_settings.feast_of_souls_hard_cap_aff );
+    profile_str += append_rng_option( rng_settings.feast_of_souls_hard_cap_demo );
     profile_str += append_rng_option( rng_settings.manifested_avarice );
   }
 
@@ -543,8 +546,12 @@ void warlock_t::copy_from( player_t* source )
   rng_settings.cunning_cruelty_ds = p->rng_settings.cunning_cruelty_ds;
   rng_settings.agony = p->rng_settings.agony;
   rng_settings.nightfall = p->rng_settings.nightfall;
-  rng_settings.avatar_of_destruction_dr = p->rng_settings.avatar_of_destruction_dr;
   rng_settings.spiteful_reconstitution = p->rng_settings.spiteful_reconstitution;
+  rng_settings.spiteful_reconstitution_hard_cap = p->rng_settings.spiteful_reconstitution_hard_cap;
+  rng_settings.demonic_knowledge_rank1_cards = p->rng_settings.demonic_knowledge_rank1_cards;
+  rng_settings.demonic_knowledge_rank2_cards = p->rng_settings.demonic_knowledge_rank2_cards;
+  rng_settings.alythesss_ire_shift = p->rng_settings.alythesss_ire_shift;
+  rng_settings.echo_of_sargeras = p->rng_settings.echo_of_sargeras;
   rng_settings.blackened_soul = p->rng_settings.blackened_soul;
   rng_settings.bleakheart_tactics = p->rng_settings.bleakheart_tactics;
   rng_settings.seeds_of_their_demise = p->rng_settings.seeds_of_their_demise;
@@ -553,6 +560,8 @@ void warlock_t::copy_from( player_t* source )
   rng_settings.succulent_soul_demo = p->rng_settings.succulent_soul_demo;
   rng_settings.feast_of_souls_aff = p->rng_settings.feast_of_souls_aff;
   rng_settings.feast_of_souls_demo = p->rng_settings.feast_of_souls_demo;
+  rng_settings.feast_of_souls_hard_cap_aff = p->rng_settings.feast_of_souls_hard_cap_aff;
+  rng_settings.feast_of_souls_hard_cap_demo = p->rng_settings.feast_of_souls_hard_cap_demo;
   rng_settings.manifested_avarice = p->rng_settings.manifested_avarice;
 }
 
@@ -664,12 +673,19 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
       }
       action_state_t* agony_state = agony->current_action->get_state( agony->state );
       timespan_t dot_tick_time    = agony->current_action->tick_time( agony_state );
-      double creeping_death_mul   = talents.creeping_death.ok() ? ( 1.0 + talents.creeping_death->effectN( 1 ).percent() ) : 1.0;
+      double creeping_death_mul   = 1.0;
+      if ( talents.creeping_death.ok() )
+      {
+        if ( !bugs || talents.creeping_death.rank() < 2 )
+          creeping_death_mul *= 1.0 + talents.creeping_death->effectN( 1 ).percent();
+        else
+          creeping_death_mul *= 1.0 + ( talents.creeping_death->effectN( 1 ).percent() * 0.5 );
+      }
 
       // Seeks to return the average expected time for the player to generate a single soul shard.
       // TOCHECK regularly.
 
-      double average = 1.0 / ( ( rng_settings.agony.setting_value / 2.0 ) * std::pow( active_agonies, -2.0 / 3.0 ) * creeping_death_mul )
+      double average = 1.0 / ( ( rng_settings.agony.setting_value * 0.5 ) * std::pow( active_agonies, -2.0 / 3.0 ) * creeping_death_mul )
                        * dot_tick_time.total_seconds() / active_agonies;
 
       if ( sim->debug )
@@ -896,7 +912,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
   return actual_amount;
 }
 
-void warlock_t::feast_of_souls_gain()
+void warlock_t::feast_of_souls_gain( bool from_quietus_seed )
 {
   // TOCHECK: 2025-08-27 The shard gained from Feast of Souls can also proc another Succulent Soul (bug?)
   if ( bugs )
@@ -907,6 +923,12 @@ void warlock_t::feast_of_souls_gain()
   buffs.succulent_soul->trigger();
   procs.succulent_soul->occur();
   procs.feast_of_souls->occur();
+
+  // NOTE: 2026-03-06 If Feast of Souls is gained by consuming Nightfall with SoC (Quietus hero talent) and after
+  // the gain you only have one stack of Succulent Soul, it will be spent without producing its effects (bug)
+  // This behavior is modeled here simply by decrementing a stack of Succulent Soul without triggering its effects
+  if ( bugs && from_quietus_seed && buffs.succulent_soul->check() == 1 )
+    buffs.succulent_soul->decrement();
 }
 
 // Setup to allow taking specific pets from Dominion of Argus, or a random one if the random enum is passed in.

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -9,6 +9,14 @@
 namespace warlock
 {
 
+enum dimensional_rift_pet_e
+{
+  DR_PET_SHADOWY_TEAR,
+  DR_PET_UNSTABLE_TEAR,
+  DR_PET_CHAOS_TEAR,
+  DR_PET_OVERFIEND
+};
+
 enum dominion_of_argus_pet_e
 {
   DOA_PET_RANDOM = -1,
@@ -94,6 +102,106 @@ struct warlock_td_t : public actor_target_data_t
   int count_affliction_dots() const;
 };
 
+// Shuffled Bag RNG (sampling without replacement)
+// Each draw removes an item until the bag is exhausted, then it automatically resets
+template<typename T>
+struct shuffled_bag_rng_t
+{
+private:
+  player_t* player;
+  std::vector<T> bag;
+  int remaining;
+
+public:
+  shuffled_bag_rng_t( std::vector<T> items, player_t* p )
+    : player( p ), bag( std::move( items ) ), remaining( as<int>( bag.size() ) )
+  { assert( !bag.empty() ); }
+
+  shuffled_bag_rng_t( std::initializer_list<T> items, player_t* p )
+    : shuffled_bag_rng_t( std::vector<T>( items ), p )
+  {}
+
+  void reset()
+  { remaining = as<int>( bag.size() ); }
+
+  T draw()
+  {
+    if ( remaining == 0 )
+      reset();
+
+    const int index = player->rng().range( 0, remaining );
+    const T item = bag[ index ];
+
+    std::swap( bag[ index ], bag[ remaining - 1 ] );
+    remaining--;
+
+    return item;
+  }
+
+  int num_remaining() const
+  { return remaining; }
+
+  int size() const
+  { return as<int>( bag.size() ); }
+};
+
+// Variant of accumulated RNG with a hard cap.
+// Chance increases per attempt and guarantees a proc once max_count is reached.
+struct accumulated_hardcap_rng_t : public proc_rng_t
+{
+private:
+  accumulated_rng_fn accumulator_fn;
+  double proc_chance;
+  unsigned max_count;
+  unsigned initial_count;
+  unsigned trigger_count;
+
+public:
+  static constexpr rng_type_e rng_type = RNG_ACCUMULATE;
+
+  accumulated_hardcap_rng_t( std::string_view n, player_t* p, double c, accumulated_rng_fn fn = nullptr,
+                                        unsigned max_count_ = std::numeric_limits<unsigned>::max(), unsigned initial_count_ = 0 )
+    : proc_rng_t( rng_type, n, p ),
+      accumulator_fn( std::move( fn ) ),
+      proc_chance( c ),
+      max_count( max_count_ ),
+      initial_count( initial_count_ ),
+      trigger_count( initial_count_ )
+  {}
+
+  void reset( reset_type_e /* reset_type */ ) override
+  { trigger_count = initial_count; }
+
+  int trigger( action_state_t* state = nullptr ) override
+  {
+    if ( proc_chance <= 0 )
+      return false;
+
+    trigger_count++;
+
+    if ( trigger_count >= max_count )
+    {
+      reset( reset_type_e::COMBAT );
+      return true;
+    }
+
+    double chance = accumulator_fn ? accumulator_fn( proc_chance, trigger_count, state ) : proc_chance * trigger_count;
+    assert( !std::isnan( chance ) ); // nan check
+    bool result = player->rng().roll( chance );
+
+    if ( player->sim->debug )
+    {
+      player->sim->print_debug( "Accumulated (Hard Cap) RNG: {}, base={:.3f} count={} max={} chance={:.5f}%", name(),
+                                proc_chance, trigger_count, max_count, chance * 100.0 );
+    }
+
+    if ( result )
+      reset( reset_type_e::COMBAT );
+
+    return result;
+  }
+};
+
 // utility to create target_effect_t compatible functions from warlock_td_t member references
 template <typename T>
 static std::function<int( actor_target_data_t* )> d_fn( T d, bool stack = true )
@@ -135,6 +243,8 @@ public:
   player_t* haunt_target; // Used for tracking the current haunt target
   double agony_accumulator;
   double corruption_accumulator;
+  int alythesss_ire_counter; // Used to consistently cycle the Alythess's Ire proc
+  int alythesss_ire_trigger; // Used to consistently cycle the Alythess's Ire proc
   std::vector<event_t*> wild_imp_spawns; // Used for tracking incoming imps from HoG TODO: Is this still needed with faster spawns?
   int diabolic_ritual; // Used to cycle between the three different Diabolic Ritual buffs
   bool demonic_art_buff_replaced; // Used to not spawn the Demonic Art demon if the buff is replaced by another
@@ -609,6 +719,7 @@ public:
     action_t* demonic_soul;
     action_t* shared_fate;
     action_t* wicked_reaping;
+    action_t* dimensional_rift;
     action_t* demonfire_infusion;
     action_t* eye_explosion;
     action_t* diabolic_gaze_1;
@@ -820,14 +931,17 @@ public:
     // Affliction
     rng_setting_t cunning_cruelty_sb = { 0.50, 0.50, "cunning_cruelty_sb" };
     rng_setting_t cunning_cruelty_ds = { 0.25, 0.25, "cunning_cruelty_ds" };
-    rng_setting_t agony = { 0.368, 0.368, "agony" };
-    rng_setting_t nightfall = { 0.13, 0.13, "nightfall" };
+    rng_setting_t agony = { 0.370, 0.370, "agony" };
+    rng_setting_t nightfall = { 0.130, 0.130, "nightfall" };
 
     // Demonology
-    rng_setting_t spiteful_reconstitution = { 0.30, 0.30, "spiteful_reconstitution" };
+    rng_setting_t spiteful_reconstitution = { 0.10, 0.10, "spiteful_reconstitution" };
+    rng_setting_t spiteful_reconstitution_hard_cap = { 21.0, 21.0, "spiteful_reconstitution_hard_cap" };
+    rng_setting_t demonic_knowledge_rank1_cards = { 10.0, 10.0, "demonic_knowledge_rank1_cards" };
+    rng_setting_t demonic_knowledge_rank2_cards = { 18.0, 18.0, "demonic_knowledge_rank2_cards" };
 
     // Destruction
-    rng_setting_t avatar_of_destruction_dr = { 0.30, 0.30, "avatar_of_destruction_dr" }; // TODO: PLACEHOLDER VALUE! Need to calculate ingame the type of RNG and the average RNG
+    rng_setting_t alythesss_ire_shift = { 0.01, 0.01, "alythesss_ire_shift" };
     rng_setting_t echo_of_sargeras = { 0.10, 0.10, "echo_of_sargeras" };
 
     // Diabolist
@@ -839,10 +953,12 @@ public:
     rng_setting_t mark_of_perotharn = { 0.15, 0.15, "mark_of_perotharn" };
 
     // Soul Harvester
-    rng_setting_t succulent_soul_aff = { 0.22, 0.22, "succulent_soul_aff" };
+    rng_setting_t succulent_soul_aff = { 0.225, 0.225, "succulent_soul_aff" };
     rng_setting_t succulent_soul_demo = { 0.15, 0.15, "succulent_soul_demo" };
-    rng_setting_t feast_of_souls_aff = { 0.15, 0.15, "feast_of_souls" };
-    rng_setting_t feast_of_souls_demo = { 0.0975, 0.0975, "feast_of_souls" };
+    rng_setting_t feast_of_souls_aff = { 0.04, 0.04, "feast_of_souls_aff" };
+    rng_setting_t feast_of_souls_demo = { 0.10, 0.10, "feast_of_souls_demo" };
+    rng_setting_t feast_of_souls_hard_cap_aff = { 26.0, 26.0, "feast_of_souls_hard_cap_aff" };
+    rng_setting_t feast_of_souls_hard_cap_demo = { 26.0, 26.0, "feast_of_souls_hard_cap_demo" };
     rng_setting_t manifested_avarice = { 0.10, 0.10, "manifested_avarice" };
   } rng_settings;
 
@@ -851,6 +967,7 @@ public:
   bool disable_auto_felstorm; // For Demonology main pet
   bool normalize_destruction_mastery;
   shuffled_rng_t* rain_of_chaos_rng;
+  shuffled_rng_t* demonic_knowledge_rng;
   real_ppm_t* ravenous_afflictions_rng;
   real_ppm_t* wrath_of_nathreza_rng;
   real_ppm_t* devil_fruit_rng;
@@ -858,8 +975,15 @@ public:
   accumulated_rng_t* shard_instability_ds_rng;
   accumulated_rng_t* shard_instability_sb_rng;
   accumulated_rng_t* fatal_echoes_rng;
+  accumulated_rng_t* fiendish_cruelty_rng;
+  accumulated_rng_t* chaotic_inferno_rng;
+  accumulated_rng_t* dimensional_rift_rng;
+  accumulated_rng_t* echo_of_sargeras_rng;
   accumulated_rng_t* succulent_soul_rng;
   accumulated_rng_t* manifested_avarice_rng;
+  accumulated_hardcap_rng_t* feast_of_souls_rng;
+  accumulated_hardcap_rng_t* spiteful_reconstitution_rng;
+  std::unique_ptr<shuffled_bag_rng_t<dimensional_rift_pet_e>> dimensional_rift_summon_rng;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );
 
@@ -918,7 +1042,7 @@ public:
   std::vector<player_t*> get_smart_targets( const std::vector<player_t*>& tl, propagate_const<dot_t*> warlock_td_t::dots_t::* dot, int n_targets, player_t* exclude = nullptr, double range = 0.0, bool really_smart = false );
   player_t* get_smart_target( const std::vector<player_t*>& tl, propagate_const<dot_t*> warlock_td_t::dots_t::* dot, player_t* exclude = nullptr, double range = 0.0, bool really_smart = false );
   double resource_gain( resource_e resource_type, double amount, gain_t* source = nullptr, action_t* action = nullptr ) override;
-  void feast_of_souls_gain();
+  void feast_of_souls_gain( bool from_quietus_seed = false );
   void summon_dominion_of_argus_pet( dominion_of_argus_pet_e pet );
 
   bool affliction() const;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -42,6 +42,8 @@ using namespace helpers;
 
       // Destruction
       bool fiendish_cruelty = false;
+      bool dimensional_rift = false;
+      bool embers_of_nihilam_1 = false;
 
       // Diabolist
       bool diabolic_ritual = false;
@@ -245,6 +247,7 @@ using namespace helpers;
         int shards_used = as<int>( last_resource_cost );
         int base_shards = as<int>( base_cost() );
 
+        // Only effective shards consumed count towards the Rain of Chaos proc
         if ( p()->buffs.rain_of_chaos->check() && shards_used > 0 )
         {
           for ( int i = 0; i < shards_used; i++ )
@@ -380,12 +383,26 @@ using namespace helpers;
 
       if ( destruction() && triggers.fiendish_cruelty )
       {
-        if ( s->result == RESULT_CRIT )
+        if ( s->result == RESULT_CRIT && p()->fiendish_cruelty_rng->trigger() )
         {
-          bool success = p()->buffs.fiendish_cruelty->trigger();
+          p()->buffs.fiendish_cruelty->trigger();
+          p()->procs.fiendish_cruelty->occur();
+        }
+      }
 
-          if ( success )
-            p()->procs.fiendish_cruelty->occur();
+      if ( destruction() && triggers.dimensional_rift )
+      {
+        if ( p()->dimensional_rift_rng->trigger() )
+          p()->proc_actions.dimensional_rift->execute_on_target( s->target );
+      }
+
+      if ( destruction() && triggers.embers_of_nihilam_1 )
+      {
+        if ( p()->echo_of_sargeras_rng->trigger() )
+        {
+          p()->proc_actions.echo_of_sargeras->execute_on_target( s->target );
+          p()->procs.echo_of_sargeras->occur();
+          p()->buffs.vision_of_nihilam->trigger();
         }
       }
     }
@@ -418,7 +435,7 @@ using namespace helpers;
         double chaotic_energies_rng = rng().range( min_percentage , 1.0 );
 
         if ( p()->normalize_destruction_mastery )
-          chaotic_energies_rng = ( 1.0 + min_percentage ) / 2.0;
+          chaotic_energies_rng = ( 1.0 + min_percentage ) * 0.5;
 
         m *= 1.0 + chaotic_energies_rng * p()->cache.mastery_value();
       }
@@ -793,7 +810,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_aff.setting_value ) )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
           p()->feast_of_souls_gain();
       }
 
@@ -1343,19 +1360,29 @@ using namespace helpers;
 
     void tick( dot_t* d ) override
     {
-      // Blizzard has not publicly released the formula for Agony's chance to generate a Soul Shard.
-      // This set of code is based on results from 500+ Soul Shard sample sizes, and matches in-game
-      // results to within 0.1% of accuracy in all tests conducted on all targets numbers up to 8.
-      // Accurate as of 08-24-2018. TOCHECK regularly. If any changes are made to this section of
-      // code, please also update the Time_to_Shard expression in sc_warlock.cpp.
+      // 2018-08-24:
+      //   Blizzard has not publicly released the formula for Agony's chance to generate a Soul Shard. This set of code is based on results from
+      //   500+ Soul Shard sample sizes, and matches in-game results to within 0.1% of accuracy in all tests conducted on all targets numbers up to 8.
+      // 2026-03-06:
+      //   New tests were conducted using over 55000+ Soul Shards in both single and multi-target scenarios. The results confirm that Blizzard is still
+      //   using the same formula for Agony, though they occasionally make unusual adjustments to talent normalization (so this should be checked regularly).
+      //   With the larger sample size, we obtained a more precise initial value for Agony's RNG 'increment_max' of 0.370 (previously 0.368).
+      // TOCHECK regularly. If any changes are made to this section of code, please also update the Time_to_Shard expression in sc_warlock.cpp.
+
       double increment_max = p()->rng_settings.agony.setting_value;
 
       double active_agonies = p()->get_active_dots( d );
       increment_max *= std::pow( active_agonies, -2.0 / 3.0 );
 
-      // 2023-09-01: Recent test noted that Creeping Death is once again renormalizing shard generation to be neutral with/without the talent.
+      // NOTE: 2026-03-06 Recent tests noted that Creeping Death is renormalizing shard generation to be neutral with/without the talent
+      // However, Creeping Death rank 2 is normalizing using -0.1 value instead of -0.2 (the value of rank 1 or half of rank 2) (bug?)
       if ( p()->talents.creeping_death.ok() )
-        increment_max *= 1.0 + p()->talents.creeping_death->effectN( 1 ).percent();
+      {
+        if ( !p()->bugs || p()->talents.creeping_death.rank() < 2 )
+          increment_max *= 1.0 + p()->talents.creeping_death->effectN( 1 ).percent();
+        else
+          increment_max *= 1.0 + ( p()->talents.creeping_death->effectN( 1 ).percent() * 0.5 );
+      }
 
       p()->agony_accumulator += rng().range( 0.0, increment_max );
 
@@ -1698,7 +1725,7 @@ using namespace helpers;
 
       p()->buffs.seed_of_corruption_is_out_dnt->trigger();
 
-      if ( time_to_execute == 0_ms && soul_harvester() && p()->buffs.nightfall->check() )
+      if ( time_to_execute == 0_ms && soul_harvester() && p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() )
       {
         if ( p()->hero.wicked_reaping.ok() )
           p()->proc_actions.wicked_reaping->execute_on_target( target );
@@ -1706,8 +1733,9 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_aff.setting_value ) )
-          p()->feast_of_souls_gain();
+        // Feast of Souls is processed before the decrement of Succulent Soul, causing the same SoC cast that gains the Succulent Soul stack to consume it
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
+          p()->feast_of_souls_gain( true );
       }
 
       // NOTE: 2026-02-26 If Nightfall is obtained during the casting of Seed of Corruption, that SoC cast
@@ -1985,7 +2013,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_aff.setting_value ) )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -2124,7 +2152,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_aff.setting_value ) )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -2593,7 +2621,7 @@ using namespace helpers;
         }
       }
 
-      if ( p()->talents.demonic_knowledge.ok() && rng().roll( p()->talents.demonic_knowledge->effectN( 1 ).percent() ) )
+      if ( p()->talents.demonic_knowledge.ok() && p()->demonic_knowledge_rng->trigger() )
       {
         p()->buffs.demonic_core->trigger();
         p()->procs.demonic_knowledge->occur();
@@ -2687,7 +2715,7 @@ using namespace helpers;
 
       if ( p()->buffs.demonic_core->check() )
       {
-        if ( p()->talents.spiteful_reconstitution.ok() && rng().roll( p()->rng_settings.spiteful_reconstitution.setting_value ) )
+        if ( p()->talents.spiteful_reconstitution.ok() && p()->spiteful_reconstitution_rng->trigger() )
         {
           p()->warlock_pet_list.wild_imps.spawn( 1u );
           p()->procs.spiteful_reconstitution->occur();
@@ -2702,7 +2730,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && rng().roll( p()->rng_settings.feast_of_souls_demo.setting_value ) )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
           p()->feast_of_souls_gain();
       }
 
@@ -3296,7 +3324,8 @@ using namespace helpers;
 
         affected_by.chaotic_energies = true;
 
-        triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok();
+        triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok(); // Incinerate FnB crits can trigger Fiendish Cruelty
+        triggers.embers_of_nihilam_1 = p->talents.embers_of_nihilam_1.ok(); // Incinerate FnB hits can trigger Embers of Nihilam 1
 
         base_multiplier *= p->talents.fire_and_brimstone->effectN( 1 ).percent();
       }
@@ -3332,13 +3361,6 @@ using namespace helpers;
 
         if ( p()->bugs && p()->talents.diabolic_embers.ok() && s->result == RESULT_CRIT )
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.incinerate_crits );
-
-        if ( p()->talents.embers_of_nihilam_1.ok() && p()->rng().roll( p()->rng_settings.echo_of_sargeras.setting_value ) )
-        {
-          p()->proc_actions.echo_of_sargeras->execute_on_target( s->target );
-          p()->procs.echo_of_sargeras->occur();
-          p()->buffs.vision_of_nihilam->trigger();
-        }
       }
     };
 
@@ -3360,6 +3382,7 @@ using namespace helpers;
       affected_by.havoc = true;
 
       triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok();
+      triggers.embers_of_nihilam_1 = p->talents.embers_of_nihilam_1.ok();
 
       add_child( fnb_action );
     }
@@ -3420,13 +3443,6 @@ using namespace helpers;
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1 * energize_mult, p()->gains.incinerate_crits );
         else if ( p()->talents.diabolic_embers.ok() )
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.incinerate_crits );
-      }
-
-      if ( p()->talents.embers_of_nihilam_1.ok() && p()->rng().roll( p()->rng_settings.echo_of_sargeras.setting_value ) )
-      {
-        p()->proc_actions.echo_of_sargeras->execute_on_target( s->target );
-        p()->procs.echo_of_sargeras->occur();
-        p()->buffs.vision_of_nihilam->trigger();
       }
     }
   };
@@ -3531,19 +3547,26 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      int rift = rng().range( 3 );
+      dimensional_rift_pet_e rift_pet_index = p()->dimensional_rift_summon_rng->draw();
 
-      switch ( rift )
+      switch ( rift_pet_index )
       {
-        case 0:
+        case DR_PET_SHADOWY_TEAR:
           p()->warlock_pet_list.shadow_rifts.spawn( p()->talents.shadowy_tear_summon->duration() );
+          p()->procs.dimensional_rift->occur();
           break;
-        case 1:
+        case DR_PET_UNSTABLE_TEAR:
           p()->warlock_pet_list.unstable_rifts.spawn( p()->talents.unstable_tear_summon->duration() );
+          p()->procs.dimensional_rift->occur();
           break;
-        case 2:
+        case DR_PET_CHAOS_TEAR:
           p()->warlock_pet_list.chaos_rifts.spawn( p()->talents.chaos_tear_summon->duration() );
+          p()->procs.dimensional_rift->occur();
           break;
+        case DR_PET_OVERFIEND:
+          p()->warlock_pet_list.overfiends.spawn();
+          p()->buffs.summon_overfiend->trigger();
+          p()->procs.avatar_of_destruction->occur();
         default:
           break;
       }
@@ -3588,7 +3611,6 @@ using namespace helpers;
 
     double havoc_rancora_mod_value;
     internal_combustion_t* internal_combustion;
-    dimensional_rift_t* dimensional_rift;
 
     chaos_bolt_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Chaos Bolt", p, p->talents.chaos_bolt, options_str ),
@@ -3600,13 +3622,11 @@ using namespace helpers;
       affected_by.touch_of_rancora = affected_by.touch_of_rancora_casted = p->hero.touch_of_rancora.ok();
 
       triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok();
+      triggers.dimensional_rift = p->talents.dimensional_rift.ok();
       triggers.diabolic_ritual = triggers.demonic_art = p->hero.diabolic_ritual.ok();
       triggers.rancora_cb_bonus = true;
 
       havoc_rancora_mod_value /= p->talents.havoc_debuff->effectN( 1 ).percent();
-
-      if ( p->talents.dimensional_rift.ok() )
-        dimensional_rift = new dimensional_rift_t( p );
 
       if ( p->talents.internal_combustion.ok() )
       {
@@ -3685,31 +3705,14 @@ using namespace helpers;
 
       p()->buffs.crashing_chaos->decrement();
 
-      if ( p()->talents.chaotic_inferno.ok() )
+      if ( p()->talents.chaotic_inferno.ok() && p()->chaotic_inferno_rng->trigger() )
       {
         // Delay the buff a bit to simulate the ingame behavior where an Incinerate cast
         // queued right after a Chaos Bolt that procs Chaotic Inferno is not affected by it
         make_event( *sim, 10_ms, [ this ] {
-          bool success = p()->buffs.chaotic_inferno->trigger();
-          if ( success )
-            p()->procs.chaotic_inferno->occur();
+          p()->buffs.chaotic_inferno->trigger();
+          p()->procs.chaotic_inferno->occur();
         } );
-      }
-
-      if ( p()->talents.dimensional_rift.ok() && rng().roll( p()->talents.dimensional_rift->effectN( 1 ).percent() ) )
-      {
-        p()->procs.dimensional_rift->occur();
-
-        if ( p()->talents.avatar_of_destruction.ok() && rng().roll( p()->rng_settings.avatar_of_destruction_dr.setting_value ) )
-        {
-          p()->warlock_pet_list.overfiends.spawn();
-          p()->buffs.summon_overfiend->trigger();
-          p()->procs.avatar_of_destruction->occur();
-        }
-        else
-        {
-          dimensional_rift->execute_on_target( target );
-        }
       }
     }
 
@@ -3933,10 +3936,20 @@ using namespace helpers;
       {
         p()->buffs.alythesss_ire->decrement();
 
-        bool success = p()->buffs.alythesss_ire->trigger();
+        p()->alythesss_ire_counter++;
 
-        if ( success )
+        if ( p()->alythesss_ire_counter >= p()->alythesss_ire_trigger )
+        {
+          p()->buffs.alythesss_ire->trigger();
           p()->procs.alythesss_ire->occur();
+
+          // NOTE: 2026-03-06 Alythess's Ire usually procs at a fixed interval of attempts. Rarely, the cycle
+          // shifts and advances the next proc; testing suggests this happens randomly in roughly ~1% of procs.
+          if ( rng().roll( p()->rng_settings.alythesss_ire_shift.setting_value ) )
+            p()->alythesss_ire_counter = rng().range( 1, p()->alythesss_ire_trigger );
+          else
+            p()->alythesss_ire_counter = 0;
+        }
       }
     }
   };
@@ -4087,7 +4100,6 @@ using namespace helpers;
   struct shadowburn_t : public warlock_spell_t
   {
     double havoc_rancora_mod_value;
-    dimensional_rift_t* dimensional_rift;
 
     shadowburn_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Shadowburn", p, p->talents.shadowburn, options_str ),
@@ -4098,12 +4110,10 @@ using namespace helpers;
       affected_by.chaos_incarnate = p->talents.chaos_incarnate.ok();
       affected_by.touch_of_rancora = p->hero.touch_of_rancora.ok();
 
+      triggers.dimensional_rift = p->talents.dimensional_rift.ok();
       triggers.diabolic_ritual = triggers.demonic_art = triggers.demonic_art_buff = p->hero.diabolic_ritual.ok();
 
       havoc_rancora_mod_value /= p->talents.havoc_debuff->effectN( 1 ).percent();
-
-      if ( p->talents.dimensional_rift.ok() )
-        dimensional_rift = new dimensional_rift_t( p );
     }
 
     bool ready() override
@@ -4150,12 +4160,6 @@ using namespace helpers;
 
         if ( success )
           p()->procs.conflagration_of_chaos_sb->occur();
-      }
-
-      if ( p()->talents.dimensional_rift.ok() && rng().roll( p()->talents.dimensional_rift->effectN( 1 ).percent() ) )
-      {
-        p()->procs.dimensional_rift->occur();
-        dimensional_rift->execute_on_target( target );
       }
 
       p()->buffs.fiendish_cruelty->decrement();
@@ -4457,6 +4461,7 @@ using namespace helpers;
       affected_by.havoc = true;
 
       triggers.fiendish_cruelty = p->talents.fiendish_cruelty.ok(); // Infernal Bolt crits can trigger Fiendish Cruelty
+      triggers.embers_of_nihilam_1 = p->talents.embers_of_nihilam_1.ok(); // Infernal Bolt hits can trigger Embers of Nihilam 1
     }
 
     void init() override
@@ -4665,15 +4670,21 @@ using namespace helpers;
     // We determined this is the probable functionality copied from Agony by first confirming the
     // DR formula was the same and then confirming that you can get procs on 1st tick.
     // The procs also have a regularity that suggest it does not use a proc chance or rppm.
-    // Last checked 09-28-2020.
+    // Last checked 2026-03-06.
     double increment_max = p->rng_settings.nightfall.setting_value;
 
     double active_corruptions = p->get_active_dots( d );
     increment_max *= std::pow( active_corruptions, -2.0 / 3.0 );
 
-    // Creeping Death no longer affects the chance of gaining Nightfall
+    // NOTE: 2026-03-06 Creeping Death no longer affects the chance of gaining Nightfall
+    // However, Creeping Death rank 2 is normalizing using -0.1 value instead of -0.2 (the value of rank 1 or half of rank 2) (bug?)
     if ( p->talents.creeping_death.ok() )
-      increment_max *= 1.0 + p->talents.creeping_death->effectN( 1 ).percent();
+    {
+      if ( !p->bugs || p->talents.creeping_death.rank() < 2 )
+        increment_max *= 1.0 + p->talents.creeping_death->effectN( 1 ).percent();
+      else
+        increment_max *= 1.0 + ( p->talents.creeping_death->effectN( 1 ).percent() * 0.5 );
+    }
 
     // Sataiel’s Volition no longer affects the chance of gaining Nightfall
     if ( p->hero.sataiels_volition.ok() )
@@ -5098,6 +5109,7 @@ using namespace helpers;
 
   void warlock_t::create_destruction_proc_actions()
   {
+    proc_actions.dimensional_rift = new dimensional_rift_t( this );
     proc_actions.demonfire_infusion = new demonfire_infusion_t( this );
 
     if ( talents.embers_of_nihilam_1.ok() )

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -789,12 +789,10 @@ namespace warlock
                                 ->set_rppm( RPPM_NONE, talents.reverse_entropy->real_ppm() );
 
     buffs.fiendish_cruelty = make_buff( this, "fiendish_cruelty", talents.fiendish_cruelty_buff )
-                                 ->set_default_value_from_effect( 1 )
-                                 ->set_chance( talents.fiendish_cruelty->effectN( 1 ).percent() ); // TODO: Check RNG type
+                                 ->set_default_value_from_effect( 1 );
 
     buffs.chaotic_inferno = make_buff( this, "chaotic_inferno_buff", talents.chaotic_inferno_buff )
-                                ->set_default_value_from_effect( 1 )
-                                ->set_chance( talents.chaotic_inferno->effectN( 2 ).percent() ); // TODO: Check RNG type
+                                ->set_default_value_from_effect( 1 );
 
     buffs.rain_of_chaos = make_buff( this, "rain_of_chaos", talents.rain_of_chaos_buff );
 
@@ -815,8 +813,7 @@ namespace warlock
                                  ->set_reverse( true );
 
     buffs.alythesss_ire = make_buff( this, "alythesss_ire", talents.alythesss_ire_buff )
-                              ->set_default_value_from_effect( 1 )
-                              ->set_chance( talents.alythesss_ire->effectN( 1 ).percent() ); // TODO: Check RNG type
+                              ->set_default_value_from_effect( 1 );
 
     buffs.vision_of_nihilam = make_buff( this, "vision_of_nihilam", talents.vision_of_nihilam )
                                   ->set_default_value( talents.embers_of_nihilam_2->effectN( 1 ).percent() )
@@ -1163,12 +1160,104 @@ namespace warlock
 
   void warlock_t::init_rng_demonology()
   {
+    // Modeling Spiteful Reconstitution as a pseudo-random distribution (PRD) with a nominal rate of 10% and a hard cap
+    // of 21 attempts. The PRD nominal rate corresponds to PRD constant C = 0.014745844781072676.
+    if ( talents.spiteful_reconstitution.ok() )
+    {
+      double c_sr = pseudo_random_c_from_p( rng_settings.spiteful_reconstitution.setting_value );
+      int spiteful_reconstitution_hardcap = static_cast<int>( rng_settings.spiteful_reconstitution_hard_cap.setting_value );
+      spiteful_reconstitution_rng = get_rng<accumulated_hardcap_rng_t>( "spiteful_reconstitution", c_sr, nullptr, spiteful_reconstitution_hardcap );
+    }
+
+    // Demonic Knowledge uses Deck of Cards RNG at 10 out of 80 (rank 1) and 18 out of 80 (rank 2)
+    // NOTE: 2026-03-06 Demonic Knowledge does not appear to use the average chance indicated in the spell data, but
+    // rather follows a deck of cards model that also does not match the expected average chance (bug)
+    if ( talents.demonic_knowledge.ok() )
+    {
+      const int max_cards = 80;
+
+      int cards = 0;
+      if ( bugs )
+      {
+        assert( talents.demonic_knowledge.rank() == 2 || talents.demonic_knowledge.rank() == 1 );
+        if ( talents.demonic_knowledge.rank() == 2 )
+          cards = static_cast<int>( rng_settings.demonic_knowledge_rank2_cards.setting_value );
+        else if ( talents.demonic_knowledge.rank() == 1 )
+          cards = static_cast<int>( rng_settings.demonic_knowledge_rank1_cards.setting_value );
+      }
+      else
+      {
+        cards = static_cast<int>( talents.demonic_knowledge->effectN( 1 ).percent() * max_cards + 0.5 );
+      }
+
+      demonic_knowledge_rng = get_shuffled_rng( "demonic_knowledge", cards, max_cards );
+    }
   }
 
   void warlock_t::init_rng_destruction()
   {
-    // TOCHECK: Presumed to use deck of cards at 3 out of 20. Long sample test needed to reconfirm in TWW/Midnight
+    // Modeling Fiendish Cruelty as a pseudo-random distribution (PRD) with a nominal
+    // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
+    if ( talents.fiendish_cruelty.ok() )
+    {
+      double c_fc = pseudo_random_c_from_p( talents.fiendish_cruelty->effectN( 1 ).percent() );
+      fiendish_cruelty_rng = get_accumulated_rng( "fiendish_cruelty", c_fc );
+    }
+
+    // Modeling Chaotic Inferno as a pseudo-random distribution (PRD) with a nominal
+    // rate of 25%, which corresponds to PRD constant C = 0.084744091852316990.
+    if ( talents.chaotic_inferno.ok() )
+    {
+      double c_ci = pseudo_random_c_from_p( talents.chaotic_inferno->effectN( 2 ).percent() );
+      chaotic_inferno_rng = get_accumulated_rng( "chaotic_inferno", c_ci );
+    }
+
+    // Rain of Chaos uses Deck of Cards RNG at 3 out of 20
     rain_of_chaos_rng = get_shuffled_rng( "rain_of_chaos", 3, 20 );
+
+    // Modeling Dimensional Rift as a pseudo-random distribution (PRD) with a nominal
+    // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
+    if ( talents.dimensional_rift.ok() )
+    {
+      double c_dr = pseudo_random_c_from_p( talents.dimensional_rift->effectN( 1 ).percent() );
+      dimensional_rift_rng = get_accumulated_rng( "dimensional_rift", c_dr );
+
+      // The pets summoned by Dimensional Rift is choosen following a Deck of Cards model of 2/2/2 out of 6.
+      // With the Avatar of Destruction talent, this is modified to a Deck of Cards model of 2/2/2/1 out of 7.
+      if ( talents.avatar_of_destruction.ok() )
+      {
+        std::vector<dimensional_rift_pet_e> deck = {
+            DR_PET_SHADOWY_TEAR,  DR_PET_SHADOWY_TEAR,
+            DR_PET_UNSTABLE_TEAR, DR_PET_UNSTABLE_TEAR,
+            DR_PET_CHAOS_TEAR,    DR_PET_CHAOS_TEAR,
+            DR_PET_OVERFIEND };
+
+        dimensional_rift_summon_rng = std::make_unique<shuffled_bag_rng_t<dimensional_rift_pet_e>>( std::move( deck ), this );
+      }
+      else
+      {
+        std::vector<dimensional_rift_pet_e> deck = {
+            DR_PET_SHADOWY_TEAR,  DR_PET_SHADOWY_TEAR,
+            DR_PET_UNSTABLE_TEAR, DR_PET_UNSTABLE_TEAR,
+            DR_PET_CHAOS_TEAR,    DR_PET_CHAOS_TEAR };
+
+        dimensional_rift_summon_rng = std::make_unique<shuffled_bag_rng_t<dimensional_rift_pet_e>>( std::move( deck ), this );
+      }
+    }
+
+    if ( talents.alythesss_ire.ok() )
+    {
+      assert( as<int>( talents.alythesss_ire->effectN( 1 ).base_value() ) != 0 );
+      alythesss_ire_trigger = 100 / as<int>( talents.alythesss_ire->effectN( 1 ).base_value() );
+    }
+
+    // Modeling Echo of Sargeras as a pseudo-random distribution (PRD) with a nominal
+    // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
+    if ( talents.embers_of_nihilam_1.ok() )
+    {
+      double c_es = pseudo_random_c_from_p( rng_settings.echo_of_sargeras.setting_value );
+      echo_of_sargeras_rng = get_accumulated_rng( "echo_of_sargeras", c_es );
+    }
   }
 
   void warlock_t::init_rng_diabolist()
@@ -1182,20 +1271,48 @@ namespace warlock
 
   void warlock_t::init_rng_soul_harvester()
   {
-    // Modeling Succulent Soul as a pseudo-random distribution (PRD) with a nominal rate of 22% (aff) / 15% (demo),
-    // which corresponds to PRD constant C = 0.066676403621508090 (aff) / C = 0.032220914373087675 (demo)
-    double c_ss = 0.0;
-    if ( affliction() )
-      c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_aff.setting_value );
-    else if ( demonology() )
-      c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_demo.setting_value );
+    // Modeling Succulent Soul as a pseudo-random distribution (PRD) with a nominal rate of 22.5% (aff) / 15% (demo),
+    // which corresponds to PRD constant C = 0.069555224955587218 (aff) / C = 0.032220914373087675 (demo)
+    if ( hero.demonic_soul.ok() )
+    {
+      assert( affliction() || demonology() );
+      double c_ss = 0.0;
+      if ( affliction() )
+        c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_aff.setting_value );
+      else if ( demonology() )
+        c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_demo.setting_value );
 
-    succulent_soul_rng = get_accumulated_rng( "succulent_soul", c_ss );
+      succulent_soul_rng = get_accumulated_rng( "succulent_soul", c_ss );
+    }
 
     // Modeling Manifested Avarice as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
-    double c_ma = pseudo_random_c_from_p( rng_settings.manifested_avarice.setting_value );
-    manifested_avarice_rng = get_accumulated_rng( "manifested_avarice", c_ma );
+    if ( hero.manifested_avarice.ok() )
+    {
+      double c_ma = pseudo_random_c_from_p( rng_settings.manifested_avarice.setting_value );
+      manifested_avarice_rng = get_accumulated_rng( "manifested_avarice", c_ma );
+    }
+
+    // Modeling Feast of Souls as a pseudo-random distribution (PRD) with a nominal rate of 4% (aff) / 10% (demo) and a hard cap
+    // of 26 attempts. The PRD nominal rate corresponds to PRD C = 0.002448555471647706 (aff) / C = 0.014745844781072676 (demo)
+    if ( hero.feast_of_souls.ok() )
+    {
+      assert( affliction() || demonology() );
+      double c_fs = 0.0;
+      int feast_of_souls_hardcap = 0;
+      if ( affliction() )
+      {
+        c_fs = pseudo_random_c_from_p( rng_settings.feast_of_souls_aff.setting_value );
+        feast_of_souls_hardcap = static_cast<int>( rng_settings.feast_of_souls_hard_cap_aff.setting_value );
+      }
+      else if ( demonology() )
+      {
+        c_fs = pseudo_random_c_from_p( rng_settings.feast_of_souls_demo.setting_value );
+        feast_of_souls_hardcap = static_cast<int>( rng_settings.feast_of_souls_hard_cap_demo.setting_value );
+      }
+
+      feast_of_souls_rng = get_rng<accumulated_hardcap_rng_t>( "feast_of_souls", c_fs, nullptr, feast_of_souls_hardcap );
+    }
   }
 
   void warlock_t::init_resources( bool force )
@@ -1366,8 +1483,12 @@ namespace warlock
     add_rng_option( rng_settings.cunning_cruelty_ds );
     add_rng_option( rng_settings.agony );
     add_rng_option( rng_settings.nightfall );
-    add_rng_option( rng_settings.avatar_of_destruction_dr );
     add_rng_option( rng_settings.spiteful_reconstitution );
+    add_rng_option( rng_settings.spiteful_reconstitution_hard_cap );
+    add_rng_option( rng_settings.demonic_knowledge_rank1_cards );
+    add_rng_option( rng_settings.demonic_knowledge_rank2_cards );
+    add_rng_option( rng_settings.alythesss_ire_shift );
+    add_rng_option( rng_settings.echo_of_sargeras );
     add_rng_option( rng_settings.blackened_soul );
     add_rng_option( rng_settings.bleakheart_tactics );
     add_rng_option( rng_settings.seeds_of_their_demise );
@@ -1376,8 +1497,9 @@ namespace warlock
     add_rng_option( rng_settings.succulent_soul_demo );
     add_rng_option( rng_settings.feast_of_souls_aff );
     add_rng_option( rng_settings.feast_of_souls_demo );
+    add_rng_option( rng_settings.feast_of_souls_hard_cap_aff );
+    add_rng_option( rng_settings.feast_of_souls_hard_cap_demo );
     add_rng_option( rng_settings.manifested_avarice );
-    add_rng_option( rng_settings.echo_of_sargeras );
   }
 
   void warlock_t::combat_begin()
@@ -1405,13 +1527,19 @@ namespace warlock
       } );
     } );
 
+    if ( dimensional_rift_summon_rng )
+      dimensional_rift_summon_rng->reset();
+
+    if ( talents.alythesss_ire.ok() )
+      alythesss_ire_counter = as<int>( rng().range( 0, alythesss_ire_trigger ) );
+
     warlock_pet_list.active = nullptr;
     havoc_target = nullptr;
     haunt_target = nullptr;
     agony_accumulator = rng().range( 0.0, 0.99 );
     corruption_accumulator = rng().range( 0.0, 0.99 );
     wild_imp_spawns.clear();
-    diabolic_ritual = as<int>( rng().range( 0, 3 ) );
+    diabolic_ritual = rng().range( 0, 3 );
     demonic_art_buff_replaced = false;
   }
 }

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -184,7 +184,7 @@ double warlock_pet_t::composite_player_critical_damage_multiplier( const action_
     // Currently bugged and giving 260% crit damage instead of 230%. Preserving the
     // option to use the intended value for now in case of future issues.
     if ( !o()->bugs )
-      m += o()->talents.demonic_brutality->effectN( 2 ).percent() / 2.0;
+      m += o()->talents.demonic_brutality->effectN( 2 ).percent() * 0.5;
     else
       m += o()->talents.demonic_brutality->effectN( 2 ).percent();
   }
@@ -675,7 +675,11 @@ struct fel_firebolt_t : public warlock_pet_spell_t
   {
     warlock_pet_spell_t::execute();
 
-    if ( ( twin != nullptr ) && rng().roll( p()->o()->talents.infernal_rapidity->effectN( 1 ).percent() ) )
+    // NOTE: 2026-03-06 It has been tested that Infernal Rapidity follows a Flat % chance model for each individual cast
+    // However, the % chance seems to be bugged and only half of what is specified in the spell data is being applied (bug)
+    double infernal_rapidity_chance = p()->o()->talents.infernal_rapidity->effectN( 1 ).percent();
+    infernal_rapidity_chance = p()->bugs ? infernal_rapidity_chance * 0.5 : infernal_rapidity_chance;
+    if ( ( twin != nullptr ) && rng().roll( infernal_rapidity_chance ) )
     {
       p()->o()->procs.infernal_rapidity->occur();
       twin->execute_on_target( target );
@@ -780,10 +784,20 @@ void wild_imp_pet_t::demise()
 
     if ( !power_siphon )
     {
+      // NOTE: 2026-03-06 It has been tested that Demoniac (Wild Imps) follows a Flat % chance model for each imp
       double core_chance = o()->talents.demonic_core_spell->effectN( 1 ).percent();
 
       if ( imploded )
+      {
         core_chance += o()->hero.sataiels_volition->effectN( 3 ).percent();
+      }
+      else
+      {
+        // NOTE: 2026-03-06 If a Wild Imp demise normally (by not being imploded), its actual Demoniac chance to generate a
+        // demonic core is about 5x lower than indicated in the spell data (in our tests it is about ~2% instead of 10%).
+        if ( o()->bugs )
+          core_chance *= 0.2;
+      }
 
       if ( !o()->talents.demoniac.ok() )
         core_chance = 0.0;
@@ -898,6 +912,7 @@ struct dreadstalker_melee_t : warlock_pet_melee_t
   {
     warlock_pet_melee_t::execute();
 
+    // NOTE: 2026-03-06 It has been tested that Carnivorous Stalkers follows a Flat % chance model for each individual melee hit
     if ( p()->o()->talents.carnivorous_stalkers.ok() && rng().roll( p()->o()->talents.carnivorous_stalkers->effectN( 1 ).percent() ) )
     {
       debug_cast<dreadstalker_t*>( p() )->dreadbite_executes++;
@@ -2050,7 +2065,7 @@ struct rift_chaos_bolt_t : public warlock_pet_spell_t
     double chaotic_energies_rng = rng().range( min_percentage , 1.0 );
 
     if ( p()->o()->normalize_destruction_mastery )
-      chaotic_energies_rng = ( min_percentage + 1.0 ) / 2.0;
+      chaotic_energies_rng = ( min_percentage + 1.0 ) * 0.5;
 
     m *= 1.0 + chaotic_energies_rng * p()->o()->cache.mastery_value();
 
@@ -2115,7 +2130,7 @@ struct overfiend_chaos_bolt_t : public warlock_pet_spell_t
     double chaotic_energies_rng = rng().range( min_percentage , 1.0 );
 
     if ( p()->o()->normalize_destruction_mastery )
-      chaotic_energies_rng = ( min_percentage + 1.0 ) / 2.0;
+      chaotic_energies_rng = ( min_percentage + 1.0 ) * 0.5;
 
     m *= 1.0 + chaotic_energies_rng * p()->o()->cache.mastery_value();
 


### PR DESCRIPTION
Many Warlock RNG events/procs have been tested. Logs and details of the results are provided here in the PR description. All observed in-game behaviors (including bugs) are implemented in SimC to make it behave as similarly to the game as possible.

## Agony Soul Shard Energize

Agony shard regeneration for Affliction has been tested in both single-target and multi-target scenarios, and with Creeping Death setting to rank1, rank2, and disabled. A total of over 83 hours of logs were collected, with over 55000+ soul shard energize procs (out of over 650k+ agony ticks). It has been confirmed that the formula used for Agony energizes remains the same, a `Dithered/Random-Walk Accumulator Mod 1` with the same kind of scaling per target: `active_agonies ^ ( -2.0 / 3.0 )`. This large sample size allowed for a more precise adjustment of the initial `inc_max` value, from the previous `0.368` to `0.370`.

A bug has been found in the normalization of shards generated when using Creeping Death (CD). It works correctly without the CD talent selected, and also works correctly with CD rank 1 (`-0.1`). However, for CD rank 2, either half the normalization is being applied, or the rank 1 normalization is being applied instead (`-0.1` instead of `-0.2`). This behavior has been implemented in SimC. This bug may be fixed in the future, so it should be checked periodically.

Logs:
- https://www.warcraftlogs.com/reports/ThcD3bLk6CH2QnzY?fight=last&type=resources&source=1&spell=107
- https://www.warcraftlogs.com/reports/HqxvbaNZ8X2jnpBL?fight=1&type=resources&spell=107&source=1
- https://www.warcraftlogs.com/reports/jdB6kYwhZ7GKmy1r?fight=last&type=resources&spell=107&source=1&ability=17941
- https://www.warcraftlogs.com/reports/jdB6kYwhZ7GKmy1r?fight=last&type=resources&spell=107&source=1&ability=17941
- https://www.warcraftlogs.com/reports/km1DBRQ9FraMX68T?fight=1&type=resources&spell=107
- https://www.warcraftlogs.com/reports/HB8nKRx7ZhGp1a93?fight=last&type=resources&source=1&spell=107

## Nightfall

Periodic ticks of Corruption/Wither can trigger Nightfall, although the percentage and rng model are not specified. Other ways to trigger Nightfall exist: with a 100% chance using Haunt with the Sataiel's Volition hero talent, or with critical ticks from certain DoTs using the Ravenous Afflictions talent, which follows an RPPM model specified in the spell data. Ravenous Afflictions was quickly tested and appears to work as expected. Extensive tests (56h+) were then conducted to check the main Nightfall RNG with Corruption/Wither ticks in both single-target and multi-target scenarios. After analyzing numerous tests, it was confirmed that this proc follows the same `Dithered/Random-Walk Accumulator Mod 1` model as Agony (this was already known and implemented in SimC). It has been verified that it also follows the same scaling with targets as Agony (`active_corruptions ^ ( -2.0 / 3.0 )`). The initial `inc_max` value for this proc was set to `0.130` in SimC, and after testing, this value has been validated as correct and accurate.

As published by Blizzard, the Creeping Death (CD) and Sataiel's Volition (SV) talents should normalize the proc so that the number of procs is the same as without these talents. This has been tested by trying all possible combinations of these talents and their ranks. The SV talent is always normalizing correctly, and CD rank 1 also always normalizes correctly. However, for CD rank 2, either half the normalization is being applied, or the rank 1 normalization is being applied instead (`-0.1` instead of `-0.2`). This same issue was also occurring with Agony. This behavior has been implemented in SimC. This bug may be fixed in the future, so it should be checked periodically.

Additionally, we've found a bug that only occurs in a specific situation. In ST (only 1 target), if Nightfall is consumed using Seed of Corruption, there seems to be an issue with the accumulator, causing the next proc to occur sooner than normal, resulting in approximately ~71.5% more procs than usual. The reason for this is unknown, but it's likely a bug. In any case, it only happens when fighting vs 1 target, a situation where SoC isn't used, so we won't be implementing this bug for now, at least not in this PR.

Logs:
- https://www.warcraftlogs.com/reports/mq6Bp8vQGnYxV3zT?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/7qMDYwrXgKx2NnAk?boss=-3&difficulty=0&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/1PY7KXRAhZjmTLr6?fight=1&type=auras&source=5&ability=1260279
- https://www.warcraftlogs.com/reports/6hqzPZRv7HJpjBmT?fight=1&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/xdTFyZj3zG27g9Xk?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/9qxD3KBgdfckN2Xb?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/Pckq2GbLJX39hFf1?fight=1&type=auras&source=1&ability=1260279&target=1
- https://www.warcraftlogs.com/reports/6YNBgpXZxrWd8D1J?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/fv2ZX1qAzPTpQh9y?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/mnc639wMHXRJNV1p?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/91Bf6W83aZY2Drjh?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/c9XyBfLQwFJMNCRg?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/QYnMrPp8ghajR1CW?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/CZXJaTqRDQkbwvyH?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/xYHNM8zDRbw7LnpP?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/tZbGKkcLm6wMJVPR?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/akyqCHBhYPpKjWcw?fight=last&type=auras&ability=1260279
- https://www.warcraftlogs.com/reports/ZYN9rXqpHj4PxR3n?fight=last&type=auras&source=1&ability=1260279
- https://www.warcraftlogs.com/reports/vgtkj2nzL9JKQMc3?fight=last&type=auras&ability=1260279

## Succulent Soul (Affliction)

Succulent Soul had already been tested for Demonology in this PR: https://github.com/simulationcraft/simc/pull/11033 . We have now tested it for Affliction. As expected, just like in Demonology, the samples also appear to correspond to an accumulator from a pseudo-random distribution (PRD), but at a different nominal rate. After more than 83 hours of logging, with a total of 54841 events and 12351 procs, its nominal PRD rate was determined to be 22.5% with good precision (we had previously established it at 22% in TWW, after less intensive testing).

Logs:
- https://www.warcraftlogs.com/reports/ThcD3bLk6CH2QnzY?fight=last&type=auras&source=1&ability=449793
- https://www.warcraftlogs.com/reports/HqxvbaNZ8X2jnpBL?fight=1&type=auras&source=1&ability=449793
- https://www.warcraftlogs.com/reports/jdB6kYwhZ7GKmy1r?fight=last&type=auras&source=1&ability=449793
- https://www.warcraftlogs.com/reports/2AFNWTvXCgt4BmJa?fight=last&type=auras&source=1&ability=449793
- https://www.warcraftlogs.com/reports/km1DBRQ9FraMX68T?fight=1&type=auras&ability=449793
- https://www.warcraftlogs.com/reports/HB8nKRx7ZhGp1a93?fight=last&type=auras&source=1&ability=449793

Histogram for the distance between procs compared to a simulation using PRD nominal 22.5% rate:
<img width="540" height="288" alt="SS1_gap_distribution_observed_vs_PRD_pnom_22p50" src="https://github.com/user-attachments/assets/bfc40a93-b148-4644-9d88-4b30f9e1674b" />

ECDF distance between procs
<img width="450" height="216" alt="SS1_ECDF_gap_comparison_observed_vs_sims_max30" src="https://github.com/user-attachments/assets/9c34c26b-c03c-47b4-b16f-3239e8f56667" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="450" height="216" alt="SS1_Hazard_by_attempt_comparison_observed_vs_sims_max20" src="https://github.com/user-attachments/assets/b5628984-f74f-4d62-b6e6-47af5c45f283" />

Tail / survival of the distance between procs (log scale):
<img width="450" height="216" alt="SS1_Survival_tail_logscale_comparison_observed_vs_sims_max30" src="https://github.com/user-attachments/assets/2cfaa965-038a-4d1b-9bba-2a58e5f294be" />

## Feast of Souls (Demonology)

Analysis of the Feast of Souls samples for Demonology suggests that it uses an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 10%. This corresponds to a PRD constant C = 0.014745844781072676. It also appears to use a hard cap on the 26th attempt, where it would have a 100% chance. This is difficult to detect with this distribution (the hard cap we see could be statistically driven in our sample), but it closely matches what was observed in the same proc for Affliction.

Logs:
- https://www.warcraftlogs.com/reports/6bxkFQd4DjnwHrc8?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/CpN2YdqtJfTH9Gmn?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/dr3qGA8MhQLzaHg2?fight=last&type=resources&source=3&spell=107&ability=450752

Histogram for the distance between procs:
<img width="475" height="208" alt="FS_Demo_V1_proc_gap_histogram_events_solid_range1_30" src="https://github.com/user-attachments/assets/704d2e86-0af8-4ea5-ba19-e0ccb04f58da" />

ECDF distance between procs
<img width="475" height="208" alt="FS_Demo_V1_ECDF_gaps_observed_vs_PRD10cap26_vs_Flat10cap26" src="https://github.com/user-attachments/assets/6ea75986-04ad-4f6f-befb-d56e7eea8df5" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="475" height="208" alt="FS_Demo_V1_Hazard_observed_vs_PRD10cap26_vs_Flat10cap26" src="https://github.com/user-attachments/assets/a4849523-6657-4400-bca3-d7949bfce006" />

Tail / survival of the distance between procs (log scale):
<img width="475" height="208" alt="FS_Demo_V1_Survival_tail_logscale_observed_vs_PRD10cap26_vs_Flat10cap26" src="https://github.com/user-attachments/assets/b902a9ab-c9bd-4693-aa2e-7e127ae61ad2" />

## Feast of Souls (Affliction)

The behavior of Feast of Souls for Affliction is strange. It seems to have a very low chance, with a hard cap at the 26th attempt, where the proc then 100% occurs if it hadn't already. Here, that hard cap is very clear, which is why, when we also observe that in the Demonology version of proc (although not as clearly in that case), we can infer that they are probably using the same hard cap in both specs. However, the average chance is different in this case, being much lower in Affliction. With the data collected so far, we obtain the following histogram of distances between procs:
<img width="475" height="260" alt="FS_T1_gap_histogram_events_range1_30" src="https://github.com/user-attachments/assets/3802c99e-50b6-4fdc-b7cd-8126e2700302" />

Although it would be convenient to obtain more samples for this proc, its distribution is very compatible with PRD nominal rate 4% (hard cap at 26, which gives a final average chance close to ~5%), which would also be the most logical knowing that demonology uses the same RNG model (although with a different nominal rate).

Logs:
- https://www.warcraftlogs.com/reports/mq6Bp8vQGnYxV3zT?fight=last&type=resources&spell=107&source=1&ability=450752
- https://www.warcraftlogs.com/reports/7qMDYwrXgKx2NnAk?boss=-3&difficulty=0&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/1PY7KXRAhZjmTLr6?fight=1&type=resources&source=5&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/6hqzPZRv7HJpjBmT?fight=1&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/xdTFyZj3zG27g9Xk?fight=last&type=resources&spell=107&source=1
- https://www.warcraftlogs.com/reports/9qxD3KBgdfckN2Xb?fight=last&type=resources&spell=107&source=1
- https://www.warcraftlogs.com/reports/Pckq2GbLJX39hFf1?fight=1&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/6YNBgpXZxrWd8D1J?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/fv2ZX1qAzPTpQh9y?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/mnc639wMHXRJNV1p?fight=last&type=resources&spell=107&source=1&ability=450752
- https://www.warcraftlogs.com/reports/91Bf6W83aZY2Drjh?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/c9XyBfLQwFJMNCRg?fight=last&type=resources&spell=107&source=1&ability=450752
- https://www.warcraftlogs.com/reports/xYHNM8zDRbw7LnpP?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/tZbGKkcLm6wMJVPR?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/akyqCHBhYPpKjWcw?fight=last&type=resources&spell=107&source=1&ability=450752
- https://www.warcraftlogs.com/reports/ZYN9rXqpHj4PxR3n?fight=last&type=resources&source=1&spell=107&ability=450752
- https://www.warcraftlogs.com/reports/vgtkj2nzL9JKQMc3?fight=last&type=resources&spell=107&source=1&ability=450752

ECDF distance between procs
<img width="475" height="260" alt="FS_T1_ECDF_gaps_observed_vs_PRD4cap26_vs_Flat4cap26" src="https://github.com/user-attachments/assets/32dc93c6-1396-429a-8bc2-d1f80d9e9a37" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="475" height="260" alt="FS_T1_Hazard_observed_vs_PRD4cap26_vs_Flat4cap26" src="https://github.com/user-attachments/assets/913ac844-8a56-41ec-8e74-117c2e5aef93" />

Tail / survival of the distance between procs (log scale):
<img width="475" height="260" alt="FS_T1_Survival_tail_log_observed_vs_PRD4cap26_vs_Flat4cap26" src="https://github.com/user-attachments/assets/052a7adf-3680-4133-8c5d-8d90c28549f0" />

Bugs have also been detected for Affliction related to Feast of Souls and Succulent Souls. When Nightfall is consumed with Seed of Corruption (thanks to the Nocturnal Yield talent), if the Quietus hero talent is learned, there is a chance of a Feast of Souls proc. When this proc occurs in this way, the same Seed of Corruption that triggered the proc also consumes one stack of Succulent Souls almost instantly. Furthermore, if the Succulent Souls buff is consumed after this (that is, if it only had one stack when it was consumed in this way), the Succulent Soul consumed in this way does not activate its effects (it deals no damage and has no chance to summon a Manifested Avarice). Multiple other scenarios have been tested, such as consuming the proc with different spenders, testing with varying numbers of stacks, and testing to consume Succulent Souls with Seed of Corruptions normally (without Nightfall proc); and this is the only scenario where this issue has been detected. This behavior has been replicated in SimC.

## Mayhem

Mayhem havoc proc has been tested. It is known (and is in the spell data) that it has an ICD of 5.1 seconds. But outside of the ICD, we don't know what type of RNG it follows. After the tests, it has been determined that the RNG when not in ICD is Flat 35%. Furthermore, it has been observed that it can proc with the extra hits from Havoc (although it almost never happens due to the ICD), but cannot proc with the extra hits from FnB. The flat 35% chance and this behavior is already modeled this way in SimC, so there's no need to modify it.

Logs:
- https://www.warcraftlogs.com/reports/YmGN79Adr1bFnytq?fight=1&type=auras&hostility=1&spells=debuffs&ability=80240&target=6

This is the histogram for the distance between procs:
<img width="459" height="258" alt="hist_MH1_attemptdist_1_25" src="https://github.com/user-attachments/assets/3d157ec7-4b2a-40cb-9013-eb76f4d19dd3" />

ECDF distance between procs
<img width="459" height="258" alt="compare_ecdf_Mayhem_MH1_vs_flat_prd" src="https://github.com/user-attachments/assets/ec5d2f54-ca08-426c-bc03-5d3716e89829" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="459" height="258" alt="compare_hazard_Mayhem_MH1_vs_flat_prd" src="https://github.com/user-attachments/assets/c834f1f7-d482-4ec0-890b-d40190e5702f" />

Tail / survival of the distance between procs (log scale):
<img width="459" height="258" alt="compare_survival_Mayhem_MH1_vs_flat_prd_log" src="https://github.com/user-attachments/assets/5d15a0b9-d5fc-49f7-bb6f-c7d7a54a90b8" />

## Fiendish Cruelty

Fiendish Cruelty RNG has been tested. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 10%. That corresponds to a PRD constant C = 0.014745844781072676. It has been proven that Incinerate FnB crits can trigger Fiendish Cruelty, and the same for Havoc extra hits (if they crit). Infernal Bolt crits can also trigger Fiendish Cruelty.

Logs:
- https://www.warcraftlogs.com/reports/YmGN79Adr1bFnytq?fight=1&type=auras&source=6&ability=1245664&eventstart=9097989

This is the histogram for the distance between procs:
<img width="459" height="255" alt="hist_sampleFC_interproc_1_30" src="https://github.com/user-attachments/assets/bb6f7ddd-7636-4a79-b1b3-ee70d5b1c7ae" />

ECDF distance between procs
<img width="459" height="255" alt="compare_ecdf_FC_vs_flat_prd_agony" src="https://github.com/user-attachments/assets/965dbd85-a5a8-48ed-92d7-e11ccb6dcf77" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="459" height="255" alt="compare_hazard_FC_vs_flat_prd_agony" src="https://github.com/user-attachments/assets/00521ecb-6a88-4211-af10-7874b7d91e83" />

Tail / survival of the distance between procs (log scale):
<img width="459" height="255" alt="compare_survival_FC_vs_flat_prd_agony_log" src="https://github.com/user-attachments/assets/2fe30292-8d24-4a47-9a14-0f1522da1304" />

## Chaotic Inferno

Chaotic Inferno RNG has been tested. Analysis suggests the samples correspond to an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 25%. That corresponds to a PRD constant C = 0.084744091852316990. 

Logs:
- https://www.warcraftlogs.com/reports/YmGN79Adr1bFnytq?fight=1&type=auras&source=6&ability=1244860

This is the histogram for the distance between procs:
<img width="459" height="255" alt="hist_sampleCI_interproc_1_20" src="https://github.com/user-attachments/assets/ae03a0e5-8d7b-409a-a3ea-91c2e96cc34b" />

ECDF distance between procs
<img width="459" height="255" alt="compare_ecdf_CI_vs_flat_prd_agony" src="https://github.com/user-attachments/assets/8a1c91dd-3e08-4713-b84f-3e360c9a8fd3" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="459" height="255" alt="compare_hazard_CI_vs_flat_prd_agony" src="https://github.com/user-attachments/assets/40ffb903-e4b3-4566-930f-dab7d8f9fc48" />

Tail / survival of the distance between procs (log scale):
<img width="459" height="255" alt="compare_survival_CI_vs_flat_prd_agony_log" src="https://github.com/user-attachments/assets/a4ad0d7e-4bdc-447a-bab9-ff0b7f34d6d4" />

## Rain of Chaos

The Rain of Chaos RNG had been determined in the past to most likely be a 3-out-of-20 Deck of Cards. We've conducted several tests to confirm this, and it has indeed been verified that this RNG follows a 3-out-of-20 Deck of Cards RNG model. Additionally, we confirm each shard spent (during Infernal) is an individual event (therefore, spells that consume multiple shards, such as RoF, roll several consecutive events). Spells that normally cost shards, if they are free due to a talent/buff and therefore they not consume shards, do not count as an event (only the explicit spending of a shard counts as an event). We can also confirm that the Deck of Cards only advances with shard spends within the Infernal window (those shards spent outside do not count and do not advance the deck). This is already modeled exactly this way in SimC, so no changes are necessary.

Logs:
- https://www.warcraftlogs.com/reports/LdrCjGc21m7hZVRJ?fight=1&type=summons&source=1
- https://www.warcraftlogs.com/reports/XxdyhVpb2CBFgD8a?fight=last&type=summons&source=1
- https://www.warcraftlogs.com/reports/JWTFkGACB3rdRDxb?fight=last&type=summons&source=1

## Dimensional Rift & Avatar of Destruction

Dimensional Rift has been tested, both as a only-talent and in conjunction with Avatar of Destruction. Two different RNG are involved here. The first is the 10% chance of CB and SB to open a Dimensional Rift, as is indicated in the talent description. The second RNG determines the type of portal that will open (or whether an Overfiend will be summoned instead, if Avatar of Destruction is used).

The first RNG, after analysis of the tests, corresponds to a nominal PRD of 10%. This corresponds to a PRD constant C = 0.014745844781072676.

The second RNG is different. The portal summoned by Dimensional Rift is chosen from a `2/2/2 Deck of Cards out of 6` (`SHADOWY_TEAR, SHADOWY_TEAR, UNSTABLE_TEAR, UNSTABLE_TEAR, CHAOS_TEAR, CHAOS_TEAR`); this is without Avatar of Destruction talent. Here, we're not talking about a typical Deck of Cards RNG with non-proc cards; we're talking about a deck with summon types, and the chosen one determines which pet is summoned. With the Avatar of Destruction talent, this is modified to a `2/2/2/1 Deck of Cards out of 7` (`SHADOWY_TEAR, SHADOWY_TEAR, UNSTABLE_TEAR, UNSTABLE_TEAR, CHAOS_TEAR, CHAOS_TEAR, OVERFIEND`). This way, if we take blocks of 6 procs (7 with Avatar of Destruction), the same 6/7 procs will always occur (what varies is their order within its block). The average chance of Overfiend with Avatar of Destruction is then 14.2857% (1 out of 7). This RNG has been implemented in SimC so that it works as observed.

Logs:
- https://www.warcraftlogs.com/reports/YnBV2H9ZwGtWrmzh?fight=3&source=3&type=summons&pins=2%24Off%24%23244F4B%24summons%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24394243%7C394235%7C387979
- https://www.warcraftlogs.com/reports/YmGN79Adr1bFnytq?fight=1&type=summons&source=6&pins=2%24Off%24%23244F4B%24summons%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24394243%7C394235%7C387979

## Alythesss Ire

After extensive testing, we observed that Alythess's Ire procs at a fixed interval of attempts (1 proc every 5 RoF casts, following the `0-0-0-0-1` pattern), matching the 20% average rate indicated in the description. However, there is a small detail: rarely, the cycle shifts and advances the next proc a random offset; testing suggests this happens randomly in roughly ~1% of procs. It has been observed to happen in a very short period after other, and on other occasions it takes a long time to occur, so it seems somewhat random. We model this behavior by giving every proc a 1% flat chance to shift the next proc a random offset (this will always advance the next proc, never delay it, just as it happens in-game).

Logs:
- https://www.warcraftlogs.com/reports/8TxNFpRG1Jbh7Zgq?fight=1&type=auras&source=1&ability=1244947
- https://www.warcraftlogs.com/reports/2Nq8FxBJvz6aGQpC?fight=last&type=auras&ability=1244947

## Embers of Nihilam I (Echo of Sargeras)

The proc from Embers of Nihilam (rank 1), which is triggered by Incinerate, has been tested. This proc does not have an ICD (not to be confused with Embers of Nihilam rank 3, which has 0.5s ICD), and it has been verified that both Incinerate and Infernal Bolt can trigger it. Furthermore, it has been verified that both the extra hits from Incinerate FnB and Havoc can also trigger the proc. After analysis, it has been determined that this chance is 10% (which was already set in SimC), but following an accumulator PRD model with a nominal rate of 10%, which corresponds to a C = 0.014745844781072676.

Logs:
- https://www.warcraftlogs.com/reports/2Nq8FxBJvz6aGQpC?fight=last&type=damage-done&source=1&ability=1265884&target=3

This is the histogram for the distance between procs:
<img width="450" height="216" alt="ECHO1_observed_gap_histogram_range1_30" src="https://github.com/user-attachments/assets/f4b20278-77b7-4fcf-9ec7-4ceff06e2dbd" />

ECDF distance between procs
<img width="450" height="216" alt="ECHO1_ECDF_gap_comparison_observed_vs_sims_max30" src="https://github.com/user-attachments/assets/18f0d63e-389c-4809-9a82-69b2ac9f02ff" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="450" height="216" alt="ECHO1_Hazard_by_attempt_comparison_observed_vs_sims_max20" src="https://github.com/user-attachments/assets/d6288621-3af5-482a-89e2-46dcc0747309" />

Tail / survival of the distance between procs (log scale):
<img width="450" height="216" alt="ECHO1_Survival_tail_logscale_comparison_observed_vs_sims_max30" src="https://github.com/user-attachments/assets/1df763b6-164a-4d41-a7ad-42b36a75d1e4" />

## Demonic Knowledge

After extensive testing, we've observed that the 8% (rank 1) and 15% (rank 2) chances stated in the description and spell data are not being met. The average is 12.5% ​​(rank 1) and 22.5% (rank 2). We've discovered that internally, a Deck of Cards with 10 out of 80 cards is being used for rank 1 and a deck of cards with 18 out of 80 cards for rank 2, which explains the observed percentages.

Logs:
- https://www.warcraftlogs.com/reports/6bxkFQd4DjnwHrc8?fight=last&type=casts&source=1&ability=105174
- https://www.warcraftlogs.com/reports/CpN2YdqtJfTH9Gmn?fight=last&type=casts&source=1&ability=105174
- https://www.warcraftlogs.com/reports/dr3qGA8MhQLzaHg2?fight=last&type=casts&source=3&ability=105174

There are exactly 18 procs for every 80 HoG casts (for DK r2), and 10 procs for every 80 HoG casts (for DK r1). This holds true for over 60+ blocks of 80 HoG casts for each log. This has allowed us to confirm that the Deck of Cards model is being used. Internally, within each block, the distribution of procs appears completely random (the card shuffling seems uniform), as can be seen in the following heatmap:
<img width="640" height="320" alt="DK_R1_1_heatmap_proc_positions_inside_80_cast_blocks" src="https://github.com/user-attachments/assets/26a5351d-6607-4e90-9aa0-984a3763caed" />

## Carnivorous Stalkers

After some testing, it was found that the type of RNG used by this proc is Flat %, and that the observed average chance matches its description and the spell data. This is already correctly implemented in SimC and no changes are needed.

Logs:
- https://www.warcraftlogs.com/reports/6bxkFQd4DjnwHrc8?fight=last&type=damage-done&source=1&ability=-104316
- https://www.warcraftlogs.com/reports/CpN2YdqtJfTH9Gmn?fight=last&type=damage-done&source=1&ability=-104316
- https://www.warcraftlogs.com/reports/dr3qGA8MhQLzaHg2?fight=last&type=damage-done&source=3&ability=-104316

This is the histogram for the distance between procs:
<img width="570" height="312" alt="FS_Dreadbite_observed_gap_hist_1to30" src="https://github.com/user-attachments/assets/0622ee49-2185-47fe-878c-6d672b55b060" />

ECDF distance between procs
<img width="570" height="312" alt="FS_Dreadbite_ECDF_gaps_observed_vs_simulations_max30" src="https://github.com/user-attachments/assets/0fefa06e-6867-4556-b590-cc916d5efe0d" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="570" height="312" alt="FS_Dreadbite_Hazard_by_attempt_observed_vs_simulations_max30" src="https://github.com/user-attachments/assets/2a86f1f4-70c6-49a3-a890-ca8da130ae9b" />

Tail / survival of the distance between procs (log scale):
<img width="570" height="312" alt="FS_Dreadbite_Survival_tail_logscale_observed_vs_simulations_max30" src="https://github.com/user-attachments/assets/20d8c72c-0365-4d90-abf7-a884c4b83ad7" />

## Infernal Rapidity

Although the description and spell data state that the chance of Infernal Rapidity is 10%, our tests yield a consistent average chance of approximately ~4.8%-5.1%, so we assume the actual chance is 5%, half of what is stated. The RNG model for this proc is Flat %.

Logs:
- https://www.warcraftlogs.com/reports/6bxkFQd4DjnwHrc8?fight=last&type=damage-done&ability=104318&source=1
- https://www.warcraftlogs.com/reports/CpN2YdqtJfTH9Gmn?fight=last&type=damage-done&ability=104318&source=1
- https://www.warcraftlogs.com/reports/yrZjCV9pMBcAPHqd?fight=last&type=damage-done&source=1&ability=-104317

This is the histogram for the distance between procs:
<img width="570" height="312" alt="FBLT_observed_gap_hist_1to100" src="https://github.com/user-attachments/assets/42092230-68dc-41aa-8c18-1906ba9e3c10" />

ECDF distance between procs
<img width="570" height="312" alt="FBLT_ECDF_gaps_observed_vs_simulations_max100" src="https://github.com/user-attachments/assets/60a68272-0f3a-460c-81d3-3b3fb3f0aee7" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="570" height="312" alt="FBLT_Hazard_by_attempt_observed_vs_simulations_max100" src="https://github.com/user-attachments/assets/35103bb4-9c2d-4928-b766-fbe21791f930" />

Tail / survival of the distance between procs (log scale):
<img width="570" height="312" alt="FBLT_Survival_tail_logscale_observed_vs_simulations_max100" src="https://github.com/user-attachments/assets/fa80a1fd-6bed-4d0c-9eb7-e1e8f30e0cf1" />

## Spiteful Reconstitution

Analysis of the Spiteful Reconstitution proc suggests that it uses an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 10%. This corresponds to a PRD constant C = 0.014745844781072676. Furthermore, it appears to have a hard cap on the 21st attempt, which has a 100% chance. We implemented this behavior in SimC, where, in addition to using Flat %, the chance of this proc was set to 30%.

Logs:
- https://www.warcraftlogs.com/reports/CpN2YdqtJfTH9Gmn?fight=last&type=summons&source=1&ability=279910
- https://www.warcraftlogs.com/reports/dr3qGA8MhQLzaHg2?fight=last&type=summons&source=3&ability=279910

This is the histogram for the distance between procs:
<img width="570" height="312" alt="SRT1SRT2_observed_gap_hist_1to30" src="https://github.com/user-attachments/assets/ddf68cc7-333a-4e81-9dbf-9f7ee0ba2cb5" />

ECDF distance between procs
<img width="570" height="312" alt="SRT1SRT2_ECDF_gaps_observed_vs_simulations_max30" src="https://github.com/user-attachments/assets/ec777489-b8be-456e-a973-35139cc27851" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="570" height="312" alt="SRT1SRT2_Hazard_by_attempt_observed_vs_simulations_max30" src="https://github.com/user-attachments/assets/66860618-f893-4358-8038-b9b5713b1df5" />

## Demoniac (Wild Imps)

According to the Demoniac description, Wild Imps have a 10% chance each to grant a Demonic Core when they die or go away. We have tested this, and it holds true when they implode. We have also tested imploding them using the Sataiel's Volition hero talent, which should raise the chance to 15%, and this is indeed working correctly in our tests. Furthermore, we have tested that the RNG type used in these cases is Flat %.

However, Wild Imps that vanish normally (either over time or after casting their six bolts) seem to have a much lower chance of granting a Demonic Core. We assume this is a bug, but currently, Wild Imps demised in this way (not imploded) only have about a ~2% chance per imp to provide a Demonic Core (following a Flat % RNG model). Since it's a proc  with such a low chance, obtaining more samples would be advisable to achieve more accurate results; but for now we're setting it at 2%, which seems close to what we've observed. As this is one of the main passives of Demonology, we recommend periodically checking if this bug has been fixed.

Logs:
- (Implosion) https://www.warcraftlogs.com/reports/gDARtLjBh3d6Gbmk?fight=last&source=1&type=damage-done&ability=196278&target=3
- (Implosion) https://www.warcraftlogs.com/reports/Nxjtk6bT1QRyDfHh?boss=-3&difficulty=0&type=damage-done&source=1&ability=196278&target=3
- https://www.warcraftlogs.com/reports/6bxkFQd4DjnwHrc8?fight=last&type=auras&source=1&ability=264173
- https://www.warcraftlogs.com/reports/CpN2YdqtJfTH9Gmn?fight=last&type=auras&source=1&ability=264173
- https://www.warcraftlogs.com/reports/Nxjtk6bT1QRyDfHh?boss=-3&difficulty=0&type=auras&source=1&ability=264173

This is the histogram for the distance between procs:
<img width="484" height="242" alt="DEMWI1_histogram_distance_between_procs_1_300" src="https://github.com/user-attachments/assets/0edf478b-48cd-42c0-b47b-3cde754566ef" />

ECDF distance between procs
<img width="484" height="264" alt="DEMWI1_vs_sims_ECDF_distance_between_procs" src="https://github.com/user-attachments/assets/9726f225-ce0f-4d1a-bee8-96241bbbc32d" />

Hazard per attempt (probability of success on attempt n since the last attempt)
<img width="484" height="264" alt="DEMWI1_vs_sims_HAZARD_per_attempt" src="https://github.com/user-attachments/assets/b351184a-fbc6-4889-807d-b0e65f2f3c4d" />

Tail / survival of the distance between procs (log scale):
<img width="484" height="264" alt="DEMWI1_vs_sims_SURVIVAL_log_distance_between_procs" src="https://github.com/user-attachments/assets/514cee99-9897-4c1e-9364-254995f1f4a4" />
