### PR TITLE
[Mage] SS AOE Blizzard optimization

### DIFF
--- a/ActionPriorityLists/default/mage_frost.simc
+++ b/ActionPriorityLists/default/mage_frost.simc
@@ -104,6 +104,7 @@ actions.ss_aoe+=/cone_of_cold,if=talent.cone_of_frost
 actions.ss_aoe+=/blizzard,if=talent.freezing_winds
 actions.ss_aoe+=/ray_of_frost,if=icicles<3|time-action.potion.last_used<25
 actions.ss_aoe+=/flurry,if=cooldown_react
+actions.ss_aoe+=/blizzard,if=active_enemies>=4
 actions.ss_aoe+=/frostbolt
 actions.ss_aoe+=/call_action_list,name=movement
 

--- a/engine/class_modules/apl/mage.cpp
+++ b/engine/class_modules/apl/mage.cpp
@@ -367,6 +367,7 @@ void frost( player_t* p )
   ss_aoe->add_action( "blizzard,if=talent.freezing_winds" );
   ss_aoe->add_action( "ray_of_frost,if=icicles<3|time-action.potion.last_used<25" );
   ss_aoe->add_action( "flurry,if=cooldown_react" );
+  ss_aoe->add_action( "blizzard,if=active_enemies>=4" );
   ss_aoe->add_action( "frostbolt" );
   ss_aoe->add_action( "call_action_list,name=movement" );
 


### PR DESCRIPTION
## Summary

| Priority | Meaning |
| - | - |
| low | above Frostbolt | 
| med | above Frozen Orb | 
| high | if Freezing Rain is up OR >= N active targets | 

## Results

| Talents | Targets | low | med | high |
| - | - | - | - | - | 
| AOE | 4+ | +0% | -1.7% | -1.6% |
| AOE | 7+ | +0.1% | -1.3% | -1.2% | 
| AOE | 10+ | +0.3% | -0.8% | -0.7% | 
| ST | 4+ | +1.1% | +0% | -0.2% | 
| ST | 7+ | +2.6% | +3.3% | +3.3% | 
| ST | 10+ | +3.4% | +5.4% | +5.5% | 

## Sims		

* AOE 4+: https://www.raidbots.com/simbot/report/bQrUiGTrZN36eVU2qgKhy9
* AOE 7+: https://www.raidbots.com/simbot/report/wNhWQVMFXQiEndjY48zZtn
* AOE 10+: https://www.raidbots.com/simbot/report/mbKKfPZ7HRyuxGU8TQTHUX
* ST 4+: https://www.raidbots.com/simbot/report/muBdczzjRteTtpwqqussXA
* ST 7+: https://www.raidbots.com/simbot/report/e2qDgN6r8vYVpYKGiywVj6
* ST 10+: https://www.raidbots.com/simbot/report/eQCQ61ijmH8X97zfPC5PtP