### PR TITLE
[DH] Focused Ray no longer bugged

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -12757,11 +12757,6 @@ public:
         .operation( hotfix::HOTFIX_SET )
         .modifier( 16.0 )
         .verification_value( 50.0 );
-    hotfix::register_effect( "Demon Hunter", "2025-03-26", "Focused Ray works on up to 3 targets", 1239241 )
-        .field( "base_value" )
-        .operation( hotfix::HOTFIX_SET )
-        .modifier( 3.0 )
-        .verification_value( 1.0 );
     hotfix::register_effect( "Demon Hunter", "2025-03-26",
                              "Collapsing star still only does 50% additional damage to primary target", 1290193 )
         .field( "base_value" )


### PR DESCRIPTION
Focused ray changed to work on up to 3 targets in 12.0.5