### PR TITLE
[DemonHunter] Voidfall proc rate is stack-dependent (per-spec)

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1222,9 +1222,9 @@ public:
     double voidfall_proc_chance_0_stacks_vengeance = 0.385;
     double voidfall_proc_chance_1_stacks_vengeance = 0.325;
     double voidfall_proc_chance_2_stacks_vengeance = 0.30;
-    double voidfall_proc_chance_0_stacks_havoc = 0.41;
-    double voidfall_proc_chance_1_stacks_havoc = 0.34;
-    double voidfall_proc_chance_2_stacks_havoc = 0.325;
+    double voidfall_proc_chance_0_stacks_devourer = 0.41;
+    double voidfall_proc_chance_1_stacks_devourer = 0.34;
+    double voidfall_proc_chance_2_stacks_devourer = 0.325;
     // How many seconds that Vengeful Retreat locks out Felblade
     double felblade_lockout_from_vengeful_retreat    = 0.6;
     bool enable_dungeon_slice                        = false;
@@ -10127,9 +10127,9 @@ void demon_hunter_t::create_options()
   add_option( opt_float( "voidfall_proc_chance_0_stacks_vengeance", options.voidfall_proc_chance_0_stacks_vengeance, 0, 1 ) );
   add_option( opt_float( "voidfall_proc_chance_1_stacks_vengeance", options.voidfall_proc_chance_1_stacks_vengeance, 0, 1 ) );
   add_option( opt_float( "voidfall_proc_chance_2_stacks_vengeance", options.voidfall_proc_chance_2_stacks_vengeance, 0, 1 ) );
-  add_option( opt_float( "voidfall_proc_chance_0_stacks_havoc", options.voidfall_proc_chance_0_stacks_havoc, 0, 1 ) );
-  add_option( opt_float( "voidfall_proc_chance_1_stacks_havoc", options.voidfall_proc_chance_1_stacks_havoc, 0, 1 ) );
-  add_option( opt_float( "voidfall_proc_chance_2_stacks_havoc", options.voidfall_proc_chance_2_stacks_havoc, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_0_stacks_devourer", options.voidfall_proc_chance_0_stacks_devourer, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_1_stacks_devourer", options.voidfall_proc_chance_1_stacks_devourer, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_2_stacks_devourer", options.voidfall_proc_chance_2_stacks_devourer, 0, 1 ) );
   add_option(
       opt_float( "felblade_lockout_from_vengeful_retreat", options.felblade_lockout_from_vengeful_retreat, 0, 1 ) );
   add_option( opt_bool( "enable_dungeon_slice", options.enable_dungeon_slice ) );
@@ -10998,9 +10998,9 @@ void demon_hunter_t::init_spells()
       hero_spec.meteor_shower_driver = talent_spell_lookup( talent.annihilator.dark_matter, 1264126 );
       hero_spec.meteor_shower_damage = hero_spec.meteor_shower_driver->effectN( 1 ).trigger();
       hero_spec.world_killer         = talent_spell_lookup( talent.annihilator.world_killer, 1256618 );
-      hero_spec.voidfall_proc_chances = { options.voidfall_proc_chance_0_stacks_havoc,
-                                          options.voidfall_proc_chance_1_stacks_havoc,
-                                          options.voidfall_proc_chance_2_stacks_havoc };
+      hero_spec.voidfall_proc_chances = { options.voidfall_proc_chance_0_stacks_devourer,
+                                          options.voidfall_proc_chance_1_stacks_devourer,
+                                          options.voidfall_proc_chance_2_stacks_devourer };
       break;
     case DEMON_HUNTER_VENGEANCE:
       hero_spec.voidfall_meteor      = talent_spell_lookup( talent.annihilator.voidfall, 1256303 );

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -916,6 +916,7 @@ public:
     const spell_data_t* thrill_of_the_fight_haste_buff;
     const spell_data_t* thrill_of_the_fight_damage_buff;
     double wounded_quarry_proc_rate;
+    std::array<double, 3> voidfall_proc_chances;
 
     // Annihilator
     const spell_data_t* voidfall_meteor;
@@ -1215,6 +1216,15 @@ public:
     double wounded_quarry_chance_vengeance = 0.30;
     // Proc rate for Wounded Quarry for Havoc
     double wounded_quarry_chance_havoc = 0.10;
+    // Voidfall proc rate per building stack count (WCL analysis, ~72k casts).
+    // Fits rate = base - k*sqrt(stacks) within 0.5pp, but no spell data
+    // parameterizes the decay, so these are likely server-side lookup tables.
+    double voidfall_proc_chance_0_stacks_vengeance = 0.385;
+    double voidfall_proc_chance_1_stacks_vengeance = 0.325;
+    double voidfall_proc_chance_2_stacks_vengeance = 0.30;
+    double voidfall_proc_chance_0_stacks_havoc = 0.41;
+    double voidfall_proc_chance_1_stacks_havoc = 0.34;
+    double voidfall_proc_chance_2_stacks_havoc = 0.325;
     // How many seconds that Vengeful Retreat locks out Felblade
     double felblade_lockout_from_vengeful_retreat    = 0.6;
     bool enable_dungeon_slice                        = false;
@@ -2948,7 +2958,8 @@ struct voidfall_building_trigger_t : public BASE
     if ( !BASE::p()->talent.annihilator.voidfall->ok() )
       return;
 
-    if ( !BASE::rng().roll( BASE::p()->talent.annihilator.voidfall->effectN( 3 ).percent() ) )
+    int stacks = std::min( BASE::p()->buff.voidfall_building->check(), 2 );
+    if ( !BASE::rng().roll( BASE::p()->hero_spec.voidfall_proc_chances[ stacks ] ) )
       return;
 
     // can't gain building while spending is up
@@ -10113,6 +10124,12 @@ void demon_hunter_t::create_options()
       opt_float( "soul_fragment_movement_consume_chance", options.soul_fragment_movement_consume_chance, 0, 1 ) );
   add_option( opt_float( "wounded_quarry_chance_vengeance", options.wounded_quarry_chance_vengeance, 0, 1 ) );
   add_option( opt_float( "wounded_quarry_chance_havoc", options.wounded_quarry_chance_havoc, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_0_stacks_vengeance", options.voidfall_proc_chance_0_stacks_vengeance, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_1_stacks_vengeance", options.voidfall_proc_chance_1_stacks_vengeance, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_2_stacks_vengeance", options.voidfall_proc_chance_2_stacks_vengeance, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_0_stacks_havoc", options.voidfall_proc_chance_0_stacks_havoc, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_1_stacks_havoc", options.voidfall_proc_chance_1_stacks_havoc, 0, 1 ) );
+  add_option( opt_float( "voidfall_proc_chance_2_stacks_havoc", options.voidfall_proc_chance_2_stacks_havoc, 0, 1 ) );
   add_option(
       opt_float( "felblade_lockout_from_vengeful_retreat", options.felblade_lockout_from_vengeful_retreat, 0, 1 ) );
   add_option( opt_bool( "enable_dungeon_slice", options.enable_dungeon_slice ) );
@@ -10981,6 +10998,9 @@ void demon_hunter_t::init_spells()
       hero_spec.meteor_shower_driver = talent_spell_lookup( talent.annihilator.dark_matter, 1264126 );
       hero_spec.meteor_shower_damage = hero_spec.meteor_shower_driver->effectN( 1 ).trigger();
       hero_spec.world_killer         = talent_spell_lookup( talent.annihilator.world_killer, 1256618 );
+      hero_spec.voidfall_proc_chances = { options.voidfall_proc_chance_0_stacks_havoc,
+                                          options.voidfall_proc_chance_1_stacks_havoc,
+                                          options.voidfall_proc_chance_2_stacks_havoc };
       break;
     case DEMON_HUNTER_VENGEANCE:
       hero_spec.voidfall_meteor      = talent_spell_lookup( talent.annihilator.voidfall, 1256303 );
@@ -10988,6 +11008,9 @@ void demon_hunter_t::init_spells()
       hero_spec.meteor_shower_driver = talent_spell_lookup( talent.annihilator.dark_matter, 1264128 );
       hero_spec.meteor_shower_damage = hero_spec.meteor_shower_driver->effectN( 1 ).trigger();
       hero_spec.world_killer         = talent_spell_lookup( talent.annihilator.world_killer, 1256616 );
+      hero_spec.voidfall_proc_chances = { options.voidfall_proc_chance_0_stacks_vengeance,
+                                          options.voidfall_proc_chance_1_stacks_vengeance,
+                                          options.voidfall_proc_chance_2_stacks_vengeance };
       break;
     default:
       hero_spec.voidfall_meteor      = spell_data_t::not_found();
@@ -10995,6 +11018,7 @@ void demon_hunter_t::init_spells()
       hero_spec.meteor_shower_driver = spell_data_t::not_found();
       hero_spec.meteor_shower_damage = spell_data_t::not_found();
       hero_spec.world_killer         = spell_data_t::not_found();
+      hero_spec.voidfall_proc_chances = { 0, 0, 0 };
       break;
   }
 


### PR DESCRIPTION
## Summary

- Voidfall building proc chance decreases with current stack count, rather than being a flat rate from spell data (`effectN(3)` = 35%)
- WCL analysis of 72k+ eligible casts shows per-stack rates with high statistical significance for both specs
- Devourer procs ~2pp higher than Vengeance at all stack levels (z-test p&lt;0.02), so each spec gets its own defaults
- Defaults exposed as per-spec player options for tuning

## WCL Data

### Vengeance (21,942 eligible Fracture casts, 325 players, S1 live)

| Stacks | Eligible | Procs | Rate | 95% CI | vs 35% |
|--------|----------|-------|------|--------|--------|
| 0 | 9,591 | 3,677 | **38.3%** | [37.4%, 39.3%] | p&lt;0.0001 |
| 1 | 7,471 | 2,432 | **32.6%** | [31.5%, 33.6%] | p&lt;0.0001 |
| 2 | 4,880 | 1,457 | **29.9%** | [28.6%, 31.2%] | p&lt;0.0001 |
| Overall | 21,942 | 7,566 | **34.5%** | [33.9%, 35.1%] | p=0.11 |

Chi-squared: X2=121.6, df=2 (p&lt;0.0001). Defaults: **0.385 / 0.325 / 0.30**

### Devourer (50,067 eligible Consume/Devour casts, 107 players)

| Stacks | Eligible | Procs | Rate | 95% CI | vs 35% |
|--------|----------|-------|------|--------|--------|
| 0 | 9,658 | 3,974 | **41.1%** | [40.2%, 42.1%] | p&lt;0.0001 |
| 1 | 22,638 | 7,712 | **34.1%** | [33.5%, 34.7%] | p=0.003 |
| 2 | 17,771 | 5,747 | **32.3%** | [31.7%, 33.0%] | p&lt;0.0001 |
| Overall | 50,067 | 17,451 | **34.9%** | [34.4%, 35.3%] | p=0.71 |

Chi-squared: X2=288.5, df=2 (p&lt;0.0001). Defaults: **0.41 / 0.34 / 0.325**

### Cross-spec comparison

| Stacks | Vengeance | Devourer | Delta | z-test |
|--------|-----------|----------|-------|--------|
| 0 | 38.3% | 41.1% | +2.8pp | p&lt;0.0001 |
| 1 | 32.6% | 34.1% | +1.5pp | p=0.017 |
| 2 | 29.9% | 32.3% | +2.4pp | p=0.001 |

No clean formula fits the data -- likely hard-coded server values.