### PR TITLE
[Core] Trigger `PF2_LANDED` callbacks on DoT, Buff and Debuff Application/refresh

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -4527,6 +4527,7 @@ void action_t::trigger_dot( action_state_t* s )
   }
 
   dot->trigger( duration );
+  player->trigger_callbacks( PROC1_NONE_HARMFUL, PROC2_LANDED, this, dot->state );
 }
 
 /**

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -678,6 +678,7 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     trigger_successes(),
     simulation_max_stack( 0 ),
     invalidate_list(),
+    triggers_callbacks( false ),
     benefit_pct(),
     trigger_pct(),
     avg_start(),
@@ -759,6 +760,10 @@ buff_t::buff_t( sim_t* sim, player_t* target, player_t* source, util::string_vie
     set_stack_behavior( buff_stack_behavior::ASYNCHRONOUS );
     set_activated( false );
   }
+
+  if ( s_data->flags( spell_attribute::SX_ALLOW_CLASS_ABILITY_PROCS ) || s_data->flags( spell_attribute::SX_ABILITY ) ||
+       s_data->flags( spell_attribute::SX_NOT_A_PROC ) )
+    triggers_callbacks = true;
 
   update_trigger_calculations();
 }
@@ -2431,6 +2436,14 @@ void buff_t::bump( int stacks, double value )
     overflow_count++;
     overflow_total += stacks;
   }
+
+  // Trigger Generic Harmful Proc Callbacks if a debuff is applied/refreshed.
+  if ( triggers_callbacks && source && player && source->is_player() && player->is_enemy() && player != source )
+    source->trigger_callbacks( PROC1_NONE_HARMFUL, PROC2_LANDED, nullptr, nullptr );
+
+  // Trigger Generic Helpful Proc Callbacks if a buff is applied/refreshed.
+  if ( triggers_callbacks && source && player && player->is_player() && source->is_player() && player == source )
+    source->trigger_callbacks( PROC1_NONE_HELPFUL, PROC2_LANDED, nullptr, nullptr );
 
   if ( changes_stack_value )
   {

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -147,6 +147,7 @@ protected:
   int trigger_attempts, trigger_successes;
   int simulation_max_stack;
   std::vector<cache_e> invalidate_list;
+  bool triggers_callbacks;
 
   // report data
 public:

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -1629,26 +1629,55 @@ void gaze_of_the_alnseer( special_effect_t& effect )
 {
   auto alnsight_spell = effect.trigger();
 
+  struct alnsight_cb_t : public dbc_proc_callback_t
+  {
+    bool refreshed;
+    cooldown_t* icd;
+    alnsight_cb_t( const special_effect_t& e ) : dbc_proc_callback_t( e.player, e ), refreshed( false ), icd( nullptr )
+    {
+      icd = e.player->get_cooldown( e.cooldown_name() );
+    }
+
+    void execute( action_t*, action_state_t* ) override
+    {
+      effect.custom_buff->trigger();
+      // This is a complete guess at the rate, but, if refreshed, occasionally youll get multiple procs that seem to ignore the internal cooldown. 
+      // Its not that often, and its not consistent at all. Need more data.
+      if ( refreshed && rng().roll( 0.05 ) )
+      {
+        make_event( *effect.player->sim, 1_ms, [ this ] {
+          // Randomly reset the ICD if refreshed to emulate the behavior where we see extra stacks being generated.
+          if ( icd )
+            icd->reset( false );
+        } );
+      }
+    }
+  };
+
   auto buff = create_buff<buff_t>( effect.player, alnsight_spell );
   auto stat = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( 1266687 ) )
                   ->set_stat_from_effect_type( A_MOD_STAT, effect.driver()->effectN( 1 ).average( effect ) );
 
-  auto alnsight         = new special_effect_t( effect.player );
-  alnsight->name_str    = "alnsight_proc";
-  alnsight->item        = effect.item;
-  alnsight->spell_id    = alnsight_spell->id();
-  alnsight->custom_buff = stat;
+  auto alnsight          = new special_effect_t( effect.player );
+  alnsight->name_str     = "alnsight_proc";
+  alnsight->item         = effect.item;
+  alnsight->spell_id     = alnsight_spell->id();
+  alnsight->custom_buff  = stat;
+  alnsight->proc_flags2_ = PF2_LANDED;
   effect.player->special_effects.push_back( alnsight );
 
-  auto alnsight_cb = new dbc_proc_callback_t( effect.player, *alnsight );
+  auto alnsight_cb = new alnsight_cb_t( *alnsight );
   alnsight_cb->activate_with_buff( buff, true );
 
+  buff->set_expire_callback( [ alnsight_cb ]( buff_t*, int, timespan_t ) { alnsight_cb->refreshed = false; } );
+
   effect.player->callbacks.register_callback_execute_function(
-      effect.driver()->id(), [ &effect, stat, buff ]( auto, auto, const action_state_t* ) {
+      effect.driver()->id(), [ &effect, stat, buff, alnsight_cb ]( auto, auto, const action_state_t* ) {
         buff->trigger();
         if ( stat->check() )
         {
           stat->trigger();
+          alnsight_cb->refreshed = true;
         }
       } );
 


### PR DESCRIPTION
Currently going the lazy route to get something mostly working fast. Will require a more substantial refactor to properly account for the buff/debuff spell attributes