### PR TITLE
[VDH] Sigil of Spite precombat + Reaver's Glaive trigger

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5363,6 +5363,7 @@ struct sigil_of_spite_t : public demon_hunter_spell_t
   {
     demon_hunter_spell_t::execute();
     sigil->place_sigil( target );
+    p()->buff.reavers_glaive->trigger();
   }
 
   std::unique_ptr<expr_t> create_expression( util::string_view name ) override

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5348,6 +5348,17 @@ struct sigil_of_spite_t : public demon_hunter_spell_t
     }
   }
 
+  void init_finished() override
+  {
+    demon_hunter_spell_t::init_finished();
+    harmful = !is_precombat;  // Do not count towards the precombat hostile action limit
+  }
+
+  bool usable_precombat() const override
+  {
+    return true;  // Has virtual travel time due to Sigil activation delay
+  }
+
   void execute() override
   {
     demon_hunter_spell_t::execute();


### PR DESCRIPTION
Two Vengeance Sigil of Spite fixes:

1. **Precombat support** — Added `init_finished()` and `usable_precombat()` overrides so Sigil of Spite can be used in precombat action lists, matching Sigil of Flame.

2. **Reaver's Glaive trigger** — The Hunt already had this trigger; Sigil of Spite was missing it.