### PR TITLE
[Priest] Fix Deaths Torment echo insanity generation

### DIFF
--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1159,6 +1159,26 @@ public:
     ab::snapshot_state( s, rt );
   }
 
+  double composite_energize_amount( const action_state_t* s ) const override
+  {
+    double ea = ab::composite_energize_amount( s );
+
+    if ( cast_state( s )->chain_number > 0 )
+    {
+      // BUG: https://github.com/SimCMinMax/WoW-BugTracker/issues/1385
+      if ( priest().bugs )
+      {
+        ea = std::round( ea * priest().talents.shadow.deaths_torment->effectN( 2 ).percent() );
+      }
+      else
+      {
+        ea *= priest().talents.shadow.deaths_torment->effectN( 2 ).percent();
+      }
+    }
+
+    return ea;
+  }
+
   double composite_da_multiplier( const action_state_t* s ) const override
   {
     double m = ab::composite_da_multiplier( s );


### PR DESCRIPTION
Deaths Torment echoes were generating full insanity (4 per echo) instead of applying the 15% effectiveness modifier. In-game testing confirms echoes generate 1 insanity each (4 * 0.15 = 0.6, rounded to 1).

Before: 4 + 4 + 4 = 12 insanity per SW:D cast with DT
After:  4 + 1 + 1 = 6 insanity per SW:D cast with DT (matches live)

This came from testing some APL update for SW:D, and the results seemed a bit to promising, so I wanted to verify in game, where it seemed that the insanity generation was not getting the 15% penalty applied.

Relevant loglines:
```
3/15/2026 22:46:35.1571  SPELL_ENERGIZE,Player-3674-0B5191D4,"Dagkar-TwistingNether-EU",0x511,0x80000000,Player-3674-0B5191D4,"Dagkar-TwistingNether-EU",0x511,0x80000000,32379,"Shadow Word: Death",0x20,Player-3674-0B5191D4,0000000000000000,297820,297820,132,1818,409,301,0,0,13,1570,15000,0,8195.69,-4351.78,2393,3.0979,240,4.0000,0.0000,13,15000
3/15/2026 22:46:35.3601  SPELL_ENERGIZE,Player-3674-0B5191D4,"Dagkar-TwistingNether-EU",0x511,0x80000000,Player-3674-0B5191D4,"Dagkar-TwistingNether-EU",0x511,0x80000000,32379,"Shadow Word: Death",0x20,Player-36740B5191D4,0000000000000000,297820,297820,132,1818,409,301,0,0,13,1770,15000,0,8195.69,-4351.78,2393,3.0979,240,1.0000,0.0000,13,15000
3/15/2026 22:46:35.5721  SPELL_ENERGIZE,Player-3674-0B5191D4,"Dagkar-TwistingNether-EU",0x511,0x80000000,Player-3674-0B5191D4,"Dagkar-TwistingNether-EU",0x511,0x80000000,32379,"Shadow Word: Death",0x20,Player-3674-0B5191D4,0000000000000000,297820,297820,132,1818,409,301,0,0,13,1870,15000,0,8195.69,-4351.78,2393,3.0979,240,1.0000,0.0000,13,15000
```



Relevant logs:
https://www.warcraftlogs.com/reports/a3ZvNrJXmw942TnG?boss=0&difficulty=0&type=resources&source=10&spell=113