### PR TITLE
fix: crucible of erratic energies never procs for melee specs

### DIFF
--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -2912,6 +2912,10 @@ void crucible_of_erratic_energies( special_effect_t& effect )
   effect.custom_buff = buff;
 
   effect.proc_flags2_ = PF2_LANDED;
+  // Spell data proc_flags (0x00015500) has no melee ability types. The driver has
+  // SX_ONLY_PROC_FROM_CLASS_ABILITIES set, which gates procs on allow_class_ability_procs,
+  // but the callback is never registered for melee actions without this addition.
+  effect.proc_flags_ = effect.driver()->proc_flags() | PF_MELEE_ABILITY;
 
   new dbc_proc_callback_t( effect.player, effect );
 }


### PR DESCRIPTION
Closes #11158

## Problem

  Crucible of Erratic Energies (264507, driver spell 1272091) never procs for
  melee specs. The driver spell's ProcTypeMask (0x00015500) contains no melee
  proc types, so the dbc_proc_callback registers only for spell/ranged/periodic
  action types. Melee actions never reach the callback at all, meaning the
  SX_ONLY_PROC_FROM_CLASS_ABILITIES check in trigger() is never evaluated for
  melee specs.

  The driver spell has SX_ONLY_PROC_FROM_CLASS_ABILITIES set. In-game testing
  confirms the trinket does proc from melee class abilities (e.g. Shadowstrike,
  Backstab) but not from auto-attacks, suggesting the live engine broadens proc
  eligibility beyond the raw ProcTypeMask when this flag is present.

  ## Fix

  In the existing crucible_of_erratic_energies handler, initialize proc_flags_
  from spell data and OR in PF_MELEE_ABILITY before the callback is created.
  This allows melee class abilities to reach the callback, where the existing
  SX_ONLY_PROC_FROM_CLASS_ABILITIES / allow_class_ability_procs gate correctly
  filters to class abilities only. Auto-attacks fire as PF_MELEE (not
  PF_MELEE_ABILITY) and are unaffected.

  ## Note

  This is an item-specific fix. The underlying issue seems to be that simc's general
  proc system does not handle SX_ONLY_PROC_FROM_CLASS_ABILITIES by expanding
  proc registration. It only uses it as a narrowing filter after proc_flags
  matching. A general fix in dbc_proc_callback_t::initialize() would be more
  correct long-term but carries broader risk. Flagging here for maintainer
  consideration.

  ## Testing

  Simulated Subtlety Rogue with Crucible equipped. Before fix:
  voidlust never appears in combat log. After fix: voidlust proc attempts on
  Backstab, Shadowstrike, Eviscerate with no auto-attack procs. Buff gained and
  tracked correctly.