### PR TITLE
[Warlock] Apply Abyssal Dominion hotfix and adjust Demonic Power, Hellbent Commander, Patient Zero, Aff 4p tier, and Nether Plating

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -233,11 +233,25 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   regen_caches[ CACHE_SPELL_HASTE ] = true;
 
   sim->register_heartbeat_event_callback( [ this ]( sim_t* ) {
-    // NOTE (2026-03-08): Some pets are currently bugged when updating Hellbent Commander stacks on arise/demise.
-    // Hellbent Commander's stacks are updated to their correct value on each heartbeat update.
+    // NOTE (2026-04-24): Some pets are currently bugged when updating Hellbent Commander stacks on arise/demise.
+    // Hellbent Commander's stacks are refreshed on each heartbeat update, but not all pets are correctly accounted for.
     if ( bugs && talents.hellbent_commander.ok() )
     {
-      const int expected_stacks = active_demon_count();
+      int expected_stacks = 0;
+
+      for ( auto pet : pet_list )
+      {
+        auto lock_pet = dynamic_cast<warlock_pet_t*>( pet );
+
+        if ( lock_pet == nullptr )
+          continue;
+        if ( lock_pet->is_sleeping() )
+          continue;
+
+        if ( lock_pet->triggers.hellbent_commander_heartbeat )
+          expected_stacks++;
+      }
+
       const int current_stacks = buffs.hellbent_commander->check();
 
       const int stack_diff = expected_stacks - current_stacks;
@@ -259,7 +273,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
       // On each Heartbeat, the player periodically applies a hidden Fel Armaments aura to the Felguard, triggering procs
       auto active_pet = warlock_pet_list.active;
       if ( active_pet && active_pet->pet_type == PET_FELGUARD )
-        this->trigger_aura_applied_callbacks( proc_data_entries.fel_armaments_2, active_pet );
+        trigger_aura_applied_callbacks( proc_data_entries.fel_armaments_2, active_pet );
     }
 
     for ( auto pet : active_pets )

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -256,6 +256,7 @@ public:
   player_t* havoc_target;
   std::vector<action_t*> havoc_spells; // Used for smarter target cache invalidation.
   player_t* haunt_target; // Used for tracking the current haunt target
+  player_t* patient_zero_target; // Used to track which target benefits from the Patient Zero talent damage increase
   std::vector<event_t*> wild_imp_spawns; // Used for tracking incoming imps from HoG TODO: Is this still needed with faster spawns?
   int diabolic_ritual; // Used to cycle between the three different Diabolic Ritual buffs
   bool demonic_art_buff_replaced; // Used to not spawn the Demonic Art demon if the buff is replaced by another

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1426,7 +1426,13 @@ using namespace helpers;
         initial_stacks += ( int )( p()->talents.sudden_onset->effectN( 2 ).base_value() );
 
       if ( active_4pc<MID1>() )
-        initial_stacks += ( int )( p()->tier.wl_affliction_12_0_class_set_4pc->effectN( 1 ).base_value() );
+      {
+        // NOTE: 2026-04-24 Tier set is only applying 1 additional stack to Agony on initial cast if Sudden Onset is not talented (bug?)
+        if ( p()->bugs && !p()->talents.sudden_onset.ok() )
+          initial_stacks += ( int )( p()->tier.wl_affliction_12_0_class_set_4pc->effectN( 1 ).base_value() * 0.5 );
+        else
+          initial_stacks += ( int )( p()->tier.wl_affliction_12_0_class_set_4pc->effectN( 1 ).base_value() );
+      }
 
       int delta_stacks = initial_stacks - td( execute_state->target )->dots.agony->current_stack();
 
@@ -1671,14 +1677,14 @@ using namespace helpers;
 
         if ( p()->talents.patient_zero.ok() )
         {
-          // NOTE (2026-02-20): Patient Zero interacts incorrectly with Sow the Seeds (bug?).
-          // In-game testing shows that its damage bonus is applied to the host of the original (main) seed, even for
-          // explosions triggered by additional seeds. If the original host of the main seed is out of range, dead, or
-          // otherwise invalid (e.g., immune) at the time of explosion, the bonus is not reassigned and is simply not applied.
+          // NOTE (2026-04-24): Patient Zero does not track seeds individually (bug?). Instead, it uses a single
+          // per-caster target reference updated by the most recently Seed of Corruption casted. Any seed explosion 
+          // hitting that target gets the Patient Zero bonus. If the target is out of range, dead, or otherwise invalid 
+          // (e.g., immune) at the time of explosion, the bonus is not reassigned and is simply not applied.
           if ( p()->bugs )
           {
-            assert( main_seed_target && "SoC does not have a valid main seed target" );
-            if ( t == main_seed_target )
+            assert( p()->patient_zero_target && "SoC does not have a valid Patient Zero target" );
+            if ( t == p()->patient_zero_target )
               m *= 1.0 + p()->talents.patient_zero->effectN( 1 ).percent();
           }
           else
@@ -1785,6 +1791,10 @@ using namespace helpers;
 
     void execute() override
     {
+      // Patient Zero target is updated on SoC cast success, not on impact or debuff application
+      if ( p()->talents.patient_zero.ok() )
+        p()->patient_zero_target = target;
+
       warlock_spell_t::execute();
 
       p()->buffs.seed_of_corruption_is_out_dnt->trigger();
@@ -3278,14 +3288,8 @@ using namespace helpers;
       timespan_t extraTyrantTime = rng().gauss<380,220>();
       auto tyrants = p()->warlock_pet_list.demonic_tyrants.spawn( data().duration() + extraTyrantTime );
 
-      int demon_counter = 0;
+      int demonic_power_counter = 0;
       const timespan_t extension_time = 15_s; // TODO: Where is this 15_s in the spell data?
-
-      for ( auto wild_imp : p()->warlock_pet_list.wild_imps )
-      {
-        if ( !wild_imp->is_sleeping() )
-          demon_counter++;
-      }
 
       for ( auto dreadstalker : p()->warlock_pet_list.dreadstalkers )
       {
@@ -3298,7 +3302,27 @@ using namespace helpers;
             dreadstalker->expiration->reschedule_time = dreadstalker->expiration->time + extension_time;
         }
 
-        demon_counter++;
+        demonic_power_counter++;
+      }
+
+      for ( auto wild_imp : p()->warlock_pet_list.wild_imps )
+      {
+        if ( !wild_imp->is_sleeping() )
+          demonic_power_counter++;
+      }
+
+      // NOTE: 2026-04-24: Vilefiend (all variants) and Felguard count for Demonic Power buff (only at Tyrant summon) (bug?)
+      if ( p()->bugs )
+      {
+        for ( auto vilefiend : p()->warlock_pet_list.vilefiends )
+        {
+          if ( !vilefiend->is_sleeping() )
+            demonic_power_counter++;
+        }
+
+        auto active_pet = p()->warlock_pet_list.active;
+        if ( active_pet && active_pet->pet_type == PET_FELGUARD )
+          demonic_power_counter++;
       }
 
       if ( p()->talents.reign_of_tyranny.ok() )
@@ -3307,12 +3331,12 @@ using namespace helpers;
           p()->buffs.dreadstalkers->extend_duration( extension_time );
       }
 
-      if ( demon_counter > 0 )
+      if ( demonic_power_counter > 0 )
       {
         for ( auto t : tyrants )
         {
           if ( t->is_active() )
-            t->buffs.demonic_power->trigger( demon_counter );
+            t->buffs.demonic_power->trigger( demonic_power_counter );
         }
       }
 

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -939,7 +939,8 @@ namespace warlock
 
     buffs.infernal_bolt = make_buff( this, "infernal_bolt", hero.infernal_bolt_buff );
 
-    buffs.abyssal_dominion = make_buff( this, "abyssal_dominion", hero.abyssal_dominion_buff );
+    buffs.abyssal_dominion = make_buff( this, "abyssal_dominion", hero.abyssal_dominion_buff )
+                                 ->set_duration( hero.abyssal_dominion_buff->duration() + talents.reign_of_tyranny->effectN( 1 ).time_value() );
 
     buffs.ruination = make_buff( this, "ruination", hero.ruination_buff );
 
@@ -1677,6 +1678,7 @@ namespace warlock
     warlock_pet_list.active = nullptr;
     havoc_target = nullptr;
     haunt_target = nullptr;
+    patient_zero_target = nullptr;
     wild_imp_spawns.clear();
     diabolic_ritual = rng().range( 0, 3 );
     demonic_art_buff_replaced = false;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -20,6 +20,7 @@ warlock_pet_t::warlock_pet_t( warlock_t* owner, util::string_view pet_name, pet_
   owner_coeff.health = 0.5;
 
   affected_by.demonic_brutality = owner->talents.demonic_brutality.ok();
+  triggers.hellbent_commander_heartbeat = owner->talents.hellbent_commander.ok();
   triggers.hellbent_commander_arise = owner->talents.hellbent_commander.ok();
   triggers.hellbent_commander_demise = owner->talents.hellbent_commander.ok();
 
@@ -271,6 +272,9 @@ felhunter_pet_t::felhunter_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 691 )->effectN( 1 ).misc_value1();
 
+  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  triggers.hellbent_commander_demise &= !bugs;
+
   action_list_str = "travel/shadow_bite";
 
   is_main_pet = true;
@@ -318,6 +322,9 @@ imp_pet_t::imp_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 688 )->effectN( 1 ).misc_value1();
 
+  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  triggers.hellbent_commander_demise &= !bugs;
+
   action_list_str = "firebolt";
 
   owner_coeff.ap_from_sp = 0.625;
@@ -359,6 +366,9 @@ sayaad_pet_t::sayaad_pet_t( warlock_t* owner, util::string_view name )
   : warlock_pet_t( owner, name, PET_SAYAAD, false )
 {
   npc_id = owner->find_spell( 366222 )->effectN( 1 ).misc_value1();
+
+  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel/whiplash/lash_of_pain";
 
@@ -418,6 +428,9 @@ voidwalker_pet_t::voidwalker_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 697 )->effectN( 1 ).misc_value1();
 
+  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  triggers.hellbent_commander_demise &= !bugs;
+
   action_list_str = "travel/consuming_shadows";
 
   is_main_pet = true;
@@ -467,6 +480,9 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
     max_energy_threshold( 100 )
 {
   npc_id = owner->talents.summon_felguard->effectN( 1 ).misc_value1();
+
+  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel";
 
@@ -864,7 +880,8 @@ void wild_imp_pet_t::demise()
     {
       for ( auto t : o()->warlock_pet_list.demonic_tyrants )
       {
-        if ( t->is_active() )
+        // NOTE: 2026-04-24: Imploded Wild Imps does not substract stacks from Demonic Power buff (bug?)
+        if ( t->is_active() && ( !bugs || !imploded ) )
           t->buffs.demonic_power->decrement();
       }
     }
@@ -893,7 +910,7 @@ void wild_imp_pet_t::demise()
     }
 
     // Manual handling of Hellbent Commander buff for Wild Imps
-    // NOTE (2026-04-08): Wild Imps are currently bugged when updating Hellbent Commander stacks on demise:
+    // NOTE (2026-04-24): Wild Imps are currently bugged when updating Hellbent Commander stacks on demise:
     // If imploded, imps summoned via HoG decrease one stack each, while those summoned via Inner Demons,
     // Spiteful Reconstitution, or To Hell and Back do not decrease any stacks.
     // If the imps demise normally or are sacrificed with Power Siphon, HoG imps decrease two stacks each,
@@ -1224,9 +1241,11 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   else
   {
     npc_id = owner->talents.vilefiend->effectN( 1 ).misc_value1();
+    // NOTE: 2026-04-24 Regular Vilefiend do not trigger Hellbent Commander on heartbeat (bug?)
+    triggers.hellbent_commander_heartbeat &= !bugs;
   }
 
-  // NOTE: 2026-04-08 Vilefiend do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-04-24 Vilefiend do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "bile_spit";
@@ -1404,7 +1423,7 @@ demonic_tyrant_t::demonic_tyrant_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->talents.summon_demonic_tyrant->effectN( owner->talents.antoran_armaments.ok() ? 4 : 1 ).misc_value1();
 
-  // NOTE: 2026-04-08 Demonic Tyrant do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-04-24 Demonic Tyrant do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
   triggers.hellbent_commander_demise &= !bugs;
 
   resource_regeneration = regen_type::DISABLED;
@@ -1586,7 +1605,7 @@ grimoire_imp_lord_t::grimoire_imp_lord_t( warlock_t* owner )
   npc_id = owner->talents.grimoire_imp_lord->effectN( 2 ).misc_value1();
   npc_suffix = "grimoire";
 
-  // NOTE: 2026-04-08 Grimoire: Imp Lord do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-04-24 Grimoire: Imp Lord do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "greater_felbolt,if=energy>=" + util::to_string( max_energy_threshold );
@@ -1662,7 +1681,7 @@ grimoire_fel_ravager_t::grimoire_fel_ravager_t( warlock_t* owner )
   npc_id = owner->talents.grimoire_fel_ravager->effectN( 2 ).misc_value1();
   npc_suffix = "grimoire";
 
-  // NOTE: 2026-04-08 Grimoire: Fel Ravager do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-04-24 Grimoire: Fel Ravager do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel/abyssal_bite,if=energy>=" + util::to_string( max_energy_threshold );
@@ -1739,7 +1758,7 @@ dominion_of_argus_pet_t::dominion_of_argus_pet_t( warlock_t* owner, std::string_
 {
   resource_regeneration = regen_type::DISABLED;
   affected_by.demonic_brutality = false;
-  // NOTE: 2026-04-08 DoA guardians do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-04-24 DoA guardians do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
   triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 }
@@ -1915,9 +1934,9 @@ struct soul_barrage_t : public warlock_pet_spell_t
 struct soul_barrage_cast_t : public dominion_of_argus_spell_base_t
 {
   soul_barrage_cast_t( dominion_of_argus_pet_t* p )
-    : dominion_of_argus_spell_base_t( "Soul Barrage Cast", p, p->find_spell( 1292384 ) )
+    : dominion_of_argus_spell_base_t( "Soul Barrage (Cast)", p, p->find_spell( 1292384 ) )
   {
-    aoe           = data().effectN( 1 ).base_value();
+    aoe           = as<int>( data().effectN( 1 ).base_value() );
     impact_action = new soul_barrage_t( p );
 
     // Merge the two actions in the HTML report for cleaner reporting
@@ -2338,7 +2357,7 @@ struct eye_beam_t : public warlock_pet_spell_t
   eye_beam_t( warlock_pet_t* p ) : warlock_pet_spell_t( "Eye Beam", p, p->o()->talents.eye_beam )
   {
     if ( p->o()->talents.nether_plating.ok() )
-      aoe = 1 + as<int>( p->o()->talents.nether_plating->effectN( 1 ).base_value() );
+      radius = p->o()->talents.nether_plating->effectN( 2 ).base_value();
   }
 
   double composite_target_multiplier( player_t* target ) const override
@@ -2483,7 +2502,8 @@ namespace diabolist
 
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
-    // NOTE: 2026-04-08 Diabolist guardians do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
+    // NOTE: 2026-04-24 Diabolist guardians do not trigger Hellbent Commander (bug?)
+    triggers.hellbent_commander_heartbeat &= !bugs;
     triggers.hellbent_commander_arise &= !bugs;
     triggers.hellbent_commander_demise &= !bugs;
     resource_regeneration = regen_type::DISABLED;
@@ -2605,7 +2625,8 @@ namespace diabolist
 
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
-    // NOTE: 2026-04-08 Diabolist guardians do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
+    // NOTE: 2026-04-24 Diabolist guardians do not trigger Hellbent Commander (bug?)
+    triggers.hellbent_commander_heartbeat &= !bugs;
     triggers.hellbent_commander_arise &= !bugs;
     triggers.hellbent_commander_demise &= !bugs;
 
@@ -2698,7 +2719,8 @@ namespace diabolist
 
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
-    // NOTE: 2026-04-08 Diabolist guardians do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
+    // NOTE: 2026-04-24 Diabolist guardians do not trigger Hellbent Commander (bug?)
+    triggers.hellbent_commander_heartbeat &= !bugs;
     triggers.hellbent_commander_arise &= !bugs;
     triggers.hellbent_commander_demise &= !bugs;
     resource_regeneration = regen_type::DISABLED;
@@ -2914,7 +2936,8 @@ rampaging_demonic_soul_t::rampaging_demonic_soul_t( warlock_t* owner, std::strin
   affected_by.demonic_brutality = false;
   action_list_str               = "soul_swipe";
   owner_coeff.sp_from_sp        = 1.0;
-  // NOTE: 2026-04-08 Demonic Soul do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-04-24 Demonic Soul do not trigger Hellbent Commander (bug?)
+  triggers.hellbent_commander_heartbeat &= !bugs;
   triggers.hellbent_commander_arise  &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 }

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -72,6 +72,7 @@ struct warlock_pet_t : public pet_t
 
   struct triggers_t
   {
+    bool hellbent_commander_heartbeat;
     bool hellbent_commander_arise;
     bool hellbent_commander_demise;
   } triggers;


### PR DESCRIPTION
# Abyssal Dominion hotfix
Blizzard has added a hotfix so that the **Abyssal Dominion** buff now adjusts its duration to match the **Tyrant** duration. Previously, it always had a fixed duration of 15 seconds, whereas it is now extended to 20 seconds when using the **Reign of Tyranny** talent, to match the Tyrant’s duration.

For this type of buff-duration modification, Blizzard usually applies the change through spell data, which is then handled automatically by the `parse_effects` system. That does not seem to be the case here, however, so we applied it manually in the code.
It would be worth checking again in the future in case Blizzard eventually implements it that way, to avoid applying the duration bonus twice in SimC.

# Demonic Power
A few strange things are going on with this **Demonic Power** buff of **Tyrant**:
- **Vilefiend** (all variants) and the **Felguard** main pet (only Felguard; other main pets do not count) contribute to **Demonic Power**, but only at the moment the **Tyrant** is summoned. Subsequent spawns/despawns of those pets while the **Tyrant** is active do not change the stack count.
- Imploded **Wild Imps** do not reduce the **Demonic Power** stack count (applicable to all **Wild Imps**: HoG Wild Imps and the others).
- Unlike **Hellbent Commander**, there is no buff stacking correction on heartbeat event, so these mismatches persist and accumulate for the rest of the **Tyrant**’s duration. However, they do not persist from one **Tyrant** to the next.

# Hellbent Commander
Some things have changed since the last adjustments made to this talent in PR #11347. Some demons that previously counted toward this talent no longer do, and a few other behaviors have changed as well. We assume this is a consequence of Blizzard’s attempt to fix the issue of certain toys and items (such as Demonic Gateway) counting toward this talent.

The table below shows how the **Hellbent Commander** buff is updated for each demon on arise/demise/heartbeat:
| pet | heartbeat | arise | demise | comment |
| --- | --- | --- | --- | --- |
| main_pets | 1 | 1 | **-** | |
| wild_imps_1(hog) | 1 | 1 | * | -> `-2` stacks on `normal`/`PS` demise, `-1` stacks on `implosion ` |
| wild_imps_2(talents) | 1 | 1 | * | -> `-1` stacks on `normal`/`PS` demise, `±0` stacks on `implosion` |
| dreadstalker | 1 | 1 | 1 | |
| vilefiend | **-** | 1 | - | |
| vilefiend_shadow | 1 | 1 | - | |
| vilefiend_fire | 1 | 1 | - | |
| tyrant | 1 | 1 | - | |
| grimoire_imp_lord | 1 | 1 | - | |
| grimoire_fel_ravager | 1 | 1 | - | |
| doomguard | 1 | 1 | 1 | |
| doa_demons(apex) | 1 | - | - | |
| diabolist_mother | **-** | - | - | |
| diabolist_pit_lord | **-** | - | - | |
| diabolist_overlord | **-** | - | - | |
| rampaging_demon_soul | **-** | - | - | |

# Patient Zero
We previously believed that **Patient Zero** only showed strange (bugged) behavior in combination with **Sow the Seeds**, but testing has confirmed that the behavior is more general and not specifically tied to that talent.

According to the tooltip, the host of the exploding Seed should receive 50% increased damage from its own Seed. In practice, however, there is always a single specific target that receives the 50% bonus damage from all Seeds. This "Patient Zero target" is simply the last target to have had **Seed of Corruption** cast on it.

The code comment below explains it fairly well:
```
// Patient Zero does not track seeds individually (bug?). Instead, it uses a single
// per-caster target reference updated by the most recently Seed of Corruption casted. Any seed explosion 
// hitting that target gets the Patient Zero bonus. If the target is out of range, dead, or otherwise invalid 
// (e.g., immune) at the time of explosion, the bonus is not reassigned and is simply not applied.
// Patient Zero target is updated on SoC cast success, not on impact or debuff application.
```

Logs:
- https://www.warcraftlogs.com/reports/4d8ma16NQknx7cjK?boss=-3&difficulty=0&type=damage-done&source=1&ability=27285&view=events
- https://www.warcraftlogs.com/reports/F69whBvMAdxzJp1L?boss=-3&difficulty=0&type=damage-done&source=1&ability=27285&view=events
- https://www.warcraftlogs.com/reports/XhVf6W8zDvwycxpN?boss=-3&difficulty=0&type=damage-done&source=1&ability=27285&view=events
- https://www.warcraftlogs.com/reports/mP6zNwgG7xFB1qMH?boss=-3&difficulty=0&type=damage-done&source=1&ability=27285&view=events
- https://www.warcraftlogs.com/reports/zc1v728fLpa4VTdF?boss=-3&difficulty=0&type=damage-done&source=1&ability=27285&view=events
- https://www.warcraftlogs.com/reports/LQpynCZ6cmWgYRX1?boss=-3&difficulty=0&type=damage-done&source=3&ability=27285&view=events
- https://www.warcraftlogs.com/reports/9AKJx8jn2FN4CHTX?boss=-3&difficulty=0&type=damage-done&source=1&ability=27285&view=events

# Affliciton 4p tier
**Affliction 4p tier set** **Agony** 2 extra stacks is only working if **Sudden Onset** is talented, otherwise it only adds 1 extra stack (instead of the 2 stated). It's probably a bug.

# Nether Plating
The number of targets (`aoe` variable) of Darkglare **Eye beam** when using **Nether Plating** talent is automatically applied by `parse_effects` system.

However, the `radius` of the spell is set manually from spell data, as this is not applied automatically.
