### PR TITLE
[Warlock] Conflagration of Chaos 12.0.5 changes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -603,10 +603,9 @@ public:
     const spell_data_t* rift_chaos_bolt; // Separate ID from Warlock's Chaos Bolt
     player_talent_t soul_fire;
     const spell_data_t* soul_fire_2; // Contains Soul Shard energize data
-    player_talent_t inferno;
+    player_talent_t chaos_incarnate; // Greater mastery value for some spells
     player_talent_t conflagration_of_chaos; // Conflagrate/Shadowburn has chance to make next cast of it a guaranteed crit
-    const spell_data_t* conflagration_of_chaos_cf; // Player buff which affects next Conflagrate
-    const spell_data_t* conflagration_of_chaos_sb; // Player buff which affects next Shadowburn
+    const spell_data_t* conflagration_of_chaos_buff; // Player buff which affects next Conflagrate/Shadowburn
     player_talent_t diabolic_embers; // Incinerate generates more Soul Shards
     player_talent_t demonfire_infusion;
     player_talent_t channel_demonfire;
@@ -617,7 +616,7 @@ public:
     const spell_data_t* summon_overfiend;
     const spell_data_t* overfiend_buff; // Buff on Warlock while Overfiend is out, generates Soul Shards
     const spell_data_t* overfiend_cb; // Chaos Bolt cast by Overfiend
-    player_talent_t chaos_incarnate; // Greater mastery value for some spells
+    player_talent_t inferno;
     player_talent_t alythesss_ire;
     const spell_data_t* alythesss_ire_buff;
     player_talent_t raging_demonfire;
@@ -858,8 +857,7 @@ public:
     propagate_const<buff_t*> fiendish_cruelty;
     propagate_const<buff_t*> chaotic_inferno;
     propagate_const<buff_t*> rain_of_chaos;
-    propagate_const<buff_t*> conflagration_of_chaos_cf;
-    propagate_const<buff_t*> conflagration_of_chaos_sb;
+    propagate_const<buff_t*> conflagration_of_chaos;
     propagate_const<buff_t*> flashpoint;
     propagate_const<buff_t*> crashing_chaos;
     propagate_const<buff_t*> alythesss_ire;
@@ -950,8 +948,7 @@ public:
     proc_t* chaotic_inferno;
     proc_t* dimensional_rift;
     proc_t* avatar_of_destruction;
-    proc_t* conflagration_of_chaos_cf;
-    proc_t* conflagration_of_chaos_sb;
+    proc_t* conflagration_of_chaos;
     proc_t* demonfire_infusion_inc;
     proc_t* demonfire_infusion_dot;
     proc_t* alythesss_ire;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -178,8 +178,7 @@ using namespace helpers;
         parse_effects( p()->buffs.backdraft ); // 117828
         parse_effects( p()->buffs.fiendish_cruelty ); // 1245664
         parse_effects( p()->buffs.chaotic_inferno ); // 1244860
-        parse_effects( p()->buffs.conflagration_of_chaos_cf ); // 387109
-        parse_effects( p()->buffs.conflagration_of_chaos_sb ); // 387110
+        parse_effects( p()->buffs.conflagration_of_chaos ); // 387109
         parse_effects( p()->buffs.crashing_chaos ); // 417282 // RoF is dummy
         parse_effects( p()->buffs.alythesss_ire ); // 1244947
       }
@@ -4102,14 +4101,14 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      p()->buffs.conflagration_of_chaos_cf->expire();
+      p()->buffs.conflagration_of_chaos->expire();
 
       if ( p()->talents.conflagration_of_chaos.ok() )
       {
-        bool success = p()->buffs.conflagration_of_chaos_cf->trigger();
+        bool success = p()->buffs.conflagration_of_chaos->trigger();
 
         if ( success )
-          p()->procs.conflagration_of_chaos_cf->occur();
+          p()->procs.conflagration_of_chaos->occur();
       }
 
       if ( p()->talents.backdraft.ok() )
@@ -4120,7 +4119,7 @@ using namespace helpers;
     {
       double amt = warlock_spell_t::calculate_direct_amount( s );
 
-      if ( p()->buffs.conflagration_of_chaos_cf->check() )
+      if ( p()->buffs.conflagration_of_chaos->check() )
       {
         s->result_total *= 1.0 + player->cache.spell_crit_chance();
         return s->result_total;
@@ -4434,14 +4433,14 @@ using namespace helpers;
 
       base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
 
-      p()->buffs.conflagration_of_chaos_sb->expire();
+      p()->buffs.conflagration_of_chaos->expire();
 
       if ( p()->talents.conflagration_of_chaos.ok() )
       {
-        bool success = p()->buffs.conflagration_of_chaos_sb->trigger();
+        bool success = p()->buffs.conflagration_of_chaos->trigger();
 
         if ( success )
-          p()->procs.conflagration_of_chaos_sb->occur();
+          p()->procs.conflagration_of_chaos->occur();
       }
 
       p()->buffs.fiendish_cruelty->decrement();
@@ -4451,7 +4450,7 @@ using namespace helpers;
     {
       double amt = warlock_spell_t::calculate_direct_amount( state );
 
-      if ( p()->buffs.conflagration_of_chaos_sb->check() )
+      if ( p()->buffs.conflagration_of_chaos->check() )
       {
         state->result_total *= 1.0 + player->cache.spell_crit_chance();
         return state->result_total;

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -487,11 +487,10 @@ namespace warlock
     talents.soul_fire = find_talent_spell( talent_tree::SPECIALIZATION, "Soul Fire" ); // Should be ID 6353
     talents.soul_fire_2 = conditional_spell_lookup( talents.soul_fire.ok(), 281490 );
 
-    talents.inferno = find_talent_spell( talent_tree::SPECIALIZATION, "Inferno" ); // Should be ID 1280483
+    talents.chaos_incarnate = find_talent_spell( talent_tree::SPECIALIZATION, "Chaos Incarnate" ); // Should be ID 387275
 
     talents.conflagration_of_chaos = find_talent_spell( talent_tree::SPECIALIZATION, "Conflagration of Chaos" ); // Should be ID 387108
-    talents.conflagration_of_chaos_cf = conditional_spell_lookup( talents.conflagration_of_chaos.ok(), 387109 );
-    talents.conflagration_of_chaos_sb = conditional_spell_lookup( talents.conflagration_of_chaos.ok() && talents.shadowburn.ok(), 387110 );
+    talents.conflagration_of_chaos_buff = conditional_spell_lookup( talents.conflagration_of_chaos.ok(), 387109 );
 
     talents.diabolic_embers = find_talent_spell( talent_tree::SPECIALIZATION, "Diabolic Embers" ); // Should be ID 387173
 
@@ -506,7 +505,7 @@ namespace warlock
     talents.overfiend_buff = conditional_spell_lookup( talents.avatar_of_destruction.ok(), 457578 );
     talents.overfiend_cb = conditional_spell_lookup( talents.avatar_of_destruction.ok(), 434589 );
 
-    talents.chaos_incarnate = find_talent_spell( talent_tree::SPECIALIZATION, "Chaos Incarnate" ); // Should be ID 387275
+    talents.inferno = find_talent_spell( talent_tree::SPECIALIZATION, "Inferno" ); // Should be ID 1280483
 
     talents.alythesss_ire = find_talent_spell( talent_tree::SPECIALIZATION, "Alythess's Ire" ); // Should be ID 1244941
     talents.alythesss_ire_buff = conditional_spell_lookup( talents.alythesss_ire.ok(), 1244947 );
@@ -837,13 +836,8 @@ namespace warlock
 
     buffs.rain_of_chaos = make_buff( this, "rain_of_chaos", talents.rain_of_chaos_buff );
 
-    buffs.conflagration_of_chaos_cf = make_buff( this, "conflagration_of_chaos_cf", talents.conflagration_of_chaos_cf )
-                                          ->set_default_value_from_effect( 1 )
-                                          ->set_chance( talents.conflagration_of_chaos->effectN( 1 ).percent() );
-
-    buffs.conflagration_of_chaos_sb = make_buff( this, "conflagration_of_chaos_sb", talents.conflagration_of_chaos_sb )
-                                          ->set_default_value_from_effect( 1 )
-                                          ->set_chance( talents.conflagration_of_chaos->effectN( 1 ).percent() );
+    buffs.conflagration_of_chaos = make_buff( this, "conflagration_of_chaos", talents.conflagration_of_chaos_buff )
+                                       ->set_chance( talents.conflagration_of_chaos->effectN( 1 ).percent() );
 
     buffs.flashpoint = make_buff( this, "flashpoint", talents.flashpoint_buff )
                            ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
@@ -1113,8 +1107,7 @@ namespace warlock
     procs.chaotic_inferno = get_proc( "chaotic_inferno" );
     procs.dimensional_rift = get_proc( "dimensional_rift" );
     procs.avatar_of_destruction = get_proc( "avatar_of_destruction" );
-    procs.conflagration_of_chaos_cf = get_proc( "conflagration_of_chaos_cf" );
-    procs.conflagration_of_chaos_sb = get_proc( "conflagration_of_chaos_sb" );
+    procs.conflagration_of_chaos = get_proc( "conflagration_of_chaos" );
     procs.alythesss_ire = get_proc( "alythesss_ire" );
     procs.reverse_entropy = get_proc( "reverse_entropy" );
     procs.rain_of_chaos = get_proc( "rain_of_chaos" );

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1688,8 +1688,6 @@ action_t* grimoire_fel_ravager_t::create_action( util::string_view name, util::s
 {
   if ( name == "abyssal_bite" )
     return new abyssal_bite_t( this, options_str );
-  if ( name == "spell_lock" )
-    return new base::spell_lock_t( this, options_str );
 
   return warlock_pet_t::create_action( name, options_str );
 }


### PR DESCRIPTION
Conflagration of Chaos Shadowburn and CoC Conflagrate buffs have been combined into a single buff spell in patch 12.0.5.

Inferno and Chaos Incarnate have swapped positions in the talent tree.
