### PR TITLE
[Warlock] Move crit-based bonus damage to composite_da_multiplier

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -4028,6 +4028,8 @@ using namespace helpers;
     {
       double m = warlock_spell_t::composite_da_multiplier( s );
 
+      m *= 1.0 + player->cache.spell_crit_chance();
+
       // The base effect of Through the Felvine is automatically applied by the parse_effects system
       // However, it is necessary to manually apply its duplicate effect during Malevolence
       if ( p()->hero.through_the_felvine.ok() && p()->hero.malevolence.ok() && p()->buffs.malevolence->check() )
@@ -4041,15 +4043,6 @@ using namespace helpers;
 
     double composite_crit_chance() const override
     { return 1.0; }
-
-    double calculate_direct_amount( action_state_t* s ) const override
-    {
-      warlock_spell_t::calculate_direct_amount( s );
-
-      s->result_total *= 1.0 + player->cache.spell_crit_chance();
-
-      return s->result_total;
-    }
   };
 
   struct conflagrate_t : public warlock_spell_t
@@ -4137,17 +4130,14 @@ using namespace helpers;
         p()->buffs.backdraft->trigger();
     }
 
-    double calculate_direct_amount( action_state_t* s ) const override
+    double composite_da_multiplier( const action_state_t* s ) const override
     {
-      double amt = warlock_spell_t::calculate_direct_amount( s );
+      double m = warlock_spell_t::composite_da_multiplier( s );
 
       if ( p()->buffs.conflagration_of_chaos->check() )
-      {
-        s->result_total *= 1.0 + player->cache.spell_crit_chance();
-        return s->result_total;
-      }
+        m *= 1.0 + player->cache.spell_crit_chance();
 
-      return amt;
+      return m;
     }
   };
 
@@ -4468,18 +4458,15 @@ using namespace helpers;
       p()->buffs.fiendish_cruelty->decrement();
     }
 
-    double calculate_direct_amount( action_state_t* state ) const override
+    double composite_da_multiplier( const action_state_t* s ) const override
     {
-      double amt = warlock_spell_t::calculate_direct_amount( state );
+      double m = warlock_spell_t::composite_da_multiplier( s );
 
       // NOTE: 2026-04-25 Conflagration of Chaos crit damage bonus is not applied to Shadowburn (bug)
       if ( p()->buffs.conflagration_of_chaos->check() && !p()->bugs )
-      {
-        state->result_total *= 1.0 + player->cache.spell_crit_chance();
-        return state->result_total;
-      }
+        m *= 1.0 + player->cache.spell_crit_chance();
 
-      return amt;
+      return m;
     }
   };
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2233,13 +2233,13 @@ struct rift_chaos_bolt_t : public warlock_pet_spell_t
     debug_cast<chaos_tear_t*>( p() )->bolts--;
   }
 
-  double calculate_direct_amount( action_state_t* s ) const override
+  double composite_da_multiplier( const action_state_t* s ) const override
   {
-    warlock_pet_spell_t::calculate_direct_amount( s );
+    double m = warlock_pet_spell_t::composite_da_multiplier( s );
 
-    s->result_total *= 1.0 + p()->current_pet_stats.composite_spell_crit;
+    m *= 1.0 + p()->current_pet_stats.composite_spell_crit;
 
-    return s->result_total;
+    return m;
   }
 
   double action_multiplier() const override
@@ -2300,13 +2300,13 @@ struct overfiend_chaos_bolt_t : public warlock_pet_spell_t
   double composite_crit_chance() const override
   { return 1.0; }
 
-  double calculate_direct_amount( action_state_t* s ) const override
+  double composite_da_multiplier( const action_state_t* s ) const override
   {
-    warlock_pet_spell_t::calculate_direct_amount( s );
+    double m = warlock_pet_spell_t::composite_da_multiplier( s );
 
-    s->result_total *= 1.0 + p()->current_pet_stats.composite_spell_crit;
+    m *= 1.0 + p()->current_pet_stats.composite_spell_crit;
 
-    return s->result_total;
+    return m;
   }
 
   double action_multiplier() const override


### PR DESCRIPTION
The Warlock has several spells that gain a bonus damage based on the player’s base critical strike chance. In SimC, this damage was being applied in `calculate_direct_amount` instead of `composite_da_multiplier`, which was not conceptually correct. The necessary changes have been made to move this crit-based bonus damage to the appropriate place.

For spells without travel time, the final result is the same in both cases. However, applying the damage modifier in `composite_da_multiplier` is more correct, and also allows the damage modifier to be properly shown in debug logs.

For spells with travel time, `composite_da_multiplier` is applied during `execute()`, while `calculate_direct_amount` is applied on `impact()`, which is conceptually different. In-game, this damage bonus is calculated on `execute()`: this was tested using a trinket that grants a large critical strike chance bonus after `execute()` but before `impact()`, and the impact damage was not affected by the trinket. This reinforces that, like most spell damage modifiers, this crit-based damage bonus is snapshotted at execute() rather than on impact.
