### PR TITLE
[Mage] Frost Profile + Spellslinger APL update 

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -265,18 +265,18 @@ void frost( player_t* p )
   default_->add_action( "run_action_list,name=ss_aoe,if=active_enemies>=3" );
   default_->add_action( "run_action_list,name=ss_st" );
 
-  cds->add_action( "potion,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|fight_remains<35" );
-  cds->add_action( "use_items" );
-  cds->add_action( "blood_fury" );
-  cds->add_action( "berserking" );
-  cds->add_action( "fireblood" );
-  cds->add_action( "ancestral_call" );
-  cds->add_action( "flurry,if=talent.frostfire_bolt,line_cd=9999", "Frostfire Opener" );
+  cds->add_action( "potion,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<35", "Potion, Items and Racials are used on cd for Frostfire and paired with either Orb or Ray as Spellslinger" );
+  cds->add_action( "use_items,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
+  cds->add_action( "blood_fury,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
+  cds->add_action( "berserking,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
+  cds->add_action( "fireblood,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
+  cds->add_action( "ancestral_call,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
+  cds->add_action( "flurry,if=talent.frostfire_bolt,line_cd=9999", "Opener Frostfire" );
   cds->add_action( "glacial_spike,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "flurry,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "ray_of_frost,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "frozen_orb,if=talent.frostfire_bolt,line_cd=9999" );
-  cds->add_action( "flurry,if=talent.splinterstorm,line_cd=9999", "Spellslinger Opener" );
+  cds->add_action( "flurry,if=talent.splinterstorm,line_cd=9999", "Opener Spellslinger" );
   cds->add_action( "frozen_orb,if=talent.splinterstorm,line_cd=9999" );
   cds->add_action( "ray_of_frost,if=talent.splinterstorm,line_cd=9999" );
   cds->add_action( "ray_of_frost,if=fight_remains<12", "End-Of-Fight Actions" );
@@ -313,31 +313,29 @@ void frost( player_t* p )
   movement->add_action( "cone_of_cold,if=talent.cone_of_frost" );
   movement->add_action( "ice_lance" );
 
-  ss_aoe->add_action( "comet_storm" );
+  ss_aoe->add_action( "comet_storm,if=buff.splinterstorm.down" );
   ss_aoe->add_action( "blizzard,if=buff.freezing_rain.up" );
   ss_aoe->add_action( "flurry,if=buff.brain_freeze.react&buff.thermal_void.down" );
-  ss_aoe->add_action( "ice_lance,if=buff.fingers_of_frost.react=2" );
   ss_aoe->add_action( "frozen_orb" );
-  ss_aoe->add_action( "glacial_spike" );
   ss_aoe->add_action( "ice_lance,if=buff.fingers_of_frost.react" );
+  ss_aoe->add_action( "glacial_spike" );
   ss_aoe->add_action( "ice_lance,if=debuff.freezing.react>=6" );
   ss_aoe->add_action( "ice_nova,if=talent.cone_of_frost&active_enemies>=4" );
   ss_aoe->add_action( "cone_of_cold,if=talent.cone_of_frost&active_enemies>=4" );
+  ss_aoe->add_action( "blizzard,if=active_enemies>=5&talent.freezing_winds&talent.freezing_rain" );
   ss_aoe->add_action( "flurry,if=cooldown_react" );
   ss_aoe->add_action( "ray_of_frost" );
-  ss_aoe->add_action( "blizzard,if=active_enemies>=7&(cooldown.frozen_orb.remains>12*spell_haste|!talent.freezing_rain)", "Only hardcast Blizzard at 7 or more targets. Holding it when Frozen Orb is about to come up is mostly QOL with a minimal impact on sim-dps." );
   ss_aoe->add_action( "frostbolt" );
   ss_aoe->add_action( "call_action_list,name=movement" );
 
-  ss_st->add_action( "comet_storm" );
+  ss_st->add_action( "comet_storm,if=buff.splinterstorm.down" );
   ss_st->add_action( "flurry,if=buff.brain_freeze.react&buff.thermal_void.down" );
-  ss_st->add_action( "ice_lance,if=buff.fingers_of_frost.react=2" );
   ss_st->add_action( "frozen_orb" );
-  ss_st->add_action( "glacial_spike" );
   ss_st->add_action( "ice_lance,if=buff.fingers_of_frost.react" );
+  ss_st->add_action( "glacial_spike" );
   ss_st->add_action( "ice_lance,if=debuff.freezing.react>=6" );
-  ss_st->add_action( "flurry,if=cooldown_react" );
   ss_st->add_action( "ray_of_frost" );
+  ss_st->add_action( "flurry,if=cooldown_react" );
   ss_st->add_action( "frostbolt" );
   ss_st->add_action( "call_action_list,name=movement" );
 }

--- a/profiles/generators/MID1/MID1_Generate_Mage.simc
+++ b/profiles/generators/MID1/MID1_Generate_Mage.simc
@@ -144,19 +144,20 @@ temporary_enchant=main_hand:thalassian_phoenix_oil_2
 
 head=voidbreakers_veil,id=250060,bonus_id=1808/13575,ilevel=289,gem_id=240983
 neck=amulet_of_the_abyssal_hymn,id=250247,bonus_id=12806/13577/13668,gem_id=240908/240908
-shoulder=mantle_of_dark_devotion,id=251085,bonus_id=12806/13577
-back=adherents_silken_shroud,id=239656,bonus_id=8960/12214/12384,ilevel=285,crafted_stats=32/49
+shoulder=mantle_of_dark_devotion,id=251085,ilevel=289
+back=rigid_scale_greatcloak,id=258575,ilevel=289
 chest=voidbreakers_robe,id=250063,bonus_id=13575,ilevel=289,enchant_id=7987
 wrist=martyrs_bindings,id=239648,bonus_id=1808/8960/12214/12384,ilevel=285,gem_id=240908,crafted_stats=32/49
 hands=voidbreakers_gloves,id=250061,bonus_id=12806/13574
 waist=voidbreakers_sage_cord,id=250057,bonus_id=1808,ilevel=289,gem_id=240908
 legs=voidbreakers_britches,id=250059,bonus_id=13575,ilevel=289,enchant_id=7935
-feet=icesteeped_sandals,id=49805,bonus_id=4786/12806
+feet=dreamscorched_striders,id=249373,ilevel=289
 finger1=eye_of_midnight,id=249920,bonus_id=12806/13577/13668,gem_id=240908/240908,enchant_id=7967
 finger2=sindorei_band_of_hope,id=249919,bonus_id=12806/13577/13668,gem_id=240908,enchant_id=7967
 trinket1=gaze_of_the_alnseer,id=249343,ilevel=289
 trinket2=vaelgors_final_stare,id=249346,bonus_id=12806/13577
-main_hand=umbral_spire_of_zuraal,id=258514,ilevel=289,enchant_id=7981
+main_hand=skybreakers_blade,id=258218,ilevel=289,enchant_id=7981
+off_hand=alnhara_lantern,id=245769,bonus_id=8791/8960/12214/12693,ilevel=285,crafted_stats=36/32
 
 save=MID1_Mage_Frost.simc
 
@@ -176,18 +177,19 @@ temporary_enchant=main_hand:thalassian_phoenix_oil_2
 
 head=voidbreakers_veil,id=250060,bonus_id=1808/13575,ilevel=289,gem_id=240983
 neck=amulet_of_the_abyssal_hymn,id=250247,bonus_id=12806/13577/13668,gem_id=240908/240908
-shoulder=mantle_of_dark_devotion,id=251085,bonus_id=12806/13577
-back=adherents_silken_shroud,id=239656,bonus_id=8960/12214/12384,ilevel=285,crafted_stats=32/49
+shoulder=mantle_of_dark_devotion,id=251085,ilevel=289
+back=rigid_scale_greatcloak,id=258575,ilevel=289
 chest=voidbreakers_robe,id=250063,bonus_id=13575,ilevel=289,enchant_id=7987
 wrist=martyrs_bindings,id=239648,bonus_id=1808/8960/12214/12384,ilevel=285,gem_id=240908,crafted_stats=32/49
 hands=voidbreakers_gloves,id=250061,bonus_id=12806/13574
 waist=voidbreakers_sage_cord,id=250057,bonus_id=1808,ilevel=289,gem_id=240908
 legs=voidbreakers_britches,id=250059,bonus_id=13575,ilevel=289,enchant_id=7935
-feet=icesteeped_sandals,id=49805,bonus_id=4786/12806
+feet=dreamscorched_striders,id=249373,ilevel=289
 finger1=eye_of_midnight,id=249920,bonus_id=12806/13577/13668,gem_id=240908/240908,enchant_id=7967
 finger2=sindorei_band_of_hope,id=249919,bonus_id=12806/13577/13668,gem_id=240908,enchant_id=7967
 trinket1=gaze_of_the_alnseer,id=249343,ilevel=289
 trinket2=vaelgors_final_stare,id=249346,bonus_id=12806/13577
-main_hand=umbral_spire_of_zuraal,id=258514,ilevel=289,enchant_id=7981
+main_hand=skybreakers_blade,id=258218,ilevel=289,enchant_id=7981
+off_hand=alnhara_lantern,id=245769,bonus_id=8791/8960/12214/12693,ilevel=285,crafted_stats=36/32
 
 save=MID1_Mage_Frost_Frostfire.simc


### PR DESCRIPTION
General:
- updated gear
- for Spellslinger pots/trinkets/racials are now used in the opener and then paired with Orb/Ray

Spellslinger:
- FoF is now spend above Glacial Spike
- the high prio IL line at 2 FoF is redundant now (and got yeeted)
- swapped flurry and ray prio in ST - you want to cast Ray first to rebuild stacks whereas in AoE you still want to spend Flurry first
- the hardcast blizzard line is now only relevant at 5+ targets with both blizzard talents
- tried to get the best out of cms (it still absolutely sucks)

Sanity-check Sims:
ST https://www.raidbots.com/simbot/report/7z5NVvaQXsUh2DyJXsgygt
AoE https://www.raidbots.com/simbot/report/hmiGCwzgWRmD7wZctrGgZp