### PR TITLE
[Demon Hunter] Fix sigil expression crash when spell is not known

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4440,6 +4440,11 @@ struct sigil_of_flame_t : public demon_hunter_spell_t
       if ( auto e = sigil->create_sigil_expression( name ) )
         return e;
     }
+    else if ( util::str_compare_ci( name, "placed" ) || util::str_compare_ci( name, "sigil_placed" ) ||
+              util::str_compare_ci( name, "activation_time" ) || util::str_compare_ci( name, "delay" ) )
+    {
+      return expr_t::create_constant( name, 0 );
+    }
 
     return demon_hunter_spell_t::create_expression( name );
   }
@@ -5379,6 +5384,11 @@ struct sigil_of_spite_t : public demon_hunter_spell_t
       if ( auto e = sigil->create_sigil_expression( name ) )
         return e;
     }
+    else if ( util::str_compare_ci( name, "placed" ) || util::str_compare_ci( name, "sigil_placed" ) ||
+              util::str_compare_ci( name, "activation_time" ) || util::str_compare_ci( name, "delay" ) )
+    {
+      return expr_t::create_constant( name, 0 );
+    }
 
     return demon_hunter_spell_t::create_expression( name );
   }
@@ -5527,6 +5537,11 @@ struct sigil_of_misery_t : public demon_hunter_spell_t
       if ( auto e = sigil->create_sigil_expression( name ) )
         return e;
     }
+    else if ( util::str_compare_ci( name, "placed" ) || util::str_compare_ci( name, "sigil_placed" ) ||
+              util::str_compare_ci( name, "activation_time" ) || util::str_compare_ci( name, "delay" ) )
+    {
+      return expr_t::create_constant( name, 0 );
+    }
 
     return demon_hunter_spell_t::create_expression( name );
   }
@@ -5573,6 +5588,11 @@ struct sigil_of_silence_t : public demon_hunter_spell_t
       if ( auto e = sigil->create_sigil_expression( name ) )
         return e;
     }
+    else if ( util::str_compare_ci( name, "placed" ) || util::str_compare_ci( name, "sigil_placed" ) ||
+              util::str_compare_ci( name, "activation_time" ) || util::str_compare_ci( name, "delay" ) )
+    {
+      return expr_t::create_constant( name, 0 );
+    }
 
     return demon_hunter_spell_t::create_expression( name );
   }
@@ -5618,6 +5638,11 @@ struct sigil_of_chains_t : public demon_hunter_spell_t
     {
       if ( auto e = sigil->create_sigil_expression( name ) )
         return e;
+    }
+    else if ( util::str_compare_ci( name, "placed" ) || util::str_compare_ci( name, "sigil_placed" ) ||
+              util::str_compare_ci( name, "activation_time" ) || util::str_compare_ci( name, "delay" ) )
+    {
+      return expr_t::create_constant( name, 0 );
     }
 
     return demon_hunter_spell_t::create_expression( name );


### PR DESCRIPTION
Sigil expressions (`placed`, `sigil_placed`, `activation_time`, `delay`) throw "No expression found" at init time when referenced via `action.sigil_name.placed` on a character that doesn't have the sigil spell. The inner sigil background action is only created when the talent/spell is active, so `create_expression` falls through to the parent class which doesn't handle sigil-specific expression names.

Returns constant 0 when the sigil pointer is null. Applied to all five sigil types for consistency.