### PR TITLE
[Warlock] Make action_state_t local in dot_refreshable_count expression

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -932,12 +932,14 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
       }
     }
 
-    return make_fn_expr( name_str, [ this, action, dot_sel, state = std::unique_ptr<action_state_t>() ]() mutable
+    return make_fn_expr( name_str, [ this, action, dot_sel ]()
     {
       size_t dot_refresh_targets = 0;
 
       if ( !action || dot_sel == refreshable_dot_e::INVALID )
         return dot_refresh_targets;
+
+      action_state_t* state = nullptr;
 
       const auto& tl = action->target_list();
       for ( auto t : tl )
@@ -973,14 +975,22 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
         }
 
         if ( !state || state->action != dot->current_action )
-          state.reset( dot->current_action->get_state() );
+        {
+          if ( state )
+            action_state_t::release( state );
 
-        dot->current_action->snapshot_state( state.get(), result_amount_type::DMG_OVER_TIME );
-        timespan_t new_duration = dot->current_action->composite_dot_duration( state.get() );
+          state = dot->current_action->get_state();
+        }
+
+        dot->current_action->snapshot_state( state, result_amount_type::DMG_OVER_TIME );
+        timespan_t new_duration = dot->current_action->composite_dot_duration( state );
 
         if ( dot->current_action->dot_refreshable( dot, new_duration ) )
           dot_refresh_targets++;
       }
+
+      if ( state )
+        action_state_t::release( state );
 
       return dot_refresh_targets;
     } );

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -3138,8 +3138,8 @@ void rangergenerals_call( special_effect_t& effect )
 
   effect.player->callbacks.register_callback_execute_function( effect.spell_id,
     [ damage, delay ]( auto, auto, const action_state_t* s ) {
-      make_event( *s->action->sim, delay, [ damage, s ] {
-        damage->execute_on_target( s->target );
+      make_event( *s->action->sim, delay, [ damage, t = s->target ] {
+        damage->execute_on_target( t );
       } );
     } );
 


### PR DESCRIPTION
In the warlock `dot_refreshable_count` expression, we were keeping a persistent `action_state_t` across evaluations, similar to how `refreshable` does for single-dot expressions. However, unlike `refreshable`, this expression operates on multiple dots across multiple targets. Because of that, it is better to use a local `state` and reuse it as much as possible within the iterations over the list of targets.

Additionally, letting `unique_ptr` delete the state is not the ideal way to handle an `action_state_t`. These objects are expected to follow the `get_state()` and `action_state_t::release()` lifecycle. Using `delete` instead of `release` does not follow this model and can also expose lifetime issues elsewhere if the same state is still being referenced incorrectly outside the expression.