### PR TITLE
[Warlock] Rename demo profile to allow automated generation

### DIFF
--- a/profiles/MID1_Raid.simc
+++ b/profiles/MID1_Raid.simc
@@ -63,7 +63,7 @@ MID1_Shaman_Enhancement_Stormbringer.simc
 MID1_Warlock_Affliction.simc
 MID1_Warlock_Affliction_Hellcaller.simc
 # # MID1_Warlock_Demonology_Soul_Harvester.simc
-# MID1_Warlock_Demonology.simc
+MID1_Warlock_Demonology.simc
 MID1_Warlock_Destruction_Diabolist.simc
 MID1_Warlock_Destruction.simc
 

--- a/profiles/generators/MID1/MID1_Generate_Warlock.simc
+++ b/profiles/generators/MID1/MID1_Generate_Warlock.simc
@@ -79,7 +79,7 @@ trinket1=locuswalkers_ribbon,id=249809,bonus_id=4786/4800/12806
 trinket2=emberwing_feather,id=250144,bonus_id=12806/13577,ilevel=289
 main_hand=spire_of_the_furious_construct,id=110031,bonus_id=12806/13577,enchant_id=8039
 
-save=MID1_Warlock_Demonology_Soul_Harvester.simc
+save=MID1_Warlock_Demonology.simc
 
 # warlock="MID1_Warlock_Demonology_Diabolist"
 # spec=demonology


### PR DESCRIPTION
Right now, Demo is not picked up by BM or Simc stack. I'm renaming the profile to allow that