### PR TITLE
[Shadow] Spread Shadow Word: Madness to multiple targets

### DIFF
--- a/ActionPriorityLists/default/priest_shadow.simc
+++ b/ActionPriorityLists/default/priest_shadow.simc
@@ -10,8 +10,9 @@ actions.precombat=snapshot_stats
 actions.precombat+=/shadowform,if=!buff.shadowform.up
 actions.precombat+=/variable,name=trinket_1_buffs,value=(trinket.1.has_buff.intellect|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit|trinket.1.is.signet_of_the_priory)&(trinket.1.cooldown.duration>=20)
 actions.precombat+=/variable,name=trinket_2_buffs,value=(trinket.2.has_buff.intellect|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit|trinket.2.is.signet_of_the_priory)&(trinket.2.cooldown.duration>=20)
-actions.precombat+=/variable,name=dr_force_prio,default=1,op=reset
-actions.precombat+=/variable,name=me_force_prio,default=1,op=reset
+actions.precombat+=/variable,name=dr_force_prio,default=0,op=reset
+actions.precombat+=/variable,name=me_force_prio,default=0,op=reset
+actions.precombat+=/variable,name=max_swm,default=0,op=reset
 actions.precombat+=/variable,name=max_vts,default=12,op=reset
 actions.precombat+=/variable,name=is_vt_possible,default=0,op=reset
 actions.precombat+=/arcane_torrent
@@ -19,6 +20,7 @@ actions.precombat+=/tentacle_slam
 
 # Executed every time the actor is available.
 actions=variable,name=holding_tentacle_slam,op=set,value=raid_event.adds.in<15
+actions+=/variable,name=max_swm,op=setif,condition=talent.distorted_reality,value=4,value_else=2,if=variable.max_swm=0
 actions+=/call_action_list,name=aoe,if=active_enemies>2
 actions+=/run_action_list,name=main
 
@@ -58,12 +60,12 @@ actions.main+=/call_action_list,name=cds,if=fight_remains<30|target.time_to_die>
 # High Priority Shadow Word: Death when you are forcing the bonus from Devour Matter
 actions.main+=/shadow_word_death,target_if=max:(target.health.pct<=20)*100+dot.shadow_word_madness.ticking,if=priest.force_devour_matter&talent.devour_matter
 # Do not overcap on insanity
-actions.main+=/shadow_word_madness,target_if=max:target.time_to_die*(dot.shadow_word_madness.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.shadow_word_madness<=1&dot.shadow_word_madness.remains<=gcd.max|insanity.deficit<=35|buff.mind_devourer.react|!raid_event.adds.exists&target.time_to_die<=10|buff.entropic_rift.up&action.shadow_word_madness.cost>0
+actions.main+=/shadow_word_madness,target_if=max:target.time_to_die*(dot.shadow_word_madness.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.shadow_word_madness<=variable.max_swm&dot.shadow_word_madness.remains<=gcd.max|insanity.deficit<=35|buff.mind_devourer.react|!raid_event.adds.exists&target.time_to_die<=10|buff.entropic_rift.up&action.shadow_word_madness.cost>0
 actions.main+=/void_volley
 # Blast more burst :wicked:
 actions.main+=/void_blast,target_if=max:(dot.shadow_word_madness.remains*1000+target.time_to_die)
 # Use Tentacle Slam to prevent capping charges or to refresh Vampiric Touch
-actions.main+=/tentacle_slam,target_if=min:dot.vampiric_touch.remains,if=dot.vampiric_touch.refreshable|cooldown.tentacle_slam.full_recharge_time<=gcd.max*2
+actions.main+=/tentacle_slam,target_if=min:dot.vampiric_touch.remains+dot.shadow_word_madness.ticking*1000*talent.maddening_tentacles,if=dot.vampiric_touch.refreshable|cooldown.tentacle_slam.full_recharge_time<=gcd.max*2
 actions.main+=/shadow_word_madness,target_if=max:dot.shadow_word_madness.remains,if=dot.shadow_word_madness.pmultiplier<1&dot.shadow_word_madness.ticking
 # Use Void Torrent if it will get near full Mastery Value
 actions.main+=/void_torrent,target_if=max:(dot.shadow_word_madness.remains*1000+target.time_to_die),if=!variable.holding_tentacle_slam&variable.dots_up
@@ -74,7 +76,7 @@ actions.main+=/mind_blast,target_if=max:dot.shadow_word_madness.remains,if=(!buf
 # MFI is a good button
 actions.main+=/mind_flay_insanity,target_if=max:dot.shadow_word_madness.remains
 # Use Tentacle Slam for Void Apparitions or Maddening Tentacles value, holding for adds if needed
-actions.main+=/tentacle_slam,target_if=min:dot.vampiric_touch.remains,if=(talent.void_apparitions|talent.maddening_tentacles)&(raid_event.adds.in>30|raid_event.adds.in>5&cooldown.tentacle_slam.full_recharge_time<=gcd.max*2)
+actions.main+=/tentacle_slam,target_if=min:dot.vampiric_touch.remains+dot.shadow_word_madness.ticking*1000*talent.maddening_tentacles,if=(talent.void_apparitions|talent.maddening_tentacles)&(raid_event.adds.in>30|raid_event.adds.in>5&cooldown.tentacle_slam.full_recharge_time<=gcd.max*2)
 # Put out Vampiric Touch on enemies that will live at least 12s and Tentacle Slam is not available soon
 actions.main+=/vampiric_touch,target_if=max:(refreshable*10000+target.time_to_die)*(dot.vampiric_touch.ticking|!variable.dots_up),if=refreshable&target.time_to_die>12&(dot.vampiric_touch.ticking|!variable.dots_up)&(variable.max_vts>0|active_enemies=1)&(action.tentacle_slam.usable_in>=dot.vampiric_touch.remains|variable.holding_tentacle_slam|!action.tentacle_slam.enabled)
 # Healing spell action list for proccing Twist of Fate. Set priest.twist_of_fate_heal_rppm=<rppm> to make this be used.

--- a/engine/class_modules/apl/apl_priest.cpp
+++ b/engine/class_modules/apl/apl_priest.cpp
@@ -52,14 +52,16 @@ void shadow( player_t* p )
   precombat->add_action( "shadowform,if=!buff.shadowform.up" );
   precombat->add_action( "variable,name=trinket_1_buffs,value=(trinket.1.has_buff.intellect|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit|trinket.1.is.signet_of_the_priory)&(trinket.1.cooldown.duration>=20)" );
   precombat->add_action( "variable,name=trinket_2_buffs,value=(trinket.2.has_buff.intellect|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit|trinket.2.is.signet_of_the_priory)&(trinket.2.cooldown.duration>=20)" );
-  precombat->add_action( "variable,name=dr_force_prio,default=1,op=reset" );
-  precombat->add_action( "variable,name=me_force_prio,default=1,op=reset" );
+  precombat->add_action( "variable,name=dr_force_prio,default=0,op=reset" );
+  precombat->add_action( "variable,name=me_force_prio,default=0,op=reset" );
+  precombat->add_action( "variable,name=max_swm,default=0,op=reset" );
   precombat->add_action( "variable,name=max_vts,default=12,op=reset" );
   precombat->add_action( "variable,name=is_vt_possible,default=0,op=reset" );
   precombat->add_action( "arcane_torrent" );
   precombat->add_action( "tentacle_slam" );
 
   default_->add_action( "variable,name=holding_tentacle_slam,op=set,value=raid_event.adds.in<15" );
+  default_->add_action( "variable,name=max_swm,op=setif,condition=talent.distorted_reality,value=4,value_else=2,if=variable.max_swm=0" );
   default_->add_action( "call_action_list,name=aoe,if=active_enemies>2" );
   default_->add_action( "run_action_list,name=main" );
 
@@ -91,16 +93,16 @@ void shadow( player_t* p )
   main->add_action( "variable,name=dots_up,op=set,value=active_dot.vampiric_touch=active_enemies&active_dot.shadow_word_pain>=active_dot.vampiric_touch,if=active_enemies<3" );
   main->add_action( "call_action_list,name=cds,if=fight_remains<30|target.time_to_die>15&(!variable.holding_tentacle_slam|active_enemies>2)&variable.dots_up" );
   main->add_action( "shadow_word_death,target_if=max:(target.health.pct<=20)*100+dot.shadow_word_madness.ticking,if=priest.force_devour_matter&talent.devour_matter", "High Priority Shadow Word: Death when you are forcing the bonus from Devour Matter" );
-  main->add_action( "shadow_word_madness,target_if=max:target.time_to_die*(dot.shadow_word_madness.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.shadow_word_madness<=1&dot.shadow_word_madness.remains<=gcd.max|insanity.deficit<=35|buff.mind_devourer.react|!raid_event.adds.exists&target.time_to_die<=10|buff.entropic_rift.up&action.shadow_word_madness.cost>0", "Do not overcap on insanity" );
+  main->add_action( "shadow_word_madness,target_if=max:target.time_to_die*(dot.shadow_word_madness.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.shadow_word_madness<=variable.max_swm&dot.shadow_word_madness.remains<=gcd.max|insanity.deficit<=35|buff.mind_devourer.react|!raid_event.adds.exists&target.time_to_die<=10|buff.entropic_rift.up&action.shadow_word_madness.cost>0", "Do not overcap on insanity" );
   main->add_action( "void_volley" );
   main->add_action( "void_blast,target_if=max:(dot.shadow_word_madness.remains*1000+target.time_to_die)", "Blast more burst :wicked:" );
-  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains,if=dot.vampiric_touch.refreshable|cooldown.tentacle_slam.full_recharge_time<=gcd.max*2", "Use Tentacle Slam to prevent capping charges or to refresh Vampiric Touch" );
+  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains+dot.shadow_word_madness.ticking*1000*talent.maddening_tentacles,if=dot.vampiric_touch.refreshable|cooldown.tentacle_slam.full_recharge_time<=gcd.max*2", "Use Tentacle Slam to prevent capping charges or to refresh Vampiric Touch" );
   main->add_action( "shadow_word_madness,target_if=max:dot.shadow_word_madness.remains,if=dot.shadow_word_madness.pmultiplier<1&dot.shadow_word_madness.ticking" );
   main->add_action( "void_torrent,target_if=max:(dot.shadow_word_madness.remains*1000+target.time_to_die),if=!variable.holding_tentacle_slam&variable.dots_up", "Use Void Torrent if it will get near full Mastery Value" );
   main->add_action( "shadow_word_pain,target_if=max:(refreshable*100000+target.time_to_die+dot.vampiric_touch.ticking*10000),if=talent.invoked_nightmare&refreshable&target.time_to_die>12&dot.vampiric_touch.ticking", "Put out Shadow Word: Pain on enemies that will live at least 12s as a filler when talented into Invoked Nightmare." );
   main->add_action( "mind_blast,target_if=max:dot.shadow_word_madness.remains,if=(!buff.mind_devourer.react|!talent.mind_devourer)", "Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption" );
   main->add_action( "mind_flay_insanity,target_if=max:dot.shadow_word_madness.remains", "MFI is a good button" );
-  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains,if=(talent.void_apparitions|talent.maddening_tentacles)&(raid_event.adds.in>30|raid_event.adds.in>5&cooldown.tentacle_slam.full_recharge_time<=gcd.max*2)", "Use Tentacle Slam for Void Apparitions or Maddening Tentacles value, holding for adds if needed" );
+  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains+dot.shadow_word_madness.ticking*1000*talent.maddening_tentacles,if=(talent.void_apparitions|talent.maddening_tentacles)&(raid_event.adds.in>30|raid_event.adds.in>5&cooldown.tentacle_slam.full_recharge_time<=gcd.max*2)", "Use Tentacle Slam for Void Apparitions or Maddening Tentacles value, holding for adds if needed" );
   main->add_action( "vampiric_touch,target_if=max:(refreshable*10000+target.time_to_die)*(dot.vampiric_touch.ticking|!variable.dots_up),if=refreshable&target.time_to_die>12&(dot.vampiric_touch.ticking|!variable.dots_up)&(variable.max_vts>0|active_enemies=1)&(action.tentacle_slam.usable_in>=dot.vampiric_touch.remains|variable.holding_tentacle_slam|!action.tentacle_slam.enabled)", "Put out Vampiric Touch on enemies that will live at least 12s and Tentacle Slam is not available soon" );
   main->add_action( "call_action_list,name=heal_for_tof,if=!buff.twist_of_fate.up&buff.twist_of_fate_can_trigger_on_ally_heal.up&talent.halo", "Healing spell action list for proccing Twist of Fate. Set priest.twist_of_fate_heal_rppm=<rppm> to make this be used." );
   main->add_action( "vampiric_touch,target_if=max:(refreshable*10000+target.time_to_die),if=refreshable&target.time_to_die>12", "Put out Vampiric Touch on enemies that will live at least 12s as a filler action." );
@@ -131,14 +133,16 @@ void shadow_ptr( player_t* p )
   precombat->add_action( "shadowform,if=!buff.shadowform.up" );
   precombat->add_action( "variable,name=trinket_1_buffs,value=(trinket.1.has_buff.intellect|trinket.1.has_buff.mastery|trinket.1.has_buff.versatility|trinket.1.has_buff.haste|trinket.1.has_buff.crit|trinket.1.is.signet_of_the_priory)&(trinket.1.cooldown.duration>=20)" );
   precombat->add_action( "variable,name=trinket_2_buffs,value=(trinket.2.has_buff.intellect|trinket.2.has_buff.mastery|trinket.2.has_buff.versatility|trinket.2.has_buff.haste|trinket.2.has_buff.crit|trinket.2.is.signet_of_the_priory)&(trinket.2.cooldown.duration>=20)" );
-  precombat->add_action( "variable,name=dr_force_prio,default=1,op=reset" );
-  precombat->add_action( "variable,name=me_force_prio,default=1,op=reset" );
+  precombat->add_action( "variable,name=dr_force_prio,default=0,op=reset" );
+  precombat->add_action( "variable,name=me_force_prio,default=0,op=reset" );
+  precombat->add_action( "variable,name=max_swm,default=0,op=reset" );
   precombat->add_action( "variable,name=max_vts,default=12,op=reset" );
   precombat->add_action( "variable,name=is_vt_possible,default=0,op=reset" );
   precombat->add_action( "arcane_torrent" );
   precombat->add_action( "tentacle_slam" );
 
   default_->add_action( "variable,name=holding_tentacle_slam,op=set,value=raid_event.adds.in<15" );
+  default_->add_action( "variable,name=max_swm,op=setif,condition=talent.distorted_reality,value=4,value_else=2,if=variable.max_swm=0" );
   default_->add_action( "call_action_list,name=aoe,if=active_enemies>2" );
   default_->add_action( "run_action_list,name=main" );
 
@@ -170,16 +174,16 @@ void shadow_ptr( player_t* p )
   main->add_action( "variable,name=dots_up,op=set,value=active_dot.vampiric_touch=active_enemies&active_dot.shadow_word_pain>=active_dot.vampiric_touch,if=active_enemies<3" );
   main->add_action( "call_action_list,name=cds,if=fight_remains<30|target.time_to_die>15&(!variable.holding_tentacle_slam|active_enemies>2)&variable.dots_up" );
   main->add_action( "shadow_word_death,target_if=max:(target.health.pct<=20)*100+dot.shadow_word_madness.ticking,if=priest.force_devour_matter&talent.devour_matter", "High Priority Shadow Word: Death when you are forcing the bonus from Devour Matter" );
-  main->add_action( "shadow_word_madness,target_if=max:target.time_to_die*(dot.shadow_word_madness.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.shadow_word_madness<=1&dot.shadow_word_madness.remains<=gcd.max|insanity.deficit<=35|buff.mind_devourer.react|!raid_event.adds.exists&target.time_to_die<=10|buff.entropic_rift.up&action.shadow_word_madness.cost>0", "Do not overcap on insanity" );
+  main->add_action( "shadow_word_madness,target_if=max:target.time_to_die*(dot.shadow_word_madness.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.shadow_word_madness<=variable.max_swm&dot.shadow_word_madness.remains<=gcd.max|insanity.deficit<=35|buff.mind_devourer.react|!raid_event.adds.exists&target.time_to_die<=10|buff.entropic_rift.up&action.shadow_word_madness.cost>0", "Do not overcap on insanity" );
   main->add_action( "void_volley" );
   main->add_action( "void_blast,target_if=max:(dot.shadow_word_madness.remains*1000+target.time_to_die)", "Blast more burst :wicked:" );
-  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains,if=dot.vampiric_touch.refreshable|cooldown.tentacle_slam.full_recharge_time<=gcd.max*2", "Use Tentacle Slam to prevent capping charges or to refresh Vampiric Touch" );
+  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains+dot.shadow_word_madness.ticking*1000*talent.maddening_tentacles,if=dot.vampiric_touch.refreshable|cooldown.tentacle_slam.full_recharge_time<=gcd.max*2", "Use Tentacle Slam to prevent capping charges or to refresh Vampiric Touch" );
   main->add_action( "shadow_word_madness,target_if=max:dot.shadow_word_madness.remains,if=dot.shadow_word_madness.pmultiplier<1&dot.shadow_word_madness.ticking" );
   main->add_action( "void_torrent,target_if=max:(dot.shadow_word_madness.remains*1000+target.time_to_die),if=!variable.holding_tentacle_slam&variable.dots_up", "Use Void Torrent if it will get near full Mastery Value" );
   main->add_action( "shadow_word_pain,target_if=max:(refreshable*100000+target.time_to_die+dot.vampiric_touch.ticking*10000),if=talent.invoked_nightmare&refreshable&target.time_to_die>12&dot.vampiric_touch.ticking", "Put out Shadow Word: Pain on enemies that will live at least 12s as a filler when talented into Invoked Nightmare." );
   main->add_action( "mind_blast,target_if=max:dot.shadow_word_madness.remains,if=(!buff.mind_devourer.react|!talent.mind_devourer)", "Use all charges of Mind Blast if Vampiric Touch and Shadow Word: Pain are active and Mind Devourer is not active or you are prepping Void Eruption" );
   main->add_action( "mind_flay_insanity,target_if=max:dot.shadow_word_madness.remains", "MFI is a good button" );
-  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains,if=(talent.void_apparitions|talent.maddening_tentacles)&(raid_event.adds.in>30|raid_event.adds.in>5&cooldown.tentacle_slam.full_recharge_time<=gcd.max*2)", "Use Tentacle Slam for Void Apparitions or Maddening Tentacles value, holding for adds if needed" );
+  main->add_action( "tentacle_slam,target_if=min:dot.vampiric_touch.remains+dot.shadow_word_madness.ticking*1000*talent.maddening_tentacles,if=(talent.void_apparitions|talent.maddening_tentacles)&(raid_event.adds.in>30|raid_event.adds.in>5&cooldown.tentacle_slam.full_recharge_time<=gcd.max*2)", "Use Tentacle Slam for Void Apparitions or Maddening Tentacles value, holding for adds if needed" );
   main->add_action( "vampiric_touch,target_if=max:(refreshable*10000+target.time_to_die)*(dot.vampiric_touch.ticking|!variable.dots_up),if=refreshable&target.time_to_die>12&(dot.vampiric_touch.ticking|!variable.dots_up)&(variable.max_vts>0|active_enemies=1)&(action.tentacle_slam.usable_in>=dot.vampiric_touch.remains|variable.holding_tentacle_slam|!action.tentacle_slam.enabled)", "Put out Vampiric Touch on enemies that will live at least 12s and Tentacle Slam is not available soon" );
   main->add_action( "call_action_list,name=heal_for_tof,if=!buff.twist_of_fate.up&buff.twist_of_fate_can_trigger_on_ally_heal.up&talent.halo", "Healing spell action list for proccing Twist of Fate. Set priest.twist_of_fate_heal_rppm=<rppm> to make this be used." );
   main->add_action( "vampiric_touch,target_if=max:(refreshable*10000+target.time_to_die),if=refreshable&target.time_to_die>12", "Put out Vampiric Touch on enemies that will live at least 12s as a filler action." );


### PR DESCRIPTION
The old APL only kept a single SWM on a target even in cleave, by spreading it we get some pretty decent gains 5-13%. Also pushes DR higher up as a talent on cleave fights, but still barely below ME.

@seanpeters86 How do we want to handle the variables dr_force, me_force? I added a new one because I wanted to know how many targets it made sense to spread to with the talents, but the sim is fine without any variables TBH

  | Build | 1T | 2T | 4T | 6T | 8T | DungeonSlice |
  |---|---|---|---|---|---|---|
  | Archon ST | ~0% | +7.0% | +6.3% | +4.8% | +2.3% | +0.5% |
  | Archon Cleave | ~0% | +7.3% | +7.5% | +6.3% | +3.7% | +0.9% |
  | Archon Cleave DR | ~0% | +9.2% | +13.6% | +11.8% | +6.8% | +1.8% |
  | Archon M+ | ~0% | +8.5% | +8.7% | +7.9% | +4.6% | +1.3% |
  | VW ST | ~0% | +6.1% | +5.2% | +4.1% | +1.7% | +0.4% |
  | VW Cleave | ~0% | +6.6% | +6.2% | +5.6% | +2.8% | +0.7% |
  | VW Cleave DR | ~0% | +9.4% | +13.5% | +11.7% | +6.8% | +1.8% |
  | VW M+ | ~0% | +7.6% | +7.5% | +6.7% | +3.6% | +0.4% |

ST: https://www.raidbots.com/simbot/report/iwgNeL9PdVXzNcpViP2oUM
2T: https://www.raidbots.com/simbot/report/tYYS6D2W7hDByZZUF1UTA7
3T: https://www.raidbots.com/simbot/report/jcApPaY1dyabhQ4sF8MhjT
4T: https://www.raidbots.com/simbot/report/eoHLMBWoV2pwZXjGqj1SrQ
6T: https://www.raidbots.com/simbot/report/wvwCB9S9BtQ3MMGcUkpnnh
Dslice: https://www.raidbots.com/simbot/report/7eTmuwaqK1VbW9sXo41ReY
Light Movement: https://www.raidbots.com/simbot/report/aDjU3JVQtGh1Xo2dWo4533