### PR TITLE
[DH] Reap damage delay

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -3035,12 +3035,14 @@ struct meteoric_fall_trigger_t : public BASE
 
     for ( int i = 0; i < stacks; ++i )
     {
-      BASE::p()->active.voidfall_meteor->execute_on_target( BASE::target );
+      make_event<delayed_execute_event_t>( *BASE::sim, BASE::p(), BASE::p()->active.voidfall_meteor, BASE::target,
+                                           ( BASE::p()->active.voidfall_meteor->travel_time() * i ) );
     }
 
     if ( BASE::p()->talent.annihilator.world_killer->ok() )
     {
-      BASE::p()->active.world_killer->execute_on_target( BASE::target );
+      make_event<delayed_execute_event_t>( *BASE::sim, BASE::p(), BASE::p()->active.world_killer, BASE::target,
+                                           ( stacks * BASE::p()->active.voidfall_meteor->travel_time() ) );
     }
   }
 };

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6124,6 +6124,7 @@ struct reap_base_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
     
     p()->consume_soul_fragments( soul_fragment::LESSER, false, fragments_consumed );
 
+    // TOCHECK: This delay is a guess based on averages in logs as there is no spelldata
     make_event( *p()->sim, 220_ms, [ this, fragments_consumed ] {
       damage_action->set_target( target );
       action_state_t* damage_state = damage_action->get_state();
@@ -6214,6 +6215,7 @@ struct eradicate_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
     p()->consume_soul_fragments( soul_fragment::LESSER, false, fragments_consumed );
     auto damage                 = p()->buff.metamorphosis->up() ? damage_action_meta : damage_action;
 
+    // TOCHECK: This delay is a guess based on averages in logs as there is no spelldata
     make_event( *p()->sim, 220_ms, [ this, fragments_consumed, damage ] {
       damage->set_target( target );
       action_state_t* damage_state = damage->get_state();

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6120,19 +6120,23 @@ struct reap_base_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
     p()->buff.reap->trigger();
 
     base_t::execute();
-    unsigned fragments_consumed = p()->consume_soul_fragments( soul_fragment::LESSER, true, souls_to_consume() );
+    unsigned fragments_consumed = souls_to_consume();
+    
+    p()->consume_soul_fragments( soul_fragment::LESSER, false, fragments_consumed );
 
-    damage_action->set_target( target );
-    action_state_t* damage_state = damage_action->get_state();
-    damage_state->target         = target;
-    damage_action->snapshot_state( damage_state, result_amount_type::DMG_DIRECT );
+    make_event( *p()->sim, 220_ms, [ this, fragments_consumed ] {
+      damage_action->set_target( target );
+      action_state_t* damage_state = damage_action->get_state();
+      damage_state->target         = target;
+      damage_action->snapshot_state( damage_state, result_amount_type::DMG_DIRECT );
 
-    if ( p()->talent.devourer.soulshaper->ok() )
-    {
-      damage_state->da_multiplier *= 1.0 + fragments_consumed * p()->talent.devourer.soulshaper->effectN( 1 ).percent();
-    }
-
-    damage_action->schedule_execute( damage_state );
+      if ( p()->talent.devourer.soulshaper->ok() )
+      {
+        damage_state->da_multiplier *=
+            1.0 + fragments_consumed * p()->talent.devourer.soulshaper->effectN( 1 ).percent();
+      }
+      damage_action->schedule_execute( damage_state );
+    } );
 
     p()->buff.moment_of_craving->expire();
   }
@@ -6206,21 +6210,24 @@ struct eradicate_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
 
     base_t::execute();
 
-    unsigned fragments_consumed = p()->consume_soul_fragments( soul_fragment::LESSER, true, souls_to_consume() );
+    unsigned fragments_consumed = souls_to_consume();
+    p()->consume_soul_fragments( soul_fragment::LESSER, false, fragments_consumed );
     auto damage                 = p()->buff.metamorphosis->up() ? damage_action_meta : damage_action;
 
-    damage->set_target( target );
-    action_state_t* damage_state = damage->get_state();
-    damage_state->target         = target;
-    damage->snapshot_state( damage_state, result_amount_type::DMG_DIRECT );
+    make_event( *p()->sim, 220_ms, [ this, fragments_consumed, damage ] {
+      damage->set_target( target );
+      action_state_t* damage_state = damage->get_state();
+      damage_state->target         = target;
+      damage->snapshot_state( damage_state, result_amount_type::DMG_DIRECT );
 
-    if ( p()->talent.devourer.soulshaper->ok() )
-    {
-      damage_state->da_multiplier *= 1.0 + fragments_consumed * p()->talent.devourer.soulshaper->effectN( 1 ).percent();
-    }
+      if ( p()->talent.devourer.soulshaper->ok() )
+      {
+        damage_state->da_multiplier *=
+            1.0 + fragments_consumed * p()->talent.devourer.soulshaper->effectN( 1 ).percent();
+      }
 
-    damage->schedule_execute( damage_state );
-
+      damage->schedule_execute( damage_state );
+    } );
     p()->buff.moment_of_craving->expire();
 
     p()->buff.eradicate->expire();

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6120,9 +6120,7 @@ struct reap_base_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
     p()->buff.reap->trigger();
 
     base_t::execute();
-    unsigned fragments_consumed = souls_to_consume();
-    
-    p()->consume_soul_fragments( soul_fragment::LESSER, false, fragments_consumed );
+    unsigned fragments_consumed = p()->consume_soul_fragments( soul_fragment::LESSER, false, souls_to_consume() );
 
     // TOCHECK: This delay is a guess based on averages in logs as there is no spelldata
     make_event( *p()->sim, 220_ms, [ this, fragments_consumed ] {
@@ -6211,8 +6209,7 @@ struct eradicate_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
 
     base_t::execute();
 
-    unsigned fragments_consumed = souls_to_consume();
-    p()->consume_soul_fragments( soul_fragment::LESSER, false, fragments_consumed );
+    unsigned fragments_consumed = p()->consume_soul_fragments( soul_fragment::LESSER, false, souls_to_consume() );
     auto damage                 = p()->buff.metamorphosis->up() ? damage_action_meta : damage_action;
 
     // TOCHECK: This delay is a guess based on averages in logs as there is no spelldata

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -6562,9 +6562,9 @@ struct voidfall_meteor_base_t : public demon_hunter_spell_t
   voidfall_meteor_base_t( util::string_view n, demon_hunter_t* p, const spell_data_t* s )
     : demon_hunter_spell_t( n, p, s )
   {
-    execute_action = p->get_background_action<voidfall_meteor_damage_t>( fmt::format( "{}_damage", name() ),
+    impact_action = p->get_background_action<voidfall_meteor_damage_t>( fmt::format( "{}_damage", name() ),
                                                                          s->effectN( 2 ).trigger() );
-    add_child( execute_action );
+    add_child( impact_action );
   }
 };
 


### PR DESCRIPTION
Delays the damage of reap/cull/eradicate based on in game numbers and returns the soul consumption to no longer be  instant, allowing the in game damage delay to still benefit from effects gained between the cast and damage event