### PR TITLE
Updated Dockerfile to use LTO_THIN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN \
     # Build
     echo "Building simc executable" && \
     clang++ -v && \
-    make -C /app/SimulationCraft/engine release CXX=clang++ -j ${THREADS} THIN_LTO=1 LLVM_PGO_GENERATE=1 OPTS+="-Os -mtune=generic" SC_DEFAULT_APIKEY=${APIKEY} && \
+    make -C /app/SimulationCraft/engine release CXX=clang++ -j ${THREADS} LTO_THIN=1 LLVM_PGO_GENERATE=1 OPTS+="-Os -mtune=generic" SC_DEFAULT_APIKEY=${APIKEY} && \
     # Collect profile guided instrumentation data
     echo "Collecting profile guided instrumentation data" && \
     LLVM_PROFILE_FILE="code-%p.profraw" ./engine/simc ${PGO_PROFILE} single_actor_batch=1 iterations=100 && \
@@ -55,7 +55,7 @@ RUN \
     # Clean & rebuild with collected profile guided data.
     echo "Rebuilding simc executable with profile data for further optimization" && \
     make -C /app/SimulationCraft/engine clean && \
-    make -C /app/SimulationCraft/engine release CXX=clang++ -j ${THREADS} THIN_LTO=1 LLVM_PGO_USE=./code.profdata OPTS+="-Os -mtune=generic" SC_DEFAULT_APIKEY=${APIKEY} && \
+    make -C /app/SimulationCraft/engine release CXX=clang++ -j ${THREADS} LTO_THIN=1 LLVM_PGO_USE=./code.profdata OPTS+="-Os -mtune=generic" SC_DEFAULT_APIKEY=${APIKEY} && \
     # Cleanup dependencies
     echo "Cleaning up" && \
     apk del build_dependencies


### PR DESCRIPTION
Fixed the Dockerfile to correctly pass `LTO_THIN` instead of `THIN_LTO`, since this is what the Makefile expects

https://github.com/simulationcraft/simc/blob/09842d3ab90a77b2384175d5ca75820a3fdc3e98/engine/Makefile#L122