### PR TITLE
[Devourer] update MID2 4pc ordering

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5588,6 +5588,7 @@ struct consume_base_t : public shattered_souls_trigger_t<voidfall_building_trigg
       {
         dh()->buff.moment_of_craving->trigger();
         dh()->cooldown.reap->reset( true );
+        dh()->buff.soulburst->expire();
         dh()->spawn_soul_fragment( dh()->proc.soul_fragment_from_soulburst, soul_fragment::LESSER,
                                    as<unsigned int>( dh()->set_bonuses.mid2_devourer_4pc->effectN( 1 ).base_value() ) );
       }
@@ -5622,7 +5623,6 @@ struct consume_base_t : public shattered_souls_trigger_t<voidfall_building_trigg
     if ( dh()->buff.soulburst->up() && soulburst )
     {
       soulburst->execute_on_target( target );
-      dh()->buff.soulburst->expire();
     }
   }
 };
@@ -5891,9 +5891,6 @@ struct reap_base_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
 
   void execute() override
   {
-    dh()->buff.reap->trigger();
-
-    base_t::execute();
     unsigned fragments_consumed = dh()->consume_soul_fragments( soul_fragment::LESSER, false, souls_to_consume() );
 
     // TOCHECK: Is this instant?
@@ -5903,6 +5900,10 @@ struct reap_base_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
     {
       dh()->buff.soulburst->trigger();
     }
+
+    dh()->buff.reap->trigger();
+
+    base_t::execute();
 
     // TOCHECK: This delay is a guess based on averages in logs as there is no spelldata
     make_event( *dh()->sim, 220_ms, [ this, fragments_consumed ] {
@@ -5987,11 +5988,12 @@ struct eradicate_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
 
   void execute() override
   {
+    unsigned fragments_consumed = dh()->consume_soul_fragments( soul_fragment::LESSER, false, souls_to_consume() );
+
     dh()->buff.reap->trigger();
 
     base_t::execute();
 
-    unsigned fragments_consumed = dh()->consume_soul_fragments( soul_fragment::LESSER, false, souls_to_consume() );
     auto damage                 = dh()->buff.metamorphosis->up() ? damage_action_meta : damage_action;
 
     // TOCHECK: This delay is a guess based on averages in logs as there is no spelldata


### PR DESCRIPTION
moved soulburst and reap soul count before execution of the actual spell
https://www.warcraftlogs.com/reports/CHvckzRdK8A1q9Qf?fight=1&source=12&type=casts&pins=0%24Separate%24%23244F4B%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%2416965052.0.0.DemonHunter%24false%241226019%5E0%24Separate%24%23909049%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%2416965052.0.0.DemonHunter%24false%241238495%5E0%24Separate%24%23a04D8A%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%2416965052.0.0.DemonHunter%24false%241297433%5E0%24Separate%24%23DF5353%24damage%240%240.0.0.Any%2416965052.0.0.DemonHunter%24true%240.0.0.Any%24false%241297432%5E0%24Separate%24rgb(78%25%2C%2B61%25%2C%2B43%25)%24damage%240%240.0.0.Any%2416965052.0.0.DemonHunter%24true%240.0.0.Any%24false%24473662%5E0%24Separate%24%23a0a0a0%24damage%240%240.0.0.Any%2416965052.0.0.DemonHunter%24true%240.0.0.Any%24false%241225823%5E0%24Separate%24%23F43F5B%24casts%240%240.0.0.Any%2416965052.0.0.DemonHunter%24true%240.0.0.Any%24false%241226019&ability=473662&view=events&start=164079&end=170671