### PR TITLE
[Warlock] Seed of Corruption and Demoniacs Fervor aff fixes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -968,7 +968,9 @@ void warlock_t::parse_player_effects()
     // Affliction Mastery
     parse_effects( warlock_base.potent_afflictions ); // 77215
     // Affliction Debuffs/DoTs
-    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.haunt, talents.shadow_of_nathreza_2 );
+    // NOTE: Shadow of Nathreza II (rank 2) only increases by 2% (as if it were rank 1) the
+    // effect #2 and #3 (pet and guardian damage) of the Haunt debuff damage bonus (bug)
+    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::haunt ), talents.haunt );
   }
 
   // Demonology

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1326,8 +1326,7 @@ using namespace helpers;
       if ( demonology() && p()->hero.demoniacs_fervor.ok() && s->chain_target == 0 )
         m *= 1.0 + p()->hero.demoniacs_fervor->effectN( 1 ).percent();
 
-      // NOTE: 2026-02-20 Demoniacs Fervor talent does not work for Affliction (bug)
-      if ( affliction() && p()->hero.demoniacs_fervor.ok() && !p()->bugs && td( s->target )->dots.unstable_affliction->is_ticking() )
+      if ( affliction() && p()->hero.demoniacs_fervor.ok() && td( s->target )->dots.unstable_affliction->is_ticking() )
         m *= 1.0 + p()->hero.demoniacs_fervor->effectN( 1 ).percent();
 
       return m;
@@ -1619,8 +1618,7 @@ using namespace helpers;
       {
         aoe = -1;
         background = dual = true;
-        // NOTE: 2026-02-20 Seed of Corruption is currently reducing damage beyond 1 target ignoring the spell data (bug)
-        reduced_aoe_targets = p->bugs ? 1 : as<int>( p->talents.seed_of_corruption->effectN( 4 ).base_value() );
+        reduced_aoe_targets = as<int>( p->talents.seed_of_corruption->effectN( 4 ).base_value() );
 
         affected_by.deaths_embrace = p->talents.deaths_embrace.ok();
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2679,8 +2679,7 @@ struct soul_swipe_base_t : public warlock_pet_spell_t
 {
   soul_swipe_base_t( std::string_view n, warlock_pet_t* p, const spell_data_t* s ) : warlock_pet_spell_t( n, p, s )
   {
-    // Soul Swipe / Rampaging Demonic Soul deals 20% extra damage for demonology
-    // We don't know for sure what effect causes it, but we assume it's this one
+    // Rampaging Demonic Soul has a custom damage modifier for demonology
     if ( p->o()->demonology() )
       base_dd_multiplier *= 1.0 + p->o()->warlock_base.demonology_warlock->effectN( 8 ).percent();
 


### PR DESCRIPTION
Blizzard has fixed the Seed of Corruption scaling bug (it was starting sqrt scaling beyond 1 target instead of 8).

Sow of Seeds has been tested to work correctly. It has been tested that the Patient Zero bug when used with Sow of Seeds still exists, though it is a very minor bug that has hardly any impact: Patient Zero damage bonus always applies to the primary seed target instead of the host of secondary ones. These behaviors were already correctly implemented in SimC and do not need changes.

Blizzard has also fixed the Demoniacs Fervor (Soul Harvester) bug that prevented it from working at all for Affliction.

In SimC, the effect of Shadow of Nathreza II was being applied twice to Haunt; this has been fixed.