### PR TITLE
[Warlock] Rename options to be whitelisted in the raidbots custom apl box

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -476,29 +476,29 @@ std::string warlock_t::create_profile( save_e stype )
   if ( stype & SAVE_PLAYER )
   {
     if ( initial_soul_shards != 3 )
-      profile_str += "soul_shards=" + util::to_string( initial_soul_shards ) + "\n";
+      profile_str += "warlock.soul_shards=" + util::to_string( initial_soul_shards ) + "\n";
     if ( !default_pet.empty() )
-      profile_str += "default_pet=" + default_pet + "\n";
+      profile_str += "warlock.default_pet=" + default_pet + "\n";
     if ( disable_auto_felstorm )
-      profile_str += "disable_felstorm=" + util::to_string( as<int>( disable_auto_felstorm ) ) + "\n";
+      profile_str += "warlock.disable_felstorm=" + util::to_string( as<int>( disable_auto_felstorm ) ) + "\n";
     if ( normalize_destruction_mastery )
       profile_str +=
-          "normalize_destruction_mastery=" + util::to_string( as<int>( normalize_destruction_mastery ) ) + "\n";
+          "warlock.normalize_destruction_mastery=" + util::to_string( as<int>( normalize_destruction_mastery ) ) + "\n";
     if ( !eye_explosion_instanced_bug_cb )
       profile_str +=
-          "eye_explosion_instanced_bug_cb=" + util::to_string( as<int>( eye_explosion_instanced_bug_cb ) ) + "\n";
+          "warlock.eye_explosion_instanced_bug_cb=" + util::to_string( as<int>( eye_explosion_instanced_bug_cb ) ) + "\n";
     if ( !eye_explosion_instanced_bug_sb )
       profile_str +=
-          "eye_explosion_instanced_bug_sb=" + util::to_string( as<int>( eye_explosion_instanced_bug_sb ) ) + "\n";
+          "warlock.eye_explosion_instanced_bug_sb=" + util::to_string( as<int>( eye_explosion_instanced_bug_sb ) ) + "\n";
     if ( eye_explosion_instanced_bug_rof )
       profile_str +=
-          "eye_explosion_instanced_bug_rof=" + util::to_string( as<int>( eye_explosion_instanced_bug_rof ) ) + "\n";
+          "warlock.eye_explosion_instanced_bug_rof=" + util::to_string( as<int>( eye_explosion_instanced_bug_rof ) ) + "\n";
     if ( fel_armaments_extra_effect_bug )
       profile_str +=
-        "fel_armaments_extra_effect_bug" + util::to_string( as<int>( fel_armaments_extra_effect_bug ) ) + "\n";
+          "warlock.fel_armaments_extra_effect_bug" + util::to_string( as<int>( fel_armaments_extra_effect_bug ) ) + "\n";
     if ( tyrant_antoran_armaments_target_mul < 1.0 )
       profile_str +=
-          "tyrant_antoran_armaments_target_mul=" + util::to_string( tyrant_antoran_armaments_target_mul ) + "\n";
+          "warlock.tyrant_antoran_armaments_target_mul=" + util::to_string( tyrant_antoran_armaments_target_mul ) + "\n";
     rng_settings.for_each( [ &profile_str ]( auto& setting ) { profile_str += append_rng_option( setting ); } );
   }
 

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1591,6 +1591,7 @@ namespace warlock
   void warlock_t::add_rng_option( warlock_t::rng_settings_t::rng_setting_t& setting )
   {
     add_option( opt_float( "warlock.rng_" + setting.option_name, setting.setting_value ) );
+    add_option( opt_deprecated( "rng_" + setting.option_name,  "warlock.rng_" + setting.option_name ) );
   }
 
   void warlock_t::create_options()
@@ -1598,14 +1599,23 @@ namespace warlock
     player_t::create_options();
 
     add_option( opt_int( "warlock.soul_shards", initial_soul_shards ) );
+    add_option( opt_deprecated( "soul_shards", "warlock.soul_shards" ) );
     add_option( opt_string( "warlock.default_pet", default_pet ) );
+    add_option( opt_deprecated( "default_pet", "warlock.default_pet" ) );
     add_option( opt_bool( "warlock.disable_felstorm", disable_auto_felstorm ) );
+    add_option( opt_deprecated( "disable_felstorm", "warlock.disable_felstorm" ) );
     add_option( opt_bool( "warlock.normalize_destruction_mastery", normalize_destruction_mastery ) );
+    add_option( opt_deprecated( "normalize_destruction_mastery", "warlock.normalize_destruction_mastery" ) );
     add_option( opt_bool( "warlock.eye_explosion_instanced_bug_cb", eye_explosion_instanced_bug_cb ) );
+    add_option( opt_deprecated( "eye_explosion_instanced_bug_cb", "warlock.eye_explosion_instanced_bug_cb" ) );
     add_option( opt_bool( "warlock.eye_explosion_instanced_bug_sb", eye_explosion_instanced_bug_sb ) );
+    add_option( opt_deprecated( "eye_explosion_instanced_bug_sb", "warlock.eye_explosion_instanced_bug_sb" ) );
     add_option( opt_bool( "warlock.eye_explosion_instanced_bug_rof", eye_explosion_instanced_bug_rof ) );
+    add_option( opt_deprecated( "eye_explosion_instanced_bug_rof", "warlock.eye_explosion_instanced_bug_rof" ) );
     add_option( opt_bool( "warlock.fel_armaments_extra_effect_bug", fel_armaments_extra_effect_bug ) );
+    add_option( opt_deprecated( "fel_armaments_extra_effect_bug", "warlock.fel_armaments_extra_effect_bug" ) );
     add_option( opt_float( "warlock.tyrant_antoran_armaments_target_mul", tyrant_antoran_armaments_target_mul, 0.0, 1.0 ));
+    add_option( opt_deprecated( "tyrant_antoran_armaments_target_mul", "warlock.tyrant_antoran_armaments_target_mul" ) );
 
     rng_settings.for_each( [ this ]( auto& setting )
     {

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1590,22 +1590,22 @@ namespace warlock
 
   void warlock_t::add_rng_option( warlock_t::rng_settings_t::rng_setting_t& setting )
   {
-    add_option( opt_float( "rng_" + setting.option_name, setting.setting_value ) );
+    add_option( opt_float( "warlock.rng_" + setting.option_name, setting.setting_value ) );
   }
 
   void warlock_t::create_options()
   {
     player_t::create_options();
 
-    add_option( opt_int( "soul_shards", initial_soul_shards ) );
-    add_option( opt_string( "default_pet", default_pet ) );
-    add_option( opt_bool( "disable_felstorm", disable_auto_felstorm ) );
-    add_option( opt_bool( "normalize_destruction_mastery", normalize_destruction_mastery ) );
-    add_option( opt_bool( "eye_explosion_instanced_bug_cb", eye_explosion_instanced_bug_cb ) );
-    add_option( opt_bool( "eye_explosion_instanced_bug_sb", eye_explosion_instanced_bug_sb ) );
-    add_option( opt_bool( "eye_explosion_instanced_bug_rof", eye_explosion_instanced_bug_rof ) );
-    add_option( opt_bool( "fel_armaments_extra_effect_bug", fel_armaments_extra_effect_bug ) );
-    add_option( opt_float( "tyrant_antoran_armaments_target_mul", tyrant_antoran_armaments_target_mul, 0.0, 1.0 ));
+    add_option( opt_int( "warlock.soul_shards", initial_soul_shards ) );
+    add_option( opt_string( "warlock.default_pet", default_pet ) );
+    add_option( opt_bool( "warlock.disable_felstorm", disable_auto_felstorm ) );
+    add_option( opt_bool( "warlock.normalize_destruction_mastery", normalize_destruction_mastery ) );
+    add_option( opt_bool( "warlock.eye_explosion_instanced_bug_cb", eye_explosion_instanced_bug_cb ) );
+    add_option( opt_bool( "warlock.eye_explosion_instanced_bug_sb", eye_explosion_instanced_bug_sb ) );
+    add_option( opt_bool( "warlock.eye_explosion_instanced_bug_rof", eye_explosion_instanced_bug_rof ) );
+    add_option( opt_bool( "warlock.fel_armaments_extra_effect_bug", fel_armaments_extra_effect_bug ) );
+    add_option( opt_float( "warlock.tyrant_antoran_armaments_target_mul", tyrant_antoran_armaments_target_mul, 0.0, 1.0 ));
 
     rng_settings.for_each( [ this ]( auto& setting )
     {

--- a/profiles/MID1/MID1_Warlock_Affliction.simc
+++ b/profiles/MID1/MID1_Warlock_Affliction.simc
@@ -170,5 +170,5 @@ off_hand=grimoire_of_the_eternal_light,id=249276,ilevel=289
 # gear_armor=531
 # set_bonus=midnight_season_1_2pc=1
 # set_bonus=midnight_season_1_4pc=1
-soul_shards=0
-default_pet=sayaad
+warlock.soul_shards=0
+warlock.default_pet=sayaad

--- a/profiles/MID1/MID1_Warlock_Affliction_Hellcaller.simc
+++ b/profiles/MID1/MID1_Warlock_Affliction_Hellcaller.simc
@@ -170,5 +170,5 @@ off_hand=grimoire_of_the_eternal_light,id=249276,ilevel=289
 # gear_armor=531
 # set_bonus=midnight_season_1_2pc=1
 # set_bonus=midnight_season_1_4pc=1
-soul_shards=0
-default_pet=sayaad
+warlock.soul_shards=0
+warlock.default_pet=sayaad

--- a/profiles/MID1/MID1_Warlock_Demonology.simc
+++ b/profiles/MID1/MID1_Warlock_Demonology.simc
@@ -118,5 +118,5 @@ main_hand=spire_of_the_furious_construct,id=110031,bonus_id=12806/13577,enchant_
 # gear_armor=531
 # set_bonus=midnight_season_1_2pc=1
 # set_bonus=midnight_season_1_4pc=1
-soul_shards=0
-default_pet=felguard
+warlock.soul_shards=0
+warlock.default_pet=felguard

--- a/profiles/MID1/MID1_Warlock_Destruction.simc
+++ b/profiles/MID1/MID1_Warlock_Destruction.simc
@@ -136,5 +136,5 @@ main_hand=spire_of_the_furious_construct,id=110031,bonus_id=12806/13577,enchant_
 # gear_armor=531
 # set_bonus=midnight_season_1_2pc=1
 # set_bonus=midnight_season_1_4pc=1
-soul_shards=0
-default_pet=sayaad
+warlock.soul_shards=0
+warlock.default_pet=sayaad

--- a/profiles/MID1/MID1_Warlock_Destruction_Diabolist.simc
+++ b/profiles/MID1/MID1_Warlock_Destruction_Diabolist.simc
@@ -136,5 +136,5 @@ main_hand=spire_of_the_furious_construct,id=110031,bonus_id=12806/13577,enchant_
 # gear_armor=531
 # set_bonus=midnight_season_1_2pc=1
 # set_bonus=midnight_season_1_4pc=1
-soul_shards=0
-default_pet=sayaad
+warlock.soul_shards=0
+warlock.default_pet=sayaad

--- a/profiles/generators/MID1/MID1_Generate_Warlock.simc
+++ b/profiles/generators/MID1/MID1_Generate_Warlock.simc
@@ -5,7 +5,7 @@ race=pandaren
 role=spell
 position=ranged_back
 talents=CkQAAAAAAAAAAAAAAAAAAAAAAwMzMzoZhhZmZmlBAAYmZxyMzsMzAAjllBGwEMDbBG2GAAAmBAAwMDzMjBGmZmZGzgZmZGAwMwA
-default_pet=sayaad
+warlock.default_pet=sayaad
 
 head=abyssal_immolators_smoldering_flames,id=250042,bonus_id=13575/1808,enchant_id=7961,gem_id=240983,ilevel=289
 neck=eternal_voidsong_chain,id=249368,bonus_id=12806/13577/13668,gem_id=240916
@@ -33,7 +33,7 @@ race=pandaren
 role=spell
 position=ranged_back
 talents=CkQAAAAAAAAAAAAAAAAAAAAAAwMzMzoZhhZmZmlBAAYmZZWmZmlxAAWgBmFjGzAysBWGAAAmBAAmZAzMjxwwMjZmZGMzMzAAmBG
-default_pet=sayaad
+warlock.default_pet=sayaad
 
 head=abyssal_immolators_smoldering_flames,id=250042,bonus_id=13575/1808,enchant_id=7961,gem_id=240983,ilevel=289
 neck=eternal_voidsong_chain,id=249368,bonus_id=12806/13577/13668,gem_id=240916
@@ -114,7 +114,7 @@ level=90
 race=Dwarf
 role=spell
 position=ranged_back
-default_pet=sayaad
+warlock.default_pet=sayaad
 talents=CsQAAAAAAAAAAAAAAAAAAAAAAwMzMzoZjhZmZmlZjxMLGjFzAAgZmxMzsAGzYYhMw2wGNWYAAgxAjNAMzAYmxYAAAYmZmBAwMDD
 
 head=abyssal_immolators_smoldering_flames,id=250042,bonus_id=13575/13575/13575/13575/1808/13575,enchant_id=7961,gem_id=240983,ilevel=289
@@ -142,7 +142,7 @@ level=90
 race=Dwarf
 role=spell
 position=ranged_back
-default_pet=sayaad
+warlock.default_pet=sayaad
 talents=CsQAAAAAAAAAAAAAAAAAAAAAAwMzMzoZjhZmZmlZjxMLGjFzAAgZmxMzsYBGYWMaMDgZL2YAAgxAjNAgZGYmxYAAAYmZmBAwMDD
 
 head=abyssal_immolators_smoldering_flames,id=250042,bonus_id=13575/13575/13575/13575/1808/13575,enchant_id=7961,gem_id=240983,ilevel=289

--- a/profiles/generators/PreRaids/PR_Generate_Warlock.simc
+++ b/profiles/generators/PreRaids/PR_Generate_Warlock.simc
@@ -5,7 +5,7 @@
 # role=spell
 # position=ranged_back
 # talents=3302013
-# default_pet=sayaad
+# warlock.default_pet=sayaad
 
 # head=horns_of_the_demon_star,id=188889,bonus_id=1498/7187/6935,gem_id=173130
 # neck=worldkiller_iris,id=189859,bonus_id=1524/7187/6935,gem_id=173130
@@ -60,7 +60,7 @@
 # role=spell
 # position=ranged_back
 # talents=2103021
-# default_pet=sayaad
+# warlock.default_pet=sayaad
 
 # head=grimveiled_hood,id=173245,bonus_id=6716/7039/6647/6649/1808/1588/6935,gem_id=173128
 # neck=worldkiller_iris,id=189859,bonus_id=1524/7187/6935,gem_id=173128


### PR DESCRIPTION
Renaming all warlock custom options to `warlock.x` to be whitelisted in the Raidbots custom APL box