### PR TITLE
[Demonology][Warlock] Removes the custom modifier to Demonic Soul

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2874,10 +2874,6 @@ struct soul_swipe_base_t : public warlock_pet_spell_t
 {
   soul_swipe_base_t( std::string_view n, warlock_pet_t* p, const spell_data_t* s ) : warlock_pet_spell_t( n, p, s )
   {
-    // Rampaging Demonic Soul has a custom damage modifier for demonology
-    if ( p->o()->demonology() )
-      base_dd_multiplier *= 1.0 + p->o()->warlock_base.demonology_warlock->effectN( 8 ).percent();
-
     base_dd_multiplier *= 1.0 + p->o()->hero.eternal_hunger->effectN( 2 ).percent();
   }
 };


### PR DESCRIPTION
With the change from a server-sided script to a whitelist the custom modifier now is not necessary and instead causes a double dip in the value of Soul Swipe, reducing the damage for more than intended. 

https://www.raidbots.com/simbot/report/myGy59qGUM5pVDdN5fVMsp 

 https://www.warcraftlogs.com/reports/6FAmtxHjch8KCzrk?fight=last&type=damage-done&source=2&ability=-1269042&view=events