### PR TITLE
[Player] fix default potion expressions

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12568,19 +12568,22 @@ std::unique_ptr<expr_t> player_t::create_expression( util::string_view expressio
 
   if ( splits.size() == 2 && splits[ 0 ] == "potion" )
   {
+    std::string default_potion_str;
     std::string_view potion_view;
 
     if ( !potion_str.empty() )
     {
       potion_view = potion_str;
     }
-    else if ( default_potion().empty() )
-    {
-      potion_view = default_potion();
-    }
     else
     {
-      return expr_t::create_constant( expression_str, false );
+      default_potion_str = default_potion();
+      if ( default_potion_str.empty() )
+      {
+        return expr_t::create_constant( expression_str, false );
+      }
+
+      potion_view = default_potion_str;
     }
 
     if ( util::str_compare_ci( potion_view, splits[ 1 ] ) )


### PR DESCRIPTION
## Summary
- Fix `potion.<name>` expressions so they use a player's class default potion when `potion=` is not explicitly set.
- Keep the generated default potion string alive while comparing through `std::string_view`.

## Cause
`player_t::create_expression()` only consulted `default_potion()` when the default was empty, so common expressions such as `potion.lights_potential_2` returned false for profiles relying on class defaults. The same code path also assigned a temporary `std::string` return value into a `std::string_view`.

## Validation
- Rebuilt `build-codex\simc.exe` with MSVC/CMake.
- Minimal Beast Mastery Hunter repro, no explicit potion:
  - Before: `actions=potion,if=potion.lights_potential_2` did not show `lights_potential`.
  - After: default and explicit `potion=lights_potential_2` runs both show `lights_potential` and `TotalEvents=59` with `threads=1 target_error=0 deterministic=1 seed=12345`.
- Negative control: `actions=potion,if=potion.tempered_potion_3` remains false and does not show the potion buff.
- Suffix alias control: `actions=potion,if=potion.lights_potential` still reaches the suffix-stripping path and shows the potion buff.
- `profiles/CI.simc iterations=10 cleanup_threads=1 output=NUL` exits 0. Existing baseline warnings about Frostbane, Static Charge, Fury default talents, and runeforges remain unchanged.

## Generated files
None.