### PR TITLE
[Warlock] Refine target filtering for several spells

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -1208,6 +1208,24 @@ public:
     return td;
   }
 
+  template <typename T>
+  bool dot_or_debuff_active( T d, warlock_td_t* t )
+  {
+    if constexpr ( std::is_invocable_v<T, warlock_td_t::debuffs_t> )
+    {
+      return std::invoke( d, t->debuffs )->check() > 0;
+    }
+    else if constexpr ( std::is_invocable_v<T, warlock_td_t::dots_t> )
+    {
+      return std::invoke( d, t->dots )->is_ticking();
+    }
+    else
+    {
+      sim->error( SEVERE, "%s dot_or_debuff_active: Unsupported type passed.\n", name() );
+      return false;
+    }
+  }
+
   action_t* create_action_warlock( util::string_view, util::string_view );
 
   action_t* create_action_affliction( util::string_view, util::string_view );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -93,6 +93,43 @@ using namespace helpers;
     const warlock_td_t* td( player_t* t ) const
     { return p()->get_target_data( t ); }
 
+    template <typename T>
+    target_filter_callback_t dot_or_debuff_only( T d )
+    {
+      return [ this, d ]( const action_t*, player_t* t ) {
+        return p()->dot_or_debuff_active( d, p()->get_target_data( t ) );
+      };
+    }
+
+    target_filter_callback_t primary_target_or( target_filter_callback_t secondary_filter )
+    {
+      return [ secondary_filter = std::move( secondary_filter ) ]( const action_t* a, player_t* t ) {
+        return t == a->target || secondary_filter( a, t );
+      };
+    }
+
+    target_filter_callback_t immolate_or_wither_only()
+    {
+      return [ this ]( const action_t*, player_t* t ) {
+        return td( t )->dots.immolate->is_ticking() || td( t )->dots.wither->is_ticking();
+      };
+    }
+
+    target_filter_callback_t corruption_or_wither_only()
+    {
+      return [ this ]( const action_t*, player_t* t ) {
+        return td( t )->dots.corruption->is_ticking() || td( t )->dots.wither->is_ticking();
+      };
+    }
+
+    target_filter_callback_t affliction_core_dots_only()
+    {
+      return [ this ]( const action_t*, player_t* t ) {
+        return td( t )->dots.corruption->is_ticking() || td( t )->dots.wither->is_ticking()
+               || td( t )->dots.agony->is_ticking() || td( t )->dots.unstable_affliction->is_ticking();
+      };
+    }
+
     void reset() override
     { action_base_t::reset(); }
 
@@ -2342,19 +2379,9 @@ using namespace helpers;
     {
       channeled = true;
 
+      target_filter_callback = affliction_core_dots_only();
+
       add_child( dark_harvest_dmg );
-    }
-
-    std::vector<player_t*>& target_list() const override
-    {
-      target_cache.list = warlock_spell_t::target_list();
-
-      range::erase_remove( target_cache.list, [ this ]( player_t* t ) {
-        return !td( t )->dots.corruption->is_ticking() && !td( t )->dots.wither->is_ticking()
-               && !td( t )->dots.agony->is_ticking() && !td( t )->dots.unstable_affliction->is_ticking();
-      } );
-
-      return target_cache.list;
     }
 
     bool ready() override
@@ -2395,6 +2422,7 @@ using namespace helpers;
     void execute() override
     {
       target_cache.is_valid = false;
+
       warlock_spell_t::execute();
     }
   };
@@ -2422,26 +2450,15 @@ using namespace helpers;
       : warlock_spell_t( "Shadow of Nathreza", p, p->talents.shadow_of_nathreza_dot )
     {
       background = dual = true;
+
+      target_filter_callback = primary_target_or( corruption_or_wither_only() );
     }
-    
-    size_t available_targets( std::vector<player_t*>& tl ) const override
+
+    void execute() override
     {
-      warlock_spell_t::available_targets( tl );
+      target_cache.is_valid = false;
 
-      // Make sure the primary target is kept first
-      auto it = range::find( tl, target );
-      if ( it != tl.end() && it != tl.begin() )
-      {
-        tl.erase( it );
-        tl.insert( tl.begin(), target );
-      }
-
-      // Secondary targets must have Wither or Corruption ticking
-      range::erase_remove( tl, [ this ]( player_t* t ) {
-        return ( t != target && !td( t )->dots.wither->is_ticking() && !td( t )->dots.corruption->is_ticking() );
-      } );
-
-      return tl.size();
+      warlock_spell_t::execute();
     }
   };
 
@@ -4602,6 +4619,8 @@ using namespace helpers;
       may_crit = false;
       cooldown->hasted = true;
 
+      target_filter_callback = immolate_or_wither_only();
+
       if ( !p->talents.demonfire_infusion.ok() || p->talents.channel_demonfire.ok() )
         add_child( channel_demonfire_tick );
 
@@ -4610,17 +4629,6 @@ using namespace helpers;
         int num_ticks = ( int )( dot_duration / base_tick_time );
         dot_duration = num_ticks * base_tick_time;
       }
-    }
-
-    std::vector<player_t*>& target_list() const override
-    {
-      target_cache.list = warlock_spell_t::target_list();
-
-      range::erase_remove( target_cache.list, [ this ]( player_t* t ) {
-        return !td( t )->dots.immolate->is_ticking() && !td( t )->dots.wither->is_ticking();
-      } );
-
-      return target_cache.list;
     }
 
     void tick( dot_t* d ) override

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -2349,15 +2349,10 @@ using namespace helpers;
     {
       target_cache.list = warlock_spell_t::target_list();
 
-      size_t i = target_cache.list.size();
-      while ( i > 0 )
-      {
-        i--;
-
-        if ( !td( target_cache.list[ i ] )->dots.corruption->is_ticking() && !td( target_cache.list[ i ] )->dots.wither->is_ticking()
-          && !td( target_cache.list[ i ] )->dots.agony->is_ticking() && !td( target_cache.list[ i ] )->dots.unstable_affliction->is_ticking() )
-          target_cache.list.erase( target_cache.list.begin() + i );
-      }
+      range::erase_remove( target_cache.list, [ this ]( player_t* t ) {
+        return !td( t )->dots.corruption->is_ticking() && !td( t )->dots.wither->is_ticking()
+               && !td( t )->dots.agony->is_ticking() && !td( t )->dots.unstable_affliction->is_ticking();
+      } );
 
       return target_cache.list;
     }
@@ -2368,11 +2363,13 @@ using namespace helpers;
         return false;
 
       target_cache.is_valid = false;
-      return target_list().size() > 0;
+      return !target_list().empty();
     }
 
     void tick( dot_t* d ) override
     {
+      target_cache.is_valid = false;
+
       warlock_spell_t::tick( d );
 
       const auto& tl = target_list();
@@ -2422,9 +2419,29 @@ using namespace helpers;
   struct shadow_of_nathreza_dmg_t : public warlock_spell_t
   {
     shadow_of_nathreza_dmg_t( warlock_t* p )
-      : warlock_spell_t( "shadow_of_nathreza", p, p->talents.shadow_of_nathreza_dot )
+      : warlock_spell_t( "Shadow of Nathreza", p, p->talents.shadow_of_nathreza_dot )
     {
       background = dual = true;
+    }
+    
+    size_t available_targets( std::vector<player_t*>& tl ) const override
+    {
+      warlock_spell_t::available_targets( tl );
+
+      // Make sure the primary target is kept first
+      auto it = range::find( tl, target );
+      if ( it != tl.end() && it != tl.begin() )
+      {
+        tl.erase( it );
+        tl.insert( tl.begin(), target );
+      }
+
+      // Secondary targets must have Wither or Corruption ticking
+      range::erase_remove( tl, [ this ]( player_t* t ) {
+        return ( t != target && !td( t )->dots.wither->is_ticking() && !td( t )->dots.corruption->is_ticking() );
+      } );
+
+      return tl.size();
     }
   };
 
@@ -3591,9 +3608,10 @@ using namespace helpers;
       add_child( fnb_action );
     }
 
+    // Custom init() to combine Havoc+FnB coefficients instead of using the generic warlock_spell_t::init() Havoc multiplier
     void init() override
     {
-      spell_t::init();
+      action_base_t::init();
 
       if ( affected_by.havoc )
       {
@@ -4598,14 +4616,9 @@ using namespace helpers;
     {
       target_cache.list = warlock_spell_t::target_list();
 
-      size_t i = target_cache.list.size();
-      while ( i > 0 )
-      {
-        i--;
-
-        if ( !td( target_cache.list[ i ] )->dots.immolate->is_ticking() && !td( target_cache.list[ i ] )->dots.wither->is_ticking() )
-          target_cache.list.erase( target_cache.list.begin() + i );
-      }
+      range::erase_remove( target_cache.list, [ this ]( player_t* t ) {
+        return !td( t )->dots.immolate->is_ticking() && !td( t )->dots.wither->is_ticking();
+      } );
 
       return target_cache.list;
     }
@@ -4627,10 +4640,11 @@ using namespace helpers;
 
     bool ready() override
     {
-      if ( p()->get_active_dots( td( target )->dots.immolate ) == 0 && p()->get_active_dots( td( target )->dots.wither ) == 0 )
+      if ( !warlock_spell_t::ready() )
         return false;
 
-      return warlock_spell_t::ready();
+      target_cache.is_valid = false;
+      return !target_list().empty();
     }
   };
 


### PR DESCRIPTION
Several changes to the Warlock module related to targeting for some spells:
- Prefer `target_filter_callback` for simple filters
- Prefer using `range::erase_remove` instead of removing entries one by one with a `while` loop in several places.
- For **Dark Harvest**, the target cache is invalidated on each tick to allow dynamic target selection in each tick, matching in-game behavior.
- In-game, **Shadow of Nathreza** always deals damage to the main target, but only damages secondary targets if they have the `Corruption` or `Wither` DoT applied. This behavior was not previously implemented in sims and has now been added in this PR.
- For **Incinerate**, inside the `init()` function, it is more correct to call `action_base_t::init()` (the immediate parent of `warlock_spell_t`) rather than `spell_t::init()`. A comment has also been added to clarify that `warlock_spell_t::init()` is intentionally not called, because the purpose of this override is to replace its behavior.
- In-game, **Channel Demonfire** cannot be cast if there are no valid targets, so, in sims, its `ready()` function has been adjusted to match that behavior.