### PR TITLE
[Subtlety] Minor APL tweaks

### DIFF
--- a/engine/class_modules/apl/apl_rogue.cpp
+++ b/engine/class_modules/apl/apl_rogue.cpp
@@ -216,15 +216,15 @@ void subtlety( player_t* p )
   default_->add_action( "call_action_list,name=race" );
   default_->add_action( "call_action_list,name=item" );
   default_->add_action( "call_action_list,name=cds" );
-  default_->add_action( "shadowstrike,if=talent.ancient_arts_3&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up))&buff.shadow_techniques.stack>=5&!buff.ancient_arts.up&!cooldown.secret_technique.ready" );
+  default_->add_action( "shadowstrike,if=talent.ancient_arts_3&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up))&buff.shadow_techniques.stack>=5&!buff.ancient_arts.up" );
   default_->add_action( "shuriken_storm,if=talent.ancient_arts_3&variable.targets>=3&(buff.supercharge_1.up)&buff.shadow_techniques.stack>=5&!buff.ancient_arts.up&!cooldown.secret_technique.ready" );
   default_->add_action( "call_action_list,name=finish,if=combo_points>=cp_max_spend-!buff.darkest_night.up" );
   default_->add_action( "call_action_list,name=build,if=variable.stealth|energy>60" );
   default_->add_action( "call_action_list,name=fill,if=!variable.stealth" );
 
-  cds->add_action( "shadow_blades,if=variable.shd_cp&cooldown.shadow_dance.charges_fractional>=1+0.8*talent.deathstalkers_mark&cooldown.secret_technique.ready&(fight_remains>90|!equipped.algethar_puzzle_box|trinket.1.proc.mastery.up)|(fight_remains<=20|target.time_to_die.remains<=20)", "Cooldowns  Delay the last Shadow Blades to line up with puzzle box if its equipped." );
+  cds->add_action( "shadow_blades,if=variable.shd_cp&cooldown.shadow_dance.charges_fractional>=1+0.8*talent.deathstalkers_mark&cooldown.secret_technique.ready&(fight_remains>90|!equipped.algethar_puzzle_box|trinket.1.proc.mastery.up|trinket.2.proc.mastery.up)|(fight_remains<=20|target.time_to_die.remains<=20)", "Cooldowns  Delay the last Shadow Blades to line up with puzzle box if its equipped." );
   cds->add_action( "shadow_dance,if=!variable.stealth&variable.shd_cp&energy>=30&((cooldown.secret_technique.ready|buff.darkest_night.up)&(cooldown.shadow_blades.remains>=30-cooldown.secret_technique.duration)|(buff.shadow_blades.up&cooldown.secret_technique.duration>=18))|(fight_remains<=10|target.time_to_die-remains<=9)" );
-  cds->add_action( "shadow_dance,if=buff.shadow_blades.up&talent.unseen_blade&buff.shadow_blades.remains<=buff.shadow_dance.duration", "Have the second Shadow Dance in Shadow Blades line up with the end of Shadow Blades instead of back-to-back for trickster." );
+  cds->add_action( "shadow_dance,if=buff.shadow_blades.up&talent.unseen_blade&buff.shadow_blades.remains<=buff.shadow_dance.duration+1", "Have the second Shadow Dance in Shadow Blades line up with the end of Shadow Blades instead of back-to-back for trickster." );
   cds->add_action( "shadow_dance,if=equipped.algethar_puzzle_box&talent.unseen_blade&!variable.stealth&variable.shd_cp&energy>=30&((cooldown.secret_technique.ready|buff.darkest_night.up)&(trinket.algethar_puzzle_box.cooldown.remains>=39-30*cooldown.shadow_blades.up))", "Used for when Shadow Blades is ready but holding for Algethar Puzzlebox trinket at the end of pull" );
   cds->add_action( "vanish,if=!variable.stealth&energy>=50&!buff.subterfuge.up&combo_points<=2" );
   cds->add_action( "shadowmeld,if=energy>=50&!variable.stealth&combo_points.deficit>=2" );
@@ -236,15 +236,15 @@ void subtlety( player_t* p )
   race->add_action( "invoke_external_buff,name=power_infusion,if=variable.racial_sync" );
 
   item->add_action( "potion,if=buff.shadow_blades.up|fight_remains<30", "Trinket and Items" );
-  item->add_action( "use_item,name=algethar_puzzle_box,if=cooldown.shadow_blades.ready&cooldown.secret_technique.remains<=2&combo_points>=6", "actions.item+=/use_item,name=light_company_guidon,use_off_gcd=1,if=buff.shadow_blades.up" );
+  item->add_action( "use_item,name=algethar_puzzle_box,if=cooldown.shadow_blades.ready&cooldown.secret_technique.remains<=2&combo_points>=6" );
   item->add_action( "use_items,slots=trinket1,if=(variable.trinket_sync_slot=1&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=2&(!trinket.2.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)" );
   item->add_action( "use_items,slots=trinket2,if=(variable.trinket_sync_slot=2&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=1&(!trinket.1.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)" );
 
-  finish->add_action( "secret_technique,if=buff.shadow_dance.up|(cooldown.secret_technique.duration<18|cooldown.shadow_dance.remains>=10)&!cooldown.shadow_dance.ready" );
   finish->add_action( "eviscerate,if=buff.darkest_night.up" );
+  finish->add_action( "secret_technique,if=buff.shadow_dance.up|(cooldown.secret_technique.duration<18|cooldown.shadow_dance.remains>=10)&!cooldown.shadow_dance.ready" );
   finish->add_action( "coup_de_grace,if=cooldown.secret_technique.remains>=3|buff.shadow_dance.up" );
-  finish->add_action( "black_powder,if=variable.targets>=3-talent.potent_powder" );
-  finish->add_action( "eviscerate,if=cooldown.secret_technique.remains>=3|buff.shadow_dance.up|buff.shadow_blades.up|talent.deathstalkers_mark", "Pool some Shadow Technique Stacks before entering Shadow Dance by not finishing right before." );
+  finish->add_action( "black_powder,if=variable.targets>=3" );
+  finish->add_action( "eviscerate,if=cooldown.secret_technique.remains>=3&talent.unseen_blade|buff.shadow_dance.up|buff.shadow_blades.up|debuff.deathstalkers_mark.stack>1|debuff.deathstalkers_mark.stack=1&buff.shadow_techniques.stack>=5", "Pool some Shadow Technique Stacks before entering Shadow Dance by not finishing right before." );
 
   build->add_action( "shuriken_storm,if=prev.shadow_dance&buff.premeditation.up&talent.danse_macabre" );
   build->add_action( "shadowstrike,if=!debuff.deathstalkers_mark.up&talent.deathstalkers_mark&!buff.darkest_night.up|variable.targets<=3|variable.priority_rotation" );

--- a/engine/class_modules/apl/rogue/subtlety.simc
+++ b/engine/class_modules/apl/rogue/subtlety.simc
@@ -1,4 +1,3 @@
-
 actions.precombat=apply_poison
 actions.precombat+=/snapshot_stats
 actions.precombat+=/variable,name=priority_rotation,value=priority_rotation
@@ -15,7 +14,7 @@ actions+=/stealth
 actions+=/call_action_list,name=race
 actions+=/call_action_list,name=item
 actions+=/call_action_list,name=cds
-actions+=/shadowstrike,if=talent.ancient_arts_3&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up))&buff.shadow_techniques.stack>=5&!buff.ancient_arts.up&!cooldown.secret_technique.ready
+actions+=/shadowstrike,if=talent.ancient_arts_3&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up))&buff.shadow_techniques.stack>=5&!buff.ancient_arts.up
 actions+=/shuriken_storm,if=talent.ancient_arts_3&variable.targets>=3&(buff.supercharge_1.up)&buff.shadow_techniques.stack>=5&!buff.ancient_arts.up&!cooldown.secret_technique.ready
 actions+=/call_action_list,name=finish,if=combo_points>=cp_max_spend-!buff.darkest_night.up
 actions+=/call_action_list,name=build,if=variable.stealth|energy>60
@@ -23,10 +22,10 @@ actions+=/call_action_list,name=fill,if=!variable.stealth
 
 # Cooldowns
 # Delay the last Shadow Blades to line up with puzzle box if its equipped.
-actions.cds=/shadow_blades,if=variable.shd_cp&cooldown.shadow_dance.charges_fractional>=1+0.8*talent.deathstalkers_mark&cooldown.secret_technique.ready&(fight_remains>90|!equipped.algethar_puzzle_box|trinket.1.proc.mastery.up)|(fight_remains<=20|target.time_to_die.remains<=20)
+actions.cds=/shadow_blades,if=variable.shd_cp&cooldown.shadow_dance.charges_fractional>=1+0.8*talent.deathstalkers_mark&cooldown.secret_technique.ready&(fight_remains>90|!equipped.algethar_puzzle_box|trinket.1.proc.mastery.up|trinket.2.proc.mastery.up)|(fight_remains<=20|target.time_to_die.remains<=20)
 actions.cds+=/shadow_dance,if=!variable.stealth&variable.shd_cp&energy>=30&((cooldown.secret_technique.ready|buff.darkest_night.up)&(cooldown.shadow_blades.remains>=30-cooldown.secret_technique.duration)|(buff.shadow_blades.up&cooldown.secret_technique.duration>=18))|(fight_remains<=10|target.time_to_die-remains<=9)
 # Have the second Shadow Dance in Shadow Blades line up with the end of Shadow Blades instead of back-to-back for trickster.
-actions.cds+=/shadow_dance,if=buff.shadow_blades.up&talent.unseen_blade&buff.shadow_blades.remains<=buff.shadow_dance.duration
+actions.cds+=/shadow_dance,if=buff.shadow_blades.up&talent.unseen_blade&buff.shadow_blades.remains<=buff.shadow_dance.duration+1
 # Used for when Shadow Blades is ready but holding for Algethar Puzzlebox trinket at the end of pull
 actions.cds+=/shadow_dance,if=equipped.algethar_puzzle_box&talent.unseen_blade&!variable.stealth&variable.shd_cp&energy>=30&((cooldown.secret_technique.ready|buff.darkest_night.up)&(trinket.algethar_puzzle_box.cooldown.remains>=39-30*cooldown.shadow_blades.up))
 actions.cds+=/vanish,if=!variable.stealth&energy>=50&!buff.subterfuge.up&combo_points<=2
@@ -41,17 +40,16 @@ actions.race+=/invoke_external_buff,name=power_infusion,if=variable.racial_sync
 
 # Trinket and Items
 actions.item=potion,if=buff.shadow_blades.up|fight_remains<30
-#actions.item+=/use_item,name=light_company_guidon,use_off_gcd=1,if=buff.shadow_blades.up
 actions.item+=/use_item,name=algethar_puzzle_box,if=cooldown.shadow_blades.ready&cooldown.secret_technique.remains<=2&combo_points>=6
 actions.item+=/use_items,slots=trinket1,if=(variable.trinket_sync_slot=1&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=2&(!trinket.2.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
 actions.item+=/use_items,slots=trinket2,if=(variable.trinket_sync_slot=2&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=1&(!trinket.1.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
 
-actions.finish=secret_technique,if=buff.shadow_dance.up|(cooldown.secret_technique.duration<18|cooldown.shadow_dance.remains>=10)&!cooldown.shadow_dance.ready
-actions.finish+=/eviscerate,if=buff.darkest_night.up
+actions.finish=eviscerate,if=buff.darkest_night.up
+actions.finish+=/secret_technique,if=buff.shadow_dance.up|(cooldown.secret_technique.duration<18|cooldown.shadow_dance.remains>=10)&!cooldown.shadow_dance.ready
 actions.finish+=/coup_de_grace,if=cooldown.secret_technique.remains>=3|buff.shadow_dance.up
-actions.finish+=/black_powder,if=variable.targets>=3-talent.potent_powder
+actions.finish+=/black_powder,if=variable.targets>=3
 # Pool some Shadow Technique Stacks before entering Shadow Dance by not finishing right before.
-actions.finish+=/eviscerate,if=cooldown.secret_technique.remains>=3|buff.shadow_dance.up|buff.shadow_blades.up|talent.deathstalkers_mark
+actions.finish+=/eviscerate,if=cooldown.secret_technique.remains>=3&talent.unseen_blade|buff.shadow_dance.up|buff.shadow_blades.up|debuff.deathstalkers_mark.stack>1|debuff.deathstalkers_mark.stack=1&buff.shadow_techniques.stack>=5
 
 actions.build=shuriken_storm,if=prev.shadow_dance&buff.premeditation.up&talent.danse_macabre
 actions.build+=/shadowstrike,if=!debuff.deathstalkers_mark.up&talent.deathstalkers_mark&!buff.darkest_night.up|variable.targets<=3|variable.priority_rotation

--- a/profiles/generators/MID1/MID1_Generate_Rogue.simc
+++ b/profiles/generators/MID1/MID1_Generate_Rogue.simc
@@ -86,7 +86,7 @@ race=pandaren
 role=attack
 position=back
 spec=subtlety
-talents=CUQAAAAAAAAAAAAAAAAAAAAAAAgx2MAAAAAwsMGLTYbZmxMjZgZmZmtxsNmZstNzMzMzMGMmZZAAAAYwYAjZxwADMLahWshZAzMYGD
+talents=CUQAAAAAAAAAAAAAAAAAAAAAAAgx2MAAAAAwsMGLTMbbjxMjZwMzMzYMbDzYbbmZmZmZMYMz2AAAAwgxAGzmhBGYW0CtYDzAmZwMGA
  
 head=masquerade_of_the_grim_jest,id=250006,bonus_id=12676/13338/13534/13575/13575/13575/13575/13575/13575/13575/13575/13575/13575/13575/13575/13575,ilevel=289,gem_id=240983
 neck=eternal_voidsong_chain,id=249368,bonus_id=13534,ilevel=289,gem_id=240908


### PR DESCRIPTION
- Minor APL tweaks for Deathstalker, forcing Ancient Arts on almost all Darkest Nights.
- Adjust default profile to no longer use Weaponmaster after a bugfix.