### PR TITLE
[Sim] guard malformed expression parsing

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12611,7 +12611,7 @@ std::unique_ptr<expr_t> player_t::create_expression( util::string_view expressio
   // pet
   if ( splits.size() >= 2 && splits[ 0 ] == "pet" )
   {
-    if ( splits[ 1 ] == "any" && splits[ 2 ] == "active" )
+    if ( splits.size() == 3 && splits[ 1 ] == "any" && splits[ 2 ] == "active" )
     {
       return make_fn_expr( expression_str, [ this ]
       {

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -3609,7 +3609,7 @@ std::unique_ptr<expr_t> sim_t::create_expression( util::string_view name_str )
   if ( splits.size() >= 3 && splits[ 0 ] == "actors" )
   {
     player_t* actor = sim_t::find_player( splits[ 1 ] );
-    if ( !target )
+    if ( !actor )
       return nullptr;
 
     auto rest = std::string( splits[ 2 ] );


### PR DESCRIPTION
## Summary
- Guard `pet.any.active` expression parsing so malformed `pet.any` no longer reads past the split-vector bounds.
- Guard `actors.<name>.<expr>` expression parsing against missing actors by checking the looked-up actor pointer instead of the sim target.

## Details
Both changes route malformed expressions through the normal invalid-expression initialization error path instead of undefined behavior or an access violation.

`pet.any.active.<trailing>` is also no longer silently accepted as `pet.any.active`; the valid generated form remains `pet.any.active`.

## Validation
- Rebuilt `build-codex` with VS2022 DevCmd + CMake.
- `simc hunter=test spec=beast_mastery level=90 race=orc role=attack position=ranged_back load_default_gear=1 load_default_talents=1 iterations=1 output=NUL actions=variable,name=bad,value=pet.any` now exits 30 with a normal initialization error.
- Same command with `value=pet.any.active` exits 0.
- Same command with `value=actors.nope.health.pct` now exits 30 with a normal initialization error instead of access violation.
- Same command with `value=actors.test.health.pct` exits 0.
- `simc display_build=2 output=NUL` exits 0.
- `simc profiles/CI.simc iterations=1 cleanup_threads=1 output=NUL` exits 0 with existing baseline profile/data warnings.
- `git diff --check origin/midnight...HEAD` passed.