### PR TITLE
fix(demon_hunter): make overflow soul fragment consumption instant

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -12287,12 +12287,15 @@ void demon_hunter_t::activate_soul_fragment( soul_fragment_t* frag )
     unsigned active_fragments = get_active_soul_fragments( frag->type );
     if ( active_fragments > max_soul_frags )
     {
-      // Find and delete the oldest active fragment of this type.
+      // Find and consume the oldest active fragment of this type.
+      // 2026-03-13 -- WCL analysis shows overflow consumption is instant in-game
+      //               (fragments go 7->6 at the same timestamp), consistent with
+      //               how Soul Cleave and Spirit Bomb consume with instant=true.
       for ( auto& it : soul_fragments )
       {
         if ( it->is_type( soul_fragment::LESSER ) && it->active() )
         {
-          it->consume( false );
+          it->consume( true );
 
           if ( sim->debug )
           {


### PR DESCRIPTION
## Summary

Soul fragment overflow currently calls `consume(false)`, which delays the consume action (and its Art of the Glaive stack trigger) by a distance-based travel time of ~600ms. WCL combat log analysis shows the overflow is actually instant in-game, with the AotG stack arriving after the same ~350ms delay that applies to all soul fragment consumption sources.

This changes overflow to `consume(true)`, matching how Soul Cleave, Spirit Bomb, and all other consumption paths already work.

## Evidence

Analyzed WCL report `8gX2vwmb6jW9czy1` fight 11 — Vengeance DH Aldrachi Reaver, ~1766s Algeth'ar Academy.

**Fragment overflow is instant in combat logs:**
Overflow events consistently show `applybuffstack → 7` and `removebuffstack → 6` at the same combat log timestamp (0ms delta). There is no travel time.

**AotG delay is uniform across all consumption sources (~350ms):**
A pure-overflow window at 3:35 in the fight (no Soul Cleave or Spirit Bomb for 2.2s) showed 6 overflow events producing 6 AotG stacks with delays of 303–460ms (mean 380ms) from the overflow event — the same range observed from normal Soul Cleave consumption.

| Overflow at | AotG at | Delay |
|---|---|---|
| +238ms | +608ms | 370ms |
| +512ms | +965ms | 453ms |
| +794ms | +1097ms | 303ms |
| +1117ms | +1474ms | 357ms |
| +1244ms | +1704ms | 460ms |
| +1529ms | +1913ms | 384ms |

Since the sim doesn't model this uniform AotG application delay for any consumption source (Soul Cleave/Spirit Bomb grant AotG instantly), the overflow path shouldn't model it either. Making overflow instant brings it in line with the rest of the sim.