### PR TITLE
[Warlock] Mayhem bug hotfix

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -192,7 +192,6 @@ int warlock_td_t::count_affliction_dots() const
 warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   : parse_player_effects_t( sim, WARLOCK, name, r ),
     havoc_target( nullptr ),
-    bugged_mayhem( false ),
     havoc_spells(),
     diabolic_ritual( 0 ),
     demonic_art_buff_replaced( false ),
@@ -214,6 +213,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
     eye_explosion_instanced_bug_cb( true ),
     eye_explosion_instanced_bug_sb( true ),
     eye_explosion_instanced_bug_rof( false ),
+    fel_armaments_extra_effect_bug( false ),
     tyrant_antoran_armaments_target_mul( 1.0 )
 {
   cooldowns.haunt = get_cooldown( "haunt" );
@@ -493,6 +493,9 @@ std::string warlock_t::create_profile( save_e stype )
     if ( eye_explosion_instanced_bug_rof )
       profile_str +=
           "eye_explosion_instanced_bug_rof=" + util::to_string( as<int>( eye_explosion_instanced_bug_rof ) ) + "\n";
+    if ( fel_armaments_extra_effect_bug )
+      profile_str +=
+        "fel_armaments_extra_effect_bug" + util::to_string( as<int>( fel_armaments_extra_effect_bug ) ) + "\n";
     if ( tyrant_antoran_armaments_target_mul < 1.0 )
       profile_str +=
           "tyrant_antoran_armaments_target_mul=" + util::to_string( tyrant_antoran_armaments_target_mul ) + "\n";
@@ -515,6 +518,7 @@ void warlock_t::copy_from( player_t* source )
   eye_explosion_instanced_bug_cb = p->eye_explosion_instanced_bug_cb;
   eye_explosion_instanced_bug_sb = p->eye_explosion_instanced_bug_sb;
   eye_explosion_instanced_bug_rof = p->eye_explosion_instanced_bug_rof;
+  fel_armaments_extra_effect_bug = p->fel_armaments_extra_effect_bug;
   tyrant_antoran_armaments_target_mul = p->tyrant_antoran_armaments_target_mul;
 
   rng_settings = p->rng_settings;

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -254,7 +254,6 @@ struct warlock_t : public parse_player_effects_t
 {
 public:
   player_t* havoc_target;
-  bool bugged_mayhem; // Used to control if in a particular moment mayhem is bugged and its not working
   std::vector<action_t*> havoc_spells; // Used for smarter target cache invalidation.
   player_t* haunt_target; // Used for tracking the current haunt target
   std::vector<event_t*> wild_imp_spawns; // Used for tracking incoming imps from HoG TODO: Is this still needed with faster spawns?
@@ -1072,6 +1071,7 @@ public:
   bool eye_explosion_instanced_bug_cb;
   bool eye_explosion_instanced_bug_sb;
   bool eye_explosion_instanced_bug_rof;
+  bool fel_armaments_extra_effect_bug;
   double tyrant_antoran_armaments_target_mul;
 
   warlock_t( sim_t* sim, util::string_view name, race_e r );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -352,7 +352,7 @@ using namespace helpers;
               // It seems that having the GoSac buff prevents these bugs
               if ( p()->bugs && !p()->buffs.grimoire_of_sacrifice->check()
                     && ( ( this->id == p()->talents.chaos_bolt->id() && p()->eye_explosion_instanced_bug_cb )
-                      || ( this->id == p()->hero.ruination_cast->id() && p()->eye_explosion_instanced_bug_sb )
+                      || ( this->id == p()->hero.ruination_cast->id() && destruction() && p()->eye_explosion_instanced_bug_cb )
                       || ( this->id == p()->talents.shadowburn->id() && p()->eye_explosion_instanced_bug_sb )
                       || ( this->id == p()->talents.rain_of_fire->id() && p()->eye_explosion_instanced_bug_rof ) ) )
               {
@@ -389,23 +389,9 @@ using namespace helpers;
         if ( n > 1u )
         {
           player_t* trigger_target = tl.at( 1u + rng().range( n - 1u ) );
-          const player_t* prev_havoc_target = p()->havoc_target;
-
           if ( td( trigger_target )->debuffs.havoc->trigger() )
           {
             assert( p()->havoc_target == trigger_target );
-
-            // NOTE: 2026-03-17 Due to a bug, Mayhem will stop working if triggered on another target while another havoc debuff is already active.
-            // This can only happen with Improved Havoc talent, which makes the ICD less than its duration.
-            // It will work correctly again if the Havoc debuff expires normally or if it is applied to the same target that already has it.
-            if ( p()->talents.improved_havoc.ok() )
-            {
-              if ( prev_havoc_target == nullptr || trigger_target == prev_havoc_target )
-                p()->bugged_mayhem = false;
-              else
-                p()->bugged_mayhem = true;
-            }
-
             p()->procs.mayhem->occur();
           }
         }
@@ -546,9 +532,7 @@ using namespace helpers;
 
     int n_targets() const override
     {
-      // NOTE: 2026-03-17 Mayhem with Improved Havoc is bugged and there are certain conditions
-      // that may cause it to stop working for a while (bug)
-      if ( destruction() && use_havoc() && ( !p()->bugs || !p()->bugged_mayhem ) )
+      if ( destruction() && use_havoc() )
       {
         assert( action_base_t::n_targets() == 0 );
         return 2;

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -123,7 +123,7 @@ namespace warlock
       parse_passive_effects( hero.mark_of_perotharn, true );
 
     // NOTE: 2026-03-21 An additional effect of Fel Armaments talent is applied even if the talent is not selected (bug)
-    if ( demonology() && bugs )
+    if ( demonology() && bugs && ( talents.fel_armaments.ok() || fel_armaments_extra_effect_bug ) )
       parse_passive_effects( talents.fel_armaments_2, true );
   }
 
@@ -1604,6 +1604,7 @@ namespace warlock
     add_option( opt_bool( "eye_explosion_instanced_bug_cb", eye_explosion_instanced_bug_cb ) );
     add_option( opt_bool( "eye_explosion_instanced_bug_sb", eye_explosion_instanced_bug_sb ) );
     add_option( opt_bool( "eye_explosion_instanced_bug_rof", eye_explosion_instanced_bug_rof ) );
+    add_option( opt_bool( "fel_armaments_extra_effect_bug", fel_armaments_extra_effect_bug ) );
     add_option( opt_float( "tyrant_antoran_armaments_target_mul", tyrant_antoran_armaments_target_mul, 0.0, 1.0 ));
 
     rng_settings.for_each( [ this ]( auto& setting )
@@ -1642,7 +1643,6 @@ namespace warlock
 
     warlock_pet_list.active = nullptr;
     havoc_target = nullptr;
-    bugged_mayhem = false;
     haunt_target = nullptr;
     wild_imp_spawns.clear();
     diabolic_ritual = rng().range( 0, 3 );


### PR DESCRIPTION
Blizzard fixed the bug affecting Mayhem when used with the Improved Havoc talent, which caused spells to stop duplicating. The corresponding SimC bug implementation has therefore been removed.

Additionally, the Fel Armaments bug has turned out to behave more inconsistently than expected, sometimes resetting to the correct state and not reapplying until the talent is selected again. As a result, the bug is now disabled by default when the talent is not selected (and always applied when the talent is selected). A custom option, `fel_armaments_extra_effect_bug` (disabled by default), is available to enable this behavior even when the talent is not selected, if desired. This option is temporary and will be removed once the bug is fixed.