### PR TITLE
[HTML] fix dps plot crash with fewer than six points

### DIFF
--- a/engine/report/report_html_player.cpp
+++ b/engine/report/report_html_player.cpp
@@ -3244,7 +3244,7 @@ void print_html_player_plots( report::sc_html_stream& os, const player_t& p, con
       auto gear_rating = scale_override >= 0 ? scale_override : p.composite_rating( util::stat_to_rating( i ) );
 
       size_t count = plot_data.size();
-      size_t rows = as<size_t>( std::ceil( count / 6 ) );
+      size_t rows = count ? ( ( count + 5 ) / 6 ) : 1;
 
       os.format(
         R"(<table class="sc"><tr class="details"><td class="details"><h4>{}</h4></td></tr><tr class="details">)",


### PR DESCRIPTION
Fixes #11287.

DPS plot HTML generation could divide by zero when `dps_plot_points < 6`.

The row count was calculated with integer division before `std::ceil`, so a plot with 5 points produced `rows = 0`, and the later `idx % rows` check crashed during HTML report generation.

This switches the calculation to integer ceiling division and keeps the minimum row count at 1.

Validation:
- Built CLI with CMake/Ninja/MSVC
- `simc profiles/MID1/MID1_Priest_Shadow.simc iterations=1 threads=1 output=NUL html=NUL dps_plot_stat=crit dps_plot_points=5 dps_plot_iterations=1 cleanup_threads=1`
- `simc profiles/MID1/MID1_Priest_Shadow.simc iterations=1 threads=1 output=NUL html=NUL dps_plot_stat=crit dps_plot_points=1 dps_plot_iterations=1 cleanup_threads=1`
- `simc profiles/MID1/MID1_Priest_Shadow.simc iterations=1 threads=1 output=NUL html=NUL dps_plot_stat=crit dps_plot_iterations=1 cleanup_threads=1`
- `git diff --check`