### PR TITLE
[Warlock] Adjust Infernal Rapidity and Unstable Soul

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -1015,6 +1015,7 @@ public:
     accumulated_rng_t* feast_of_souls;
     accumulated_rng_t* demoniac_imp_fade;
     accumulated_rng_t* spiteful_reconstitution;
+    double infernal_rapidity_prd_c_value;
   } prd_rng;
 
   struct flat_rng_t
@@ -1022,7 +1023,6 @@ public:
     simple_proc_t* immolate_crit_energize; // TODO: Need to check the type of rng
     simple_proc_t* demoniac_imp_implosion;
     simple_proc_t* carnivorous_stalkers;
-    simple_proc_t* infernal_rapidity;
     simple_proc_t* demonfire_infusion_dot; // TODO: Need to check the type of rng
     simple_proc_t* demonfire_infusion_inc; // TODO: Need to check the type of rng
     simple_proc_t* alythesss_ire_shift;

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1285,13 +1285,12 @@ namespace warlock
     if ( talents.carnivorous_stalkers.ok() )
       flat_rng.carnivorous_stalkers = get_simple_proc_rng( "carnivorous_stalkers", talents.carnivorous_stalkers->effectN( 1 ).percent() );
 
-    // NOTE: 2026-03-06 It has been tested that Infernal Rapidity follows a Flat % chance model for each individual cast
-    // However, the % chance seems to be bugged and only half of what is specified in the spell data is being applied (bug)
+    // Modeling Infernal Rapidity as a pseudo-random distribution (PRD) with a nominal rate of 10%, which corresponds to PRD constant
+    // C = 0.014745844781072676. Each Wild Imp uses its own independent accumulator PRD, reset to 0 on spawn. Since a single Wild Imp
+    // can cast at most 6 Fel Firebolts, the PRD never has time to fully ramp up, resulting in an average proc chance of ~4.80%.
     if ( talents.infernal_rapidity.ok() )
     {
-      double infernal_rapidity_chance = talents.infernal_rapidity->effectN( 1 ).percent();
-      infernal_rapidity_chance = bugs ? infernal_rapidity_chance * 0.5 : infernal_rapidity_chance;
-      flat_rng.infernal_rapidity = get_simple_proc_rng( "infernal_rapidity", infernal_rapidity_chance );
+      prd_rng.infernal_rapidity_prd_c_value = prd::find_constant( talents.infernal_rapidity->effectN( 1 ).percent() );
     }
 
     // Modeling Spiteful Reconstitution as a pseudo-random distribution (PRD) with an uncapped nominal rate of 10%.

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -640,7 +640,7 @@ wild_imp_pet_t::wild_imp_pet_t( warlock_t* owner )
 
   // Each Wild Imp uses its own independent accumulator PRD, reset to 0 on arise
   if ( owner->talents.infernal_rapidity.ok() )
-    prd_rng_infernal_rapidity = get_accumulated_rng( "infernal_rapidity_i" + actor_index, owner->prd_rng.infernal_rapidity_prd_c_value );
+    prd_rng_infernal_rapidity = get_accumulated_rng( "infernal_rapidity_i" + std::to_string( actor_index ), owner->prd_rng.infernal_rapidity_prd_c_value );
 }
 
 struct fel_firebolt_t : public warlock_pet_spell_t

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -637,12 +637,17 @@ wild_imp_pet_t::wild_imp_pet_t( warlock_t* owner )
 
   resource_regeneration = regen_type::DISABLED;
   owner_coeff.health = 0.15;
+
+  // Each Wild Imp uses its own independent accumulator PRD, reset to 0 on arise
+  if ( owner->talents.infernal_rapidity.ok() )
+    prd_rng_infernal_rapidity = get_accumulated_rng( "infernal_rapidity_i" + actor_index, owner->prd_rng.infernal_rapidity_prd_c_value );
 }
 
 struct fel_firebolt_t : public warlock_pet_spell_t
 {
   fel_firebolt_t* twin = nullptr;
   const bool is_twin;
+  mutable bool target_cache_unstable_soul_state = false;
 
   fel_firebolt_t( warlock_pet_t* p, bool _is_twin = false )
     : warlock_pet_spell_t( "fel_firebolt", p, p->find_spell( 104318 ) ),
@@ -692,11 +697,64 @@ struct fel_firebolt_t : public warlock_pet_spell_t
     }
   }
 
+  size_t available_targets( std::vector<player_t*>& tl ) const override
+  {
+    warlock_pet_spell_t::available_targets( tl );
+
+    // If there is more than one target, Unstable Soul always fires all extra hits,
+    // even if some targets are hit multiple times
+    if ( p()->buffs.unstable_soul->check() )
+    {
+      const int n_tar = n_targets();
+      const size_t og_tar_count = tl.size();
+
+      if ( n_tar > 1 && og_tar_count > 1 && og_tar_count < as<size_t>( n_tar ) )
+      {
+        size_t remaining_tar = as<size_t>( n_tar ) - og_tar_count;
+
+        tl.reserve( as<size_t>( n_tar ) );
+        while ( remaining_tar >= og_tar_count )
+        {
+          for ( size_t i = 0; i < og_tar_count; ++i )
+            tl.push_back( tl[ i ] );
+
+          remaining_tar -= og_tar_count;
+        }
+
+        if ( remaining_tar > 0 )
+        {
+          std::vector<player_t*> shuff_tar( tl.begin(), tl.begin() + og_tar_count );
+          rng().shuffle( shuff_tar.begin(), shuff_tar.end() );
+
+          for ( size_t i = 0; i < remaining_tar; ++i )
+            tl.push_back( shuff_tar[ i ] );
+        }
+      }
+    }
+
+    return tl.size();
+  }
+
+  std::vector<player_t*>& target_list() const override
+  {
+    // Invalidate the target cache whenever the current Unstable Soul buff state differs from the cached one,
+    // since available_targets() builds a different target list depending on whether the buff is active or not.
+    const bool unstable_soul_buff = p()->buffs.unstable_soul->check();
+    if ( target_cache_unstable_soul_state != unstable_soul_buff )
+    {
+      target_cache.is_valid = false;
+      target_cache_unstable_soul_state = unstable_soul_buff;
+    }
+
+    return warlock_pet_spell_t::target_list();
+  }
+
   void execute() override
   {
     warlock_pet_spell_t::execute();
 
-    if ( ( twin != nullptr ) && p()->o()->flat_rng.infernal_rapidity->trigger() )
+    // Extra Fel Firebolts from Infernal Rapidity cannot proc Infernal Rapidity again
+    if ( ( twin != nullptr ) && ( p()->bugs ? debug_cast<wild_imp_pet_t*>( p() )->prd_rng_infernal_rapidity->trigger() : rng().roll( p()->o()->talents.infernal_rapidity->effectN( 1 ).percent() ) ) )
     {
       p()->o()->procs.infernal_rapidity->occur();
       twin->execute_on_target( target );
@@ -765,6 +823,11 @@ void wild_imp_pet_t::arise()
   is_hog_imp = ( duration == o()->warlock_base.wild_imp->duration() ); // TODO: Only valid because duration diff, look for a safer way
   power_siphon = false;
   imploded = false;
+
+  // Each Wild Imp uses its own independent accumulator PRD, reset to 0 on arise
+  if ( o()->talents.infernal_rapidity.ok() )
+    prd_rng_infernal_rapidity->reset( reset_type_e::COMBAT );
+
   o()->buffs.wild_imps->trigger();
 
   if ( o()->talents.summon_demonic_tyrant.ok() )

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -429,6 +429,7 @@ struct wild_imp_pet_t : public warlock_pet_t
   bool imploded;
   timespan_t infernal_command_ev_ts;
   timespan_t infernal_command_ev_offset;
+  accumulated_rng_t* prd_rng_infernal_rapidity;
 
   wild_imp_pet_t( warlock_t* );
   void init_base_stats() override;


### PR DESCRIPTION
# Infernal Rapidity

The **Infernal Rapidity** talent is supposed to give each **Fel Firebolt** a 10% chance to cast another one at no cost and with greater effectiveness, but in testing it was observed to have a proc rate of around ~4.7%–5.0% (and SimC has actually implemented it as 5%).

After testing it more thoroughly, the issue seems to be that the game to use a 10% accumulator PRD, but each Wild Imp has its own separate one, starting at 0 and resetting for each imp. Since a single Wild Imp can only cast up to 6 Fel Firebolts, the PRD never has time to fully ramp up. Under those conditions, the average proc chance comes out to ~4.80%, which matches the observations very closely.

The distribution of number of total casts per wild imp also lines up with this, which strongly suggests that this is indeed how it works. From a sample of 7425 summoned Wild Imps (46715 Fel Firebolts total, ~4.86% average proc rate), we get the following distribution of wild imps with N casts (compared to 5% flat and 10% PRD per imp):
| Casts per Imp | Observed | 5% Flat | PRD 10% per imp |
| ---: | ---: | ---: | ---: |
| **6** | 5392 | 5458.1 | 5391.4 |
| **7** | 1905 | 1723.6 | 1929.7 |
| **8** | 124 | 226.8 | 102.1 |
| **9** | 4 | 15.9 | 1.8 |
<img width="576" height="352" alt="IR_vs_sim_extra_chance_by_bolt_index_v2" src="https://github.com/user-attachments/assets/513ccff0-fc66-4658-82c9-2564957cd659" />

Logs:
- https://www.warcraftlogs.com/reports/CcQWB9nLPxY3tF4A?fight=last&source=1&type=damage-done&pins=2%24Off%24%23244F4B%24damage%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24104318
- https://www.warcraftlogs.com/reports/bBvWw87QzpnxhLGm?fight=last&source=1&type=damage-done&pins=2%24Off%24%23244F4B%24damage%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%24104318

# Unstable Soul

**Unstable Soul** is a buff applied to **To Hell and Back** Wild Imps. It increases the damage of their **Fel Firebolt** and causes it to hit up to 4 additional targets.

Log observations indicate that whenever more than one target is available, all 4 additional hits are still performed even if fewer than 5 total targets exist. In those cases, the extra hits are distributed among the available targets, which may cause some targets to be hit multiple times, including the primary target.

This PR implements that behavior in SimC.
