### PR TITLE
[Warlock][Demonology] Remove the Behavior who reduces demonic cores proc chance on imps fade from 10% to 2%

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -807,13 +807,6 @@ void wild_imp_pet_t::demise()
       {
         core_chance += o()->hero.sataiels_volition->effectN( 3 ).percent();
       }
-      else
-      {
-        // NOTE: 2026-03-06 If a Wild Imp demise normally (by not being imploded), its actual Demoniac chance to generate a
-        // demonic core is about 5x lower than indicated in the spell data (in our tests it is about ~2% instead of 10%).
-        if ( o()->bugs )
-          core_chance *= 0.2;
-      }
 
       if ( !o()->talents.demoniac.ok() )
         core_chance = 0.0;


### PR DESCRIPTION
https://www.wowhead.com/news/mythic-fallen-king-salhadaar-nerfed-midnight-hotfixes-for-march-31st-381073?utm_source=discord-webhook 

As the bug have been hotfixed opening PR to remove the behavior in simc. 

Wait for confirmation by Millan before merge, by the logs i looked it does seem to have been fixed but better safe than sorry. 