### PR TITLE
[Action] fix report-only variable actions

### DIFF
--- a/engine/action/variable.cpp
+++ b/engine/action/variable.cpp
@@ -125,7 +125,10 @@ variable_t::variable_t( player_t* player, std::string_view options_str )
   }
 
   if ( operation == OPERATION_REPORT )
+  {
     var->report = true;
+    background = true;
+  }
 }
 
 void variable_t::init_finished()
@@ -326,6 +329,8 @@ void variable_t::execute()
         var->current_value_ = value_expression->eval();
       else
         var->current_value_ = value_else_expression->eval();
+      break;
+    case OPERATION_REPORT:
       break;
     default:
       assert( 0 );


### PR DESCRIPTION
## Summary
- Treat `variable,op=report` as a report configuration action instead of an executable APL action.
- Handle `OPERATION_REPORT` as a no-op if it ever reaches `variable_t::execute()`.

## Details
`op=report` only enables sample-sequence reporting for the named variable. Before this change it was still added to the foreground action list, so a standalone report action could execute and hit the debug `assert(0)` path in `variable_t::execute()`.

Marking the action as `background` matches the existing action contract for actions that should not be directly executed from an action list, and keeps the report-only action out of variable mutation/constant tracking.

## Testing
- Built with local CMake/Ninja Visual Studio configuration.
- `simc.exe build-codex\variable_report_repro.simc iterations=1 max_time=1 output=NUL cleanup_threads=1`
- `simc.exe build-codex\variable_report_sequence.simc iterations=1 max_time=2 report_details=1 output=build-codex\variable_report_sequence.txt html=build-codex\variable_report_sequence.html cleanup_threads=1`
- Verified the generated HTML sample sequence contains `VAR [set]` for the reported variable.
- `simc.exe profiles\CI.simc iterations=10 output=build-codex\ci_variable_report_validation.txt cleanup_threads=1`
- `git diff --check`