### PR TITLE
[paladin] Mark Holy Paladin actors as invalid.

### DIFF
--- a/engine/class_modules/paladin/sc_paladin.cpp
+++ b/engine/class_modules/paladin/sc_paladin.cpp
@@ -3998,6 +3998,19 @@ bool paladin_t::validate_fight_style( fight_style_e style ) const
   return true;
 }
 
+// paladin_t::validate_actor ================================================
+bool paladin_t::validate_actor()
+{
+  if ( specialization() == PALADIN_HOLY )
+  {
+    if ( !quiet )
+      sim->error( "Holy Paladin for {} is not currently supported.", *this );
+    return false;
+  }
+
+  return true;
+}
+
 void paladin_t::init_special_effects()
 {
   player_t::init_special_effects();

--- a/engine/class_modules/paladin/sc_paladin.hpp
+++ b/engine/class_modules/paladin/sc_paladin.hpp
@@ -777,6 +777,7 @@ public:
   parsed_assisted_combat_rule_t parse_assisted_combat_rule( const assisted_combat_rule_data_t& rule,
                                                             const assisted_combat_step_data_t& step ) const override;
   virtual bool validate_fight_style( fight_style_e style ) const override;
+  virtual bool validate_actor() override;
   virtual void reset() override;
   virtual std::unique_ptr<expr_t> create_expression( util::string_view name ) override;
 


### PR DESCRIPTION
see #11305

> The Holy Paladin APL has not been updated in >5 years, so it is multiple expansions out of date at this point. Holy-specific implementations may not exist.