### PR TITLE
feat: Adds the ability to use spaces in simc input

### DIFF
--- a/engine/class_modules/apl/ConvertAPL.py
+++ b/engine/class_modules/apl/ConvertAPL.py
@@ -28,6 +28,18 @@ ignored_comments = [
     '# Executed every time the actor is available.',
 ]
 
+def strip_whitespace_preserve_quotes(s):
+    """Strip whitespace outside of double-quoted regions."""
+    result = []
+    in_quotes = False
+    for c in s:
+        if c == '"':
+            in_quotes = not in_quotes
+            result.append(c)
+        elif in_quotes or not c.isspace():
+            result.append(c)
+    return ''.join(result)
+
 # Returns the next SimC string/line in file (defined as a comment line or TCI syntax to next whitespace)
 def read_by_whitespace(fileObj):
     for line in fileObj:
@@ -35,8 +47,9 @@ def read_by_whitespace(fileObj):
             if line.strip() not in ignored_comments:
                 yield line
         else:
-            for token in line.split(): # If it doesn't then just yield until next whitespace as TCI commands count them as line breaks
-                yield token
+            stripped = strip_whitespace_preserve_quotes(line)
+            if stripped:
+                yield stripped
 
 # Opens the input file and generates C++ syntax apl from the given TCI syntax APL. List of sub-action lists returned in subaplList and list of actions (with comments) returned in aplList. aplList is formatted already.
 def read_apl(inputFilePath):

--- a/engine/sim/option.cpp
+++ b/engine/sim/option.cpp
@@ -722,13 +722,32 @@ void option_db_t::parse_line( util::string_view line )
     return;
   }
 
-  auto tokens = util::string_split_allow_quotes( line, " \t\n\r" );
+  // Strip whitespace outside of double-quoted regions.
+  // Since spaces are never valid within option tokens (they are
+  // already used as token separators), this is a lossless operation
+  // that allows users to write readable .simc files with spaces.
+  std::string stripped;
+  stripped.reserve( line.size() );
+  bool in_quotes = false;
+  for ( char c : line )
+  {
+    if ( c == '"' )
+    {
+      in_quotes = !in_quotes;
+      stripped += c;
+    }
+    else if ( in_quotes || !is_white_space( c ) )
+    {
+      stripped += c;
+    }
+  }
 
-  for( const auto& token : tokens )
+  auto tokens = util::string_split_allow_quotes( stripped, " \t\n\r" );
+
+  for ( const auto& token : tokens )
   {
     parse_token( token );
   }
-
 }
 
 // option_db_t::parse_token =================================================


### PR DESCRIPTION
This PR adds whitespace stripping outside of double-quoted regions to both the C++ option parser (option.cpp) and the Python APL converter (ConvertAPL.py). This allows users to write more readable .simc files using spaces 

e.g.,
```
actions.ec_st += /sunfire, target_if= remains < 2 | refreshable & variable.eclipse_down
```
instead of 
```
actions.ec_st+=/sunfire,target_if=remains<2|refreshable&variable.eclipse_down
```

Important, while minor this is still a **breaking change**

This removes support for same-line option definitions that relied on spaces as token separators (e.g., `name=Vinter race=human`). 

Because spaces are now stripped, multiple definitions on one line will be merged into a single token. Each option must now be on its own line.

This tradeoff is intentional since same-line definitions aren't used anywhere in the current profiles, and allowing spaces in input significantly improves readability and lowers the barrier for others editing .simc files.