### PR TITLE
[Warlock] Update HoG travel time and Wild Imp spawn timing

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -2566,7 +2566,7 @@ using namespace helpers;
 
       hog_impact_t( warlock_t* p )
         : warlock_spell_t( "Hand of Gul'dan (Impact)", p, p->talents.hog_impact ),
-        meteor_time( 20_ms )
+        meteor_time( 8_ms )
       {
         aoe = -1;
         dual = true;
@@ -2609,9 +2609,32 @@ using namespace helpers;
 
       void execute() override
       {
-        // NOTE: Some effects only affects one of HoG's hits in AoE (bug?), randomly selected
+        // NOTE: Some effects only affect one of HoG's hits in AoE (bug?), randomly selected
         const std::vector<player_t*>& tl = target_list();
         state.last_hit_random_target     = rng().range( as<int>( tl.size() ) );
+
+        // Wild Imp spawn events
+        // NOTE: Old Behavior (pre Midnight):
+        //   Wild Imp spawns appear to have been sped up in Shadowlands. Last tested 2021-04-16.
+        //   HoG will spawn a meteor on cast finish. Travel time in spell data is 0.7 seconds.
+        //   However, damage event occurs before spell effect lands, happening 0.4 seconds after cast.
+        //   Imps then spawn roughly every 0.18 seconds after the damage event.
+        // NOTE: New Behavior (from Midnight onwards):
+        //   The HoG meteor damage event no longer takes 0.4 seconds after cast impact (only about 8ms).
+        //   Wild Imps spawn on HoG meteor execute, not from HoG meteor damage impact.
+        //   Wild Imps spawn sequentially, with a 1-2ms delay from one spawn to the next.
+        //   Last tested: 2026-05-03
+        static constexpr std::array<double, 2> imp_delay{ 1.0, 2.0 };
+
+        double delay = 0.0;
+        for ( int i = 1; i <= state.shards_used; i++ )
+        {
+          delay += rng().range( imp_delay );
+          const double expected_delay = static_cast<double>( ( 3 * i + 1 ) / 2 );
+
+          auto ev = make_event<imp_delay_event_t>( *sim, p(), delay, expected_delay, i - 1 );
+          p()->wild_imp_spawns.push_back( ev );
+        }
 
         warlock_spell_t::execute();
       }
@@ -2628,31 +2651,6 @@ using namespace helpers;
         m *= state.shards_used * ( 1.0 + gloom );
 
         return m;
-      }
-
-      void impact( action_state_t* s ) override
-      {
-        warlock_spell_t::impact( s );
-
-        // Only trigger Wild Imps once for the original target impact.
-        // Still keep it in impact instead of execute because of travel delay.
-        if ( result_is_hit( s->result ) && s->target == target )
-        {
-          // NOTE: Old Behavior (pre Midnight):
-          //   Wild Imp spawns appear to have been sped up in Shadowlands. Last tested 2021-04-16.
-          //   HoG will spawn a meteor on cast finish. Travel time in spell data is 0.7 seconds.
-          //   However, damage event occurs before spell effect lands, happening 0.4 seconds after cast.
-          //   Imps then spawn roughly every 0.18 seconds seconds after the damage event.
-          // NOTE: New Behavior (from Midnight onwards):
-          //   Wild Imps spawn on HoG impact almost instantly, with a 1ms delay between them
-          //   The HoG damage event no longer takes 0.4 seconds after cast (only a few milliseconds)
-          //   Last tested: 2026-02-20
-          for ( int i = 1; i <= debug_cast<hog_impact_state_t*>( s )->state.shards_used; i++ )
-          {
-            auto ev = make_event<imp_delay_event_t>( *sim, p(), ( 1.0 * i ), ( 1.0 * i ), i - 1 );
-            p()->wild_imp_spawns.push_back( ev );
-          }
-        }
       }
     };
 
@@ -4899,7 +4897,7 @@ using namespace helpers;
   {
     struct ruination_impact_t : public warlock_spell_t
     {
-      hand_of_guldan_t::hog_impact_t* hog_impact_spell;
+      hand_of_guldan_t::hog_impact_t* hog_impact_spell = nullptr;
 
       ruination_impact_t( warlock_t* p )
         : warlock_spell_t( "Ruination (Impact)", p, p->hero.ruination_impact )
@@ -4914,7 +4912,7 @@ using namespace helpers;
         {
           hog_impact_spell = new hand_of_guldan_t::hog_impact_t( p );
           hog_impact_spell->state.shards_used = as<int>( p->hero.ruination_buff->effectN( 2 ).base_value() );
-          hog_impact_spell->state.rancora_empowered = false;    // Ruination HoG impact is never rancora empowered
+          hog_impact_spell->state.rancora_empowered = false; // Ruination HoG impact is never rancora empowered
         }
       }
 
@@ -4926,7 +4924,9 @@ using namespace helpers;
         {
           if ( demonology() )
           {
-            make_event( *sim, 0_ms, [ this, t = target ] {
+            // Ruination appears to trigger a HoG-like meteor after a certain delay, which summons the Wild Imps.
+            // This delay can be modeled fairly closely using a normal distribution.
+            make_event( *sim, rng().gauss<395,35>(), [ this, t = target ] {
               hog_impact_spell->execute_on_target( t );
             } );
           }


### PR DESCRIPTION
The event timing chain for **Hand of Gul'dan**, **Ruination**, and **Wild Imp spawns** has been analyzed in detail using logs.

**Hand of Gul'dan** cast is a spell (`105174`) that uses a `travel_time` of `1_ms` in SimC to mimic in-game ordering of cast-consumed effects. The spell data lists `700_ms`, but that value is not used in-game. This then triggers the AoE **Hand of Gul'dan Meteor** (`86040`), a separate spell which starts the Wild Imp summon chain in its `execute()`. After its `~8ms` `travel_time` (spell data lists `0_ms`, but logs show a clear small delay), the meteor impact deals damage to the targets. The sequential Wild Imp spawn chain has a `1-2ms` delay between spawns, including the first one.

The sequence of events for HoG would be as follows:
```
HoG Cast execute()
→ +1 ms (HoG Cast travel_time)
→ HoG Cast impact()
→ HoG Meteor execute()
  │
  ├─ Wild Imp spawn branch:
  │   → ~1-2 ms → WI 1 spawn
  │   → ~1-2 ms → WI 2 spawn
  │   → ~1-2 ms → WI 3 spawn
  │
  └─ HoG Meteor damage branch:
      → +~8 ms (HoG Meteor travel_time)
      → HoG Meteor impact() → HoG Meteor damage
```

**Ruination** initially works in a similar way. The cast (`434635`) has around `1000_ms` of `travel_time`, matching spell data. It then triggers the AoE **Ruination Meteor** (`434636`), which is instant (`travel_time=0_ms`, as indicated by spell data). After the impact, **Ruination** for Demonology does not appear to summon Wild Imps directly. Instead, it triggers a **HoG Meteor**, which deals damage and summons the wild imps. This **HoG Meteor** trigger from **Ruination** has a delay of around `~395ms`, with some variance that can be modeled fairly closely using a normal distribution.

The sequence of events for Ruination would be as follows:
```
Ruination Cast execute()
→ +~1000 ms (Ruination Cast travel_time)
→ Ruination Cast impact()
→ Ruination Meteor execute()
→ Ruination Meteor impact() → Ruination damage
  → ~395ms delay
  → HoG-like meteor execute
      │
      ├─ Wild Imp spawn branch:
      │   → ~1-2 ms → WI 1 spawn
      │   → ~1-2 ms → WI 2 spawn
      │   → ~1-2 ms → WI 3 spawn
      │
      └─ HoG Meteor damage branch:
          → +~8 ms (HoG Meteor travel_time)
          → HoG Meteor impact() → HoG Meteor damage
```

As a side note, both in SimC and in-game, if an **Implosion** is spell-queued while finishing a **Hand of Gul'dan** cast (with a cast time longer than the minimum `0.75s` gcd), the Wild Imps may spawn after the **Implosion** cast, meaning they would not be accounted for that **Implosion**. According to in-game logs, this happens around `~14%` of the time (measured with ~50ms latency, so it may vary), resulting in an average of `2.58` Wild Imps spawned after HoG that would be included in the pool of the next queued **Implosion**, out of a maximum of `3`. This is similar to the average value obtained in SimC in this same situation after this PR. In any case, for this reason, it is generally not recommended to cast **Implosion** immediately after a non-Demonic Art **HoG** unless there were already at least 6 Wild Imps active beforehand.

Logs:
- `(1)` https://www.warcraftlogs.com/reports/qQbh9KN8f2d6HJrA?fight=last&type=damage-done&source=1
- `(2)` https://www.warcraftlogs.com/reports/kVLHNG7vdbYQZn96?fight=last&type=damage-done&source=1
- `(3)` https://www.warcraftlogs.com/reports/1akn36YZybBvtXqp?fight=last&type=damage-done&source=1

A figure corresponding to the log `(2)`, showing the time between the HoG and Implosion casts across 1426 cases (orange indicates cases where the Wild Imps from the last HoG were included in the next Implosion, while blue indicates cases where they were not):
<img width="600" height="312" alt="ladhit002_hog_to_implosion_full_scatter_en" src="https://github.com/user-attachments/assets/28190f53-bdad-4354-b46c-a19205012386" />
