### PR TITLE
[Warlock] Add Xalan's Cruelty and Xalan's Ferocity 'Apply Aura Pet (174)' effects to whitelisted spells

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -266,12 +266,12 @@ warlock_pet_spell_t::warlock_pet_spell_t( util::string_view token, warlock_pet_t
   : base_t( token, p, s ),
     affected_by()
 {
-  affected_by.xalans_cruelty_effect_6 = p->o()->hero.xalans_cruelty.ok() && data().affected_by( p->o()->hero.xalans_cruelty->effectN( 6 ) );
+  affected_by.xalans_cruelty_effect_6 = p->o()->hero.xalans_cruelty.ok() && data().affected_by_label( p->o()->hero.xalans_cruelty->effectN( 6 ) );
   if ( sim->dbc->wowv() < wowv_t{ 12, 0, 7 } ) // TODO: Effect is missing from 12.0.7 PTR; remove this check once added
-    affected_by.xalans_cruelty_effect_9 = p->o()->hero.xalans_cruelty.ok() && data().affected_by( p->o()->hero.xalans_cruelty->effectN( 9 ) );
+    affected_by.xalans_cruelty_effect_9 = p->o()->hero.xalans_cruelty.ok() && data().affected_by_label( p->o()->hero.xalans_cruelty->effectN( 9 ) );
 
-  affected_by.xalans_ferocity_effect_6 = p->o()->hero.xalans_ferocity.ok() && data().affected_by( p->o()->hero.xalans_ferocity->effectN( 6 ) );
-  affected_by.xalans_ferocity_effect_7 = p->o()->hero.xalans_ferocity.ok() && data().affected_by( p->o()->hero.xalans_ferocity->effectN( 7 ) );
+  affected_by.xalans_ferocity_effect_6 = p->o()->hero.xalans_ferocity.ok() && data().affected_by_label( p->o()->hero.xalans_ferocity->effectN( 6 ) );
+  affected_by.xalans_ferocity_effect_7 = p->o()->hero.xalans_ferocity.ok() && data().affected_by_label( p->o()->hero.xalans_ferocity->effectN( 7 ) );
 }
 
 warlock_pet_spell_t::warlock_pet_spell_t( warlock_pet_t* p, util::string_view n )

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1990,6 +1990,17 @@ struct immolation_tick_t : public warlock_pet_spell_t
     aoe = -1;
     background = may_crit = true;
   }
+
+  double composite_crit_chance_multiplier() const override
+  {
+    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
+
+    // Xalan's Ferocity effect #6 (id=1166684) is 'Apply Aura Pet (174)' and requires manual handling
+    if ( p()->o()->hero.xalans_ferocity.ok() )
+      m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 6 ).percent();
+
+    return m;
+  }
 };
 
 struct infernal_melee_t : warlock_pet_melee_t
@@ -2097,6 +2108,17 @@ struct rift_shadow_bolt_t : public warlock_pet_spell_t
   {
       background = dual = true;
   }
+
+  double composite_crit_chance_multiplier() const override
+  {
+    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
+
+    // Xalan's Cruelty effect #6 (id=1190450) is 'Apply Aura Pet (174)' and requires manual handling
+    if ( p()->o()->hero.xalans_cruelty.ok() )
+      m *= 1.0 + p()->o()->hero.xalans_cruelty->effectN( 6 ).percent();
+
+    return m;
+  }
 };
 
 struct shadow_barrage_t : public warlock_pet_spell_t
@@ -2157,6 +2179,17 @@ struct chaos_barrage_tick_t : public warlock_pet_spell_t
     : warlock_pet_spell_t( "Chaos Barrage (tick)", p, p->o()->talents.chaos_barrage_tick )
   {
       background = dual = true;
+  }
+
+  double composite_crit_chance_multiplier() const override
+  {
+    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
+
+    // Xalan's Ferocity effect #7 (id=1190448) is 'Apply Aura Pet (174)' and requires manual handling
+    if ( p()->o()->hero.xalans_ferocity.ok() )
+      m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 7 ).percent();
+
+    return m;
   }
 };
 
@@ -2253,6 +2286,17 @@ struct rift_chaos_bolt_t : public warlock_pet_spell_t
       chaotic_energies_rng = ( min_percentage + 1.0 ) * 0.5;
 
     m *= 1.0 + chaotic_energies_rng * p()->o()->cache.mastery_value();
+
+    return m;
+  }
+
+  double composite_crit_chance_multiplier() const override
+  {
+    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
+
+    // Xalan's Ferocity effect #7 (id=1190448) is 'Apply Aura Pet (174)' and requires manual handling
+    if ( p()->o()->hero.xalans_ferocity.ok() )
+      m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 7 ).percent();
 
     return m;
   }
@@ -2469,6 +2513,17 @@ struct wrath_of_nathreza_t : public warlock_pet_spell_t
 
     if ( debug_cast<desperate_soul_t*>( p() )->wraths <= 0 )
       make_event( sim, 0_ms, [ this ]() { player->cast_pet()->dismiss(); } );
+  }
+
+  double composite_crit_chance_multiplier() const override
+  {
+    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
+
+    // Xalan's Cruelty effect #9 (id=1322330) is 'Apply Aura Pet (174)' and requires manual handling
+    if ( p()->o()->hero.xalans_cruelty.ok() )
+      m *= 1.0 + p()->o()->hero.xalans_cruelty->effectN( 9 ).percent();
+
+    return m;
   }
 };
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -262,6 +262,45 @@ timespan_t warlock_simple_pet_t::available() const
   return cd_remains;
 }
 
+warlock_pet_spell_t::warlock_pet_spell_t( util::string_view token, warlock_pet_t* p, const spell_data_t* s )
+  : base_t( token, p, s ),
+    affected_by()
+{
+  affected_by.xalans_cruelty_effect_6 = p->o()->hero.xalans_cruelty.ok() && data().affected_by( p->o()->hero.xalans_cruelty->effectN( 6 ) );
+  if ( sim->dbc->wowv() < wowv_t{ 12, 0, 7 } ) // TODO: Effect is missing from 12.0.7 PTR; remove this check once added
+    affected_by.xalans_cruelty_effect_9 = p->o()->hero.xalans_cruelty.ok() && data().affected_by( p->o()->hero.xalans_cruelty->effectN( 9 ) );
+
+  affected_by.xalans_ferocity_effect_6 = p->o()->hero.xalans_ferocity.ok() && data().affected_by( p->o()->hero.xalans_ferocity->effectN( 6 ) );
+  affected_by.xalans_ferocity_effect_7 = p->o()->hero.xalans_ferocity.ok() && data().affected_by( p->o()->hero.xalans_ferocity->effectN( 7 ) );
+}
+
+warlock_pet_spell_t::warlock_pet_spell_t( warlock_pet_t* p, util::string_view n )
+  : warlock_pet_spell_t( n, p, p->find_pet_spell( n ) )
+{ }
+
+double warlock_pet_spell_t::composite_crit_chance_multiplier() const
+{
+  double m = base_t::composite_crit_chance_multiplier();
+
+  // Xalan's Cruelty effect #6 (id=1190450) is 'Apply Aura Pet (174)' and requires manual handling
+  if ( affected_by.xalans_cruelty_effect_6 )
+    m *= 1.0 + p()->o()->hero.xalans_cruelty->effectN( 6 ).percent();
+
+  // Xalan's Cruelty effect #9 (id=1322330) is 'Apply Aura Pet (174)' and requires manual handling
+  if ( affected_by.xalans_cruelty_effect_9 )
+    m *= 1.0 + p()->o()->hero.xalans_cruelty->effectN( 9 ).percent();
+
+  // Xalan's Ferocity effect #6 (id=1166684) is 'Apply Aura Pet (174)' and requires manual handling
+  if ( affected_by.xalans_ferocity_effect_6 )
+    m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 6 ).percent();
+
+  // Xalan's Ferocity effect #7 (id=1190448) is 'Apply Aura Pet (174)' and requires manual handling
+  if ( affected_by.xalans_ferocity_effect_7 )
+    m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 7 ).percent();
+
+  return m;
+}
+
 namespace base
 {
 
@@ -1990,17 +2029,6 @@ struct immolation_tick_t : public warlock_pet_spell_t
     aoe = -1;
     background = may_crit = true;
   }
-
-  double composite_crit_chance_multiplier() const override
-  {
-    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
-
-    // Xalan's Ferocity effect #6 (id=1166684) is 'Apply Aura Pet (174)' and requires manual handling
-    if ( p()->o()->hero.xalans_ferocity.ok() )
-      m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 6 ).percent();
-
-    return m;
-  }
 };
 
 struct infernal_melee_t : warlock_pet_melee_t
@@ -2108,17 +2136,6 @@ struct rift_shadow_bolt_t : public warlock_pet_spell_t
   {
       background = dual = true;
   }
-
-  double composite_crit_chance_multiplier() const override
-  {
-    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
-
-    // Xalan's Cruelty effect #6 (id=1190450) is 'Apply Aura Pet (174)' and requires manual handling
-    if ( p()->o()->hero.xalans_cruelty.ok() )
-      m *= 1.0 + p()->o()->hero.xalans_cruelty->effectN( 6 ).percent();
-
-    return m;
-  }
 };
 
 struct shadow_barrage_t : public warlock_pet_spell_t
@@ -2179,17 +2196,6 @@ struct chaos_barrage_tick_t : public warlock_pet_spell_t
     : warlock_pet_spell_t( "Chaos Barrage (tick)", p, p->o()->talents.chaos_barrage_tick )
   {
       background = dual = true;
-  }
-
-  double composite_crit_chance_multiplier() const override
-  {
-    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
-
-    // Xalan's Ferocity effect #7 (id=1190448) is 'Apply Aura Pet (174)' and requires manual handling
-    if ( p()->o()->hero.xalans_ferocity.ok() )
-      m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 7 ).percent();
-
-    return m;
   }
 };
 
@@ -2286,17 +2292,6 @@ struct rift_chaos_bolt_t : public warlock_pet_spell_t
       chaotic_energies_rng = ( min_percentage + 1.0 ) * 0.5;
 
     m *= 1.0 + chaotic_energies_rng * p()->o()->cache.mastery_value();
-
-    return m;
-  }
-
-  double composite_crit_chance_multiplier() const override
-  {
-    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
-
-    // Xalan's Ferocity effect #7 (id=1190448) is 'Apply Aura Pet (174)' and requires manual handling
-    if ( p()->o()->hero.xalans_ferocity.ok() )
-      m *= 1.0 + p()->o()->hero.xalans_ferocity->effectN( 7 ).percent();
 
     return m;
   }
@@ -2513,17 +2508,6 @@ struct wrath_of_nathreza_t : public warlock_pet_spell_t
 
     if ( debug_cast<desperate_soul_t*>( p() )->wraths <= 0 )
       make_event( sim, 0_ms, [ this ]() { player->cast_pet()->dismiss(); } );
-  }
-
-  double composite_crit_chance_multiplier() const override
-  {
-    double m = warlock_pet_spell_t::composite_crit_chance_multiplier();
-
-    // Xalan's Cruelty effect #9 (id=1322330) is 'Apply Aura Pet (174)' and requires manual handling
-    if ( p()->o()->hero.xalans_cruelty.ok() )
-      m *= 1.0 + p()->o()->hero.xalans_cruelty->effectN( 9 ).percent();
-
-    return m;
   }
 };
 

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -362,12 +362,19 @@ public:
 struct warlock_pet_spell_t : public warlock_pet_action_t<spell_t>
 {
 public:
-  warlock_pet_spell_t( warlock_pet_t* p, util::string_view n ) : base_t( n, p, p->find_pet_spell( n ) )
-  { }
+  struct affected_by_t
+  {
+    bool xalans_cruelty_effect_6 = false;
+    bool xalans_cruelty_effect_9 = false;
+    bool xalans_ferocity_effect_6 = false;
+    bool xalans_ferocity_effect_7 = false;
+  } affected_by;
 
-  warlock_pet_spell_t( util::string_view token, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() )
-    : base_t( token, p, s )
-  { }
+  warlock_pet_spell_t( util::string_view token, warlock_pet_t* p, const spell_data_t* s = spell_data_t::nil() );
+
+  warlock_pet_spell_t( warlock_pet_t* p, util::string_view n );
+
+  double composite_crit_chance_multiplier() const override;
 };
 
 namespace base


### PR DESCRIPTION
Currently, `Apply Aura Pet (174)` effects are not automatically handled by the `parse_effects` system, so they must be implemented manually. For Warlock, there are two of these effects in the **Xalan's Cruelty** talent and another two in the **Xalan's Ferocity** talent. All of them are percentage modifiers to critical hit chance: `Apply Percent Modifier w/ Label (218): Spell Critical Chance (7)`. In-game, this is usually described as *"gain X% more critical strike chance from all sources"*. We implement each effect for its corresponding whitelisted spells in the `composite_crit_chance_multiplier` function.

**Xalan's Cruelty** affects `Shadow Bolt (394238)` (the spell of the pet `Shadow Barrage`, summoned by `Dimensional Rift`) and `Wrath of Nathreza (1278047)` (the spell of the pet `Desperate Soul` from aff apex talents).

**Xalan's Ferocity** affects `Immolation (20153)` (periodic damage from the various `Infernal` pets), `Chaos Barrage (387985)` (the spell of the pet `Unstable Tear`, summoned by `Dimensional Rift`), and `Chaos Bolt (394246)` (the spell of the pet `Chaos Tear`, summoned by `Dimensional Rift`).

The effects:
```
Name             : Xalan's Cruelty (id=440040) [Spell Family (5), Passive, Hidden] 
Talent Entry     : Hellcaller (Affliction, Destruction) [tree=hero, row=2, col=4, max_rank=1, req_points=0]
Class            : Warlock
School           : Physical
Spell Type       : None
Labels           : 16: Class Spells
                 : 19: Warlock Spells
                 : 292
                 : 3343: Destruction Warlock (137046 effect#9), Destruction Warlock (137046 effect#10), Destruction Warlock (137046 effect#11), Destruction Warlock (137046 effect#12), Will of Xalan (441531 effect#2)
Attributes       : Passive (6), Do Not Display (Spellbook, Aura Icon, Combat Log) (7)
Effects          :
...
#6 (id=1190450)  : Apply Aura Pet (174) | Apply Percent Modifier w/ Label (218): Spell Critical Chance (7)
                   Base Value: 10 | Scaled Value: 10 | Misc Value: 7 | Misc Value 2: 3844 (Label) | Radius: 60 yards | Target: Self (1)
                   Affected Spells (Label): Shadow Bolt (394238)
...
#9 (id=1322330)  : Apply Aura Pet (174) | Apply Percent Modifier w/ Label (218): Spell Critical Chance (7)
                   Base Value: 10 | Scaled Value: 10 | Misc Value: 7 | Misc Value 2: 6704 (Label) | Radius: 100 yards | Target: Self and Summons in Area (120)
                   Affected Spells (Label): Wrath of Nathreza (1278047)
Description      : Shadow damage dealt by your spells and abilities is increased by $s3% and your Shadow spells gain $s1% more critical strike chance from all sources.
```

```
Name             : Xalan's Ferocity (id=440044) [Spell Family (5), Passive, Hidden] 
Talent Entry     : Hellcaller (Affliction, Destruction) [tree=hero, row=2, col=1, max_rank=1, req_points=0]
Class            : Warlock
School           : Physical
Spell Type       : None
Labels           : 16: Class Spells
                 : 19: Warlock Spells
                 : 292
                 : 3344: Destruction Warlock (137046 effect#5), Destruction Warlock (137046 effect#6), Destruction Warlock (137046 effect#7), Destruction Warlock (137046 effect#8), Will of Xalan (441531 effect#1)
Attributes       : Passive (6), Do Not Display (Spellbook, Aura Icon, Combat Log) (7), Aura Points On Client (268)
Effects          :
...
#6 (id=1166684)  : Apply Aura Pet (174) | Apply Percent Modifier w/ Label (218): Spell Critical Chance (7)
                   Base Value: 10 | Scaled Value: 10 | Misc Value: 7 | Misc Value 2: 3843 (Label) | Radius: 60 yards | Target: Self (1)
                   Affected Spells (Label): Immolation (20153)
#7 (id=1190448)  : Apply Aura Pet (174) | Apply Percent Modifier w/ Label (218): Spell Critical Chance (7)
                   Base Value: 10 | Scaled Value: 10 | Misc Value: 7 | Misc Value 2: 3845 (Label) | Radius: 60 yards | Target: Self (1)
                   Affected Spells (Label): Chaos Barrage (387985), Chaos Bolt (394246)
...
Description      : Fire damage dealt by your spells and abilities is increased by $s1% and your Fire spells gain $s4% more critical strike chance from all sources.
```