### PR TITLE
[Mage] Frost - Added target swapping for SS

### DIFF
--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -277,42 +277,50 @@ void frost( player_t* p )
   action_priority_list_t* movement = p->get_action_priority_list( "movement" );
   action_priority_list_t* ss_aoe = p->get_action_priority_list( "ss_aoe" );
   action_priority_list_t* ss_st = p->get_action_priority_list( "ss_st" );
+  action_priority_list_t* ss_tarswap = p->get_action_priority_list( "ss_tarswap" );
 
   precombat->add_action( "arcane_intellect" );
   precombat->add_action( "snapshot_stats" );
+  precombat->add_action( "variable,name=target_swapping,op=reset,default=0" );
   precombat->add_action( "summon_water_elemental" );
-  precombat->add_action( "blizzard,if=talent.frostfire_bolt|active_enemies>=4&talent.freezing_rain", "Frostfire can open with a precast Blizzard against all target counts. Spellslinger AoE starts at 4+, but Blizzard is only cast with Freezing Rain." );
+  precombat->add_action( "blizzard,if=talent.frostfire_bolt|active_enemies>=4&(talent.freezing_rain|talent.freezing_winds)", "Frostfire can open with a precast Blizzard against all target counts. Spellslinger AoE starts at 4+, but Blizzard is only cast with any of the Blizzard talents." );
   precombat->add_action( "glacial_spike" );
   precombat->add_action( "frostbolt" );
 
   default_->add_action( "call_action_list,name=cds" );
   default_->add_action( "run_action_list,name=ff_aoe,if=talent.frostfire_bolt&active_enemies>=3", "Frostfire AoE starts at 3+ targets." );
   default_->add_action( "run_action_list,name=ff_st,if=talent.frostfire_bolt" );
-  default_->add_action( "run_action_list,name=ss_aoe,if=active_enemies>=4", "Spellslinger AoE starts at 4+ targets." );
+  default_->add_action( "run_action_list,name=ss_tarswap,if=variable.target_swapping" );
+  default_->add_action( "run_action_list,name=ss_aoe,if=active_enemies>=4", "Spellslinger AoE starts at 4+ targets" );
   default_->add_action( "run_action_list,name=ss_st" );
 
-  cds->add_action( "use_item,name=nevermelting_ice_crystal,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20", "Potion, Items and Racials are used on cd for Frostfire and paired with either Orb or Ray as Spellslinger. Use Haste trinkets always after pot, Crit trinkets always before pot, and Mastery trinkets after pot if crit is your highest stat and before pot otherwise." );
-  cds->add_action( "use_item,name=freightrunners_flask,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
-  cds->add_action( "use_item,name=vaelgors_final_stare,if=(stat.haste_rating>stat.crit_rating|stat.versatility_rating>stat.crit_rating)&(time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20)" );
-  cds->add_action( "potion,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<35" );
-  cds->add_action( "use_item,name=vaelgors_final_stare,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
-  cds->add_action( "use_items,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
-  cds->add_action( "blood_fury,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
-  cds->add_action( "berserking,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
-  cds->add_action( "fireblood,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
-  cds->add_action( "ancestral_call,if=time=0|talent.frostfire_bolt|prev_gcd.1.frozen_orb|prev_gcd.1.ray_of_frost|debuff.freezing.react<6&cooldown.ray_of_frost.charges>=1|fight_remains<20" );
+  cds->add_action( "variable,name=ff_trinket_timing,value=talent.frostfire_bolt", "Potion, Items and Racials are used on cd for Frostfire and paired with either Orb or Ray as Spellslinger." );
+  cds->add_action( "variable,name=ss_trinket_timing,value=talent.splinterstorm&(time=0|fight_remains<15|prev_gcd.1.frozen_orb|cooldown.ray_of_frost.charges>=1&debuff.freezing.react<6&!buff.fingers_of_frost.react&(icicles<3|time-action.potion.last_used<25))" );
+  cds->add_action( "use_item,name=nevermelting_ice_crystal,if=variable.ff_trinket_timing|variable.ss_trinket_timing", "Use Haste trinkets always after pot, Crit trinkets always before pot, and Mastery trinkets after pot if Crit is your highest stat and before pot otherwise." );
+  cds->add_action( "use_item,name=freightrunners_flask,if=variable.ff_trinket_timing|variable.ss_trinket_timing" );
+  cds->add_action( "use_item,name=vaelgors_final_stare,if=(variable.ff_trinket_timing|variable.ss_trinket_timing)&(stat.haste_rating>stat.crit_rating|stat.versatility_rating>stat.crit_rating)" );
+  cds->add_action( "potion,if=variable.ff_trinket_timing|variable.ss_trinket_timing|fight_remains<35" );
+  cds->add_action( "use_item,name=vaelgors_final_stare,if=variable.ff_trinket_timing|variable.ss_trinket_timing" );
+  cds->add_action( "use_items" );
+  cds->add_action( "blood_fury,if=variable.ff_trinket_timing|variable.ss_trinket_timing" );
+  cds->add_action( "berserking,if=variable.ff_trinket_timing|variable.ss_trinket_timing" );
+  cds->add_action( "fireblood,if=variable.ff_trinket_timing|variable.ss_trinket_timing" );
+  cds->add_action( "ancestral_call,if=variable.ff_trinket_timing|variable.ss_trinket_timing" );
   cds->add_action( "flurry,if=talent.frostfire_bolt,line_cd=9999", "Opener Frostfire" );
   cds->add_action( "glacial_spike,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "flurry,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "ray_of_frost,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "frozen_orb,if=talent.frostfire_bolt,line_cd=9999" );
   cds->add_action( "ice_lance,if=active_enemies<=3&talent.flash_freeze&talent.splinterstorm,line_cd=9999", "Opener Spellslinger ST" );
-  cds->add_action( "ray_of_frost,if=active_enemies<=3&talent.splinterstorm,line_cd=9999" );
-  cds->add_action( "flurry,if=active_enemies>=4&talent.wintertide&talent.splinterstorm,line_cd=9999", "Opener Spellslinger AoE" );
+  cds->add_action( "ray_of_frost,if=active_enemies<=3&talent.splinterstorm&!variable.target_swapping,line_cd=9999" );
+  cds->add_action( "ray_of_frost,target_if=min:debuff.freezing.react,if=active_enemies<=3&talent.splinterstorm&variable.target_swapping,line_cd=9999" );
+  cds->add_action( "flurry,if=active_enemies>=4&talent.wintertide&talent.splinterstorm&!variable.target_swapping,line_cd=9999", "Opener Spellslinger AoE" );
+  cds->add_action( "flurry,target_if=min:debuff.freezing.react,if=active_enemies>=4&talent.wintertide&talent.splinterstorm&variable.target_swapping,line_cd=9999" );
   cds->add_action( "frozen_orb,if=active_enemies>=4&talent.splinterstorm,line_cd=9999" );
-  cds->add_action( "ray_of_frost,if=active_enemies>=4&talent.splinterstorm,line_cd=9999" );
-  cds->add_action( "ray_of_frost,if=fight_remains<12", "End-Of-Fight Actions" );
-  cds->add_action( "ice_lance,if=fight_remains<gcd.max*1.5" );
+  cds->add_action( "ray_of_frost,if=active_enemies>=4&talent.splinterstorm&!variable.target_swapping,line_cd=9999" );
+  cds->add_action( "ray_of_frost,target_if=min:debuff.freezing.react,if=active_enemies>=4&talent.splinterstorm&variable.target_swapping,line_cd=9999" );
+  cds->add_action( "ray_of_frost,if=fight_remains<12&!variable.target_swapping", "End-Of-Fight Actions" );
+  cds->add_action( "ray_of_frost,target_if=min:debuff.freezing.react,if=fight_remains<12&variable.target_swapping" );
   cds->add_action( "invoke_external_buff,name=power_infusion,if=buff.power_infusion.down", "Externals" );
 
   ff_aoe->add_action( "blizzard,if=buff.freezing_rain.up" );
@@ -355,7 +363,7 @@ void frost( player_t* p )
   ss_aoe->add_action( "ice_lance,if=debuff.freezing.react>=6" );
   ss_aoe->add_action( "ice_nova,if=talent.cone_of_frost" );
   ss_aoe->add_action( "cone_of_cold,if=talent.cone_of_frost" );
-  ss_aoe->add_action( "blizzard,if=active_enemies>=5&talent.freezing_winds&talent.freezing_rain" );
+  ss_aoe->add_action( "blizzard,if=talent.freezing_winds" );
   ss_aoe->add_action( "ray_of_frost,if=icicles<3|time-action.potion.last_used<25" );
   ss_aoe->add_action( "flurry,if=cooldown_react" );
   ss_aoe->add_action( "frostbolt" );
@@ -372,6 +380,23 @@ void frost( player_t* p )
   ss_st->add_action( "flurry,if=cooldown_react" );
   ss_st->add_action( "frostbolt" );
   ss_st->add_action( "call_action_list,name=movement" );
+
+  ss_tarswap->add_action( "comet_storm", "Played when the variable target_swapping=1. It's the ST/AoE rotation but always targets the enemy with the lowest Freezing stacks when casting a spell that generates Freezing." );
+  ss_tarswap->add_action( "blizzard,target_if=active_enemies>=4&buff.freezing_rain.up" );
+  ss_tarswap->add_action( "flurry,target_if=min:debuff.freezing.react,if=buff.brain_freeze.react&buff.thermal_void.down" );
+  ss_tarswap->add_action( "ice_lance,if=buff.fingers_of_frost.react=2" );
+  ss_tarswap->add_action( "frozen_orb" );
+  ss_tarswap->add_action( "glacial_spike,target_if=min:debuff.freezing.react" );
+  ss_tarswap->add_action( "ice_lance,if=buff.fingers_of_frost.react" );
+  ss_tarswap->add_action( "ice_lance,target_if=min:debuff.freezing.react>=6,if=active_enemies<=2&debuff.freezing.react>=6", "Against 2 targets, wait for both to have 6+ freezing stacks before casting IL. Against 3+ targets cast IL as soon as any one target has 6+ stacks." );
+  ss_tarswap->add_action( "ice_lance,target_if=debuff.freezing.react>=6,if=active_enemies>=3" );
+  ss_tarswap->add_action( "ice_nova,if=active_enemies>=4&talent.cone_of_frost" );
+  ss_tarswap->add_action( "cone_of_cold,if=active_enemies>=4&talent.cone_of_frost" );
+  ss_tarswap->add_action( "blizzard,if=active_enemies>=4&talent.freezing_winds" );
+  ss_tarswap->add_action( "ray_of_frost,target_if=min:debuff.freezing.react,if=icicles<3|time-action.potion.last_used<25" );
+  ss_tarswap->add_action( "flurry,target_if=min:debuff.freezing.react,if=cooldown_react" );
+  ss_tarswap->add_action( "frostbolt,target_if=min:debuff.freezing.react" );
+  ss_tarswap->add_action( "call_action_list,name=movement" );
 }
 //frost_apl_end
 


### PR DESCRIPTION
- introduced a variable for ss and ff each that bundles their updated trinket conditions
- refined blizzard usage for ss with freezing winds
- introduced target swapping for SS which is enabled by setting `apl_variable.target_swapping=1`