### PR TITLE
[Havoc] Preemptive Strike procs on Furious Throws glaive

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -8180,6 +8180,11 @@ struct throw_glaive_t : public demon_hunter_attack_t
     if ( hit_any_target && furious_throws )
     {
       make_event<delayed_execute_event_t>( *sim, p(), furious_throws, target, 400_ms );
+
+      if ( p()->active.preemptive_strike )
+      {
+        make_event<delayed_execute_event_t>( *sim, p(), p()->active.preemptive_strike, target, 400_ms );
+      }
     }
 
     if ( td( target )->debuffs.serrated_glaive->up() )


### PR DESCRIPTION
Preemptive Strike wasn't proccing on the Furious Throws extra glaive from Screaming Brutality auto glaives. The main throw glaive correctly triggered Preemptive Strike (immediate), but the Furious Throws glaive (delayed 400ms) did not.

Fixed by scheduling a delayed Preemptive Strike event alongside the Furious Throws delayed event in `throw_glaive_t::execute()`.

Affects all throw glaive sources (manual cast + all 3 Screaming Brutality paths: blade dance, death sweep, slash proc).

### Verified in-game

Every individual glaive (including Furious Throws) triggers Preemptive Strike on first hit (not bounces). For example, Blade Dance with Screaming Brutality + Furious Throws producing 2 secondary glaives yields 6 Preemptive Strike hits: primary glaive, FT from primary, secondary glaive 1, FT from secondary 1, secondary glaive 2, FT from secondary 2.

### Sim comparison (4 targets, Havoc Aldrachi Reaver, 5000 iterations)

| Metric | Before | After |
|---|---|---|
| Total DPS | 16,395,140 | 16,688,808 (+1.8%) |
| Preemptive Strike pDPS | 174,713 | 339,325 (~2x) |
| Preemptive Strike % of total | 1.07% | 2.03% |

### Exhaustive talent interaction testing

Ran debug sims across 18 talent combinations (PS, FT, SB, SG, SC individually, all pairs, key triples, and all together) to verify no duplicate procs or missing interactions.