### PR TITLE
[Warlock] Always process Shard Instability buff

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1477,7 +1477,7 @@ using namespace helpers;
 
       // NOTE: 2026-04-29 If Shard Instability buff is gained during the casting of Unstable Affliction, that UA cast benefits from the cost
       // reduction but does not consume the effect (bug?). As expected, a Fatal Echoes UA proc does not consume it either.
-      if ( p()->talents.shard_instability.ok() && time_to_execute == 0_ms && !is_fatal_echoes_execute )
+      if ( time_to_execute == 0_ms && !is_fatal_echoes_execute )
       {
         // NOTE: 2026-04-29 Unstable Affliction consumes all Shard Instability stacks at once (bug)
         if ( p()->bugs )


### PR DESCRIPTION
To implement the Blizzard hotfixes introduced in the previous Warlock PR (#11421), a condition was added so that the **Shard Instability** buff would not be consumed if the **Unstable Affliction** executed was not instant or if it came from the **Fatal Echoes** proc. However, an additional check was also added requiring the **Shard Instability** talent to be selected, which is incorrect.

In **Hellcaller**, this buff can also be gained without having the **Shard Instability** talent selected. As a result, in that case (**Hellcaller** with **Shard Instability** talent not selected), the buff would never be consumed, while **UA** would still benefit from it, which is incorrect.

This PR fixes that issue.