### PR TITLE
[Warlock] Shadowburn missing Conflagration of Chaos crit damage bonus bug

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -4474,7 +4474,8 @@ using namespace helpers;
     {
       double amt = warlock_spell_t::calculate_direct_amount( state );
 
-      if ( p()->buffs.conflagration_of_chaos->check() )
+      // NOTE: 2026-04-25 Conflagration of Chaos crit damage bonus is not applied to Shadowburn (bug)
+      if ( p()->buffs.conflagration_of_chaos->check() && !p()->bugs )
       {
         state->result_total *= 1.0 + player->cache.spell_crit_chance();
         return state->result_total;


### PR DESCRIPTION
**Conflagration of Chaos** crit bonus damage is not applied to **Shadowburn** (SB). It is working well for **Conflagrate** (CF).

This might be happening because when they unified the **Conflagration of Chaos** buffs from **Conflagrate** and **Shadowburn**, they didn't actually create a new buff, but rather modified the **CoC** **CF** buff adding the **SB** stuff to it, and perhaps they forgot to add the **SB** bonus damage part.

We also took the opportunity to retest that the critical damage bonus granted by this talent is equal to the player’s base critical strike chance (without taking into account effects that increase crit chance for whitelisted spells, such as **Devastation**, **Xalan's Ferocity**, or **Xalan's Cruelty** talents). This was only tested with **CF**, since it is the only one currently working, but once the **SB** bug is fixed, the bonus should behave the same way there as well. For example, in the following logs the player’s base crit chance is `21.63%`, so the final damage is multiplied by `1.2163` if the spell is affected by **CoC**.

**Logs**
_`21.63%` player crit base chance, `+6%` crit chance to CF and SB (whitelisted spells in Devastation rank2 talent), and `+2.76%` crit chance to CF from Xalan's Ferocity talent, and `+5.80%` crit chance to SB from Xalan's Ferocity and Xalan's Cruelty talents. `230%` crit dmg instead of `200%` because Ruin rank2 talent_ 
- (log without CoC talent): https://www.warcraftlogs.com/reports/RvXhJY3dkNAzaDQW?fight=last&type=damage-done&source=1&pins=2%24Off%24%23244F4B%24damage%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%2417962%7C17877
- (log with CoC talent): https://www.warcraftlogs.com/reports/A6ajqN2bhJM4w8Dd?fight=last&source=1&type=damage-done&pins=2%24Off%24%23244F4B%24damage%24-1%24163876261.0.0.Warlock%240.0.0.Any%24true%240.0.0.Any%24true%2417962%7C17877