### PR TITLE
[Warlock] Refactor proc RNG handling

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -152,7 +152,7 @@ void warlock_td_t::target_demise()
 
   if ( warlock.hero.demonic_soul.ok() && warlock.hero.feast_of_souls.ok() )
   {
-    if ( warlock.feast_of_souls_rng->trigger() )
+    if ( warlock.prd_rng.feast_of_souls->trigger() )
     {
       warlock.sim->print_log( "Player {} demised. Warlock {} triggers Feast of Souls.", target->name(), warlock.name() );
 
@@ -190,10 +190,6 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   : parse_player_effects_t( sim, WARLOCK, name, r ),
     havoc_target( nullptr ),
     havoc_spells(),
-    agony_accumulator( 0.0 ),
-    corruption_accumulator( 0.0 ),
-    alythesss_ire_counter( 0 ),
-    alythesss_ire_trigger( 0 ),
     diabolic_ritual( 0 ),
     demonic_art_buff_replaced( false ),
     n_active_pets( 0 ),
@@ -354,52 +350,6 @@ double warlock_t::composite_mastery() const
   return m;
 }
 
-double warlock_t::pseudo_random_p_from_c( double c ) const
-{
-  if ( c <= 0 )
-    return 0.0;
-
-  double p_proc_by_n       = 0;
-  double sum_n_p_proc_on_n = 0;
-
-  int max_fails = as<int>( std::ceil( 1 / c ) );
-  for ( int n = 1; n <= max_fails; ++n )
-  {
-    double p_proc_on_n = std::min( 1.0, n * c ) * ( 1 - p_proc_by_n );
-    p_proc_by_n += p_proc_on_n;
-    sum_n_p_proc_on_n += n * p_proc_on_n;
-  }
-
-  return ( 1 / sum_n_p_proc_on_n );
-}
-
-double warlock_t::pseudo_random_c_from_p( double p ) const
-{
-  if ( p <= 0 )
-    return 0.0;
-
-  double c_upper = p;
-  double c_lower = 0;
-  double c_mid;
-  double p2 = 1;
-  while ( true )
-  {
-    c_mid = ( c_upper + c_lower ) * 0.5;
-    double p1 = pseudo_random_p_from_c( c_mid );
-    if ( std::abs( p1 - p2 ) <= 1e-12 )
-      break;
-
-    if ( p1 > p )
-      c_upper = c_mid;
-    else
-      c_lower = c_mid;
-
-    p2 = p1;
-  }
-
-  return c_mid;
-}
-
 // Used to determine how many Wild Imps are waiting to be spawned from Hand of Guldan
 int warlock_t::get_spawning_imp_count()
 { return as<int>( wild_imp_spawns.size() ); }
@@ -526,27 +476,10 @@ std::string warlock_t::create_profile( save_e stype )
     if ( normalize_destruction_mastery )
       profile_str += "normalize_destruction_mastery=" + util::to_string( normalize_destruction_mastery ) + "\n";
 
-    profile_str += append_rng_option( rng_settings.cunning_cruelty_sb );
-    profile_str += append_rng_option( rng_settings.cunning_cruelty_ds );
-    profile_str += append_rng_option( rng_settings.agony );
-    profile_str += append_rng_option( rng_settings.nightfall );
-    profile_str += append_rng_option( rng_settings.spiteful_reconstitution );
-    profile_str += append_rng_option( rng_settings.spiteful_reconstitution_hard_cap );
-    profile_str += append_rng_option( rng_settings.demonic_knowledge_rank1_cards );
-    profile_str += append_rng_option( rng_settings.demonic_knowledge_rank2_cards );
-    profile_str += append_rng_option( rng_settings.alythesss_ire_shift );
-    profile_str += append_rng_option( rng_settings.echo_of_sargeras );
-    profile_str += append_rng_option( rng_settings.blackened_soul );
-    profile_str += append_rng_option( rng_settings.bleakheart_tactics );
-    profile_str += append_rng_option( rng_settings.seeds_of_their_demise );
-    profile_str += append_rng_option( rng_settings.mark_of_perotharn );
-    profile_str += append_rng_option( rng_settings.succulent_soul_aff );
-    profile_str += append_rng_option( rng_settings.succulent_soul_demo );
-    profile_str += append_rng_option( rng_settings.feast_of_souls_aff );
-    profile_str += append_rng_option( rng_settings.feast_of_souls_demo );
-    profile_str += append_rng_option( rng_settings.feast_of_souls_hard_cap_aff );
-    profile_str += append_rng_option( rng_settings.feast_of_souls_hard_cap_demo );
-    profile_str += append_rng_option( rng_settings.manifested_avarice );
+    rng_settings.for_each( [ this, &profile_str ]( auto& setting )
+    {
+      profile_str += append_rng_option( setting );
+    } );
   }
 
   return profile_str;
@@ -563,27 +496,7 @@ void warlock_t::copy_from( player_t* source )
   disable_auto_felstorm = p->disable_auto_felstorm;
   normalize_destruction_mastery = p->normalize_destruction_mastery;
 
-  rng_settings.cunning_cruelty_sb = p->rng_settings.cunning_cruelty_sb;
-  rng_settings.cunning_cruelty_ds = p->rng_settings.cunning_cruelty_ds;
-  rng_settings.agony = p->rng_settings.agony;
-  rng_settings.nightfall = p->rng_settings.nightfall;
-  rng_settings.spiteful_reconstitution = p->rng_settings.spiteful_reconstitution;
-  rng_settings.spiteful_reconstitution_hard_cap = p->rng_settings.spiteful_reconstitution_hard_cap;
-  rng_settings.demonic_knowledge_rank1_cards = p->rng_settings.demonic_knowledge_rank1_cards;
-  rng_settings.demonic_knowledge_rank2_cards = p->rng_settings.demonic_knowledge_rank2_cards;
-  rng_settings.alythesss_ire_shift = p->rng_settings.alythesss_ire_shift;
-  rng_settings.echo_of_sargeras = p->rng_settings.echo_of_sargeras;
-  rng_settings.blackened_soul = p->rng_settings.blackened_soul;
-  rng_settings.bleakheart_tactics = p->rng_settings.bleakheart_tactics;
-  rng_settings.seeds_of_their_demise = p->rng_settings.seeds_of_their_demise;
-  rng_settings.mark_of_perotharn = p->rng_settings.mark_of_perotharn;
-  rng_settings.succulent_soul_aff = p->rng_settings.succulent_soul_aff;
-  rng_settings.succulent_soul_demo = p->rng_settings.succulent_soul_demo;
-  rng_settings.feast_of_souls_aff = p->rng_settings.feast_of_souls_aff;
-  rng_settings.feast_of_souls_demo = p->rng_settings.feast_of_souls_demo;
-  rng_settings.feast_of_souls_hard_cap_aff = p->rng_settings.feast_of_souls_hard_cap_aff;
-  rng_settings.feast_of_souls_hard_cap_demo = p->rng_settings.feast_of_souls_hard_cap_demo;
-  rng_settings.manifested_avarice = p->rng_settings.manifested_avarice;
+  rng_settings = p->rng_settings;
 }
 
 stat_e warlock_t::convert_hybrid_stat( stat_e s ) const
@@ -705,8 +618,7 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
 
       // Seeks to return the average expected time for the player to generate a single soul shard.
       // TOCHECK regularly.
-
-      double average = 1.0 / ( ( rng_settings.agony.setting_value * 0.5 ) * std::pow( active_agonies, -2.0 / 3.0 ) * creeping_death_mul )
+      double average = 1.0 / ( ( rng_settings.agony_energize.setting_value * 0.5 ) * std::pow( active_agonies, -2.0 / 3.0 ) * creeping_death_mul )
                        * dot_tick_time.total_seconds() / active_agonies;
 
       if ( sim->debug )
@@ -1089,7 +1001,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
   {
     for ( int i = 0; i < as<int>( actual_amount ); i++ )
     {
-      if ( succulent_soul_rng->trigger() )
+      if ( prd_rng.succulent_soul->trigger() )
       {
         buffs.succulent_soul->trigger();
         procs.succulent_soul->occur();

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -104,7 +104,7 @@ struct warlock_td_t : public actor_target_data_t
 
 // Shuffled Bag RNG (sampling without replacement)
 // Each draw removes an item until the bag is exhausted, then it automatically resets
-template<typename T>
+template <typename T>
 struct shuffled_bag_rng_t
 {
 private:
@@ -145,60 +145,73 @@ public:
   { return as<int>( bag.size() ); }
 };
 
-// Variant of accumulated RNG with a hard cap.
-// Chance increases per attempt and guarantees a proc once max_count is reached.
-struct accumulated_hardcap_rng_t : public proc_rng_t
+// Fixed-cycle proc helper
+// Advances a counter on each call and triggers every Nth event
+struct fixed_cycle_proc_t : public proc_rng_t
 {
 private:
-  accumulated_rng_fn accumulator_fn;
-  double proc_chance;
-  unsigned max_count;
-  unsigned initial_count;
+  using proc_reset_counter_fn = std::function<unsigned( unsigned )>;
+
+  proc_reset_counter_fn proc_reset_fn;
+  unsigned counter;
   unsigned trigger_count;
+  bool random_initial_state;
 
 public:
-  static constexpr rng_type_e rng_type = RNG_ACCUMULATE;
+  static constexpr rng_type_e rng_type = RNG_CUSTOM;
 
-  accumulated_hardcap_rng_t( std::string_view n, player_t* p, double c, accumulated_rng_fn fn = nullptr,
-                                        unsigned max_count_ = std::numeric_limits<unsigned>::max(), unsigned initial_count_ = 0 )
+  fixed_cycle_proc_t( std::string_view n, player_t* p, unsigned trigger_count_,
+                      bool random_initial_state_ = false, proc_reset_counter_fn proc_reset_fn_ = nullptr )
     : proc_rng_t( rng_type, n, p ),
-      accumulator_fn( std::move( fn ) ),
-      proc_chance( c ),
-      max_count( max_count_ ),
-      initial_count( initial_count_ ),
-      trigger_count( initial_count_ )
-  {}
+      proc_reset_fn( proc_reset_fn_ ),
+      counter( 0u ),
+      trigger_count( trigger_count_ ),
+      random_initial_state( random_initial_state_ )
+  { assert( trigger_count > 0u ); }
 
-  void reset( reset_type_e /* reset_type */ ) override
-  { trigger_count = initial_count; }
-
-  int trigger( action_state_t* state = nullptr ) override
+  void reset( reset_type_e reset_type ) override
   {
-    if ( proc_chance <= 0 )
-      return false;
+    switch ( reset_type )
+    {
+      case reset_type_e::COMBAT:
+        counter = proc_reset_fn ? proc_reset_fn( trigger_count ) : 0u;
+        assert( counter < trigger_count );
+        break;
+      case reset_type_e::ITERATION:
+        counter = random_initial_state ? player->rng().range( 0u, trigger_count ) : 0u;
+        break;
+      default:
+        assert( false && "Unhandled reset_type_e value" );
+    }
+  }
 
-    trigger_count++;
+  int trigger( action_state_t* = nullptr ) override
+  {
+    counter++;
 
-    if ( trigger_count >= max_count )
+    if ( player->sim->debug )
+      player->sim->print_debug( "Fixed Cycle Proc: {}, current_count={} trigger_count={}, proc={}", name(), counter,
+                                trigger_count, counter >= trigger_count );
+
+    if ( counter >= trigger_count )
     {
       reset( reset_type_e::COMBAT );
       return true;
     }
 
-    double chance = accumulator_fn ? accumulator_fn( proc_chance, trigger_count, state ) : proc_chance * trigger_count;
-    assert( !std::isnan( chance ) ); // nan check
-    bool result = player->rng().roll( chance );
+    return false;
+  }
 
-    if ( player->sim->debug )
-    {
-      player->sim->print_debug( "Accumulated (Hard Cap) RNG: {}, base={:.3f} count={} max={} chance={:.5f}%", name(),
-                                proc_chance, trigger_count, max_count, chance * 100.0 );
-    }
+  unsigned get_counter() const
+  { return counter; }
 
-    if ( result )
-      reset( reset_type_e::COMBAT );
+  unsigned get_trigger_count() const
+  { return trigger_count; }
 
-    return result;
+  void set_counter( unsigned v )
+  {
+    assert( v < trigger_count );
+    counter = v;
   }
 };
 
@@ -241,10 +254,6 @@ public:
   player_t* havoc_target;
   std::vector<action_t*> havoc_spells; // Used for smarter target cache invalidation.
   player_t* haunt_target; // Used for tracking the current haunt target
-  double agony_accumulator;
-  double corruption_accumulator;
-  int alythesss_ire_counter; // Used to consistently cycle the Alythess's Ire proc
-  int alythesss_ire_trigger; // Used to consistently cycle the Alythess's Ire proc
   std::vector<event_t*> wild_imp_spawns; // Used for tracking incoming imps from HoG TODO: Is this still needed with faster spawns?
   int diabolic_ritual; // Used to cycle between the three different Diabolic Ritual buffs
   bool demonic_art_buff_replaced; // Used to not spawn the Demonic Art demon if the buff is replaced by another
@@ -925,6 +934,62 @@ public:
     proc_t* manifested_avarice;
   } procs;
 
+  struct cycle_proc_t
+  {
+    fixed_cycle_proc_t* alythesss_ire;
+  } cycle_proc;
+
+  struct deck_rng_t
+  {
+    shuffled_rng_t* rain_of_chaos;
+    shuffled_rng_t* demonic_knowledge;
+    std::unique_ptr<shuffled_bag_rng_t<dimensional_rift_pet_e>> dimensional_rift_summon;
+  } deck_rng;
+
+  struct rppm_rng_t
+  {
+    real_ppm_t* ravenous_afflictions;
+    real_ppm_t* wrath_of_nathreza;
+    real_ppm_t* devil_fruit;
+  } rppm_rng;
+
+  struct progress_rng_t
+  {
+    threshold_rng_t* agony_energize;
+    threshold_rng_t* nightfall;
+  } progress_rng;
+
+  struct prd_rng_t
+  {
+    accumulated_rng_t* cunning_cruelty;
+    accumulated_rng_t* shard_instability_ds;
+    accumulated_rng_t* shard_instability_sb;
+    accumulated_rng_t* fatal_echoes;
+    accumulated_rng_t* fiendish_cruelty;
+    accumulated_rng_t* chaotic_inferno;
+    accumulated_rng_t* dimensional_rift;
+    accumulated_rng_t* echo_of_sargeras;
+    accumulated_rng_t* succulent_soul;
+    accumulated_rng_t* manifested_avarice;
+    accumulated_rng_t* feast_of_souls;
+    accumulated_rng_t* spiteful_reconstitution;
+  } prd_rng;
+
+  struct flat_rng_t
+  {
+    simple_proc_t* immolate_crit_energize; // TODO: Need to check the type of rng
+    simple_proc_t* carnivorous_stalkers;
+    simple_proc_t* infernal_rapidity;
+    simple_proc_t* demonfire_infusion_dot; // TODO: Need to check the type of rng
+    simple_proc_t* demonfire_infusion_inc; // TODO: Need to check the type of rng
+    simple_proc_t* alythesss_ire_shift;
+    simple_proc_t* wither_crit_energize;   // TODO: Need to check the type of rng
+    simple_proc_t* blackened_soul;         // TODO: Need to check the type of rng and chance value
+    simple_proc_t* bleakheart_tactics;     // TODO: Need to check the type of rng and chance value
+    simple_proc_t* seeds_of_their_demise;  // TODO: Need to check the type of rng and chance value
+    simple_proc_t* mark_of_perotharn;      // TODO: Need to check the type of rng and chance value
+  } flat_rng;
+
   // TODO: Need to check that these RNG values ​​are still correct in Midnight
   struct rng_settings_t
   {
@@ -936,10 +1001,10 @@ public:
     };
 
     // Affliction
+    rng_setting_t agony_energize = { 0.370, 0.370, "agony_energize" };
+    rng_setting_t nightfall = { 0.130, 0.130, "nightfall" };
     rng_setting_t cunning_cruelty_sb = { 0.50, 0.50, "cunning_cruelty_sb" };
     rng_setting_t cunning_cruelty_ds = { 0.25, 0.25, "cunning_cruelty_ds" };
-    rng_setting_t agony = { 0.370, 0.370, "agony" };
-    rng_setting_t nightfall = { 0.130, 0.130, "nightfall" };
 
     // Demonology
     rng_setting_t spiteful_reconstitution = { 0.10, 0.10, "spiteful_reconstitution" };
@@ -967,30 +1032,38 @@ public:
     rng_setting_t feast_of_souls_hard_cap_aff = { 26.0, 26.0, "feast_of_souls_hard_cap_aff" };
     rng_setting_t feast_of_souls_hard_cap_demo = { 26.0, 26.0, "feast_of_souls_hard_cap_demo" };
     rng_setting_t manifested_avarice = { 0.10, 0.10, "manifested_avarice" };
+
+    template <typename F>
+    void for_each( F&& f )
+    {
+      f( agony_energize );
+      f( nightfall );
+      f( cunning_cruelty_sb );
+      f( cunning_cruelty_ds );
+      f( spiteful_reconstitution );
+      f( spiteful_reconstitution_hard_cap );
+      f( demonic_knowledge_rank1_cards );
+      f( demonic_knowledge_rank2_cards );
+      f( alythesss_ire_shift );
+      f( echo_of_sargeras );
+      f( blackened_soul );
+      f( bleakheart_tactics );
+      f( seeds_of_their_demise );
+      f( mark_of_perotharn );
+      f( succulent_soul_aff );
+      f( succulent_soul_demo );
+      f( feast_of_souls_aff );
+      f( feast_of_souls_demo );
+      f( feast_of_souls_hard_cap_aff );
+      f( feast_of_souls_hard_cap_demo );
+      f( manifested_avarice );
+    }
   } rng_settings;
 
   int initial_soul_shards;
   std::string default_pet;
   bool disable_auto_felstorm; // For Demonology main pet
   bool normalize_destruction_mastery;
-  shuffled_rng_t* rain_of_chaos_rng;
-  shuffled_rng_t* demonic_knowledge_rng;
-  real_ppm_t* ravenous_afflictions_rng;
-  real_ppm_t* wrath_of_nathreza_rng;
-  real_ppm_t* devil_fruit_rng;
-  accumulated_rng_t* cunning_cruelty_rng;
-  accumulated_rng_t* shard_instability_ds_rng;
-  accumulated_rng_t* shard_instability_sb_rng;
-  accumulated_rng_t* fatal_echoes_rng;
-  accumulated_rng_t* fiendish_cruelty_rng;
-  accumulated_rng_t* chaotic_inferno_rng;
-  accumulated_rng_t* dimensional_rift_rng;
-  accumulated_rng_t* echo_of_sargeras_rng;
-  accumulated_rng_t* succulent_soul_rng;
-  accumulated_rng_t* manifested_avarice_rng;
-  accumulated_hardcap_rng_t* feast_of_souls_rng;
-  accumulated_hardcap_rng_t* spiteful_reconstitution_rng;
-  std::unique_ptr<shuffled_bag_rng_t<dimensional_rift_pet_e>> dimensional_rift_summon_rng;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );
 
@@ -1013,8 +1086,6 @@ public:
   void parse_player_effects();
   const spell_data_t* conditional_spell_lookup( bool fn, int id );
   void add_rng_option( warlock_t::rng_settings_t::rng_setting_t& );
-  double pseudo_random_p_from_c( double c ) const;
-  double pseudo_random_c_from_p( double p ) const;
   int get_spawning_imp_count(); // TODO: Decide if still needed
   timespan_t time_to_imps( int count ); // TODO: Decide if still needed
   int active_demon_count( bool include_diabolist = true ) const;
@@ -1059,13 +1130,13 @@ public:
   bool hellcaller() const;
   bool soul_harvester() const;
 
-  template<set_bonus_type_e Tier>
+  template <set_bonus_type_e Tier>
   bool active_2pc() const
   {
     return sets->has_set_bonus( specialization(), Tier, B2 );
   }
 
-  template<set_bonus_type_e Tier>
+  template <set_bonus_type_e Tier>
   bool active_4pc() const
   {
     return sets->has_set_bonus( specialization(), Tier, B4 );
@@ -1153,8 +1224,6 @@ namespace helpers
     virtual const char* name() const override;
     virtual void execute() override;
   };
-
-  void nightfall_updater( warlock_t* p, dot_t* d );
 
   void trigger_blackened_soul( warlock_t* p, bool malevolence );
 

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -252,7 +252,7 @@ using namespace helpers;
         {
           for ( int i = 0; i < shards_used; i++ )
           {
-            if ( p()->rain_of_chaos_rng->trigger() )
+            if ( p()->deck_rng.rain_of_chaos->trigger() )
             {
               // Random extra duration time between 0_ms and 820_ms following a uniform distribution
               const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 0.0, 820.0 ) );
@@ -285,7 +285,7 @@ using namespace helpers;
           if ( destruction() && p()->hero.touch_of_rancora.ok() && triggers.rancora_cb_bonus )
             adjustment += -timespan_t::from_seconds( p()->hero.touch_of_rancora->effectN( 3 ).base_value() );
 
-          switch( p()->diabolic_ritual )
+          switch ( p()->diabolic_ritual )
           {
             case 0:
               if ( p()->buffs.ritual_overlord->check() )
@@ -383,7 +383,7 @@ using namespace helpers;
 
       if ( destruction() && triggers.fiendish_cruelty )
       {
-        if ( s->result == RESULT_CRIT && p()->fiendish_cruelty_rng->trigger() )
+        if ( s->result == RESULT_CRIT && p()->prd_rng.fiendish_cruelty->trigger() )
         {
           p()->buffs.fiendish_cruelty->trigger();
           p()->procs.fiendish_cruelty->occur();
@@ -392,13 +392,13 @@ using namespace helpers;
 
       if ( destruction() && triggers.dimensional_rift )
       {
-        if ( p()->dimensional_rift_rng->trigger() )
+        if ( p()->prd_rng.dimensional_rift->trigger() )
           p()->proc_actions.dimensional_rift->execute_on_target( s->target );
       }
 
       if ( destruction() && triggers.embers_of_nihilam_1 )
       {
-        if ( p()->echo_of_sargeras_rng->trigger() )
+        if ( p()->prd_rng.echo_of_sargeras->trigger() )
         {
           p()->proc_actions.echo_of_sargeras->execute_on_target( s->target );
           p()->procs.echo_of_sargeras->occur();
@@ -411,7 +411,7 @@ using namespace helpers;
     {
       action_base_t::tick( d );
 
-      if ( affliction() && triggers.ravenous_afflictions && d->state->result == RESULT_CRIT && p()->ravenous_afflictions_rng->trigger() )
+      if ( affliction() && triggers.ravenous_afflictions && d->state->result == RESULT_CRIT && p()->rppm_rng.ravenous_afflictions->trigger() )
       {
         p()->buffs.nightfall->trigger();
         p()->procs.ravenous_afflictions->occur();
@@ -568,11 +568,11 @@ using namespace helpers;
     bool soul_harvester() const
     { return p()->soul_harvester(); }
 
-    template<set_bonus_type_e Tier>
+    template <set_bonus_type_e Tier>
     bool active_2pc() const
     { return p()->active_2pc<Tier>(); }
 
-    template<set_bonus_type_e Tier>
+    template <set_bonus_type_e Tier>
     bool active_4pc() const
     { return p()->active_4pc<Tier>(); }
   };
@@ -719,8 +719,11 @@ using namespace helpers;
       {
         warlock_spell_t::tick( d );
 
-        if ( result_is_hit( d->state->result ) && p()->talents.nightfall.ok() )
-          helpers::nightfall_updater( p(), d );
+        if ( result_is_hit( d->state->result ) && p()->talents.nightfall.ok() && p()->progress_rng.nightfall->trigger( d->state ) )
+        {
+          p()->procs.nightfall->occur();
+          p()->buffs.nightfall->trigger();
+        }
       }
     };
 
@@ -810,7 +813,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
           p()->feast_of_souls_gain();
       }
 
@@ -824,13 +827,13 @@ using namespace helpers;
 
       if ( result_is_hit( s->result ) )
       {
-        if ( p()->talents.shard_instability.ok() && p()->shard_instability_sb_rng->trigger() )
+        if ( p()->talents.shard_instability.ok() && p()->prd_rng.shard_instability_sb->trigger() )
         {
           p()->buffs.shard_instability->trigger();
           p()->procs.shard_instability->occur();
         }
 
-        if ( p()->talents.cunning_cruelty.ok() && p()->cunning_cruelty_rng->trigger() )
+        if ( p()->talents.cunning_cruelty.ok() && p()->prd_rng.cunning_cruelty->trigger() )
         {
           p()->procs.shadowbolt_volley->occur();
           volley->execute_on_target( s->target );
@@ -945,7 +948,7 @@ using namespace helpers;
 
       auto pet = w->warlock_pet_list.active;
 
-      switch( pet->pet_type )
+      switch ( pet->pet_type )
       {
         case PET_FELGUARD:
         case PET_FELHUNTER:
@@ -967,7 +970,7 @@ using namespace helpers;
 
       auto pet = w->warlock_pet_list.active;
 
-      switch( pet->pet_type )
+      switch ( pet->pet_type )
       {
         case PET_FELGUARD:
         case PET_FELHUNTER:
@@ -1025,13 +1028,16 @@ using namespace helpers;
 
         if ( affliction() )
         {
-          if ( result_is_hit( d->state->result ) && p()->talents.nightfall.ok() )
-            helpers::nightfall_updater( p(), d );
+          if ( result_is_hit( d->state->result ) && p()->talents.nightfall.ok() && p()->progress_rng.nightfall->trigger( d->state ) )
+          {
+            p()->procs.nightfall->occur();
+            p()->buffs.nightfall->trigger();
+          }
         }
 
         if ( destruction() )
         {
-          if ( d->state->result == RESULT_CRIT && rng().roll( p()->hero.wither_direct->effectN( 2 ).percent() ) )
+          if ( d->state->result == RESULT_CRIT && p()->flat_rng.wither_crit_energize->trigger() )
             p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.wither_crits );
 
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.wither );
@@ -1039,7 +1045,7 @@ using namespace helpers;
           if ( p()->talents.flashpoint.ok() && d->state->target->health_percentage() >= p()->talents.flashpoint->effectN( 2 ).base_value() )
             p()->buffs.flashpoint->trigger();
 
-          if ( p()->talents.demonfire_infusion.ok() && p()->rng().roll( p()->talents.demonfire_infusion->effectN( 1 ).percent() ) )
+          if ( p()->talents.demonfire_infusion.ok() && p()->flat_rng.demonfire_infusion_dot->trigger() )
           {
             p()->proc_actions.demonfire_infusion->execute_on_target( d->target );
             p()->procs.demonfire_infusion_dot->occur();
@@ -1060,7 +1066,7 @@ using namespace helpers;
           }
         }
 
-        if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && rng().roll( p()->rng_settings.mark_of_perotharn.setting_value ) )
+        if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->flat_rng.mark_of_perotharn->trigger() )
         {
           // Wither stack gain by Mark of Perotharn does not directly trigger collapse in that tick (it will be trigged on the next tick)
           d->increment( 1 );
@@ -1069,7 +1075,7 @@ using namespace helpers;
 
         if ( p()->hero.devil_fruit.ok() )
         {
-          if ( p()->devil_fruit_rng->trigger() )
+          if ( p()->rppm_rng.devil_fruit->trigger() )
           {
             p()->buffs.malevolence->trigger( timespan_t::from_seconds( p()->hero.devil_fruit->effectN( 1 ).base_value() ) );
             p()->procs.devil_fruit->occur();
@@ -1117,7 +1123,7 @@ using namespace helpers;
     {
       warlock_spell_t::impact( s );
 
-      if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && rng().roll( p()->rng_settings.mark_of_perotharn.setting_value ) )
+      if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->flat_rng.mark_of_perotharn->trigger() )
       {
         // Wither stack gain by Mark of Perotharn does not directly trigger collapse (it will be trigged on the next Wither tick)
         td( s->target )->dots.wither->increment( 1 );
@@ -1179,14 +1185,14 @@ using namespace helpers;
 
       bool seeds_triggered = false;
 
-      if ( affliction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && rng().roll( p()->rng_settings.seeds_of_their_demise.setting_value ) )
+      if ( affliction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && p()->flat_rng.seeds_of_their_demise->trigger() )
       {
         p()->buffs.shard_instability->trigger();
         p()->procs.seeds_of_their_demise->occur();
         seeds_triggered = true;
       }
 
-      if ( destruction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && rng().roll( p()->rng_settings.seeds_of_their_demise.setting_value ) )
+      if ( destruction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && p()->flat_rng.seeds_of_their_demise->trigger() )
       {
         p()->buffs.flashpoint->trigger( 2 );
         p()->procs.seeds_of_their_demise->occur();
@@ -1327,8 +1333,9 @@ using namespace helpers;
 
     void last_tick( dot_t* d ) override
     {
+      // TOCHECK: Is this reset to a random state still a thing?
       if ( p()->get_active_dots( d ) == 1 )
-        p()->agony_accumulator = rng().range( 0.0, 0.99 );
+        p()->progress_rng.agony_energize->reset( reset_type_e::COMBAT );
 
       warlock_spell_t::last_tick( d );
     }
@@ -1360,37 +1367,8 @@ using namespace helpers;
 
     void tick( dot_t* d ) override
     {
-      // 2018-08-24:
-      //   Blizzard has not publicly released the formula for Agony's chance to generate a Soul Shard. This set of code is based on results from
-      //   500+ Soul Shard sample sizes, and matches in-game results to within 0.1% of accuracy in all tests conducted on all targets numbers up to 8.
-      // 2026-03-06:
-      //   New tests were conducted using over 55000+ Soul Shards in both single and multi-target scenarios. The results confirm that Blizzard is still
-      //   using the same formula for Agony, though they occasionally make unusual adjustments to talent normalization (so this should be checked regularly).
-      //   With the larger sample size, we obtained a more precise initial value for Agony's RNG 'increment_max' of 0.370 (previously 0.368).
-      // TOCHECK regularly. If any changes are made to this section of code, please also update the Time_to_Shard expression in sc_warlock.cpp.
-
-      double increment_max = p()->rng_settings.agony.setting_value;
-
-      double active_agonies = p()->get_active_dots( d );
-      increment_max *= std::pow( active_agonies, -2.0 / 3.0 );
-
-      // NOTE: 2026-03-06 Recent tests noted that Creeping Death is renormalizing shard generation to be neutral with/without the talent
-      // However, Creeping Death rank 2 is normalizing using -0.1 value instead of -0.2 (the value of rank 1 or half of rank 2) (bug?)
-      if ( p()->talents.creeping_death.ok() )
-      {
-        if ( !p()->bugs || p()->talents.creeping_death.rank() < 2 )
-          increment_max *= 1.0 + p()->talents.creeping_death->effectN( 1 ).percent();
-        else
-          increment_max *= 1.0 + ( p()->talents.creeping_death->effectN( 1 ).percent() * 0.5 );
-      }
-
-      p()->agony_accumulator += rng().range( 0.0, increment_max );
-
-      if ( p()->agony_accumulator >= 1 )
-      {
+      if ( p()->progress_rng.agony_energize->trigger( d->state ) )
         p()->resource_gain( RESOURCE_SOUL_SHARD, 1.0, p()->gains.agony );
-        p()->agony_accumulator -= 1.0;
-      }
 
       warlock_spell_t::tick( d );
 
@@ -1427,7 +1405,7 @@ using namespace helpers;
       {
         p()->buffs.succulent_soul->decrement();
 
-        if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
+        if ( p()->hero.manifested_avarice.ok() && p()->prd_rng.manifested_avarice->trigger() )
         {
           p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
           p()->buffs.manifested_demonic_soul->trigger();
@@ -1475,7 +1453,7 @@ using namespace helpers;
       {
         for ( int i = 0; i < stacks; i++ )
         {
-          if ( p()->fatal_echoes_rng->trigger() )
+          if ( p()->prd_rng.fatal_echoes->trigger() )
           {
             p()->procs.fatal_echoes->occur();
             make_event( sim, 1_ms, [ this, t = d->state->target ] {
@@ -1734,7 +1712,7 @@ using namespace helpers;
           p()->proc_actions.shared_fate->execute_on_target( target );
 
         // Feast of Souls is processed before the decrement of Succulent Soul, causing the same SoC cast that gains the Succulent Soul stack to consume it
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
           p()->feast_of_souls_gain( true );
       }
 
@@ -1750,7 +1728,7 @@ using namespace helpers;
       {
         p()->buffs.succulent_soul->decrement();
 
-        if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
+        if ( p()->hero.manifested_avarice.ok() && p()->prd_rng.manifested_avarice->trigger() )
         {
           p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
           p()->buffs.manifested_demonic_soul->trigger();
@@ -1858,7 +1836,7 @@ using namespace helpers;
         if ( result_is_hit( s->result ) )
         {
           // DoT (Malefic Grasp) extra tick crits can trigger Ravenous Afflictions
-          if ( p()->talents.ravenous_afflictions.ok() && s->result == RESULT_CRIT && p()->ravenous_afflictions_rng->trigger() )
+          if ( p()->talents.ravenous_afflictions.ok() && s->result == RESULT_CRIT && p()->rppm_rng.ravenous_afflictions->trigger() )
           {
             p()->buffs.nightfall->trigger();
             p()->procs.ravenous_afflictions->occur();
@@ -2013,7 +1991,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -2026,14 +2004,14 @@ using namespace helpers;
       if ( result_is_hit( d->state->result ) )
       {
         // NOTE: 2026-02-20 Malefic Grasp can proc Shard Instability
-        if ( p()->talents.shard_instability.ok() && p()->shard_instability_ds_rng->trigger() )
+        if ( p()->talents.shard_instability.ok() && p()->prd_rng.shard_instability_ds->trigger() )
         {
           p()->buffs.shard_instability->trigger();
           p()->procs.shard_instability->occur();
         }
 
         // NOTE: 2026-02-20 Malefic Grasp can proc Cunning Cruelty (PRD: 50% nominal rate if SB is used, 25% nominal rate if DS is used)
-        if ( p()->talents.cunning_cruelty.ok() && p()->cunning_cruelty_rng->trigger() )
+        if ( p()->talents.cunning_cruelty.ok() && p()->prd_rng.cunning_cruelty->trigger() )
         {
           p()->procs.shadowbolt_volley->occur();
           volley->execute_on_target( d->target );
@@ -2152,7 +2130,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -2164,13 +2142,13 @@ using namespace helpers;
 
       if ( result_is_hit( d->state->result ) )
       {
-        if ( p()->talents.shard_instability.ok() && p()->shard_instability_ds_rng->trigger() )
+        if ( p()->talents.shard_instability.ok() && p()->prd_rng.shard_instability_ds->trigger() )
         {
           p()->buffs.shard_instability->trigger();
           p()->procs.shard_instability->occur();
         }
 
-        if ( p()->talents.cunning_cruelty.ok() && p()->cunning_cruelty_rng->trigger() )
+        if ( p()->talents.cunning_cruelty.ok() && p()->prd_rng.cunning_cruelty->trigger() )
         {
           p()->procs.shadowbolt_volley->occur();
           volley->execute_on_target( d->target );
@@ -2621,7 +2599,7 @@ using namespace helpers;
         }
       }
 
-      if ( p()->talents.demonic_knowledge.ok() && p()->demonic_knowledge_rng->trigger() )
+      if ( p()->talents.demonic_knowledge.ok() && p()->deck_rng.demonic_knowledge->trigger() )
       {
         p()->buffs.demonic_core->trigger();
         p()->procs.demonic_knowledge->occur();
@@ -2631,7 +2609,7 @@ using namespace helpers;
       {
           p()->buffs.succulent_soul->decrement();
 
-          if ( p()->hero.manifested_avarice.ok() && p()->manifested_avarice_rng->trigger() )
+          if ( p()->hero.manifested_avarice.ok() && p()->prd_rng.manifested_avarice->trigger() )
           {
             p()->warlock_pet_list.demonic_souls.spawn( p()->hero.manifested_avarice_spell->duration() );
             p()->buffs.manifested_demonic_soul->trigger();
@@ -2715,7 +2693,7 @@ using namespace helpers;
 
       if ( p()->buffs.demonic_core->check() )
       {
-        if ( p()->talents.spiteful_reconstitution.ok() && p()->spiteful_reconstitution_rng->trigger() )
+        if ( p()->talents.spiteful_reconstitution.ok() && p()->prd_rng.spiteful_reconstitution->trigger() )
         {
           p()->warlock_pet_list.wild_imps.spawn( p()->warlock_base.wild_imp_2->duration(), 1u );
           p()->procs.spiteful_reconstitution->occur();
@@ -2730,7 +2708,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->feast_of_souls_rng->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
           p()->feast_of_souls_gain();
       }
 
@@ -3415,7 +3393,7 @@ using namespace helpers;
       if ( p()->talents.fire_and_brimstone.ok() )
         fnb_action->execute_on_target( target );
 
-      if ( p()->talents.demonfire_infusion.ok() && p()->rng().roll( p()->talents.demonfire_infusion->effectN( 2 ).percent() ) )
+      if ( p()->talents.demonfire_infusion.ok() && p()->flat_rng.demonfire_infusion_inc->trigger() )
       {
         p()->proc_actions.demonfire_infusion->execute_on_target( target );
         p()->procs.demonfire_infusion_inc->occur();
@@ -3463,7 +3441,7 @@ using namespace helpers;
       {
         warlock_spell_t::tick( d );
 
-        if ( d->state->result == RESULT_CRIT && rng().roll( p()->warlock_base.immolate_old->effectN( 2 ).percent() ) )
+        if ( d->state->result == RESULT_CRIT && p()->flat_rng.immolate_crit_energize->trigger() )
           p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.immolate_crits );
 
         p()->resource_gain( RESOURCE_SOUL_SHARD, 0.1, p()->gains.immolate );
@@ -3471,7 +3449,7 @@ using namespace helpers;
         if ( p()->talents.flashpoint.ok() && d->state->target->health_percentage() >= p()->talents.flashpoint->effectN( 2 ).base_value() )
           p()->buffs.flashpoint->trigger();
 
-        if ( p()->talents.demonfire_infusion.ok() && p()->rng().roll( p()->talents.demonfire_infusion->effectN( 1 ).percent() ) )
+        if ( p()->talents.demonfire_infusion.ok() && p()->flat_rng.demonfire_infusion_dot->trigger() )
         {
           p()->proc_actions.demonfire_infusion->execute_on_target( d->target );
           p()->procs.demonfire_infusion_dot->occur();
@@ -3547,7 +3525,7 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      dimensional_rift_pet_e rift_pet_index = p()->dimensional_rift_summon_rng->draw();
+      dimensional_rift_pet_e rift_pet_index = p()->deck_rng.dimensional_rift_summon->draw();
 
       switch ( rift_pet_index )
       {
@@ -3705,7 +3683,7 @@ using namespace helpers;
 
       p()->buffs.crashing_chaos->decrement();
 
-      if ( p()->talents.chaotic_inferno.ok() && p()->chaotic_inferno_rng->trigger() )
+      if ( p()->talents.chaotic_inferno.ok() && p()->prd_rng.chaotic_inferno->trigger() )
       {
         // Delay the buff a bit to simulate the ingame behavior where an Incinerate cast
         // queued right after a Chaos Bolt that procs Chaotic Inferno is not affected by it
@@ -3936,19 +3914,10 @@ using namespace helpers;
       {
         p()->buffs.alythesss_ire->decrement();
 
-        p()->alythesss_ire_counter++;
-
-        if ( p()->alythesss_ire_counter >= p()->alythesss_ire_trigger )
+        if ( p()->cycle_proc.alythesss_ire->trigger() )
         {
           p()->buffs.alythesss_ire->trigger();
           p()->procs.alythesss_ire->occur();
-
-          // NOTE: 2026-03-06 Alythess's Ire usually procs at a fixed interval of attempts. Rarely, the cycle
-          // shifts and advances the next proc; testing suggests this happens randomly in roughly ~1% of procs.
-          if ( rng().roll( p()->rng_settings.alythesss_ire_shift.setting_value ) )
-            p()->alythesss_ire_counter = rng().range( 1, p()->alythesss_ire_trigger );
-          else
-            p()->alythesss_ire_counter = 0;
         }
       }
     }
@@ -4489,7 +4458,7 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       // 2026-02-18 Infernal Bolt can proc Demonfire Infusion
-      if ( p()->talents.demonfire_infusion.ok() && p()->rng().roll( p()->talents.demonfire_infusion->effectN( 2 ).percent() ) )
+      if ( p()->talents.demonfire_infusion.ok() && p()->flat_rng.demonfire_infusion_inc->trigger() )
       {
         p()->proc_actions.demonfire_infusion->execute_on_target( target );
         p()->procs.demonfire_infusion_inc->occur();
@@ -4664,42 +4633,6 @@ using namespace helpers;
   // Diabolist Actions End
   // Helper Functions Begin
 
-  void helpers::nightfall_updater( warlock_t* p, dot_t* d )
-  {
-    // Blizzard did not publicly release how nightfall was changed.
-    // We determined this is the probable functionality copied from Agony by first confirming the
-    // DR formula was the same and then confirming that you can get procs on 1st tick.
-    // The procs also have a regularity that suggest it does not use a proc chance or rppm.
-    // Last checked 2026-03-06.
-    double increment_max = p->rng_settings.nightfall.setting_value;
-
-    double active_corruptions = p->get_active_dots( d );
-    increment_max *= std::pow( active_corruptions, -2.0 / 3.0 );
-
-    // NOTE: 2026-03-06 Creeping Death no longer affects the chance of gaining Nightfall
-    // However, Creeping Death rank 2 is normalizing using -0.1 value instead of -0.2 (the value of rank 1 or half of rank 2) (bug?)
-    if ( p->talents.creeping_death.ok() )
-    {
-      if ( !p->bugs || p->talents.creeping_death.rank() < 2 )
-        increment_max *= 1.0 + p->talents.creeping_death->effectN( 1 ).percent();
-      else
-        increment_max *= 1.0 + ( p->talents.creeping_death->effectN( 1 ).percent() * 0.5 );
-    }
-
-    // Sataiel’s Volition no longer affects the chance of gaining Nightfall
-    if ( p->hero.sataiels_volition.ok() )
-      increment_max *= 1.0 + p->hero.sataiels_volition->effectN( 1 ).percent();
-
-    p->corruption_accumulator += p->rng().range( 0.0, increment_max );
-
-    if ( p->corruption_accumulator >= 1 )
-    {
-      p->procs.nightfall->occur();
-      p->buffs.nightfall->trigger();
-      p->corruption_accumulator -= 1.0;
-    }
-  }
-
   void helpers::trigger_blackened_soul( warlock_t* p, bool malevolence )
   {
     if ( !malevolence && p->cooldowns.blackened_soul->down() )
@@ -4729,7 +4662,7 @@ using namespace helpers;
       if ( p->buffs.malevolence->check() && !malevolence )
         tdata->dots.wither->increment( as<int>( p->hero.malevolence->effectN( 2 ).base_value() ) );
 
-      if ( p->hero.bleakheart_tactics.ok() && !malevolence && p->rng().roll( p->rng_settings.bleakheart_tactics.setting_value ) )
+      if ( p->hero.bleakheart_tactics.ok() && !malevolence && p->flat_rng.bleakheart_tactics->trigger() )
       {
         tdata->dots.wither->increment( 1 );
         p->procs.bleakheart_tactics->occur();
@@ -4747,7 +4680,7 @@ using namespace helpers;
           p->sim->print_debug( "{} wither stack collapse in {} started (seeds of their demise) (stack gain check). wither_current_stack={}, wither_target_health_percentage={:.2f}%",
                       p->name(), target->name(), tdata->dots.wither->current_stack(), target->health_percentage() );
         }
-        else if ( p->rng().roll( p->rng_settings.blackened_soul.setting_value ) )
+        else if ( p->flat_rng.blackened_soul->trigger() )
         {
           tdata->debuffs.blackened_soul->trigger();
           p->procs.blackened_soul->occur();
@@ -4801,7 +4734,7 @@ using namespace helpers;
       return;
 
     // TOCHECK: Spell data suggests ~2 RPPM (hasted) - verify in-game
-    if ( !p->wrath_of_nathreza_rng->trigger() )
+    if ( !p->rppm_rng.wrath_of_nathreza->trigger() )
       return;
 
     p->proc_actions.wrath_of_nathreza->execute_on_target( target );
@@ -4864,8 +4797,8 @@ using namespace helpers;
       dot->decrement( 1 );
       assert( ( dot->is_ticking() && dot->current_stack() > 0 ) && "UA stack decrement event should not cancel the DoT" );
 
-      // if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && dot->is_ticking() && dot->current_stack() > 0 && p->fatal_echoes_rng->trigger() )
-      if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && p->fatal_echoes_rng->trigger() )
+      // if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && dot->is_ticking() && dot->current_stack() > 0 && p->prd_rng.fatal_echoes->trigger() )
+      if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && p->prd_rng.fatal_echoes->trigger() )
       {
         p->procs.fatal_echoes->occur();
         dot->current_action->set_target( target );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1135,45 +1135,130 @@ namespace warlock
 
   void warlock_t::init_rng_affliction()
   {
-    ravenous_afflictions_rng = get_rppm( "ravenous_afflictions", talents.ravenous_afflictions );
-    wrath_of_nathreza_rng = get_rppm( "wrath_of_nathreza", talents.shadow_of_nathreza_3 );
+    // Agony energize proc
+    {
+      // 2018-08-24:
+      //   Blizzard has not publicly released the formula for Agony's chance to generate a Soul Shard. This set of code is based on results from
+      //   500+ Soul Shard sample sizes, and matches in-game results to within 0.1% of accuracy in all tests conducted on all targets numbers up to 8.
+      // 2026-03-06:
+      //   New tests were conducted using over 55000+ Soul Shards in both single and multi-target scenarios. The results confirm that Blizzard is still
+      //   using the same formula for Agony, though they occasionally make unusual adjustments to talent normalization (so this should be checked regularly).
+      //   With the larger sample size, we obtained a more precise initial value for Agony's RNG 'increment_max' of 0.370 (previously 0.368).
+      // TOCHECK regularly. If any changes are made to this section of code, please also update the Time_to_Shard expression in sc_warlock.cpp.
+      double inc_max = rng_settings.agony_energize.setting_value;
+
+      // NOTE: 2026-03-06 Recent tests noted that Creeping Death is renormalizing shard generation to be neutral with/without the talent
+      // However, Creeping Death rank 2 is normalizing using -0.1 value instead of -0.2 (the value of rank 1 or half of rank 2) (bug?)
+      if ( talents.creeping_death.ok() )
+      {
+        if ( !bugs || talents.creeping_death.rank() < 2 )
+          inc_max *= 1.0 + talents.creeping_death->effectN( 1 ).percent();
+        else
+          inc_max *= 1.0 + ( talents.creeping_death->effectN( 1 ).percent() * 0.5 );
+      }
+
+      progress_rng.agony_energize = get_threshold_rng( "agony_energize", inc_max,
+        [ this ]( double increment_max, action_state_t* s ) {
+          assert( s );
+          auto tdata = get_target_data( s->target );
+          assert( tdata );
+          dot_t* agony_dot = tdata->dots.agony;
+          unsigned active_agonies = get_active_dots( agony_dot );
+          assert( agony_dot && agony_dot->is_ticking() && active_agonies > 0 );
+          increment_max *= std::pow( active_agonies, -2.0 / 3.0 );
+          return rng().range( 0.0, increment_max );
+        }, true, true );
+    }
+
+    // Nightfall proc
+    if ( talents.nightfall.ok() )
+    {
+      // Blizzard did not publicly release how nightfall was changed.
+      // We determined this is the probable functionality copied from Agony by first confirming the
+      // DR formula was the same and then confirming that you can get procs on 1st tick.
+      // The procs also have a regularity that suggest it does not use a proc chance or rppm.
+      // Last checked 2026-03-06.
+      double inc_max = rng_settings.nightfall.setting_value;
+
+      // NOTE: 2026-03-06 Creeping Death no longer affects the chance of gaining Nightfall
+      // However, Creeping Death rank 2 is normalizing using -0.1 value instead of -0.2 (the value of rank 1 or half of rank 2) (bug?)
+      if ( talents.creeping_death.ok() )
+      {
+        if ( !bugs || talents.creeping_death.rank() < 2 )
+          inc_max *= 1.0 + talents.creeping_death->effectN( 1 ).percent();
+        else
+          inc_max *= 1.0 + ( talents.creeping_death->effectN( 1 ).percent() * 0.5 );
+      }
+
+      // Sataiel’s Volition no longer affects the chance of gaining Nightfall
+      if ( hero.sataiels_volition.ok() )
+        inc_max *= 1.0 + hero.sataiels_volition->effectN( 1 ).percent();
+
+      progress_rng.nightfall = get_threshold_rng( "nightfall", inc_max,
+        [ this ]( double increment_max, action_state_t* s ) {
+          assert( s );
+          auto tdata = get_target_data( s->target );
+          assert( tdata );
+          dot_t* corruption_dot = hero.wither.ok() ? tdata->dots.wither : tdata->dots.corruption;
+          unsigned active_corruptions = get_active_dots( corruption_dot );
+          assert( corruption_dot && corruption_dot->is_ticking() && active_corruptions > 0 );
+          increment_max *= std::pow( active_corruptions, -2.0 / 3.0 );
+          return rng().range( 0.0, increment_max );
+        }, true, true );
+    }
+
+    rppm_rng.ravenous_afflictions = get_rppm( "ravenous_afflictions", talents.ravenous_afflictions );
+    rppm_rng.wrath_of_nathreza = get_rppm( "wrath_of_nathreza", talents.shadow_of_nathreza_3 );
 
     // Modeling Cunning Cruelty as a pseudo-random distribution (PRD) with a nominal rate of 50% (SB) / 25% (DS) (MG uses DS rate if
     // selected, SB rate otherwise) which corresponds to PRD constant C = 0.302103025348741965 (SB) / C = 0.084744091852316990 (DS)
     if ( talents.cunning_cruelty.ok() )
     {
-      double c_cc = pseudo_random_c_from_p( talents.drain_soul.ok() ? rng_settings.cunning_cruelty_ds.setting_value : rng_settings.cunning_cruelty_sb.setting_value );
-      cunning_cruelty_rng = get_accumulated_rng( "cunning_cruelty", c_cc );
+      double c_cc = prd::find_constant( talents.drain_soul.ok() ? rng_settings.cunning_cruelty_ds.setting_value : rng_settings.cunning_cruelty_sb.setting_value );
+      prd_rng.cunning_cruelty = get_accumulated_rng( "cunning_cruelty", c_cc );
     }
 
     // Modeling Shard Instability as a pseudo-random distribution (PRD) with a nominal rate of 10% (DS/MG) / 20% (SB),
     // which corresponds to PRD constant C = 0.014745844781072676 (DS/MG) / C = 0.055704042949781852 (SB)
     if ( talents.shard_instability.ok() )
     {
-      double c_ds = pseudo_random_c_from_p( talents.shard_instability->effectN( 1 ).percent() );
-      shard_instability_ds_rng = get_accumulated_rng( "shard_instability_ds", c_ds );
-      double c_sb = pseudo_random_c_from_p( talents.shard_instability->effectN( 2 ).percent() );
-      shard_instability_sb_rng = get_accumulated_rng( "shard_instability_sb", c_sb );
+      double c_ds = prd::find_constant( talents.shard_instability->effectN( 1 ).percent() );
+      prd_rng.shard_instability_ds = get_accumulated_rng( "shard_instability_ds", c_ds );
+      double c_sb = prd::find_constant( talents.shard_instability->effectN( 2 ).percent() );
+      prd_rng.shard_instability_sb = get_accumulated_rng( "shard_instability_sb", c_sb );
     }
 
     // Modeling Fatal Echoes as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
     if ( talents.fatal_echoes.ok() )
     {
-      double c_fe = pseudo_random_c_from_p( talents.fatal_echoes->effectN( 1 ).percent() );
-      fatal_echoes_rng = get_accumulated_rng( "fatal_echoes", c_fe );
+      double c_fe = prd::find_constant( talents.fatal_echoes->effectN( 1 ).percent() );
+      prd_rng.fatal_echoes = get_accumulated_rng( "fatal_echoes", c_fe );
     }
   }
 
   void warlock_t::init_rng_demonology()
   {
+    // NOTE: 2026-03-06 It has been tested that Carnivorous Stalkers follows a Flat % chance model for each individual melee hit
+    if ( talents.carnivorous_stalkers.ok() )
+      flat_rng.carnivorous_stalkers = get_simple_proc_rng( "carnivorous_stalkers", talents.carnivorous_stalkers->effectN( 1 ).percent() );
+
+    // NOTE: 2026-03-06 It has been tested that Infernal Rapidity follows a Flat % chance model for each individual cast
+    // However, the % chance seems to be bugged and only half of what is specified in the spell data is being applied (bug)
+    if ( talents.infernal_rapidity.ok() )
+    {
+      double infernal_rapidity_chance = talents.infernal_rapidity->effectN( 1 ).percent();
+      infernal_rapidity_chance = bugs ? infernal_rapidity_chance * 0.5 : infernal_rapidity_chance;
+      flat_rng.infernal_rapidity = get_simple_proc_rng( "infernal_rapidity", infernal_rapidity_chance );
+    }
+
     // Modeling Spiteful Reconstitution as a pseudo-random distribution (PRD) with a nominal rate of 10% and a hard cap
     // of 21 attempts. The PRD nominal rate corresponds to PRD constant C = 0.014745844781072676.
     if ( talents.spiteful_reconstitution.ok() )
     {
-      double c_sr = pseudo_random_c_from_p( rng_settings.spiteful_reconstitution.setting_value );
+      double c_sr = prd::find_constant( rng_settings.spiteful_reconstitution.setting_value );
       int spiteful_reconstitution_hardcap = static_cast<int>( rng_settings.spiteful_reconstitution_hard_cap.setting_value );
-      spiteful_reconstitution_rng = get_rng<accumulated_hardcap_rng_t>( "spiteful_reconstitution", c_sr, nullptr, spiteful_reconstitution_hardcap );
+      prd_rng.spiteful_reconstitution = get_accumulated_rng( "spiteful_reconstitution", c_sr, spiteful_reconstitution_hardcap );
     }
 
     // Demonic Knowledge uses Deck of Cards RNG at 10 out of 80 (rank 1) and 18 out of 80 (rank 2)
@@ -1197,37 +1282,39 @@ namespace warlock
         cards = static_cast<int>( talents.demonic_knowledge->effectN( 1 ).percent() * max_cards + 0.5 );
       }
 
-      demonic_knowledge_rng = get_shuffled_rng( "demonic_knowledge", cards, max_cards );
+      deck_rng.demonic_knowledge = get_shuffled_rng( "demonic_knowledge", cards, max_cards );
     }
   }
 
   void warlock_t::init_rng_destruction()
   {
+    flat_rng.immolate_crit_energize = get_simple_proc_rng( "immolate_crit_energize", warlock_base.immolate_old->effectN( 2 ).percent() );
+
     // Modeling Fiendish Cruelty as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
     if ( talents.fiendish_cruelty.ok() )
     {
-      double c_fc = pseudo_random_c_from_p( talents.fiendish_cruelty->effectN( 1 ).percent() );
-      fiendish_cruelty_rng = get_accumulated_rng( "fiendish_cruelty", c_fc );
+      double c_fc = prd::find_constant( talents.fiendish_cruelty->effectN( 1 ).percent() );
+      prd_rng.fiendish_cruelty = get_accumulated_rng( "fiendish_cruelty", c_fc );
     }
 
     // Modeling Chaotic Inferno as a pseudo-random distribution (PRD) with a nominal
     // rate of 25%, which corresponds to PRD constant C = 0.084744091852316990.
     if ( talents.chaotic_inferno.ok() )
     {
-      double c_ci = pseudo_random_c_from_p( talents.chaotic_inferno->effectN( 2 ).percent() );
-      chaotic_inferno_rng = get_accumulated_rng( "chaotic_inferno", c_ci );
+      double c_ci = prd::find_constant( talents.chaotic_inferno->effectN( 2 ).percent() );
+      prd_rng.chaotic_inferno = get_accumulated_rng( "chaotic_inferno", c_ci );
     }
 
     // Rain of Chaos uses Deck of Cards RNG at 3 out of 20
-    rain_of_chaos_rng = get_shuffled_rng( "rain_of_chaos", 3, 20 );
+    deck_rng.rain_of_chaos = get_shuffled_rng( "rain_of_chaos", 3, 20 );
 
     // Modeling Dimensional Rift as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
     if ( talents.dimensional_rift.ok() )
     {
-      double c_dr = pseudo_random_c_from_p( talents.dimensional_rift->effectN( 1 ).percent() );
-      dimensional_rift_rng = get_accumulated_rng( "dimensional_rift", c_dr );
+      double c_dr = prd::find_constant( talents.dimensional_rift->effectN( 1 ).percent() );
+      prd_rng.dimensional_rift = get_accumulated_rng( "dimensional_rift", c_dr );
 
       // The pets summoned by Dimensional Rift is choosen following a Deck of Cards model of 2/2/2 out of 6.
       // With the Avatar of Destruction talent, this is modified to a Deck of Cards model of 2/2/2/1 out of 7.
@@ -1239,7 +1326,7 @@ namespace warlock
             DR_PET_CHAOS_TEAR,    DR_PET_CHAOS_TEAR,
             DR_PET_OVERFIEND };
 
-        dimensional_rift_summon_rng = std::make_unique<shuffled_bag_rng_t<dimensional_rift_pet_e>>( std::move( deck ), this );
+        deck_rng.dimensional_rift_summon = std::make_unique<shuffled_bag_rng_t<dimensional_rift_pet_e>>( std::move( deck ), this );
       }
       else
       {
@@ -1248,22 +1335,38 @@ namespace warlock
             DR_PET_UNSTABLE_TEAR, DR_PET_UNSTABLE_TEAR,
             DR_PET_CHAOS_TEAR,    DR_PET_CHAOS_TEAR };
 
-        dimensional_rift_summon_rng = std::make_unique<shuffled_bag_rng_t<dimensional_rift_pet_e>>( std::move( deck ), this );
+        deck_rng.dimensional_rift_summon = std::make_unique<shuffled_bag_rng_t<dimensional_rift_pet_e>>( std::move( deck ), this );
       }
+    }
+
+    if ( talents.demonfire_infusion.ok() )
+    {
+      flat_rng.demonfire_infusion_dot = get_simple_proc_rng( "demonfire_infusion_dot", talents.demonfire_infusion->effectN( 1 ).percent() );
+      flat_rng.demonfire_infusion_inc = get_simple_proc_rng( "demonfire_infusion_incinerate", talents.demonfire_infusion->effectN( 2 ).percent() );
     }
 
     if ( talents.alythesss_ire.ok() )
     {
-      assert( as<int>( talents.alythesss_ire->effectN( 1 ).base_value() ) != 0 );
-      alythesss_ire_trigger = 100 / as<int>( talents.alythesss_ire->effectN( 1 ).base_value() );
+      flat_rng.alythesss_ire_shift = get_simple_proc_rng( "alythesss_ire_shift", rng_settings.alythesss_ire_shift.setting_value );
+
+      const unsigned chance = as<unsigned>( talents.alythesss_ire->effectN( 1 ).base_value() );
+      assert( chance != 0u );
+      assert( 100u % chance == 0u );
+      const unsigned alythesss_ire_trigger = 100u / chance;
+
+      cycle_proc.alythesss_ire = get_rng<fixed_cycle_proc_t>( "alythesss_ire", alythesss_ire_trigger, true, [ this ]( unsigned trigger_count ){
+        // NOTE: 2026-03-06 Alythess's Ire usually procs at a fixed interval of attempts. Rarely, the cycle
+        // shifts and advances the next proc; testing suggests this happens randomly in roughly ~1% of procs.
+        return flat_rng.alythesss_ire_shift->trigger() ? rng().range( 1u, trigger_count ) : 0u;
+      } );
     }
 
     // Modeling Echo of Sargeras as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
     if ( talents.embers_of_nihilam_1.ok() )
     {
-      double c_es = pseudo_random_c_from_p( rng_settings.echo_of_sargeras.setting_value );
-      echo_of_sargeras_rng = get_accumulated_rng( "echo_of_sargeras", c_es );
+      double c_es = prd::find_constant( rng_settings.echo_of_sargeras.setting_value );
+      prd_rng.echo_of_sargeras = get_accumulated_rng( "echo_of_sargeras", c_es );
     }
   }
 
@@ -1273,7 +1376,13 @@ namespace warlock
 
   void warlock_t::init_rng_hellcaller()
   {
-    devil_fruit_rng = get_rppm( "devil_fruit", hero.devil_fruit );
+    flat_rng.wither_crit_energize = get_simple_proc_rng( "wither_crit_energize", hero.wither_direct->effectN( 2 ).percent() );
+    flat_rng.blackened_soul = get_simple_proc_rng( "blackened_soul", rng_settings.blackened_soul.setting_value );
+    flat_rng.bleakheart_tactics = get_simple_proc_rng( "bleakheart_tactics", rng_settings.bleakheart_tactics.setting_value );
+    flat_rng.seeds_of_their_demise = get_simple_proc_rng( "seeds_of_their_demise", rng_settings.seeds_of_their_demise.setting_value );
+    flat_rng.mark_of_perotharn = get_simple_proc_rng( "mark_of_perotharn", rng_settings.mark_of_perotharn.setting_value );
+
+    rppm_rng.devil_fruit = get_rppm( "devil_fruit", hero.devil_fruit );
   }
 
   void warlock_t::init_rng_soul_harvester()
@@ -1285,19 +1394,19 @@ namespace warlock
       assert( affliction() || demonology() );
       double c_ss = 0.0;
       if ( affliction() )
-        c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_aff.setting_value );
+        c_ss = prd::find_constant( rng_settings.succulent_soul_aff.setting_value );
       else if ( demonology() )
-        c_ss = pseudo_random_c_from_p( rng_settings.succulent_soul_demo.setting_value );
+        c_ss = prd::find_constant( rng_settings.succulent_soul_demo.setting_value );
 
-      succulent_soul_rng = get_accumulated_rng( "succulent_soul", c_ss );
+      prd_rng.succulent_soul = get_accumulated_rng( "succulent_soul", c_ss );
     }
 
     // Modeling Manifested Avarice as a pseudo-random distribution (PRD) with a nominal
     // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
     if ( hero.manifested_avarice.ok() )
     {
-      double c_ma = pseudo_random_c_from_p( rng_settings.manifested_avarice.setting_value );
-      manifested_avarice_rng = get_accumulated_rng( "manifested_avarice", c_ma );
+      double c_ma = prd::find_constant( rng_settings.manifested_avarice.setting_value );
+      prd_rng.manifested_avarice = get_accumulated_rng( "manifested_avarice", c_ma );
     }
 
     // Modeling Feast of Souls as a pseudo-random distribution (PRD) with a nominal rate of 4% (aff) / 10% (demo) and a hard cap
@@ -1309,16 +1418,16 @@ namespace warlock
       int feast_of_souls_hardcap = 0;
       if ( affliction() )
       {
-        c_fs = pseudo_random_c_from_p( rng_settings.feast_of_souls_aff.setting_value );
+        c_fs = prd::find_constant( rng_settings.feast_of_souls_aff.setting_value );
         feast_of_souls_hardcap = static_cast<int>( rng_settings.feast_of_souls_hard_cap_aff.setting_value );
       }
       else if ( demonology() )
       {
-        c_fs = pseudo_random_c_from_p( rng_settings.feast_of_souls_demo.setting_value );
+        c_fs = prd::find_constant( rng_settings.feast_of_souls_demo.setting_value );
         feast_of_souls_hardcap = static_cast<int>( rng_settings.feast_of_souls_hard_cap_demo.setting_value );
       }
 
-      feast_of_souls_rng = get_rng<accumulated_hardcap_rng_t>( "feast_of_souls", c_fs, nullptr, feast_of_souls_hardcap );
+      prd_rng.feast_of_souls = get_accumulated_rng( "feast_of_souls", c_fs, feast_of_souls_hardcap );
     }
   }
 
@@ -1486,27 +1595,10 @@ namespace warlock
     add_option( opt_bool( "disable_felstorm", disable_auto_felstorm ) );
     add_option( opt_bool( "normalize_destruction_mastery", normalize_destruction_mastery ) );
 
-    add_rng_option( rng_settings.cunning_cruelty_sb );
-    add_rng_option( rng_settings.cunning_cruelty_ds );
-    add_rng_option( rng_settings.agony );
-    add_rng_option( rng_settings.nightfall );
-    add_rng_option( rng_settings.spiteful_reconstitution );
-    add_rng_option( rng_settings.spiteful_reconstitution_hard_cap );
-    add_rng_option( rng_settings.demonic_knowledge_rank1_cards );
-    add_rng_option( rng_settings.demonic_knowledge_rank2_cards );
-    add_rng_option( rng_settings.alythesss_ire_shift );
-    add_rng_option( rng_settings.echo_of_sargeras );
-    add_rng_option( rng_settings.blackened_soul );
-    add_rng_option( rng_settings.bleakheart_tactics );
-    add_rng_option( rng_settings.seeds_of_their_demise );
-    add_rng_option( rng_settings.mark_of_perotharn );
-    add_rng_option( rng_settings.succulent_soul_aff );
-    add_rng_option( rng_settings.succulent_soul_demo );
-    add_rng_option( rng_settings.feast_of_souls_aff );
-    add_rng_option( rng_settings.feast_of_souls_demo );
-    add_rng_option( rng_settings.feast_of_souls_hard_cap_aff );
-    add_rng_option( rng_settings.feast_of_souls_hard_cap_demo );
-    add_rng_option( rng_settings.manifested_avarice );
+    rng_settings.for_each( [ this ]( auto& setting )
+    {
+      add_rng_option( setting );
+    } );
   }
 
   void warlock_t::combat_begin()
@@ -1534,17 +1626,12 @@ namespace warlock
       } );
     } );
 
-    if ( dimensional_rift_summon_rng )
-      dimensional_rift_summon_rng->reset();
-
-    if ( talents.alythesss_ire.ok() )
-      alythesss_ire_counter = as<int>( rng().range( 0, alythesss_ire_trigger ) );
+    if ( deck_rng.dimensional_rift_summon )
+      deck_rng.dimensional_rift_summon->reset();
 
     warlock_pet_list.active = nullptr;
     havoc_target = nullptr;
     haunt_target = nullptr;
-    agony_accumulator = rng().range( 0.0, 0.99 );
-    corruption_accumulator = rng().range( 0.0, 0.99 );
     wild_imp_spawns.clear();
     diabolic_ritual = rng().range( 0, 3 );
     demonic_art_buff_replaced = false;

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1252,8 +1252,9 @@ namespace warlock
       flat_rng.infernal_rapidity = get_simple_proc_rng( "infernal_rapidity", infernal_rapidity_chance );
     }
 
-    // Modeling Spiteful Reconstitution as a pseudo-random distribution (PRD) with a nominal rate of 10% and a hard cap
-    // of 21 attempts. The PRD nominal rate corresponds to PRD constant C = 0.014745844781072676.
+    // Modeling Spiteful Reconstitution as a pseudo-random distribution (PRD) with an uncapped nominal rate of 10%.
+    // That nominal rate corresponds to PRD constant C = 0.014745844781072676.
+    // A separate hard cap of 21 attempts is then applied on top of the PRD, raising the effective average proc chance to ~10.06%.
     if ( talents.spiteful_reconstitution.ok() )
     {
       double c_sr = prd::find_constant( rng_settings.spiteful_reconstitution.setting_value );
@@ -1409,8 +1410,9 @@ namespace warlock
       prd_rng.manifested_avarice = get_accumulated_rng( "manifested_avarice", c_ma );
     }
 
-    // Modeling Feast of Souls as a pseudo-random distribution (PRD) with a nominal rate of 4% (aff) / 10% (demo) and a hard cap
-    // of 26 attempts. The PRD nominal rate corresponds to PRD C = 0.002448555471647706 (aff) / C = 0.014745844781072676 (demo)
+    // Modeling Feast of Souls as a pseudo-random distribution (PRD) with an uncapped nominal rate of 4% (aff) / 10% (demo). Those
+    // nominal rates correspond to PRD constants C = 0.002448555471647706 (aff) / C = 0.014745844781072676 (demo). A separate hard
+    // cap of 26 attempts is then applied on top of the PRD, raising the effective average proc chance to ~4.94% (aff) / ~10.01% (demo).
     if ( hero.feast_of_souls.ok() )
     {
       assert( affliction() || demonology() );

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -690,11 +690,7 @@ struct fel_firebolt_t : public warlock_pet_spell_t
   {
     warlock_pet_spell_t::execute();
 
-    // NOTE: 2026-03-06 It has been tested that Infernal Rapidity follows a Flat % chance model for each individual cast
-    // However, the % chance seems to be bugged and only half of what is specified in the spell data is being applied (bug)
-    double infernal_rapidity_chance = p()->o()->talents.infernal_rapidity->effectN( 1 ).percent();
-    infernal_rapidity_chance = p()->bugs ? infernal_rapidity_chance * 0.5 : infernal_rapidity_chance;
-    if ( ( twin != nullptr ) && rng().roll( infernal_rapidity_chance ) )
+    if ( ( twin != nullptr ) && p()->o()->flat_rng.infernal_rapidity->trigger() )
     {
       p()->o()->procs.infernal_rapidity->occur();
       twin->execute_on_target( target );
@@ -959,8 +955,7 @@ struct dreadstalker_melee_t : warlock_pet_melee_t
   {
     warlock_pet_melee_t::execute();
 
-    // NOTE: 2026-03-06 It has been tested that Carnivorous Stalkers follows a Flat % chance model for each individual melee hit
-    if ( p()->o()->talents.carnivorous_stalkers.ok() && rng().roll( p()->o()->talents.carnivorous_stalkers->effectN( 1 ).percent() ) )
+    if ( p()->o()->talents.carnivorous_stalkers.ok() && p()->o()->flat_rng.carnivorous_stalkers->trigger() )
     {
       debug_cast<dreadstalker_t*>( p() )->dreadbite_executes++;
       p()->o()->procs.carnivorous_stalkers->occur();


### PR DESCRIPTION
The custom `pseudo_random_p_from_c` and `pseudo_random_c_from_p` functions have been removed in favor of the new and faster core PRD C calculations.

Since support for a hard cap has recently been added to the `accumulated_rng_t` class, this functionality is now used for accumulator procs with hard caps. These have been migrated from the custom `accumulated_hardcap_rng_t` class, which has been removed as it is no longer needed.

Custom handling of the `nightfall` and `agony_energize` procs has been moved to the `threshold_rng_t` class, which is specialized for this type of RNG proc (functionality remains unchanged).

A new custom class, `fixed_cycle_proc_t`, has been introduced to handle the cyclic "Alythess's Ire" proc in a more structured way.

`simple_proc_t` is now used for Flat % Chance RNGs, with their initialization moved to `init_rng` functions.

RNG/procs have been reorganized into separate structs for better organization. The current categories are: `cycle_proc`, `deck_rng`, `rppm_rng`, `progress_rng`, `prd_rng`, and `flat_rng`.

Some flat procs that directly affect a buff’s trigger chance are still handled through the `set_chance` and/or `trigger` functions on their `buff_t`.

A new `for_each` method has been added to `rng_settings` struct to simplify maintenance when adding or removing members.