### PR TITLE
Add raid_events=absorb

### DIFF
--- a/engine/class_modules/sc_enemy.cpp
+++ b/engine/class_modules/sc_enemy.cpp
@@ -92,6 +92,19 @@ struct enemy_t : public player_t
   void demise() override;
   double armor_coefficient( int level, tank_dummy_e diff );
   std::unique_ptr<expr_t> create_expression( util::string_view expression_str ) override;
+
+  bool has_absorb() const override
+  {
+    return range::any_of( absorb_buff_list,
+                          []( const absorb_buff_t* ab ) { return ab->check_value() > 0; } );
+  }
+
+  double current_absorb_amount() const override
+  {
+    return range::accumulate( absorb_buff_list, 0.0,
+                              []( const absorb_buff_t* ab ) { return ab->check_value(); } );
+  }
+
   timespan_t available() const override
   {
     return waiting_time;

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -58,6 +58,7 @@
 #include "sim/plot.hpp"
 #include "sim/proc.hpp"
 #include "sim/proc_rng.hpp"
+#include "sim/raid_event.hpp"
 #include "sim/scale_factor_control.hpp"
 #include "sim/sim.hpp"
 #include "util/io.hpp"
@@ -4474,6 +4475,21 @@ void player_t::init_assessors()
     state->target->do_damage( state );
     return assessor::CONTINUE;
   } );
+
+  // Credit absorbed-on-enemy damage back to attacker stats when an absorb raid event is configured.
+  if ( !is_enemy() && range::any_of( sim->raid_events,
+                                     []( const auto& e ) { return e->type == "absorb"; } ) )
+  {
+    assessor_out_damage.add( assessor::TARGET_DAMAGE + 1, []( result_amount_type, action_state_t* s ) {
+      if ( s->target && s->target->is_enemy() )
+      {
+        double absorbed = s->result_mitigated - s->result_absorbed;
+        if ( absorbed > 0 )
+          s->result_amount += absorbed;
+      }
+      return assessor::CONTINUE;
+    } );
+  }
 
   // Logging and debug .. Technically, this should probably be in action_t::assess_damage, but we
   // don't need this piece of code for the vast majority of sims, so it makes sense to yank it out
@@ -12089,6 +12105,9 @@ std::unique_ptr<expr_t> player_t::create_expression( util::string_view expressio
 
   if ( expression_str == "is_enemy" )
     return expr_t::create_constant( "is_enemy", is_enemy() );
+
+  if ( expression_str == "has_absorb" )
+    return make_fn_expr( expression_str, [ this ] { return has_absorb() ? 1.0 : 0.0; } );
 
   if ( expression_str == "attack_haste" )
     return make_fn_expr( expression_str, [this] { return cache.attack_haste(); } );

--- a/engine/player/player.hpp
+++ b/engine/player/player.hpp
@@ -1413,6 +1413,10 @@ public:
   virtual void assess_damage_imminent_pre_absorb( school_e, result_amount_type, action_state_t* );
   virtual void assess_damage_imminent( school_e, result_amount_type, action_state_t* );
   virtual void do_damage( action_state_t* );
+
+  virtual bool has_absorb() const { return false; }
+  virtual double current_absorb_amount() const { return 0.0; }
+
   virtual void assess_heal( school_e, result_amount_type, action_state_t* );
   virtual void trigger_callbacks( proc_types, proc_types2, action_t* action, action_state_t* state,
                                   proc_trigger_type_e pt_type = TRIGGER_ACTION );

--- a/engine/sim/raid_event.cpp
+++ b/engine/sim/raid_event.cpp
@@ -5,6 +5,7 @@
 
 #include "action/heal.hpp"
 #include "action/action.hpp"
+#include "action/action_state.hpp"
 #include "action/spell.hpp"
 #include "buff/buff.hpp"
 #include "dbc/dbc.hpp"
@@ -1667,6 +1668,68 @@ struct vulnerable_event_t final : public raid_event_t
   }
 };
 
+// Absorb ===================================================================
+
+struct absorb_event_t final : public raid_event_t
+{
+  double amount;
+  std::string school_str;
+  std::string target_str;
+  school_e school;
+  target_specific_t<absorb_buff_t> absorb_buffs;
+
+  absorb_event_t( sim_t* s, std::string_view options_str )
+    : raid_event_t( s, "absorb" ), amount( 0.0 ), school( SCHOOL_NONE ), absorb_buffs( false )
+  {
+    add_option( opt_float( "amount", amount ) );
+    add_option( opt_string( "school", school_str ) );
+    add_option( opt_string( "target", target_str ) );
+
+    parse_options( options_str );
+
+    if ( sim->fight_style == FIGHT_STYLE_DUNGEON_ROUTE )
+      target_str = "Pull_" + util::to_string( pull ) + "_" + target_str;
+
+    if ( !school_str.empty() )
+    {
+      school = util::parse_school_type( school_str );
+      if ( school == SCHOOL_NONE )
+        throw std::invalid_argument( fmt::format( "Unknown absorb raid event school '{}'", school_str ) );
+    }
+  }
+
+  player_t* resolve_target() const
+  {
+    if ( target_str.empty() )
+      return sim->target;
+    if ( player_t* t = sim->find_player( target_str ) )
+      return t;
+    throw std::invalid_argument( fmt::format( "Unknown absorb raid event target '{}'", target_str ) );
+  }
+
+  void _start() override
+  {
+    player_t* target = resolve_target();
+    absorb_buff_t*& buff = absorb_buffs[ target ];
+    if ( !buff )
+    {
+      buff = make_buff<absorb_buff_t>( target, fmt::format( "raid_event_absorb_{}", internal_id ) );
+      if ( school != SCHOOL_NONE )
+        buff->set_absorb_school( school );
+    }
+
+    // No amount => unbreakable; infinity makes consume() never reduce to 0.
+    double value = amount > 0 ? amount : std::numeric_limits<double>::infinity();
+    buff->trigger( 1, value, -1.0, timespan_t::max() );
+  }
+
+  void _finish() override
+  {
+    if ( absorb_buff_t* buff = absorb_buffs[ resolve_target() ] )
+      buff->expire();
+  }
+};
+
 // Position Switch ==========================================================
 
 struct position_event_t : public raid_event_t
@@ -2311,6 +2374,8 @@ std::unique_ptr<raid_event_t> raid_event_t::create( sim_t* sim, util::string_vie
     return std::unique_ptr<raid_event_t>( new stun_event_t( sim, options_str ) );
   if ( name == "vulnerable" )
     return std::unique_ptr<raid_event_t>( new vulnerable_event_t( sim, options_str ) );
+  if ( name == "absorb" )
+    return std::unique_ptr<raid_event_t>( new absorb_event_t( sim, options_str ) );
   if ( name == "position_switch" )
     return std::unique_ptr<raid_event_t>( new position_event_t( sim, options_str ) );
   if ( name == "flying" )


### PR DESCRIPTION
## What

- `raid_events=absorb` — new event that puts an `absorb_buff_t` on a target enemy. Options: `target=`, `amount=`, `school=` plus standard timing controls. No `amount=` means unbreakable for the window.
- `target.has_absorb` APL expression and `player_t::has_absorb()` / `current_absorb_amount()` helpers (scoped to enemy actors via `enemy_t` overrides).
- Attacker DPS attribution: when an action damages an enemy with an active absorb, the attacker's stats credit the rolled mitigated damage instead of just the post-absorb HP impact. Implemented as a virtual `credited_damage_amount` on `player_t`, overridden on `enemy_t` to add the absorbed delta. `result_amount` semantics are preserved.

## Use case

Encounter modeling — boss / add mechanics with absorb shields (Aleria-style fights). Analogous in shape to `raid_event=vulnerable`; class APLs and class modules can react to shielded targets via the helpers and the `target.has_absorb` expression.
