### PR TITLE
[Warlock] New expression for main warlock dots

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -807,6 +807,163 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
       return this->time_to_imps( amt );
     } );
   }
+  else if ( splits.size() == 2 && splits[ 0 ] == "dot_refreshable_count" )
+  {
+    enum class refreshable_dot_e
+    {
+      INVALID = -1,
+      WITHER,
+      IMMOLATE,
+      CORRUPTION,
+      AGONY,
+      UA,
+      SOC
+    };
+
+    unsigned int action_id = 0;
+    refreshable_dot_e dot_sel = refreshable_dot_e::INVALID;
+    const auto& dot_name = splits[ 1 ];
+    if ( dot_name == "wither" )
+    {
+      if ( hero.wither.ok() )
+      {
+        dot_sel = refreshable_dot_e::WITHER;
+        action_id = hero.wither_direct->id();
+      }
+    }
+    else if ( dot_name == "immolate" )
+    {
+      if ( destruction() )
+      {
+        dot_sel = refreshable_dot_e::IMMOLATE;
+        action_id = warlock_base.immolate_old->id();
+      }
+    }
+    else if ( dot_name == "corruption" )
+    {
+      if ( affliction() )
+      {
+        dot_sel = refreshable_dot_e::CORRUPTION;
+        action_id = warlock_base.corruption->id();
+      }
+    }
+    else if ( dot_name == "agony" )
+    {
+      if ( affliction() )
+      {
+        dot_sel = refreshable_dot_e::AGONY;
+        action_id = talents.agony->id();
+      }
+    }
+    else if ( dot_name == "unstable_affliction" )
+    {
+      if ( affliction() )
+      {
+        dot_sel = refreshable_dot_e::UA;
+        action_id = talents.unstable_affliction->id();
+      }
+    }
+    else if ( dot_name == "seed_of_corruption" )
+    {
+      if ( affliction() )
+      {
+        dot_sel = refreshable_dot_e::SOC;
+        action_id = talents.seed_of_corruption->id();
+      }
+    }
+    else if ( dot_name == "immolate_or_wither" || dot_name == "wither_or_immolate" )
+    {
+      if ( hero.wither.ok() )
+      {
+        dot_sel = refreshable_dot_e::WITHER;
+        action_id = hero.wither_direct->id();
+      }
+      else if ( destruction() )
+      {
+        dot_sel = refreshable_dot_e::IMMOLATE;
+        action_id = warlock_base.immolate_old->id();
+      }
+    }
+    else if ( dot_name == "corruption_or_wither" || dot_name == "wither_or_corruption" )
+    {
+      if ( hero.wither.ok() )
+      {
+        dot_sel = refreshable_dot_e::WITHER;
+        action_id = hero.wither_direct->id();
+      }
+      else if ( affliction() )
+      {
+        dot_sel = refreshable_dot_e::CORRUPTION;
+        action_id = warlock_base.corruption->id();
+      }
+    }
+
+    action_t* action = nullptr;
+    if ( action_id != 0 )
+    {
+      for ( auto a : action_list )
+      {
+        if ( a->id == action_id )
+        {
+          action = a;
+          break;
+        }
+      }
+    }
+
+    return make_fn_expr( name_str, [ this, action, dot_sel, state = std::unique_ptr<action_state_t>() ]() mutable
+    {
+      size_t dot_refresh_targets = 0;
+
+      if ( !action || dot_sel == refreshable_dot_e::INVALID )
+        return dot_refresh_targets;
+
+      const auto& tl = action->target_list();
+      for ( auto t : tl )
+      {
+        warlock_td_t* tdata = get_target_data( t );
+
+        auto& dot = [ dot_sel, tdata ]() -> auto&
+        {
+          switch ( dot_sel )
+          {
+            case refreshable_dot_e::WITHER:
+              return tdata->dots.wither;
+            case refreshable_dot_e::IMMOLATE:
+              return tdata->dots.immolate;
+            case refreshable_dot_e::CORRUPTION:
+              return tdata->dots.corruption;
+            case refreshable_dot_e::AGONY:
+              return tdata->dots.agony;
+            case refreshable_dot_e::UA:
+              return tdata->dots.unstable_affliction;
+            case refreshable_dot_e::SOC:
+              return tdata->dots.seed_of_corruption;
+            default:
+              assert( false && "Unhandled refreshable_dot_e value" );
+              return tdata->dots.corruption;
+          }
+        }();
+
+        if ( dot == nullptr || !dot->is_ticking() )
+        {
+          dot_refresh_targets++;
+          continue;
+        }
+
+        if ( !state || state->action != dot->current_action )
+          state.reset( dot->current_action->get_state() );
+
+        dot->current_action->snapshot_state( state.get(), result_amount_type::DMG_OVER_TIME );
+        timespan_t new_duration = dot->current_action->composite_dot_duration( state.get() );
+
+        if ( dot->current_action->dot_refreshable( dot, new_duration ) )
+          dot_refresh_targets++;
+      }
+
+      return dot_refresh_targets;
+    } );
+  }
 
   return player_t::create_expression( name_str );
 }


### PR DESCRIPTION
New `dot_refreshable_count.<dot>` expression for warlock class that returns the number of valid targets with a dot in "refreshable" state (remember that "refreshable" also includes those who do not have the dot active).
Only the main dots were added: `Wither`, `Immolate`, `Corruption`, `Agony`, `Unstable Affliction`, and `Seed of Corruption`

The new expressions are the following:
- `dot_refreshable_count.wither`
- `dot_refreshable_count.immolate`
- `dot_refreshable_count.corruption`
- `dot_refreshable_count.agony`
- `dot_refreshable_count.unstable_affliction`
- `dot_refreshable_count.seed_of_corruption`
- `dot_refreshable_count.immolate_or_wither` (or `dot_refreshable_count.wither_or_immolate`)
- `dot_refreshable_count.corruption_or_wither` (or `dot_refreshable_count.wither_or_corruption`)

`dot_refreshable_count.immolate_or_wither` (and its alternative naming) for destruction spec is dynamic and will take into account the `wither` or `immolate` dot depending on whether `wither` hero talent is selected or not.
And the same applies to `dot_refreshable_count.corruption_or_wither` (and its alternative naming), but with `wither` or `corruption` for affliction spec.