### PR TITLE
[Warlock] Demoniac RNG, Destro hotfixes, Aff Cascading Calamity from Fatal Echoes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -210,9 +210,9 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
     default_pet(),
     disable_auto_felstorm( false ),
     normalize_destruction_mastery( false ),
-    eye_explosion_instanced_bug_cb( true ),
-    eye_explosion_instanced_bug_sb( true ),
-    eye_explosion_instanced_bug_rof( false ),
+    eye_explosion_instanced_bug_cb( false ),
+    eye_explosion_instanced_bug_sb( false ),
+    eye_explosion_instanced_bug_rof( true ),
     fel_armaments_extra_effect_bug( false ),
     tyrant_antoran_armaments_target_mul( 1.0 )
 {
@@ -484,13 +484,13 @@ std::string warlock_t::create_profile( save_e stype )
     if ( normalize_destruction_mastery )
       profile_str +=
           "warlock.normalize_destruction_mastery=" + util::to_string( as<int>( normalize_destruction_mastery ) ) + "\n";
-    if ( !eye_explosion_instanced_bug_cb )
+    if ( eye_explosion_instanced_bug_cb )
       profile_str +=
           "warlock.eye_explosion_instanced_bug_cb=" + util::to_string( as<int>( eye_explosion_instanced_bug_cb ) ) + "\n";
-    if ( !eye_explosion_instanced_bug_sb )
+    if ( eye_explosion_instanced_bug_sb )
       profile_str +=
           "warlock.eye_explosion_instanced_bug_sb=" + util::to_string( as<int>( eye_explosion_instanced_bug_sb ) ) + "\n";
-    if ( eye_explosion_instanced_bug_rof )
+    if ( !eye_explosion_instanced_bug_rof )
       profile_str +=
           "warlock.eye_explosion_instanced_bug_rof=" + util::to_string( as<int>( eye_explosion_instanced_bug_rof ) ) + "\n";
     if ( fel_armaments_extra_effect_bug )

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -356,7 +356,7 @@ public:
     const spell_data_t* grimoire_of_sacrifice_proc; // Damage data is here, but RPPM of proc trigger is in buff data
 
     // Affliction
-    const spell_data_t* agony;
+    player_talent_t agony;
     player_talent_t unstable_affliction;
     const spell_data_t* unstable_affliction_2; // Soul Shard on demise (learned automatically)
     player_talent_t seed_of_corruption;
@@ -899,7 +899,8 @@ public:
 
     // Demonology
     proc_t* demonic_core_dogs;
-    proc_t* demonic_core_imps;
+    proc_t* demonic_core_imps_fade;
+    proc_t* demonic_core_imps_implosion;
     proc_t* carnivorous_stalkers;
     proc_t* infernal_rapidity;
     proc_t* spiteful_reconstitution;
@@ -976,12 +977,14 @@ public:
     accumulated_rng_t* succulent_soul;
     accumulated_rng_t* manifested_avarice;
     accumulated_rng_t* feast_of_souls;
+    accumulated_rng_t* demoniac_imp_fade;
     accumulated_rng_t* spiteful_reconstitution;
   } prd_rng;
 
   struct flat_rng_t
   {
     simple_proc_t* immolate_crit_energize; // TODO: Need to check the type of rng
+    simple_proc_t* demoniac_imp_implosion;
     simple_proc_t* carnivorous_stalkers;
     simple_proc_t* infernal_rapidity;
     simple_proc_t* demonfire_infusion_dot; // TODO: Need to check the type of rng
@@ -1011,6 +1014,7 @@ public:
     rng_setting_t cunning_cruelty_ds = { 0.25, 0.25, "cunning_cruelty_ds" };
 
     // Demonology
+    rng_setting_t demoniac_imp_fade_hard_cap = { 21.0, 21.0, "demoniac_imp_fade_hard_cap" };
     rng_setting_t spiteful_reconstitution = { 0.10, 0.10, "spiteful_reconstitution" };
     rng_setting_t spiteful_reconstitution_hard_cap = { 21.0, 21.0, "spiteful_reconstitution_hard_cap" };
     rng_setting_t demonic_knowledge_rank1_cards = { 10.0, 10.0, "demonic_knowledge_rank1_cards" };
@@ -1044,6 +1048,7 @@ public:
       f( nightfall );
       f( cunning_cruelty_sb );
       f( cunning_cruelty_ds );
+      f( demoniac_imp_fade_hard_cap );
       f( spiteful_reconstitution );
       f( spiteful_reconstitution_hard_cap );
       f( demonic_knowledge_rank1_cards );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1505,10 +1505,14 @@ using namespace helpers;
           {
             p()->procs.fatal_echoes->occur();
             make_event( sim, 1_ms, [ this, t = d->state->target ] {
+              const bool prev_ua_ticking = td( t )->dots.unstable_affliction->is_ticking();
               this->set_target( t );
               this->is_fatal_echoes_execute = true;
               this->execute();
               this->is_fatal_echoes_execute = false;
+              // When UA is applied by Fatal Echoes, Cascading Calamity is also triggered
+              if ( p()->talents.cascading_calamity.ok() && !prev_ua_ticking )
+                p()->buffs.cascading_calamity->trigger();
             } );
           }
         }
@@ -1903,7 +1907,7 @@ using namespace helpers;
     struct agony_mg_t : public mg_extra_tick_base_t
     {
       agony_mg_t( warlock_t* p )
-        : mg_extra_tick_base_t( "Agony (Malefic Grasp)", p, ( p->talents.malefic_grasp.ok() && p->talents.agony->ok() ) ? p->talents.agony_mg : spell_data_t::not_found() )
+        : mg_extra_tick_base_t( "Agony (Malefic Grasp)", p, ( p->talents.malefic_grasp.ok() && p->talents.agony.ok() ) ? p->talents.agony_mg : spell_data_t::not_found() )
       {
         // NOTE: 2026-02-20 Agony (Malefic Grasp) extra tick is not whitelisted in the Direct Damage component of many effects
         // (Summoner's Embrace, Niskaran Methods, Mastery: Potent Afflictions), and others don't even have this effect currently
@@ -1980,7 +1984,7 @@ using namespace helpers;
 
       if ( p->talents.malefic_grasp.ok() )
       {
-        if ( p->talents.agony->ok() )
+        if ( p->talents.agony.ok() )
         {
           agony_mg = new agony_mg_t( p );
           add_child( agony_mg );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -185,7 +185,7 @@ namespace warlock
     talents.malefic_grasp = find_talent_spell( talent_tree::SPECIALIZATION, "Malefic Grasp" ); // Should be ID 1261149
     talents.malefic_grasp_2 = conditional_spell_lookup( talents.malefic_grasp.ok(), 1261153 );
     talents.malefic_grasp_3 = conditional_spell_lookup( talents.malefic_grasp.ok(), 1279659 );
-    talents.agony_mg = conditional_spell_lookup( talents.malefic_grasp.ok() && talents.agony->ok(), 1261166 );
+    talents.agony_mg = conditional_spell_lookup( talents.malefic_grasp.ok() && talents.agony.ok(), 1261166 );
     talents.unstable_affliction_mg = conditional_spell_lookup( talents.malefic_grasp.ok() && talents.unstable_affliction.ok(), 1261176 );
     talents.corruption_mg = conditional_spell_lookup( talents.malefic_grasp.ok(), 1261158 );
     talents.wither_mg = conditional_spell_lookup( talents.malefic_grasp.ok(), 1279686 );
@@ -1075,7 +1075,8 @@ namespace warlock
   void warlock_t::init_procs_demonology()
   {
     procs.demonic_core_dogs = get_proc( "demonic_core_dogs" );
-    procs.demonic_core_imps = get_proc( "demonic_core_imps" );
+    procs.demonic_core_imps_fade = get_proc( "demonic_core_imps_fade" );
+    procs.demonic_core_imps_implosion = get_proc( "demonic_core_imps_implosion" );
     procs.carnivorous_stalkers = get_proc( "carnivorous_stalkers" );
     procs.infernal_rapidity = get_proc( "infernal_rapidity" );
     procs.spiteful_reconstitution = get_proc( "spiteful_reconstitution" );
@@ -1244,6 +1245,19 @@ namespace warlock
 
   void warlock_t::init_rng_demonology()
   {
+    if ( talents.demoniac.ok() )
+    {
+      // Modeling Demoniac (Wild Imp fade) as a pseudo-random distribution (PRD) with a nominal rate of 10% and a hard cap of 21 attempts.
+      // The corresponding PRD constant, calculated with that cap included, is C = 0.014559015812945588.
+      int demoniac_imp_fade_hardcap = static_cast<int>( rng_settings.demoniac_imp_fade_hard_cap.setting_value );
+      double c_dwif = prd::find_constant( talents.demonic_core_spell->effectN( 1 ).percent(), demoniac_imp_fade_hardcap );
+      prd_rng.demoniac_imp_fade = get_accumulated_rng( "demoniac_imp_fade", c_dwif, demoniac_imp_fade_hardcap );
+
+      // NOTE: 2026-04-05 It has been tested that Demoniac (Wild Imp implosion) follows a Flat % chance model for each wild imp imploded
+      double demoniac_imp_implosion_chance = talents.demonic_core_spell->effectN( 1 ).percent() + hero.sataiels_volition->effectN( 3 ).percent();
+      flat_rng.demoniac_imp_implosion = get_simple_proc_rng( "demoniac_imp_implosion", demoniac_imp_implosion_chance);
+    }
+
     // NOTE: 2026-03-06 It has been tested that Carnivorous Stalkers follows a Flat % chance model for each individual melee hit
     if ( talents.carnivorous_stalkers.ok() )
       flat_rng.carnivorous_stalkers = get_simple_proc_rng( "carnivorous_stalkers", talents.carnivorous_stalkers->effectN( 1 ).percent() );

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -798,23 +798,27 @@ void wild_imp_pet_t::demise()
       }
     }
 
-    if ( !power_siphon )
+    if ( o()->talents.demoniac.ok() )
     {
-      // NOTE: 2026-03-06 It has been tested that Demoniac (Wild Imps) follows a Flat % chance model for each imp
-      double core_chance = o()->talents.demonic_core_spell->effectN( 1 ).percent();
-
-      if ( imploded )
+      if ( !power_siphon )
       {
-        core_chance += o()->hero.sataiels_volition->effectN( 3 ).percent();
+        if ( imploded )
+        {
+          if ( o()->flat_rng.demoniac_imp_implosion->trigger() )
+          {
+            o()->buffs.demonic_core->trigger();
+            o()->procs.demonic_core_imps_implosion->occur();
+          }
+        }
+        else
+        {
+          if ( o()->prd_rng.demoniac_imp_fade->trigger() )
+          {
+            o()->buffs.demonic_core->trigger();
+            o()->procs.demonic_core_imps_fade->occur();
+          }
+        }
       }
-
-      if ( !o()->talents.demoniac.ok() )
-        core_chance = 0.0;
-
-      bool success = o()->buffs.demonic_core->trigger( 1, buff_t::DEFAULT_VALUE(), core_chance );
-
-      if ( success )
-        o()->procs.demonic_core_imps->occur();
     }
 
     // Manual handling of Hellbent Commander buff for Wild Imps


### PR DESCRIPTION
# Demonology: Demoniac RNG

With Blizzard’s hotfix to the Demoniac proc for Wild Imps, we rechecked the type of RNG and real chance value used for each Demoniac case. This had already been checked in PR #11110 , but after the hotfix we wanted to verify it again, especially the hotfixed proc, since it had already shown some unusual results in the past. Tests were conducted again for both Wild Imps dying naturally and for Wild Imps dying after being imploded, and in the latter case also when using the Sataiel's Volition talent.

**- Wild Imp Implosion (10%):**

It has been verified that imploded Wild Imps follow a Flat % model with a 10% chance.

Logs:
- https://www.warcraftlogs.com/reports/K2nLFWZcRyqaYCfD?fight=last&type=auras&source=1&ability=264173&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24264173%2441

This is the histogram for the distance between procs compared with simulations of different RNG models:
<img width="726" height="429" alt="dcwiimpl1_sample_vs_flat_vs_prd_vs_agony_gap_histogram_overlay_randomized" src="https://github.com/user-attachments/assets/018ba094-083b-43c2-9583-9b810194ebe1" />

ECDF distance between procs:
<img width="420" height="248" alt="dcwiimpl1_ecdf_distance_between_procs_randomized" src="https://github.com/user-attachments/assets/3468b112-5d8b-44e6-a30a-a1f4f90b56bd" />

Hazard per attempt (probability of success on attempt n since the last attempt):
<img width="420" height="248" alt="dcwiimpl1_hazard_per_attempt_randomized" src="https://github.com/user-attachments/assets/57c356c8-137e-45cd-bc58-67f3f6b6b05e" />

Tail / survival of the distance between procs (log scale):
<img width="420" height="248" alt="dcwiimpl1_tail_survival_distance_between_procs_log_randomized" src="https://github.com/user-attachments/assets/0aaeaf75-20bd-4f0b-bb00-1267d9d956ef" />

**- Wild Imp Implosion + Sataiel's Volition (15%):**

It has been verified that imploded Wild Imps follow a Flat % model with a 15% chance. Therefore, the Sataiel's Volition talent appears to be working correctly by adding that 5% to the base 10%.

Logs:
- https://www.warcraftlogs.com/reports/Z3PNq9FApW6MRTwC?fight=last&type=auras&source=1&ability=264173&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24264173%2441

This is the histogram for the distance between procs compared with simulations of different RNG models:
<img width="726" height="429" alt="dcwiimpl2_sample_vs_flat15_vs_prd15_vs_agony15_gap_histogram_overlay_randomized" src="https://github.com/user-attachments/assets/1322df42-cc7d-403b-b7b2-e2e6c1d22820" />

ECDF distance between procs:
<img width="420" height="248" alt="dcwiimpl2_ecdf_distance_between_procs_randomized" src="https://github.com/user-attachments/assets/d54afb22-b985-4be2-bcc1-17eddfbda90e" />

Hazard per attempt (probability of success on attempt n since the last attempt):
<img width="420" height="248" alt="dcwiimpl2_hazard_per_attempt_randomized" src="https://github.com/user-attachments/assets/b9a57e0a-51d8-4498-aa69-7a0d6fe14493" />

Tail / survival of the distance between procs (log scale):
<img width="420" height="248" alt="dcwiimpl2_tail_survival_distance_between_procs_log_randomized" src="https://github.com/user-attachments/assets/7e443385-f934-4bb5-8726-630d0a162185" />

**- Wild Imp Fade (10%):**

Although we initially believed the RNG type used was Flat, a new analysis after the chance fix suggests that this is not the case. Analysis of the Wild Imp fade proc suggests that it uses an accumulator from a pseudo-random distribution (PRD) with a nominal rate of 10% and a hard cap of 21 attempts. The corresponding PRD constant, calculated with that cap included, is C = 0.014559015812945588.

Logs:
- (1) https://www.warcraftlogs.com/reports/13AnJWXbd4GjDqz8?fight=last&type=auras&source=1&ability=264173&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24264173%2441
- (2) https://www.warcraftlogs.com/reports/LMtjHha46m32rDJz?fight=last&type=auras&source=1&ability=264173&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24264173%2441
- (3) https://www.warcraftlogs.com/reports/2CHMafhR7Y18j9pt?fight=last&source=1&type=auras&ability=264173&pins=2%24Off%24%23244F4B%24auras-gained%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24264173%2441

This is the histogram for the distance between procs compared with simulations of different RNG models (based on logs 1 and 2):
<img width="726" height="429" alt="dcwildimp23_sample_vs_flat_vs_prd_vs_agony_gap_histogram_overlay" src="https://github.com/user-attachments/assets/d01e1951-3ab5-41f3-9730-14adf213915e" />

The same (histogram for the distance between procs) but for another one of the tests (based on log 3):
<img width="726" height="429" alt="dcwildimp4_sample_vs_flat10_vs_prd10_vs_agony10_gap_histogram_overlay_constrained" src="https://github.com/user-attachments/assets/11aeafbf-8579-4610-a9b5-e606f7275e2d" />

ECDF distance between procs (based on logs 1 and 2):
<img width="420" height="248" alt="dcwildimp23_ecdf_distance_between_procs" src="https://github.com/user-attachments/assets/46d38920-a31e-4ef4-aafc-8edc1f0aa816" />

The same (ECDF distance between procs) but for another one of the tests (based on log 3):
<img width="420" height="248" alt="dcwildimp4_ecdf_distance_between_procs_constrained" src="https://github.com/user-attachments/assets/b09186a4-6c88-40de-a788-bb4b8f061ee1" />

Hazard per attempt (probability of success on attempt n since the last attempt) (based on logs 1 and 2):
<img width="420" height="248" alt="dcwildimp23_hazard_per_attempt" src="https://github.com/user-attachments/assets/9413234a-d247-4d47-9bd6-be033bcdcabf" />

The same (hazard per attempt) but for another one of the tests (based on log 3):
<img width="420" height="248" alt="dcwildimp4_hazard_per_attempt_constrained" src="https://github.com/user-attachments/assets/bc23be02-8016-4645-ae04-7cc9237fec84" />

Tail / survival of the distance between procs (log scale) (based on logs 1 and 2):
<img width="420" height="248" alt="dcwildimp23_tail_survival_distance_between_procs_log" src="https://github.com/user-attachments/assets/ad8bc92a-c161-4ab2-aab3-176ad9204b59" />

The same (tail / survival of the distance between procs) but for another one of the tests (based on log 3):
<img width="420" height="248" alt="dcwildimp4_tail_survival_distance_between_procs_log_constrained" src="https://github.com/user-attachments/assets/22ea92a5-dbad-414f-b4e6-40a1bc71e8f2" />


# Destruction: Eye Explosion (Diabolist) hotfix

Blizzard has announced a hotfix that supposedly fixes the issue where Eye Explosion (Diabolist) was not triggering correctly in instanced content. After several tests, it has been verified that the bug has indeed been fixed when the trigger is Chaos Bolt, Shadowburn, or Ruination. However, when the trigger is Rain of Fire, it still does not work correctly in most cases in instanced content. Therefore, for now the options added for these bugs will not be removed yet, but their default values are being changed. By default, the implementation of this bug will now be disabled for Chaos Bolt, Shadowburn, and Ruination, and enabled for Rain of Fire. The default values now are:
```
eye_explosion_instanced_bug_cb=0
eye_explosion_instanced_bug_sb=0
eye_explosion_instanced_bug_rof=1
```
Additionally, it is worth noting that for Chaos Bolt, Shadowburn, and Ruination, the Eye Explosion trigger can still occasionally fail if the player is at maximum range from the target, although this only happens occasionally (and inconsistently). Also, Eye Explosion does not trigger if the player is not already in combat with the target before casting the spell (though we believe this is intentional rather than a bug). These behaviors are not implemented in SimC, as they are not especially relevant, occur inconsistently, have little overall impact, and are easy to avoid.

# Affliction: trigger Cascading Calamity from Fatal Echoes proc

In-game, when Unstable Affliction DoT is automatically reapplied after one ends through Fatal Echoes proc, this triggers Cascading Calamity. This was not happening in the sim implementation, where it only occurred if the proc happened in a UA DoT stack decrease, not in a DoT expiration.