### PR TITLE
[Player] guard malformed time_to expression parsing

### DIFF
--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12072,6 +12072,11 @@ std::unique_ptr<expr_t> player_t::create_expression( util::string_view expressio
     auto parts = util::string_split<util::string_view>( expression_str, "_" );
     double percent = -1.0;
 
+    if ( parts.size() < 3 )
+    {
+      throw sc_invalid_apl_argument( fmt::format( "Invalid 'time_to_' expression '{}'.", expression_str ) );
+    }
+
     if ( util::str_in_str_ci( parts[ 2 ], "die" ) )
     {
       percent = 0.0;

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -12833,6 +12833,11 @@ std::unique_ptr<expr_t> player_t::create_resource_expression( util::string_view 
     {
       auto parts = util::string_split<util::string_view>( splits[ 1 ], "_" );
 
+      if ( parts.size() < 3 )
+      {
+        throw sc_invalid_apl_argument( fmt::format( "Invalid resource expression '{}'.", expression_str ) );
+      }
+
       // foo.time_to_max
       if ( util::str_in_str_ci( parts[ 2 ], "max" ) )
       {


### PR DESCRIPTION
## Summary
- Guard malformed global `time_to_` player expressions before reading the third split segment
- Guard malformed resource `time_to_` expressions such as `fury.time_to_` before reading the third split segment
- Convert both cases from undefined behavior into normal APL parse errors

## Cause
`player_t::create_expression()` accepts any expression prefixed with `time_to_`, splits it on `_`, then reads `parts[2]`. Because `util::string_split()` skips empty entries, the literal `time_to_` produces only `{time, to}`, so the old code read past the end of the vector.

`player_t::create_resource_expression()` had the same shape for resource expressions. A malformed resource expression like `fury.time_to_` also split to only `{time, to}` before the parser read `parts[2]`.

## Validation
- Rebuilt Release `build-fast` with MSVC 14.44 / Ninja through `VsDevCmd.bat`
- Before global fix: `build-baseline/simc.exe profiles/MID1/MID1_Demon_Hunter_Havoc.simc actions=/wait,sec=time_to_ iterations=1 target_error=0 cleanup_threads=1` produced `Invalid expression 'time_to_': bad allocation`
- After global fix: `build-fast/simc.exe profiles/MID1/MID1_Demon_Hunter_Havoc.simc actions=/wait,sec=time_to_ iterations=1 target_error=0 cleanup_threads=1` reports `Invalid 'time_to_' expression 'time_to_'.`
- Before resource fix: `build-baseline/simc.exe profiles/MID1/MID1_Demon_Hunter_Havoc.simc actions=/wait,sec=fury.time_to_ iterations=1 target_error=0 cleanup_threads=1` produced `Invalid expression 'fury.time_to_': string too long`
- After resource fix: `build-fast/simc.exe profiles/MID1/MID1_Demon_Hunter_Havoc.simc actions=/wait,sec=fury.time_to_ iterations=1 target_error=0 cleanup_threads=1` reports `Invalid resource expression 'fury.time_to_'.`
- Control: `build-fast/simc.exe profiles/MID1/MID1_Demon_Hunter_Havoc.simc actions=/wait,sec=time_to_pct_ iterations=1 target_error=0 cleanup_threads=1` still reports the existing `No pct value given for 'time_to_pct_' expression.` error
- Controls: `build-fast/simc.exe profiles/MID1/MID1_Demon_Hunter_Havoc.simc actions+=/wait,sec=fury.time_to_max iterations=1 target_error=0 cleanup_threads=1 output=NUL` and `actions+=/wait,sec=fury.time_to_80 ... output=NUL` both exit 0
- Smoke: `build-fast/simc.exe profiles/CI.simc iterations=10 target_error=0 cleanup_threads=1 output=NUL` exits 0 with existing baseline warnings

## Risk
Low. Valid `time_to_die`, `time_to_pct_*`, and `<resource>.time_to_*` expressions still have at least three split segments and continue through the existing parser paths.