### PR TITLE
[Rogue] adjust fatebound delayed coinflip resolution timing

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -8069,8 +8069,6 @@ void actions::rogue_action_t<Base>::trigger_hand_of_fate( const action_state_t* 
         current_is_heads ? fatebound_t::coinflip_e::TAILS : fatebound_t::coinflip_e::HEADS;
     }
 
-    resolve_fatebound_coinflip( coin_target, result );
-
     if ( p()->talent.fatebound.controlled_chaos->ok() )
     {
       int streak = as<int>( p()->talent.fatebound.controlled_chaos->effectN( 1 ).base_value() );
@@ -8081,6 +8079,8 @@ void actions::rogue_action_t<Base>::trigger_hand_of_fate( const action_state_t* 
         trigger_fatebound_coinflip( coin_target, result, 250_ms );
       }
     }
+
+    resolve_fatebound_coinflip( coin_target, result );
   } );
 }
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -2221,6 +2221,8 @@ public:
   void trigger_doomblade( const action_state_t* );
   void trigger_echoing_reprimand( const action_state_t* state );
   void trigger_fatal_flourish( const action_state_t* );
+  void resolve_fatebound_coinflip( player_t* coin_target, fatebound_t::coinflip_e result );
+  void trigger_fatebound_coinflip( player_t* coin_target, fatebound_t::coinflip_e result, timespan_t delay = timespan_t::zero() );
   void trigger_fatebound_coinflip( const action_state_t* state, fatebound_t::coinflip_e result, timespan_t delay = timespan_t::zero() );
   void trigger_fatebound_edge_case( const action_state_t* state );
   void trigger_fazed( const action_state_t* state );
@@ -8026,87 +8028,87 @@ void actions::rogue_action_t<Base>::trigger_hand_of_fate( const action_state_t* 
   if ( cast_state( state )->get_combo_points() < p()->talent.fatebound.hand_of_fate->effectN( 1 ).base_value() )
     return;
 
-  fatebound_t::coinflip_e result;
-
-  // No stacks of either buff or equal stacks of both buffs (thanks to only using edge case)
-  // Nothing to bias, just flip the coin fairly
-  if ( p()->buffs.fatebound_coin_tails->total_stack() == p()->buffs.fatebound_coin_heads->total_stack() )
-  {
-    result = p()->rng().roll( 0.5 ) ? fatebound_t::coinflip_e::HEADS : fatebound_t::coinflip_e::TAILS;
-  }
-  // Flip the coin, potentially with a bias toward matching the last face flipped
-  else
-  {
-    double matching_odds = 0.5;
-    if ( biased )
-    {
-      // TODO: Validate how these stack with the presumed base 50/50 chance and one another
-      if ( p()->talent.fatebound.mean_streak->ok() )
-      {
-        matching_odds += matching_odds * p()->talent.fatebound.mean_streak->effectN( 1 ).percent();
-      }
-      if ( p()->talent.fatebound.destiny_defined->ok() )
-      {
-        matching_odds += p()->talent.fatebound.destiny_defined->effectN( 3 ).percent();
-      }
-      if ( p()->buffs.fatebound_lucky_coin->check() )
-      {
-        // MIDNIGHT TOCHECK -- Is this additive?
-        matching_odds += p()->spell.fatebound_lucky_coin_buff->effectN( 5 ).percent();
-      }
-    }
-
-    // TODO: it's an assumption that if you have both buffs (thanks, edge case) the bias prefers the one with more stacks
-    // (since the last one you hit before the edge case has to be the one with more stacks)
-    const bool is_match = p()->rng().roll( matching_odds );
-    const bool current_is_heads = p()->buffs.fatebound_coin_heads->check() > p()->buffs.fatebound_coin_tails->check();
-    result = is_match ?
-      current_is_heads ? fatebound_t::coinflip_e::HEADS : fatebound_t::coinflip_e::TAILS :
-      current_is_heads ? fatebound_t::coinflip_e::TAILS : fatebound_t::coinflip_e::HEADS;
-  }
-
-  trigger_fatebound_coinflip( state, result, current_delay );
-
-  if ( p()->talent.fatebound.controlled_chaos->ok() )
-  {
-    int streak = as<int>( p()->talent.fatebound.controlled_chaos->effectN( 1 ).base_value() );
-    if ( ( p()->buffs.fatebound_coin_tails->total_stack() >= streak && result == fatebound_t::coinflip_e::HEADS ) ||
-         ( p()->buffs.fatebound_coin_heads->total_stack() >= streak && result == fatebound_t::coinflip_e::TAILS ) )
-    {
-      // 250ms so it does not coincide with an Overflowing Purse roll at the same time for now
-      trigger_fatebound_coinflip( state, result, 250_ms + current_delay );
-    }
-  }
-}
-
-template <typename Base>
-void actions::rogue_action_t<Base>::trigger_fatebound_coinflip( const action_state_t* state, fatebound_t::coinflip_e result, timespan_t delay )
-{
   auto coin_target = state->target->is_enemy() ? state->target : p()->target;
-  make_event( *p()->sim, delay, [ this, coin_target, result, delay ] {
-    p()->sim->print_log( "{} triggered fatebound coinflip with result '{}' and {} delay", *p(), fatebound_t::coinflip_string( result ), delay );
-    if ( result == fatebound_t::coinflip_e::HEADS || result == fatebound_t::coinflip_e::EDGE )
+  make_event( *p()->sim, current_delay, [ this, coin_target, biased ] {
+    fatebound_t::coinflip_e result;
+
+    // No stacks of either buff or equal stacks of both buffs (thanks to only using edge case)
+    // Nothing to bias, just flip the coin fairly
+    if ( p()->buffs.fatebound_coin_tails->total_stack() == p()->buffs.fatebound_coin_heads->total_stack() )
     {
-      p()->buffs.fatebound_coin_heads->increment();
-      if ( result != fatebound_t::coinflip_e::EDGE )
-      {
-        p()->buffs.fatebound_coin_tails->expire();
-      }
+      result = p()->rng().roll( 0.5 ) ? fatebound_t::coinflip_e::HEADS : fatebound_t::coinflip_e::TAILS;
     }
-    if ( result == fatebound_t::coinflip_e::TAILS || result == fatebound_t::coinflip_e::EDGE )
+    // Flip the coin, potentially with a bias toward matching the last face flipped
+    else
     {
-      // Don't fling tails coins at enemies precombat, since that'll start combat (assume the player knows not to have an enemy targeted)
-      if ( !ab::is_precombat )
+      double matching_odds = 0.5;
+      if ( biased )
       {
-        p()->active.fatebound.fatebound_coin_tails->trigger_secondary_action( coin_target );
+        // TODO: Validate how these stack with the presumed base 50/50 chance and one another
+        if ( p()->talent.fatebound.mean_streak->ok() )
+        {
+          matching_odds += matching_odds * p()->talent.fatebound.mean_streak->effectN( 1 ).percent();
+        }
+        if ( p()->talent.fatebound.destiny_defined->ok() )
+        {
+          matching_odds += p()->talent.fatebound.destiny_defined->effectN( 3 ).percent();
+        }
+        if ( p()->buffs.fatebound_lucky_coin->check() )
+        {
+          // MIDNIGHT TOCHECK -- Is this additive?
+          matching_odds += p()->spell.fatebound_lucky_coin_buff->effectN( 5 ).percent();
+        }
       }
-      if ( result != fatebound_t::coinflip_e::EDGE )
+
+      // TODO: it's an assumption that if you have both buffs (thanks, edge case) the bias prefers the one with more stacks
+      // (since the last one you hit before the edge case has to be the one with more stacks)
+      const bool is_match = p()->rng().roll( matching_odds );
+      const bool current_is_heads = p()->buffs.fatebound_coin_heads->check() > p()->buffs.fatebound_coin_tails->check();
+      result = is_match ?
+        current_is_heads ? fatebound_t::coinflip_e::HEADS : fatebound_t::coinflip_e::TAILS :
+        current_is_heads ? fatebound_t::coinflip_e::TAILS : fatebound_t::coinflip_e::HEADS;
+    }
+
+    resolve_fatebound_coinflip( coin_target, result );
+
+    if ( p()->talent.fatebound.controlled_chaos->ok() )
+    {
+      int streak = as<int>( p()->talent.fatebound.controlled_chaos->effectN( 1 ).base_value() );
+      if ( ( p()->buffs.fatebound_coin_tails->total_stack() >= streak && result == fatebound_t::coinflip_e::HEADS ) ||
+           ( p()->buffs.fatebound_coin_heads->total_stack() >= streak && result == fatebound_t::coinflip_e::TAILS ) )
       {
-        // 2026-04-26 -- Logs suggest that the first tails attack is calculated before this fades
-        p()->buffs.fatebound_coin_heads->expire( !ab::is_precombat ? 1_ms : 0_ms );
+        // 250ms so it does not coincide with an Overflowing Purse roll at the same time for now
+        trigger_fatebound_coinflip( coin_target, result, 250_ms );
       }
     }
   } );
+}
+
+template <typename Base>
+void actions::rogue_action_t<Base>::resolve_fatebound_coinflip( player_t* coin_target, fatebound_t::coinflip_e result )
+{
+  if ( result == fatebound_t::coinflip_e::HEADS || result == fatebound_t::coinflip_e::EDGE )
+  {
+    p()->buffs.fatebound_coin_heads->increment();
+    if ( result != fatebound_t::coinflip_e::EDGE )
+    {
+      p()->buffs.fatebound_coin_tails->expire();
+    }
+  }
+  if ( result == fatebound_t::coinflip_e::TAILS || result == fatebound_t::coinflip_e::EDGE )
+  {
+    // Don't fling tails coins at enemies precombat, since that'll start combat (assume the player knows not to have an enemy targeted)
+    if ( !ab::is_precombat )
+    {
+      p()->active.fatebound.fatebound_coin_tails->trigger_secondary_action( coin_target );
+    }
+    if ( result != fatebound_t::coinflip_e::EDGE )
+    {
+      // 2026-04-26 -- Logs suggest that the first tails attack is calculated before this fades
+      p()->buffs.fatebound_coin_heads->expire( !ab::is_precombat ? 1_ms : 0_ms );
+    }
+  }
+
   if ( p()->talent.fatebound.rush_to_the_inevitable->ok() )
   {
     double energize_normal = p()->specialization() == ROGUE_ASSASSINATION
@@ -8124,6 +8126,22 @@ void actions::rogue_action_t<Base>::trigger_fatebound_coinflip( const action_sta
     if ( !p()->buffs.fatebound_lucky_coin->check() )
       p()->buffs.fatebound_coin_flips->trigger();
   }
+}
+
+template <typename Base>
+void actions::rogue_action_t<Base>::trigger_fatebound_coinflip( player_t* coin_target, fatebound_t::coinflip_e result, timespan_t delay )
+{
+  make_event( *p()->sim, delay, [ this, coin_target, result, delay ] {
+    p()->sim->print_log( "{} triggered fatebound coinflip with result '{}' and {} delay", *p(), fatebound_t::coinflip_string( result ), delay );
+    resolve_fatebound_coinflip( coin_target, result );
+  } );
+}
+
+template <typename Base>
+void actions::rogue_action_t<Base>::trigger_fatebound_coinflip( const action_state_t* state, fatebound_t::coinflip_e result, timespan_t delay )
+{
+  auto coin_target = state->target->is_enemy() ? state->target : p()->target;
+  trigger_fatebound_coinflip( coin_target, result, delay );
 }
 
 template <typename Base>


### PR DESCRIPTION
## Summary

This fixes Fatebound coinflip timing for delayed flips.

Previously, delayed Hand of Fate flips could resolve using stale pre-queue state, which caused multi-flip chains like Overflowing Purse to evaluate from the wrong streak context. Coinflip side effects like Rush to the Inevitable energy gain and Lucky Coin progress could also be applied when the flip was scheduled rather than when it actually resolved.

## Changes

- Defer Hand of Fate coin result selection until the delayed event executes
- Resolve delayed multi-flip chains from current Fatebound state instead of queued state
- Move Fatebound coin side effects to flip resolution time
- Add a target-based delayed coinflip path so delayed flips do not depend on action_state lifetime

## Behavior impact

- Overflowing Purse delayed flips now evolve from earlier flip outcomes correctly
- Rush to the Inevitable and Lucky Coin progression now line up with actual coin resolution timing
- Immediate flips continue to behave the same apart from using the shared resolution path

## Validation

- Checked `engine/class_modules/sc_rogue.cpp` for diagnostics: no errors
- Ran a debug sim and verified that delayed Tails flips now resolve at their delayed timestamp and use updated streak state

### External log validation

Cross-referenced against a live Fatebound Rogue log ([Imperator Averzian Mythic](https://www.warcraftlogs.com/reports/mf3a8cyVPrbxWGq6?fight=8)):

**Delayed chain timing** — [Rush to the Inevitable energy events](https://www.warcraftlogs.com/reports/mf3a8cyVPrbxWGq6?fight=8&type=resources&source=83&spellid=103&view=events) show repeated pairs separated by ~250–300ms, consistent with separate delayed event resolutions rather than a single precomputed burst:
- `00:45.632` and `00:45.929`
- `01:05.601` and `01:05.934`
- `03:07.859` and `03:08.112`

**Buff state changes between paired events** — [Fatebound Coin (Heads) aura log](https://www.warcraftlogs.com/reports/mf3a8cyVPrbxWGq6?fight=8&type=auras&source=83&ability=452923&view=events) and [Fatebound Coin (Tails) aura log](https://www.warcraftlogs.com/reports/mf3a8cyVPrbxWGq6?fight=8&type=auras&source=83&ability=452917&view=events) show streak state actively changing within those delayed windows:
- At `00:45`: Heads removed `00:45.632` → Tails applied `00:45.659`, Tails stack[2] `00:45.955`
- At `01:05`: Heads removed `01:05.601` → Tails applied `01:05.636`, stacking to [3] by `01:06.314`
- At `03:07`: Heads removed `03:07.859` → Tails applied `03:07.887`, Tails stack[2] `03:08.136`

This confirms that the inputs to the equal-stacks check ([L8037](https://github.com/simulationcraft/simc/blob/rogue-fatebound-flips/engine/class_modules/sc_rogue.cpp#L8037)) and current-side derivation ([L8066](https://github.com/simulationcraft/simc/blob/rogue-fatebound-flips/engine/class_modules/sc_rogue.cpp#L8066)) differ meaningfully between chained delayed resolutions in real gameplay, validating that evaluating these at execution time rather than queue time produces correct results.