### PR TITLE
[Build] enable IPO/LTO for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(SC_NO_NETWORKING "Disable all networking related stuff." OFF)
 option(SC_USE_FLAT_INSTALL "Install files into a flat folder structure" ${WIN32})
 
 option(SC_EVENT_QUEUE_DEBUG "Enable Event Queue Debug Info" OFF)
+option(SC_ENABLE_LTO "Enable IPO/LTO for non-Debug builds" ON)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
@@ -53,6 +54,26 @@ function(sc_common_compiler_options target)
   )
 endfunction()
 
+if(SC_ENABLE_LTO)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT SC_IPO_SUPPORTED OUTPUT SC_IPO_OUTPUT LANGUAGES CXX)
+  if(SC_IPO_SUPPORTED)
+    message(STATUS "IPO/LTO enabled for non-Debug builds")
+  else()
+    message(STATUS "IPO/LTO requested but not supported by this toolchain: ${SC_IPO_OUTPUT}")
+  endif()
+endif()
+
+function(sc_enable_lto target)
+  if(SC_ENABLE_LTO AND SC_IPO_SUPPORTED)
+    set_target_properties(${target} PROPERTIES
+      INTERPROCEDURAL_OPTIMIZATION_RELEASE ON
+      INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON
+      INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON
+    )
+  endif()
+endfunction()
+
 
 ### Git Hash ###
 # Get the current working branch
@@ -80,6 +101,7 @@ endif()
 add_executable(simc engine/sc_main.cpp)
 target_link_libraries(simc engine)
 sc_common_compiler_options(simc)
+sc_enable_lto(simc)
 
 install(TARGETS simc DESTINATION ${SIMC_INSTALL_BIN})
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -9,6 +9,7 @@ include(../source_files/cmake_engine.txt)
 add_library(engine ${source_files})
 target_include_directories(engine PUBLIC . ./include ./lib)
 sc_common_compiler_options(engine)
+sc_enable_lto(engine)
 
 # Make cmake selections visible to C++ code
 if(SC_NO_THREADING)

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -36,6 +36,7 @@ if (${QT_VERSION_MAJOR} EQUAL 6)
 endif()
 
 sc_common_compiler_options(SimulationCraft)
+sc_enable_lto(SimulationCraft)
 
 target_include_directories(SimulationCraft PUBLIC ../engine/)
 target_link_libraries(SimulationCraft 


### PR DESCRIPTION
## Summary

- add `SC_ENABLE_LTO` CMake option, default ON
- use `check_ipo_supported()` and skip gracefully when IPO/LTO is unavailable
- enable target-level IPO/LTO for non-Debug builds on `engine`, `simc`, and `SimulationCraft`

## Why

CMake Release builds currently use the platform defaults only. On MSVC + Ninja this produced `/O2 /Ob2 /DNDEBUG` without `/GL` or `/LTCG`. A no-code A/B showed that enabling CMake IPO/LTO produces output-equivalent sims with a consistent runtime win.

## Validation

Toolchain: Windows, MSVC 19.44.35217.0, CMake 3.31.6, Ninja, `BUILD_GUI=OFF`.

Initial no-code A/B, same source, baseline Release vs `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`, `threads=1 target_error=0 deterministic=1 seed=123456 cleanup_threads=1`, 5 interleaved repeats. DPS and `TotalEvents` matched exactly in all valid cases.

| Profile | Mean win | Median win |
| --- | ---: | ---: |
| `profiles/CI.simc iterations=10` | 5.48% | 6.23% |
| Windwalker DungeonSlice 2000 | 9.26% | 10.65% |
| Windwalker ST 2000 | 12.48% | 12.21% |
| Shadow Priest ST 2000 | 10.40% | 10.35% |
| Havoc DH 5T 2000 | 8.91% | 9.47% |
| Dev Evoker 5T 2000 | 9.05% | 10.32% |

The requested full `profiles/CI.simc fight_style=DungeonSlice` control is invalid on this checkout because Demon Hunter disables DungeonSlice by default (`engine/class_modules/sc_demon_hunter.cpp:11273`), and the hinted `enable_dungeon_slice=1` is a Demon Hunter actor option rather than a global profile option. I used Windwalker DungeonSlice as the substituted DungeonSlice control.

Final validation on this branch, based on current `origin/midnight` (`cfbfbe4`):

- `cmake -S . -B build-pr-lto-off -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF -DSC_ENABLE_LTO=OFF`
- `cmake --build build-pr-lto-off --parallel`
- `cmake -S . -B build-pr-lto-on -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build-pr-lto-on --parallel`

Confirmed `SC_ENABLE_LTO=OFF` has no `/GL` or `/LTCG`; default ON has `/GL` compile flags and `/LTCG` link flags. The existing MSVC warning at `engine/class_modules/sc_druid.cpp:8909` appears unchanged in both builds.

Final A/B, 5 interleaved repeats:

| Profile | DPS / TotalEvents | Mean win | Median win |
| --- | --- | ---: | ---: |
| `profiles/CI.simc iterations=10` | exact match | 5.50% | 4.65% |
| Windwalker ST 2000 | exact match | 10.66% | 10.95% |

## Risk

- Release build time increases on my machine: earlier full build comparison was ~36.9s baseline vs ~59.8s IPO.
- Some packagers may prefer faster local builds or smaller toolchain requirements, so this is opt-out with `-DSC_ENABLE_LTO=OFF`.
- Unsupported IPO/LTO toolchains print a status message and continue without enabling IPO/LTO.
- GUI target has the same target-level property applied, but my local validation was CLI-only with `BUILD_GUI=OFF`.