### PR TITLE
[Rogue] guard envenom remains expression parsing

### DIFF
--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -9298,7 +9298,7 @@ std::unique_ptr<expr_t> rogue_t::create_action_expression( action_t& action, std
       return range::contains( danse_macabre_tracker, action.data().id() );
     } );
   }
-  else if ( split[ 0 ] == "buff" && split[ 1 ] == "envenom" && split[ 2 ] == "remains" && split.size() == 4 )
+  else if ( split.size() == 4 && split[ 0 ] == "buff" && split[ 1 ] == "envenom" && split[ 2 ] == "remains" )
   {
     size_t buff_idx = as<size_t>( util::to_int( split[ 3 ] ) );
     return make_fn_expr( name_str, [ this, buff_idx ]() {


### PR DESCRIPTION
## Summary
- Check the split segment count before matching Rogue's `buff.envenom.remains.N` action expression
- Preserve the existing invalid-expression behavior for malformed shorter inputs such as `buff` and `buff.envenom`

## Cause
`rogue_t::create_action_expression()` split the action expression name on `.` and then checked `split[0]`, `split[1]`, and `split[2]` before verifying `split.size() == 4` for the special `buff.envenom.remains.N` expression.

APL identifiers are guaranteed to have at least one segment, but malformed names such as `buff` or `buff.envenom` are not guaranteed to have three. Moving the size check first avoids out-of-bounds vector reads while keeping the valid four-segment path unchanged.

## Validation
- Rebuilt Release `build-fast` with MSVC 14.44 / Ninja through `VsDevCmd.bat`
- Malformed control: `build-fast/simc.exe profiles/MID1/MID1_Rogue_Assassination.simc actions=/wait,sec=1,if=buff iterations=1 target_error=0 cleanup_threads=1` still reports `Invalid expression 'buff': No expression found.`
- Malformed control: `build-fast/simc.exe profiles/MID1/MID1_Rogue_Assassination.simc actions=/wait,sec=1,if=buff.envenom iterations=1 target_error=0 cleanup_threads=1` still reports `Invalid expression 'buff.envenom': No expression found.`
- Valid control: `build-fast/simc.exe profiles/MID1/MID1_Rogue_Assassination.simc actions+=/wait,sec=1,if=buff.envenom.remains.1 iterations=1 target_error=0 cleanup_threads=1 output=NUL` exits 0
- Rogue smoke: `build-fast/simc.exe profiles/MID1/MID1_Rogue_Assassination.simc iterations=1 target_error=0 cleanup_threads=1 output=NUL` exits 0
- CI smoke: `build-fast/simc.exe profiles/CI.simc iterations=10 target_error=0 cleanup_threads=1 output=NUL` exits 0 with existing baseline warnings

## Risk
Low. This only reorders a size check ahead of indexed vector accesses. Valid `buff.envenom.remains.N` expressions still take the same branch.