### PR TITLE
[Death Knight] guard lesser ghoul expression parsing

### DIFF
--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -14147,19 +14147,20 @@ std::unique_ptr<expr_t> death_knight_t::create_expression( std::string_view name
 
   if ( util::str_compare_ci( splits[ 0 ], "lesser_ghoul" ) )
   {
-    if ( util::str_compare_ci( splits[ 1 ], "count" ) )
+    if ( splits.size() == 2 && util::str_compare_ci( splits[ 1 ], "count" ) )
     {
       return make_fn_expr( "lesser_ghoul_count", [ this ]() { return active_lesser_ghouls.size(); } );
     }
-    if ( util::str_compare_ci( splits[ 1 ], "oldest" ) )
+    if ( splits.size() == 3 && util::str_compare_ci( splits[ 1 ], "oldest" ) )
     {
       if ( util::str_compare_ci( splits[ 2 ], "remains" ) )
       {
-        return make_fn_expr( "oldest_lesser_ghoul_remains",
-                             [ this ]() { return active_lesser_ghouls[ 0 ]->expiration->remains(); } );
+        return make_fn_expr( "oldest_lesser_ghoul_remains", [ this ]() {
+          return active_lesser_ghouls.empty() ? timespan_t::zero() : active_lesser_ghouls[ 0 ]->expiration->remains();
+        } );
       }
     }
-    throw sc_invalid_apl_argument( fmt::format( "Unknown lesser_ghoul expression '{}'.", splits[ 1 ] ) );
+    throw sc_invalid_apl_argument( fmt::format( "Unknown lesser_ghoul expression '{}'.", name_str ) );
   }
 
   if ( util::str_compare_ci( splits[ 0 ], "runeforge" ) && splits.size() == 2 )


### PR DESCRIPTION
## Summary
- Guard Death Knight `lesser_ghoul.*` expression parsing before reading missing split segments.
- Return zero for `lesser_ghoul.oldest.remains` when no lesser ghoul is active.

## Cause
`death_knight_t::create_expression()` handled any expression beginning with `lesser_ghoul` but read `splits[1]` and sometimes `splits[2]` before confirming those segments existed. The same parser also built `lesser_ghoul.oldest.remains` by reading `active_lesser_ghouls[0]`, which is empty before the first lesser ghoul is active and after all lesser ghouls despawn.

`active_lesser_ghouls` is populated in `lesser_ghoul_pet_t::arise()` and erased in `demise()`, so an empty list is a normal state. Returning zero for `oldest.remains` matches the inactive/remains behavior used by nearby expressions such as active Death and Decay remains.

## Validation
- Rebuilt `build-fast` with MSVC/Ninja through `VsDevCmd.bat`.
- Before fix: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc actions=/wait,sec=1,if=lesser_ghoul iterations=1 target_error=0 cleanup_threads=1` aborted in `fmt\base.h:433`.
- Before fix: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc actions=/wait,sec=1,if=lesser_ghoul.oldest.remains iterations=1 target_error=0 cleanup_threads=1` exited with an access violation.
- After fix: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc actions=/wait,sec=1,if=lesser_ghoul iterations=1 target_error=0 cleanup_threads=1` reports `Unknown lesser_ghoul expression 'lesser_ghoul'`.
- After fix: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc actions=/wait,sec=1,if=lesser_ghoul.oldest iterations=1 target_error=0 cleanup_threads=1` reports `Unknown lesser_ghoul expression 'lesser_ghoul.oldest'`.
- After fix: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc actions=/wait,sec=1,if=lesser_ghoul.oldest.remains iterations=1 target_error=0 cleanup_threads=1 output=NUL` exits 0.
- Control: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc actions=/wait,sec=1,if=lesser_ghoul.count iterations=1 target_error=0 cleanup_threads=1 output=NUL` exits 0.
- Smoke: `build-fast/simc.exe profiles/MID1/MID1_Death_Knight_Blood.simc iterations=1 target_error=0 cleanup_threads=1 output=NUL` exits 0.
- Smoke: `build-fast/simc.exe profiles/CI.simc iterations=10 target_error=0 cleanup_threads=1 output=NUL` exits 0 with existing baseline warnings.

## Risk
Low. This only tightens expression parser segment checks and handles the normal no-active-lesser-ghoul state for `oldest.remains`.