### PR TITLE
[Warlock] Hellbent Commander behavior and npc_id for pets

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -226,6 +226,27 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   regen_caches[ CACHE_SPELL_HASTE ] = true;
 
   sim->register_heartbeat_event_callback( [ this ]( sim_t* ) {
+    // NOTE (2026-03-08): Wild Imps are currently bugged when updating Hellbent Commander stacks on demise.
+    // Hellbent Commander's stacks are updated to their correct value on each heartbeat update.
+    if ( bugs && talents.hellbent_commander.ok() )
+    {
+      const int expected_stacks = active_demon_count( !bugs );
+      const int current_stacks = buffs.hellbent_commander->check();
+
+      const int stack_diff = expected_stacks - current_stacks;
+      if ( stack_diff > 0 )
+        buffs.hellbent_commander->trigger( stack_diff );
+      else if (stack_diff < 0 )
+        buffs.hellbent_commander->decrement( std::abs( stack_diff ) );
+
+      if ( stack_diff != 0 )
+      {
+        this->sim->print_debug( "{} heartbeat event update {} buff stack number from stacks_before={} to stacks_after={}",
+                        this->name(), buffs.hellbent_commander->name(), current_stacks, expected_stacks );
+      }
+      assert( ( buffs.hellbent_commander->check() == expected_stacks ) && "Incorrent Demon Count for Hellbent Commander" );
+    }
+
     for ( auto pet : active_pets )
     {
       auto lock_pet = dynamic_cast<warlock_pet_t*>( pet );
@@ -820,7 +841,7 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
       SOC
     };
 
-    unsigned int action_id = 0;
+    unsigned action_id = 0;
     refreshable_dot_e dot_sel = refreshable_dot_e::INVALID;
     const auto& dot_name = splits[ 1 ];
     if ( dot_name == "wither" )
@@ -1240,7 +1261,7 @@ warlock::warlock_t::pets_t::pets_t( warlock_t* w )
     grimoire_imp_lords( "demonic_imp_lord", w ),
     grimoire_fel_ravagers( "demonic_fel_ravager", w ),
     wild_imps( "wild_imp", w ),
-    doomguards( "Doomguard", w ),
+    doomguards( "doomguard", w ),
     lady_sacrolash( "lady_sacrolash", w ),
     grand_warlock_alythess( "grand_warlock_alythess", w ),
     antoran_inquisitor( "antoran_inquisitor", w ),

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -267,7 +267,8 @@ public:
     // Demonology
     const spell_data_t* demonology_warlock; // Spec aura
     const spell_data_t* master_demonologist; // Demonology Mastery - Increased demon damage
-    const spell_data_t* wild_imp; // Data for pet summoning
+    const spell_data_t* wild_imp; // Data for pet summoning (HoG)
+    const spell_data_t* wild_imp_2; // Data for pet summoning (Inner Demons / Spiteful Reconstitution / To Hell and Back)
     const spell_data_t* fel_firebolt_2; // Still a separate spell (learned automatically). Reduces pet's energy cost
 
     // Destruction
@@ -474,13 +475,15 @@ public:
     player_talent_t doom;
     const spell_data_t* doom_debuff;
     const spell_data_t* doom_dmg;
-    player_talent_t hellbent_commander; // TODO: Hellbent Commander has some strange interactions, such as temporarily losing 6 stacks when 3 imps demise (implement this behavior?)
+    player_talent_t hellbent_commander;
     const spell_data_t* hellbent_commander_buff;
     player_talent_t grimoire_imp_lord;
     player_talent_t grimoire_fel_ravager;
     const spell_data_t* grimoire_of_service_buff;
     player_talent_t summon_vilefiend;
     const spell_data_t* vilefiend;
+    const spell_data_t* gloomhound;
+    const spell_data_t* charhound;
     const spell_data_t* bile_spit;
     const spell_data_t* headbutt;
 
@@ -501,6 +504,10 @@ public:
     player_talent_t dominion_of_argus_3;
     const spell_data_t* dominion_of_argus_1_buff;
     const spell_data_t* dominion_of_argus_3_gain;
+    const spell_data_t* doa_lady_sacrolash_summon;
+    const spell_data_t* doa_grand_warlock_alythess_summon;
+    const spell_data_t* doa_antoran_inquisitor_summon;
+    const spell_data_t* doa_antoran_jailer_summon;
 
     // Destruction
     player_talent_t chaos_bolt;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -2717,7 +2717,7 @@ using namespace helpers;
       {
         if ( p()->talents.spiteful_reconstitution.ok() && p()->spiteful_reconstitution_rng->trigger() )
         {
-          p()->warlock_pet_list.wild_imps.spawn( 1u );
+          p()->warlock_pet_list.wild_imps.spawn( p()->warlock_base.wild_imp_2->duration(), 1u );
           p()->procs.spiteful_reconstitution->occur();
         }
       }
@@ -2866,7 +2866,7 @@ using namespace helpers;
         unsigned new_imps = ( launch_counter / as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() ) ) * as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
         if ( new_imps > 0 )
         {
-          auto imps = p()->warlock_pet_list.wild_imps.spawn( new_imps );
+          auto imps = p()->warlock_pet_list.wild_imps.spawn( p()->warlock_base.wild_imp_2->duration(), new_imps );
           for ( auto imp : imps )
           {
             imp->buffs.imp_gang_boss->trigger();
@@ -3072,7 +3072,7 @@ using namespace helpers;
         unsigned new_imps = ( sac_counter / as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() ) ) * as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
         if ( new_imps > 0 )
         {
-          auto imps = p()->warlock_pet_list.wild_imps.spawn( new_imps );
+          auto imps = p()->warlock_pet_list.wild_imps.spawn( p()->warlock_base.wild_imp_2->duration(), new_imps );
           for ( auto imp : imps )
           {
             imp->buffs.imp_gang_boss->trigger();
@@ -3248,7 +3248,7 @@ using namespace helpers;
   struct summon_lady_sacrolash_t : public warlock_spell_t
   {
     summon_lady_sacrolash_t( std::string_view n, warlock_t* p )
-      : warlock_spell_t( n, p, p->find_spell( 1282501 ) )
+      : warlock_spell_t( n, p, p->talents.doa_lady_sacrolash_summon )
     {
       harmful = may_crit = false;
       background = not_a_proc = true;
@@ -3264,7 +3264,7 @@ using namespace helpers;
   struct summon_grand_warlock_alythess_t : public warlock_spell_t
   {
     summon_grand_warlock_alythess_t( std::string_view n, warlock_t* p )
-      : warlock_spell_t( n, p, p->find_spell( 1282502 ) )
+      : warlock_spell_t( n, p, p->talents.doa_grand_warlock_alythess_summon )
     {
       harmful = may_crit = false;
       background = not_a_proc = true;
@@ -3280,7 +3280,7 @@ using namespace helpers;
   struct summon_antoran_inquisitor_t : public warlock_spell_t
   {
     summon_antoran_inquisitor_t( std::string_view n, warlock_t* p )
-      : warlock_spell_t( n, p, p->find_spell( 1276283 ) )
+      : warlock_spell_t( n, p, p->talents.doa_antoran_inquisitor_summon )
     {
       harmful = may_crit = false;
       background = not_a_proc = true;
@@ -3296,7 +3296,7 @@ using namespace helpers;
   struct summon_antoran_jailer_t : public warlock_spell_t
   {
     summon_antoran_jailer_t( std::string_view n, warlock_t* p )
-      : warlock_spell_t( n, p, p->find_spell( 1276182 ) )
+      : warlock_spell_t( n, p, p->talents.doa_antoran_jailer_summon )
     {
       harmful = may_crit = false;
       background = not_a_proc = true;

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -29,7 +29,8 @@ namespace warlock
     // Demonology
     warlock_base.demonology_warlock = find_specialization_spell( "Demonology Warlock", WARLOCK_DEMONOLOGY ); // Should be ID 137044
     warlock_base.master_demonologist = find_mastery_spell( WARLOCK_DEMONOLOGY ); // Should be ID 77219
-    warlock_base.wild_imp = conditional_spell_lookup( warlock_base.demonology_warlock->ok(), 104317 ); // Contains pet summoning information
+    warlock_base.wild_imp = conditional_spell_lookup( warlock_base.demonology_warlock->ok(), 104317 ); // Contains pet summoning information (HoG)
+    warlock_base.wild_imp_2 = conditional_spell_lookup( warlock_base.demonology_warlock->ok(), 279910 ); // Pet summoning information for Inner Demons, Spiteful Reconstitution and To Hell and Back
     warlock_base.fel_firebolt_2 = conditional_spell_lookup( warlock_base.demonology_warlock->ok(), 334591 ); // 20% cost reduction for Wild Imps
 
     // Destruction
@@ -338,9 +339,11 @@ namespace warlock
     talents.stabilized_portals = find_talent_spell( talent_tree::SPECIALIZATION, "Stabilized Portals" ); // Should be ID 1276661
 
     talents.mark_of_shatug = find_talent_spell( talent_tree::SPECIALIZATION, "Mark of Shatug" ); // Should be ID 455449
+    talents.gloomhound = conditional_spell_lookup( talents.mark_of_shatug.ok(), 455465 );
     talents.gloom_slash = conditional_spell_lookup( talents.mark_of_shatug.ok(), 455491 );
 
     talents.mark_of_fharg = find_talent_spell( talent_tree::SPECIALIZATION, "Mark of F'harg" ); // Should be ID 455450
+    talents.charhound = conditional_spell_lookup( talents.mark_of_fharg.ok(), 455476 );
     talents.infernal_presence = conditional_spell_lookup( talents.mark_of_fharg.ok(), 428453 );
     talents.infernal_presence_dmg = conditional_spell_lookup( talents.mark_of_fharg.ok(), 428455 );
 
@@ -349,6 +352,10 @@ namespace warlock
     talents.dominion_of_argus_3 = find_talent_spell( talent_tree::SPECIALIZATION, "Dominion of Argus", 3 ); // Should be ID 1276222 (III)
     talents.dominion_of_argus_1_buff = conditional_spell_lookup( talents.dominion_of_argus_1.ok(), 1276166 );
     talents.dominion_of_argus_3_gain = conditional_spell_lookup( talents.dominion_of_argus_3.ok(), 1276318 );
+    talents.doa_lady_sacrolash_summon = conditional_spell_lookup( talents.dominion_of_argus_1.ok(), 1282501 );
+    talents.doa_grand_warlock_alythess_summon = conditional_spell_lookup( talents.dominion_of_argus_1.ok(), 1282502 );
+    talents.doa_antoran_inquisitor_summon = conditional_spell_lookup( talents.dominion_of_argus_1.ok(), 1276283 );
+    talents.doa_antoran_jailer_summon = conditional_spell_lookup( talents.dominion_of_argus_1.ok(), 1276182 );
 
     // Additional Tier Set spell data
     tier.wl_demonology_12_0_class_set_2pc = sets->set( WARLOCK_DEMONOLOGY, MID1, B2 ); // Should be ID 1264871
@@ -736,7 +743,7 @@ namespace warlock
                              ->set_tick_time_behavior( buff_tick_time_behavior::UNHASTED )
                              ->set_tick_zero( true )
                              ->set_tick_callback( [ this ]( buff_t*, int, timespan_t ) {
-                               warlock_pet_list.wild_imps.spawn();
+                               warlock_pet_list.wild_imps.spawn( warlock_base.wild_imp_2->duration(), 1u );
                              } );
 
     buffs.tyrants_oblation = make_buff( this, "tyrants_oblation", talents.tyrants_oblation_buff )

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -9,6 +9,7 @@ namespace warlock
 warlock_pet_t::warlock_pet_t( warlock_t* owner, util::string_view pet_name, pet_e pt, bool guardian )
   : pet_t( owner->sim, owner, pet_name, pt, guardian ),
     affected_by(),
+    triggers(),
     special_action( nullptr ),
     melee_attack( nullptr ),
     summon_stats( nullptr ),
@@ -19,6 +20,7 @@ warlock_pet_t::warlock_pet_t( warlock_t* owner, util::string_view pet_name, pet_
   owner_coeff.health = 0.5;
 
   affected_by.demonic_brutality = owner->talents.demonic_brutality.ok();
+  triggers.hellbent_commander = owner->talents.hellbent_commander.ok();
 
   register_on_arise_callback( this, [ owner ]() { owner->n_active_pets++; } );
   register_on_demise_callback( this, [ owner ]( const player_t* ) { owner->n_active_pets--; } );
@@ -199,11 +201,10 @@ void warlock_pet_t::arise()
 
   pet_t::arise();
 
-  // NOTE: 2026-02-17 Diabolist guardians do not count towards Hellbent Commander, but they do benefit from its damage increase (bug?)
-  if ( o()->talents.hellbent_commander.ok() && ( !bugs || !is_diabolist_guardian ) )
+  if ( triggers.hellbent_commander )
   {
     o()->buffs.hellbent_commander->trigger();
-    assert( ( o()->buffs.hellbent_commander->check() == o()->active_demon_count( !bugs ) ) && "Incorrent Demon Count for Hellbent Commander" );
+    assert( ( bugs || o()->buffs.hellbent_commander->check() == o()->active_demon_count( !bugs ) ) && "Incorrent Demon Count for Hellbent Commander" );
   }
 }
 
@@ -211,8 +212,7 @@ void warlock_pet_t::demise()
 {
   if ( !current.sleeping )
   {
-    // NOTE: 2026-02-17 Diabolist guardians do not count towards Hellbent Commander, but they do benefit from its damage increase (bug?)
-    if ( o()->talents.hellbent_commander.ok() && ( !bugs || !is_diabolist_guardian ) )
+    if ( triggers.hellbent_commander )
     {
       o()->buffs.hellbent_commander->decrement();
     }
@@ -223,7 +223,7 @@ void warlock_pet_t::demise()
   if ( melee_attack )
     melee_attack->reset();
 
-  assert( ( !o()->talents.hellbent_commander.ok() || o()->buffs.hellbent_commander->check() == o()->active_demon_count( !bugs ) ) && "Incorrent Demon Count for Hellbent Commander" );
+  assert( ( bugs || !o()->talents.hellbent_commander.ok() || o()->buffs.hellbent_commander->check() == o()->active_demon_count( !bugs ) ) && "Incorrent Demon Count for Hellbent Commander" );
 }
 
  // TODO: Add all pet spells to base warlock data
@@ -263,6 +263,8 @@ namespace base
 felhunter_pet_t::felhunter_pet_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_FELHUNTER, false )
 {
+  npc_id = owner->find_spell( 691 )->effectN( 1 ).misc_value1();
+
   action_list_str = "travel/shadow_bite";
 
   is_main_pet = true;
@@ -308,6 +310,8 @@ action_t* felhunter_pet_t::create_action( util::string_view name, util::string_v
 imp_pet_t::imp_pet_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_IMP, false ), firebolt_cost( find_spell( 3110 )->cost( POWER_ENERGY ) )
 {
+  npc_id = owner->find_spell( 688 )->effectN( 1 ).misc_value1();
+
   action_list_str = "firebolt";
 
   owner_coeff.ap_from_sp = 0.625;
@@ -348,6 +352,8 @@ timespan_t imp_pet_t::available() const
 sayaad_pet_t::sayaad_pet_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_SAYAAD, false )
 {
+  npc_id = owner->find_spell( 366222 )->effectN( 1 ).misc_value1();
+
   action_list_str = "travel/whiplash/lash_of_pain";
 
   is_main_pet = true;
@@ -404,6 +410,8 @@ action_t* sayaad_pet_t::create_action( util::string_view name, util::string_view
 voidwalker_pet_t::voidwalker_pet_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_VOIDWALKER, false )
 {
+  npc_id = owner->find_spell( 697 )->effectN( 1 ).misc_value1();
+
   action_list_str = "travel/consuming_shadows";
 
   is_main_pet = true;
@@ -452,6 +460,8 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
     min_energy_threshold( find_spell( 89751 )->cost( POWER_ENERGY ) ),
     max_energy_threshold( 100 )
 {
+  npc_id = owner->talents.summon_felguard->effectN( 1 ).misc_value1();
+
   action_list_str = "travel";
 
   if ( !owner->disable_auto_felstorm )
@@ -612,8 +622,13 @@ action_t* felguard_pet_t::create_action( util::string_view name, util::string_vi
 /// Wild Imp Begin
 
 wild_imp_pet_t::wild_imp_pet_t( warlock_t* owner )
-  : warlock_pet_t( owner, "wild_imp", PET_WILD_IMP, true ), firebolt( nullptr ), power_siphon( false ), imploded( false )
+  : warlock_pet_t( owner, "wild_imp", PET_WILD_IMP, true ), firebolt( nullptr ), is_hog_imp( true ), power_siphon( false ), imploded( false )
 {
+  npc_id = owner->warlock_base.wild_imp->effectN( 1 ).misc_value1();
+
+  // Manually handle the Wild Imps contribution to Hellbent Commander to replicate its bugged behavior
+  triggers.hellbent_commander &= !bugs;
+
   resource_regeneration = regen_type::DISABLED;
   owner_coeff.health = 0.15;
 }
@@ -745,6 +760,7 @@ void wild_imp_pet_t::arise()
 {
   warlock_pet_t::arise();
 
+  is_hog_imp = ( duration == o()->warlock_base.wild_imp->duration() ); // TODO: Only valid because duration diff, look for a safer way
   power_siphon = false;
   imploded = false;
   o()->buffs.wild_imps->trigger();
@@ -757,6 +773,10 @@ void wild_imp_pet_t::arise()
         t->buffs.demonic_power->trigger();
     }
   }
+
+  // Manual handling of Hellbent Commander buff for Wild Imps
+  if ( bugs && o()->talents.hellbent_commander.ok() )
+    o()->buffs.hellbent_commander->trigger();
 
   // Start casting fel firebolts
   firebolt->set_target( o()->target );
@@ -808,6 +828,29 @@ void wild_imp_pet_t::demise()
         o()->procs.demonic_core_imps->occur();
     }
 
+    // Manual handling of Hellbent Commander buff for Wild Imps
+    // NOTE (2026-03-08): Wild Imps are currently bugged when updating Hellbent Commander stacks on demise:
+    // If imploded, imps summoned via HoG decrease one stack each, while those summoned via Inner Demons,
+    // Spiteful Reconstitution, or To Hell and Back do not decrease any stacks.
+    // If the imps demise normally or are sacrificed with Power Siphon, HoG imps decrease two stacks each,
+    // while all other imps decrease one stack each.
+    // Hellbent Commander's stacks are updated to their correct value on each heartbeat update.
+    if ( bugs && o()->talents.hellbent_commander.ok() )
+    {
+      if ( imploded )
+      {
+        if ( is_hog_imp )
+          o()->buffs.hellbent_commander->decrement();
+      }
+      else
+      {
+        if ( is_hog_imp )
+          o()->buffs.hellbent_commander->decrement( 2 );
+        else
+          o()->buffs.hellbent_commander->decrement();
+      }
+    }
+
     if ( expiration )
       event_t::cancel( expiration );
   }
@@ -832,6 +875,8 @@ double wild_imp_pet_t::composite_player_multiplier( school_e school ) const
 
 dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "dreadstalker", PET_DREADSTALKER, true )
 {
+  npc_id = owner->talents.call_dreadstalkers_2->effectN( 1 ).misc_value1();
+
   action_list_str = "leap/travel/dreadbite";
   resource_regeneration  = regen_type::DISABLED;
 
@@ -847,6 +892,8 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "drea
 dreadstalker_t::dreadstalker_t( warlock_t* owner, util::string_view pet_name, pet_e pet_type )
   : warlock_pet_t( owner, pet_name, pet_type, true )
 {
+  npc_id = owner->talents.call_dreadstalkers_2->effectN( 1 ).misc_value1();
+
   action_list_str = "leap/travel/dreadbite";
   resource_regeneration  = regen_type::DISABLED;
 
@@ -1101,6 +1148,21 @@ action_t* dreadstalker_t::create_action( util::string_view name, util::string_vi
 vilefiend_t::vilefiend_t( warlock_t* owner )
   : warlock_simple_pet_t( owner, "vilefiend", PET_VILEFIEND )
 {
+  if ( owner->talents.mark_of_shatug.ok() )
+  {
+    npc_id = owner->talents.gloomhound->effectN( 1 ).misc_value1();
+    npc_suffix = "vilefiend";
+  }
+  else if ( owner->talents.mark_of_fharg.ok() )
+  {
+    npc_id = owner->talents.charhound->effectN( 1 ).misc_value1();
+    npc_suffix = "vilefiend";
+  }
+  else
+  {
+    npc_id = owner->talents.vilefiend->effectN( 1 ).misc_value1();
+  }
+
   action_list_str = "bile_spit";
   action_list_str += "/travel";
   action_list_str += "/headbutt";
@@ -1272,6 +1334,8 @@ action_t* vilefiend_t::create_action( util::string_view name, util::string_view 
 demonic_tyrant_t::demonic_tyrant_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_DEMONIC_TYRANT, true )
 {
+  npc_id = owner->talents.summon_demonic_tyrant->effectN( owner->talents.antoran_armaments.ok() ? 4 : 1 ).misc_value1();
+
   resource_regeneration = regen_type::DISABLED;
   if ( o()->talents.antoran_armaments.ok() )
     action_list_str = "leap/travel/burning_cleave";
@@ -1379,6 +1443,8 @@ struct doom_bolt_volley_t : public warlock_pet_spell_t
 doomguard_t::doomguard_t( warlock_t* owner )
   : warlock_simple_pet_t( owner, "doomguard", PET_DOOMGUARD )
 {
+  npc_id = owner->talents.summon_doomguard->effectN( 1 ).misc_value1();
+
   action_list_str = "doom_bolt_volley";
 
   // 2026-02-17: Validated coefficients
@@ -1431,6 +1497,9 @@ grimoire_imp_lord_t::grimoire_imp_lord_t( warlock_t* owner )
   : warlock_pet_t( owner, "grimoire_imp_lord", PET_SERVICE_IMP ),
     max_energy_threshold( 125 )
 {
+  npc_id = owner->talents.grimoire_imp_lord->effectN( 2 ).misc_value1();
+  npc_suffix = "grimoire";
+
   action_list_str = "greater_felbolt,if=energy>=" + util::to_string( max_energy_threshold );
 }
 
@@ -1501,6 +1570,9 @@ grimoire_fel_ravager_t::grimoire_fel_ravager_t( warlock_t* owner )
   : warlock_pet_t( owner, "grimoire_fel_ravager", PET_SERVICE_FELHUNTER ),
     max_energy_threshold( 160 )
 {
+  npc_id = owner->talents.grimoire_fel_ravager->effectN( 2 ).misc_value1();
+  npc_suffix = "grimoire";
+
   action_list_str = "travel/abyssal_bite,if=energy>=" + util::to_string( max_energy_threshold );
 }
 
@@ -1646,6 +1718,8 @@ struct shadow_nova_t : public dominion_of_argus_spell_base_t
 lady_sacrolash_t::lady_sacrolash_t( warlock_t* owner )
   : dominion_of_argus_pet_t( owner, "lady_sacrolash", PET_LADY_SACROLASH )
 {
+  npc_id = owner->talents.doa_lady_sacrolash_summon->effectN( 1 ).misc_value1();
+
   owner_coeff.sp_from_sp = 1.0;
 }
 
@@ -1684,6 +1758,8 @@ struct blaze_missile_t : public dominion_of_argus_spell_base_t
 grand_warlock_alythess_t::grand_warlock_alythess_t( warlock_t* owner )
   : dominion_of_argus_pet_t( owner, "grand_warlock_alythess", PET_GRAND_WARLOCK_ALYTHESS )
 {
+  npc_id = owner->talents.doa_grand_warlock_alythess_summon->effectN( 1 ).misc_value1();
+
   owner_coeff.sp_from_sp = 1.0;
 }
 
@@ -1722,6 +1798,8 @@ struct mind_sear_channel_t : public dominion_of_argus_spell_base_t
 antoran_inquisitor_t::antoran_inquisitor_t( warlock_t* owner )
   : dominion_of_argus_pet_t( owner, "antoran_inquisitor", PET_ANTORAN_INQUISITOR )
 {
+  npc_id = owner->talents.doa_antoran_inquisitor_summon->effectN( 1 ).misc_value1();
+
   owner_coeff.sp_from_sp = 1.0;
 }
 
@@ -1777,6 +1855,8 @@ struct soul_barrage_cast_t : public dominion_of_argus_spell_base_t
 antoran_jailer_t::antoran_jailer_t( warlock_t* owner )
   : dominion_of_argus_pet_t( owner, "antoran_jailer", PET_ANTORAN_JAILER )
 {
+  npc_id = owner->talents.doa_antoran_jailer_summon->effectN( 1 ).misc_value1();
+
   owner_coeff.sp_from_sp = 1.0;
 }
 
@@ -1798,6 +1878,8 @@ namespace destruction
 infernal_t::infernal_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_INFERNAL, true ), immolation( nullptr )
 {
+  npc_id = owner->talents.summon_infernal_main->effectN( 1 ).misc_value1();
+
   resource_regeneration = regen_type::DISABLED;
 
   type = MAIN;
@@ -1892,6 +1974,9 @@ double infernal_t::composite_player_multiplier( school_e school ) const
 
 infernal_roc_t::infernal_roc_t( warlock_t* owner, util::string_view name ) : destruction::infernal_t( owner, name )
 {
+  npc_id = owner->talents.summon_infernal_roc->effectN( 1 ).misc_value1();
+  npc_suffix = "roc";
+
   type                   = RAIN;
   owner_coeff.ap_from_sp = 1.5;
   owner_coeff.sp_from_sp = 1.5;
@@ -1904,6 +1989,8 @@ infernal_roc_t::infernal_roc_t( warlock_t* owner, util::string_view name ) : des
 shadowy_tear_t::shadowy_tear_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
 {
+  npc_id = owner->talents.shadowy_tear_summon->effectN( 1 ).misc_value1();
+
   resource_regeneration = regen_type::DISABLED;
 
   action_list_str = "shadow_barrage";
@@ -1963,6 +2050,8 @@ action_t* shadowy_tear_t::create_action( util::string_view name, util::string_vi
 unstable_tear_t::unstable_tear_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
 {
+  npc_id = owner->talents.unstable_tear_summon->effectN( 1 ).misc_value1();
+
   resource_regeneration = regen_type::DISABLED;
 
   action_list_str = "chaos_barrage";
@@ -2019,6 +2108,8 @@ action_t* unstable_tear_t::create_action( util::string_view name, util::string_v
 chaos_tear_t::chaos_tear_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
 {
+  npc_id = owner->talents.chaos_tear_summon->effectN( 1 ).misc_value1();
+
   resource_regeneration = regen_type::DISABLED;
 
   action_list_str = "chaos_bolt";
@@ -2095,6 +2186,8 @@ action_t* chaos_tear_t::create_action( util::string_view name, util::string_view
 overfiend_t::overfiend_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_WARLOCK, true )
 {
+  npc_id = owner->talents.summon_overfiend->effectN( 1 ).misc_value1();
+
   resource_regeneration = regen_type::DISABLED;
 
   action_list_str = "chaos_bolt";
@@ -2158,6 +2251,8 @@ namespace affliction
 darkglare_t::darkglare_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_DARKGLARE, true )
 {
+  npc_id = owner->talents.summon_darkglare->effectN( 1 ).misc_value1();
+
   action_list_str += "eye_beam";
 }
 
@@ -2251,7 +2346,12 @@ namespace diabolist
   overlord_t::overlord_t( warlock_t* owner, util::string_view name )
     : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
   {
+    npc_id = owner->hero.summon_overlord->effectN( 1 ).misc_value1();
+
     is_diabolist_guardian = true;
+    affected_by.demonic_brutality = false;
+    // NOTE: 2026-02-17 Diabolist guardians do not count towards Hellbent Commander, but they do benefit from its damage increase (bug?)
+    triggers.hellbent_commander &= !bugs;
     resource_regeneration = regen_type::DISABLED;
 
     owner_coeff.ap_from_sp = 1.0;
@@ -2334,8 +2434,12 @@ namespace diabolist
   mother_of_chaos_t::mother_of_chaos_t( warlock_t* owner, util::string_view name )
     : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
   {
+    npc_id = owner->hero.summon_mother->effectN( 1 ).misc_value1();
+
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
+    // NOTE: 2026-02-17 Diabolist guardians do not count towards Hellbent Commander, but they do benefit from its damage increase (bug?)
+    triggers.hellbent_commander &= !bugs;
 
     action_list_str = "chaos_salvo";
   }
@@ -2414,8 +2518,12 @@ namespace diabolist
   pit_lord_t::pit_lord_t( warlock_t* owner, util::string_view name )
     : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
   {
+    npc_id = owner->hero.summon_pit_lord->effectN( 1 ).misc_value1();
+
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
+    // NOTE: 2026-02-17 Diabolist guardians do not count towards Hellbent Commander, but they do benefit from its damage increase (bug?)
+    triggers.hellbent_commander &= !bugs;
     resource_regeneration = regen_type::DISABLED;
 
     action_list_str = "felseeker";
@@ -2508,6 +2616,8 @@ namespace diabolist
   infernal_fragment_t::infernal_fragment_t( warlock_t* owner, util::string_view name )
     : destruction::infernal_t( owner, name )
   {
+    npc_id = owner->hero.infernal_fragmentation->effectN( 1 ).misc_value1();
+
     type = FRAG;
     owner_coeff.ap_from_sp = 1.5 * owner->hero.abyssal_dominion->effectN( 4 ).percent();
     owner_coeff.sp_from_sp = 1.5 * owner->hero.abyssal_dominion->effectN( 4 ).percent();
@@ -2520,6 +2630,8 @@ namespace diabolist
   diabolic_imp_t::diabolic_imp_t( warlock_t* owner, util::string_view name )
     : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true )
   {
+    npc_id = owner->hero.diabolic_imp->effectN( 1 ).misc_value1();
+
     resource_regeneration = regen_type::DISABLED;
 
     action_list_str = "diabolic_bolt";
@@ -2613,6 +2725,8 @@ struct soul_swipe_t : public soul_swipe_base_t
 rampaging_demonic_soul_t::rampaging_demonic_soul_t( warlock_t* owner, std::string_view name )
   : warlock_pet_t( owner, name, PET_WARLOCK_RANDOM, true ), summon_spell( nullptr )
 {
+  npc_id = owner->hero.manifested_avarice_spell->effectN( 1 ).misc_value1();
+
   resource_regeneration         = regen_type::DISABLED;
   affected_by.demonic_brutality = false;
   action_list_str               = "soul_swipe";

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -70,6 +70,11 @@ struct warlock_pet_t : public pet_t
     bool demonic_brutality;
   } affected_by;
 
+  struct triggers_t
+  {
+    bool hellbent_commander;
+  } triggers;
+
   action_t* special_action; // Used for pet interrupts (Axe Toss, Spell Lock)
   melee_attack_t* melee_attack;
   stats_t* summon_stats;
@@ -417,6 +422,7 @@ struct felguard_pet_t : public warlock_pet_t
 struct wild_imp_pet_t : public warlock_pet_t
 {
   action_t* firebolt;
+  bool is_hog_imp;
   bool power_siphon;
   bool imploded;
 


### PR DESCRIPTION
The corresponding `npc_id` has been added to each pet to improve the final reporting. In some cases where the NPC name alone could be confusing, an `npc_suffix` has also been added.

The correct duration has been set for each Wild Imp summon depending on its source summon spell.

The current bugged behavior of `Hellbent Commander` has been replicated in SimC:
- Diabolist pets do not contribute to the buff stacks (this was already implemented).
- The main bugged behavior of this buff are the stack increments/decrements from Wild Imps. Based on several observations, it currently behaves in-game as follows:
  - Wild Imps summoned via `Hand of Gul'dan` wrongly decrement 2 stacks each when they die normally or if sacrificed by `Power Siphon`. However, if they are imploded, they correctly decrement 1 stack each.
  - Wild Imps summoned via `Inner Demons`, `Spiteful Reconstitution`, or `To Hell and Back` correctly decrement 1 stack each when they die or are sacrificed by `Power Siphon`. However, if they are imploded, they wrongly do not decrement any stacks.
  - All Wild Imps correctly add 1 stack to the buff when they are summoned (although they only increment it, they do not update it to the correct value).
  - Periodically, on each game heartbeat, the buff is updated to its correct value.
- The rest of the Warlock pets behave correctly: they add 1 stack on arise and remove 1 stack when they die (though they only increment/decrement the stack value, they do not update it to the correct value).