### PR TITLE
[Warlock] Adjust Hellcaller and Feast of Souls RNG

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -96,8 +96,22 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                                ->set_duration( 0_ms )
                                ->set_tick_zero( false )
                                ->set_period( p.hero.blackened_soul_trigger->effectN( 1 ).period() )
-                               ->set_tick_callback( [ this, target ]( buff_t*, int, timespan_t ) {
-                                 warlock.proc_actions.blackened_soul->execute_on_target( target );
+                               ->set_tick_callback( [ &p, target ]( buff_t* blackened_soul_debuff, int, timespan_t ) {
+                                  auto tdata = p.get_target_data( target );
+                                  if ( tdata->dots.wither->is_ticking() )
+                                  {
+                                    p.proc_actions.blackened_soul->execute_on_target( target );
+                                  }
+                                  else
+                                  {
+                                    // blackened_soul is a 0-duration frozen-stack debuff, so expiring it from its
+                                    // tick callback is safe; tick_t will not apply post-callback stack changes.
+                                    assert( blackened_soul_debuff->freeze_stacks );
+                                    assert( blackened_soul_debuff->buff_duration() == 0_ms );
+                                    assert( blackened_soul_debuff->expiration.empty() );
+                                    assert( blackened_soul_debuff->tick_event == nullptr );
+                                    blackened_soul_debuff->expire();
+                                  }
                                } )
                                ->set_tick_behavior( buff_tick_behavior::REFRESH )
                                ->set_freeze_stacks( true )
@@ -226,7 +240,6 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   cooldowns.felstorm_icd = get_cooldown( "felstorm_icd" );
   cooldowns.echo_of_sargeras = get_cooldown( "echo_of_sargeras_icd" );
   cooldowns.blackened_soul = get_cooldown( "blackened_soul_icd" );
-  cooldowns.seeds_of_their_demise = get_cooldown( "seeds_of_their_demise_icd" );
 
   resource_regeneration = regen_type::DYNAMIC;
   regen_caches[ CACHE_HASTE ] = true;

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -100,7 +100,8 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                                  warlock.proc_actions.blackened_soul->execute_on_target( target );
                                } )
                                ->set_tick_behavior( buff_tick_behavior::REFRESH )
-                               ->set_freeze_stacks( true );
+                               ->set_freeze_stacks( true )
+                               ->set_max_stack( 99 );
 
   debuffs.wither = make_buff( *this, "wither", p.hero.wither_dot )
                        ->set_refresh_behavior( buff_refresh_behavior::DURATION )

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -817,7 +817,6 @@ public:
     propagate_const<cooldown_t*> felstorm_icd;
     propagate_const<cooldown_t*> echo_of_sargeras; // ICD for Embers of Nihilam rank 4 procs
     propagate_const<cooldown_t*> blackened_soul; // Internal cooldown on triggering stack increase to Wither
-    propagate_const<cooldown_t*> seeds_of_their_demise; // Estimated internal cooldown, a guess at how Blizzard is minimizing lucky streaks
   } cooldowns;
 
   // Buffs
@@ -994,6 +993,7 @@ public:
   {
     threshold_rng_t* agony_energize;
     threshold_rng_t* nightfall;
+    threshold_rng_t* seeds_of_their_demise;
   } progress_rng;
 
   struct prd_rng_t
@@ -1026,7 +1026,6 @@ public:
     simple_proc_t* alythesss_ire_shift;
     simple_proc_t* wither_crit_energize;   // TODO: Need to check the type of rng
     simple_proc_t* blackened_soul;
-    simple_proc_t* seeds_of_their_demise;  // TODO: Need to check the type of rng and chance value
   } flat_rng;
 
   struct rng_settings_t
@@ -1065,7 +1064,7 @@ public:
     // Hellcaller
     rng_setting_t blackened_soul = { 0.23, 0.23, "blackened_soul", 0.0 };
     rng_setting_t bleakheart_tactics = { 0.15, 0.15, "bleakheart_tactics", 0.0 };
-    rng_setting_t seeds_of_their_demise = { 0.15, 0.15, "seeds_of_their_demise", 0.0 };
+    rng_setting_t seeds_of_their_demise = { 0.240, 0.240, "seeds_of_their_demise", 0.0 };
     rng_setting_t mark_of_perotharn = { 0.15, 0.15, "mark_of_perotharn", 0.0 };
 
     // Soul Harvester

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -165,7 +165,7 @@ public:
   fixed_cycle_proc_t( std::string_view n, player_t* p, unsigned trigger_count_,
                       bool random_initial_state_ = false, proc_reset_counter_fn proc_reset_fn_ = nullptr )
     : proc_rng_t( rng_type, n, p ),
-      proc_reset_fn( proc_reset_fn_ ),
+      proc_reset_fn( std::move( proc_reset_fn_ ) ),
       counter( 0u ),
       trigger_count( trigger_count_ ),
       random_initial_state( random_initial_state_ )
@@ -1011,6 +1011,8 @@ public:
     accumulated_rng_t* feast_of_souls;
     accumulated_rng_t* demoniac_imp_fade;
     accumulated_rng_t* spiteful_reconstitution;
+    accumulated_rng_t* bleakheart_tactics;
+    accumulated_rng_t* mark_of_perotharn;
     double infernal_rapidity_prd_c_value;
   } prd_rng;
 
@@ -1023,13 +1025,10 @@ public:
     simple_proc_t* demonfire_infusion_inc; // TODO: Need to check the type of rng
     simple_proc_t* alythesss_ire_shift;
     simple_proc_t* wither_crit_energize;   // TODO: Need to check the type of rng
-    simple_proc_t* blackened_soul;         // TODO: Need to check the type of rng and chance value
-    simple_proc_t* bleakheart_tactics;     // TODO: Need to check the type of rng and chance value
+    simple_proc_t* blackened_soul;
     simple_proc_t* seeds_of_their_demise;  // TODO: Need to check the type of rng and chance value
-    simple_proc_t* mark_of_perotharn;      // TODO: Need to check the type of rng and chance value
   } flat_rng;
 
-  // TODO: Need to check that these RNG values ​​are still correct in Midnight
   struct rng_settings_t
   {
     struct rng_setting_t
@@ -1037,44 +1036,47 @@ public:
       double setting_value;
       double default_value;
       std::string option_name;
+      double min = std::numeric_limits<double>::lowest();
+      double max = std::numeric_limits<double>::max();
     };
 
     // Affliction
-    rng_setting_t agony_energize = { 0.370, 0.370, "agony_energize" };
-    rng_setting_t nightfall = { 0.130, 0.130, "nightfall" };
-    rng_setting_t cunning_cruelty_sb = { 0.50, 0.50, "cunning_cruelty_sb" };
-    rng_setting_t cunning_cruelty_ds = { 0.25, 0.25, "cunning_cruelty_ds" };
+    rng_setting_t agony_energize = { 0.370, 0.370, "agony_energize", 0.0 };
+    rng_setting_t nightfall = { 0.130, 0.130, "nightfall", 0.0 };
+    rng_setting_t cunning_cruelty_sb = { 0.50, 0.50, "cunning_cruelty_sb", 0.0 };
+    rng_setting_t cunning_cruelty_ds = { 0.25, 0.25, "cunning_cruelty_ds", 0.0 };
 
     // Demonology
-    rng_setting_t demoniac_imp_fade_hard_cap = { 21.0, 21.0, "demoniac_imp_fade_hard_cap" };
-    rng_setting_t spiteful_reconstitution = { 0.10, 0.10, "spiteful_reconstitution" };
-    rng_setting_t spiteful_reconstitution_hard_cap = { 21.0, 21.0, "spiteful_reconstitution_hard_cap" };
-    rng_setting_t demonic_knowledge_rank1_cards = { 6.0, 6.0, "demonic_knowledge_rank1_cards" };
-    rng_setting_t demonic_knowledge_rank2_cards = { 12.0, 12.0, "demonic_knowledge_rank2_cards" };
-    rng_setting_t demonic_knowledge_deck_size = { 80.0, 80.0, "demonic_knowledge_deck_size" };
+    rng_setting_t demoniac_imp_fade_hard_cap = { 21.0, 21.0, "demoniac_imp_fade_hard_cap", 0.0 };
+    rng_setting_t spiteful_reconstitution = { 0.10, 0.10, "spiteful_reconstitution", 0.0 };
+    rng_setting_t spiteful_reconstitution_hard_cap = { 21.0, 21.0, "spiteful_reconstitution_hard_cap", 0.0 };
+    rng_setting_t demonic_knowledge_rank1_cards = { 6.0, 6.0, "demonic_knowledge_rank1_cards", 0.0 };
+    rng_setting_t demonic_knowledge_rank2_cards = { 12.0, 12.0, "demonic_knowledge_rank2_cards", 0.0 };
+    rng_setting_t demonic_knowledge_deck_size = { 80.0, 80.0, "demonic_knowledge_deck_size", 0.0 };
 
     // Destruction
-    rng_setting_t rain_of_chaos_cards = { 3.0, 3.0, "rain_of_chaos_cards" };
-    rng_setting_t rain_of_chaos_deck_size = { 20.0, 20.0, "rain_of_chaos_deck_size" };
-    rng_setting_t alythesss_ire_shift = { 0.01, 0.01, "alythesss_ire_shift" };
-    rng_setting_t echo_of_sargeras = { 0.10, 0.10, "echo_of_sargeras" };
+    rng_setting_t rain_of_chaos_cards = { 3.0, 3.0, "rain_of_chaos_cards", 0.0 };
+    rng_setting_t rain_of_chaos_deck_size = { 20.0, 20.0, "rain_of_chaos_deck_size", 0.0 };
+    rng_setting_t alythesss_ire_shift = { 0.01, 0.01, "alythesss_ire_shift", 0.0 };
+    rng_setting_t echo_of_sargeras = { 0.10, 0.10, "echo_of_sargeras", 0.0 };
 
     // Diabolist
 
     // Hellcaller
-    rng_setting_t blackened_soul = { 0.10, 0.10, "blackened_soul" };
-    rng_setting_t bleakheart_tactics = { 0.15, 0.15, "bleakheart_tactics" };
-    rng_setting_t seeds_of_their_demise = { 0.15, 0.15, "seeds_of_their_demise" };
-    rng_setting_t mark_of_perotharn = { 0.15, 0.15, "mark_of_perotharn" };
+    rng_setting_t blackened_soul = { 0.23, 0.23, "blackened_soul", 0.0 };
+    rng_setting_t bleakheart_tactics = { 0.15, 0.15, "bleakheart_tactics", 0.0 };
+    rng_setting_t seeds_of_their_demise = { 0.15, 0.15, "seeds_of_their_demise", 0.0 };
+    rng_setting_t mark_of_perotharn = { 0.15, 0.15, "mark_of_perotharn", 0.0 };
 
     // Soul Harvester
-    rng_setting_t succulent_soul_aff = { 0.225, 0.225, "succulent_soul_aff" };
-    rng_setting_t succulent_soul_demo = { 0.15, 0.15, "succulent_soul_demo" };
-    rng_setting_t feast_of_souls_aff = { 0.04, 0.04, "feast_of_souls_aff" };
-    rng_setting_t feast_of_souls_demo = { 0.10, 0.10, "feast_of_souls_demo" };
-    rng_setting_t feast_of_souls_hard_cap_aff = { 26.0, 26.0, "feast_of_souls_hard_cap_aff" };
-    rng_setting_t feast_of_souls_hard_cap_demo = { 26.0, 26.0, "feast_of_souls_hard_cap_demo" };
-    rng_setting_t manifested_avarice = { 0.10, 0.10, "manifested_avarice" };
+    rng_setting_t succulent_soul_aff = { 0.225, 0.225, "succulent_soul_aff", 0.0 };
+    rng_setting_t succulent_soul_demo = { 0.15, 0.15, "succulent_soul_demo", 0.0 };
+    rng_setting_t feast_of_souls_aff = { 0.12, 0.12, "feast_of_souls_aff", 0.0 };
+    rng_setting_t feast_of_souls_aff_quietus = { 0.04, 0.04, "feast_of_souls_aff_quietus", 0.0 };
+    rng_setting_t feast_of_souls_demo = { 0.10, 0.10, "feast_of_souls_demo", 0.0 };
+    rng_setting_t feast_of_souls_hard_cap_aff = { 26.0, 26.0, "feast_of_souls_hard_cap_aff", 0.0 };
+    rng_setting_t feast_of_souls_hard_cap_demo = { 26.0, 26.0, "feast_of_souls_hard_cap_demo", 0.0 };
+    rng_setting_t manifested_avarice = { 0.10, 0.10, "manifested_avarice", 0.0 };
 
     template <typename F>
     void for_each( F&& f )
@@ -1100,6 +1102,7 @@ public:
       f( succulent_soul_aff );
       f( succulent_soul_demo );
       f( feast_of_souls_aff );
+      f( feast_of_souls_aff_quietus );
       f( feast_of_souls_demo );
       f( feast_of_souls_hard_cap_aff );
       f( feast_of_souls_hard_cap_demo );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -868,7 +868,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain();
       }
 
@@ -1120,20 +1120,30 @@ using namespace helpers;
         }
 
         // Seeds of their Demise collapse conditions must be checked periodically for every Wither tick
-        if ( !td( d->target )->debuffs.blackened_soul->check() )
+        bool collapse = false;
+        collapse = collapse || ( p()->hero.seeds_of_their_demise.ok() && d->current_stack() > 1 && d->target->health_percentage() <= p()->hero.seeds_of_their_demise->effectN( 2 ).base_value() );
+        collapse = collapse || ( p()->hero.seeds_of_their_demise.ok() && d->current_stack() >= as<int>( p()->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
+        if ( collapse )
         {
-          bool collapse = false;
-          collapse = collapse || ( p()->hero.seeds_of_their_demise.ok() && d->current_stack() > 1 && d->target->health_percentage() <= p()->hero.seeds_of_their_demise->effectN( 2 ).base_value() );
-          collapse = collapse || ( p()->hero.seeds_of_their_demise.ok() && d->current_stack() >= as<int>( p()->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
-          if ( collapse )
+          const int prev_collapse_stacks = td( d->target )->debuffs.blackened_soul->check();
+          assert( prev_collapse_stacks >= 0 );
+          const int diff_stacks = d->current_stack() - prev_collapse_stacks;
+
+          assert( d->current_stack() >= 1 );
+          if ( diff_stacks > 0 )
+            td( d->target )->debuffs.blackened_soul->trigger( diff_stacks );
+          else if ( diff_stacks < 0 )
+            td( d->target )->debuffs.blackened_soul->decrement( -diff_stacks );
+
+          assert( td( d->target )->debuffs.blackened_soul->check() );
+          if ( !prev_collapse_stacks )
           {
-            td( d->target )->debuffs.blackened_soul->trigger();
             p()->sim->print_debug( "{} wither stack collapse in {} started (seeds of their demise) (wither tick check). wither_current_stack={}, wither_target_health_percentage={:.2f}%",
                                    p()->name(), d->target->name(), d->current_stack(), d->target->health_percentage() );
           }
         }
 
-        if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->flat_rng.mark_of_perotharn->trigger() )
+        if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
         {
           // Wither stack gain by Mark of Perotharn does not directly trigger collapse in that tick (it will be trigged on the next tick)
           // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
@@ -1200,7 +1210,7 @@ using namespace helpers;
     {
       warlock_spell_t::impact( s );
 
-      if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->flat_rng.mark_of_perotharn->trigger() )
+      if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
       {
         auto& wither_dot = td( s->target )->dots.wither;
         auto& wither_debuff = td( s->target )->debuffs.wither;
@@ -1260,16 +1270,26 @@ using namespace helpers;
 
       player_t* tar = s->target;
 
-      if ( td( tar )->dots.wither->current_stack() <= 1 )
-      {
-        make_event( *sim, 0_ms, [ this, tar ] {
-          if ( td( tar )->debuffs.blackened_soul->check() )
-          {
-            td( tar )->debuffs.blackened_soul->expire();
-            p()->sim->print_debug( "{} wither stack collapse in {} ended. wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
-          }
-        } );
-      }
+      assert( td( tar )->debuffs.blackened_soul->check() );
+      make_event( *sim, 0_ms, [ this, tar ] {
+        if ( tar->is_sleeping() )
+          return;
+
+        auto blackened_soul_debuff = td( tar )->debuffs.blackened_soul;
+        assert( blackened_soul_debuff->check() );
+
+        if ( td( tar )->dots.wither->current_stack() <= 1 )
+        {
+          blackened_soul_debuff->expire();
+          p()->sim->print_debug( "{} wither stack collapse in {} ended (wither stacks reach 1). wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
+        }
+        else
+        {
+          blackened_soul_debuff->decrement();
+          if ( !blackened_soul_debuff->check() )
+            p()->sim->print_debug( "{} wither stack collapse in {} ended (collapse consumed its stacks). wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
+        }
+      } );
 
       bool seeds_triggered = false;
 
@@ -1282,7 +1302,7 @@ using namespace helpers;
 
       if ( destruction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && p()->flat_rng.seeds_of_their_demise->trigger() )
       {
-        p()->buffs.flashpoint->trigger( 2 );
+        p()->buffs.flashpoint->trigger( as<int>( p()->hero.seeds_of_their_demise->effectN( 3 ).base_value() ) );
         p()->procs.seeds_of_their_demise->occur();
         seeds_triggered = true;
       }
@@ -1540,7 +1560,6 @@ using namespace helpers;
       if ( p()->talents.cascading_calamity.ok() && dot->is_ticking() )
         p()->buffs.cascading_calamity->trigger();
 
-      // timespan_t dot_new_last_duration = dot->time_to_next_full_tick() + composite_dot_duration( s ); // TODO: Alternative that takes into account the extra tick on refresh; which is more appropriate?
       timespan_t dot_new_last_duration = composite_dot_duration( s );
       // NOTE: If Blizzard change the UA DoT Behavior, this need to be redesigned
       assert( dot_behavior == DOT_REFRESH_DURATION && "UA DoT Behavior has changed" );
@@ -1871,7 +1890,7 @@ using namespace helpers;
           p()->proc_actions.shared_fate->execute_on_target( main_seed_target );
 
         // Feast of Souls is processed before the decrement of Succulent Soul, causing the same SoC cast that gains the Succulent Soul stack to consume it
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain( true );
       }
 
@@ -2147,7 +2166,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -2286,7 +2305,7 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
+        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain();
       }
       p()->buffs.nightfall->decrement();
@@ -5195,48 +5214,56 @@ using namespace helpers;
         stacks = as<int>( p->hero.malevolence->effectN( 1 ).base_value() );
       }
 
+      // Wither extra stack from Malevolence Effect #2 does not benefit from Bleakheart Tactics
+      if ( p->buffs.malevolence->check() && !malevolence )
+      {
+        stacks += as<int>( p->hero.malevolence->effectN( 2 ).base_value() );
+      }
+
+      // Bleakheart Tactics proc uses a global BLP (PRD-accumulator)
+      // Malevolence stack gains do not benefit from Bleakheart Tactics
+      if ( p->hero.bleakheart_tactics.ok() && !malevolence && p->prd_rng.bleakheart_tactics->trigger() )
+      {
+        stacks += as<int>( p->hero.bleakheart_tactics->effectN( 3 ).base_value() );
+        p->procs.bleakheart_tactics->occur();
+      }
+
+      assert( stacks >= 1 );
       tdata->dots.wither->increment( stacks );
       tdata->debuffs.wither->bump( stacks );
       assert( tdata->dots.wither->current_stack() == tdata->debuffs.wither->check() && tdata->dots.wither->remains() == tdata->debuffs.wither->remains() );
       stack_gained = true;
 
-      // Wither extra stack from Malevolence Effect #2 does not benefit from Bleakheart Tactics
-      if ( p->buffs.malevolence->check() && !malevolence )
-      {
-        const int inc = as<int>( p->hero.malevolence->effectN( 2 ).base_value() );
-        tdata->dots.wither->increment( inc );
-        tdata->debuffs.wither->bump( inc );
-        assert( tdata->dots.wither->current_stack() == tdata->debuffs.wither->check() && tdata->dots.wither->remains() == tdata->debuffs.wither->remains() );
-      }
+      const int prev_collapse_stacks = tdata->debuffs.blackened_soul->check();
+      assert( prev_collapse_stacks >= 0 );
+      bool collapse = false; // Malevolence no longer initiates collapse automatically. Last tested 2026-03-17
+      collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots.wither->current_stack() > 1 && target->health_percentage() <= p->hero.seeds_of_their_demise->effectN( 2 ).base_value() );
+      collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots.wither->current_stack() >= as<int>( p->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
 
-      // Malevolence stack gains do not benefit from Bleakheart Tactics
-      if ( p->hero.bleakheart_tactics.ok() && !malevolence && p->flat_rng.bleakheart_tactics->trigger() )
+      if ( collapse )
       {
-        const int inc = as<int>( p->hero.bleakheart_tactics->effectN( 3 ).base_value() );
-        tdata->dots.wither->increment( inc );
-        tdata->debuffs.wither->bump( inc );
-        assert( tdata->dots.wither->current_stack() == tdata->debuffs.wither->check() && tdata->dots.wither->remains() == tdata->debuffs.wither->remains() );
-        p->procs.bleakheart_tactics->occur();
-      }
+        const int diff_stacks = tdata->dots.wither->current_stack() - prev_collapse_stacks;
 
-      if ( !tdata->debuffs.blackened_soul->check() )
-      {
-        bool collapse = false; // Malevolence no longer initiates collapse automatically. Last tested 2026-03-17
-        collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots.wither->current_stack() > 1 && target->health_percentage() <= p->hero.seeds_of_their_demise->effectN( 2 ).base_value() );
-        collapse = collapse || ( p->hero.seeds_of_their_demise.ok() && tdata->dots.wither->current_stack() >= as<int>( p->hero.seeds_of_their_demise->effectN( 1 ).base_value() ) );
+        assert( tdata->dots.wither->current_stack() >= 1 );
+        if ( diff_stacks > 0 )
+          tdata->debuffs.blackened_soul->trigger( diff_stacks );
+        else if ( diff_stacks < 0 )
+          tdata->debuffs.blackened_soul->decrement( -diff_stacks );
 
-        if ( collapse )
+        assert( tdata->debuffs.blackened_soul->check() );
+        if ( !prev_collapse_stacks )
         {
-          tdata->debuffs.blackened_soul->trigger();
           p->sim->print_debug( "{} wither stack collapse in {} started (seeds of their demise) (stack gain check). wither_current_stack={}, wither_target_health_percentage={:.2f}%",
                       p->name(), target->name(), tdata->dots.wither->current_stack(), target->health_percentage() );
         }
-        else if ( p->flat_rng.blackened_soul->trigger() && !malevolence ) // Malevolence stack gains do not trigger Blackened Soul collapse proc
-        {
-          tdata->debuffs.blackened_soul->trigger();
-          p->procs.blackened_soul->occur();
-          p->sim->print_debug( "{} wither stack collapse in {} started (blackened soul proc). wither_current_stack={}", p->name(), target->name(), tdata->dots.wither->current_stack() );
-        }
+      }
+      else if ( !prev_collapse_stacks && !malevolence && p->flat_rng.blackened_soul->trigger() ) // Malevolence stack gains do not trigger Blackened Soul collapse proc
+      {
+        const int new_collapse_stacks = tdata->dots.wither->current_stack();
+        assert( new_collapse_stacks >= 1 && !tdata->debuffs.blackened_soul->check() );
+        tdata->debuffs.blackened_soul->trigger( new_collapse_stacks );
+        p->procs.blackened_soul->occur();
+        p->sim->print_debug( "{} wither stack collapse in {} started (blackened soul proc). wither_current_stack={}", p->name(), target->name(), tdata->dots.wither->current_stack() );
       }
 
       if ( malevolence )
@@ -5344,8 +5371,6 @@ using namespace helpers;
   {
     warlock_t* p = static_cast<warlock_t*>( player() );
 
-    // if ( dot->is_ticking() && dot->tick_event && dot->current_action && dot->remains() > 0_ms ) // TODO: Alternative that takes into account the extra tick on refresh; which is more appropriate?
-    // if ( dot->is_ticking() && dot->tick_event && dot->current_action && dot->remains() > 0_ms && dot->current_stack() > 1 )
     if ( dot->is_ticking() && dot->tick_event && dot->current_action && dot->remains() > 0_ms )
     {
       player_t* target = dot->target;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1270,45 +1270,37 @@ using namespace helpers;
 
       player_t* tar = s->target;
 
-      assert( td( tar )->debuffs.blackened_soul->check() );
-      make_event( *sim, 0_ms, [ this, tar ] {
-        if ( tar->is_sleeping() )
-          return;
+      // Blackened Soul damage impact runs during blackened_soul_debuff tick callback.
+      // Its frozen stacks make direct expire/decrement safe here without deferring to a follow-up event.
+      auto& blackened_soul_debuff = td( tar )->debuffs.blackened_soul;
+      assert( blackened_soul_debuff->check() );
+      assert( blackened_soul_debuff->freeze_stacks );
+      assert( blackened_soul_debuff->buff_duration() == 0_ms );
+      assert( blackened_soul_debuff->expiration.empty() );
+      assert( blackened_soul_debuff->tick_event == nullptr );
+      if ( td( tar )->dots.wither->current_stack() <= 1 )
+      {
+        blackened_soul_debuff->expire();
+        p()->sim->print_debug( "{} wither stack collapse in {} ended (wither stacks reach 1). wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
+      }
+      else
+      {
+        blackened_soul_debuff->decrement();
+        if ( !blackened_soul_debuff->check() )
+          p()->sim->print_debug( "{} wither stack collapse in {} ended (collapse consumed its stacks). wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
+      }
 
-        auto blackened_soul_debuff = td( tar )->debuffs.blackened_soul;
-        assert( blackened_soul_debuff->check() );
-
-        if ( td( tar )->dots.wither->current_stack() <= 1 )
-        {
-          blackened_soul_debuff->expire();
-          p()->sim->print_debug( "{} wither stack collapse in {} ended (wither stacks reach 1). wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
-        }
-        else
-        {
-          blackened_soul_debuff->decrement();
-          if ( !blackened_soul_debuff->check() )
-            p()->sim->print_debug( "{} wither stack collapse in {} ended (collapse consumed its stacks). wither_current_stack={}", p()->name(), tar->name(), td( tar )->dots.wither->current_stack() );
-        }
-      } );
-
-      bool seeds_triggered = false;
-
-      if ( affliction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && p()->flat_rng.seeds_of_their_demise->trigger() )
+      if ( affliction() && p()->hero.seeds_of_their_demise.ok() && p()->progress_rng.seeds_of_their_demise->trigger( s ) )
       {
         p()->buffs.shard_instability->trigger();
         p()->procs.seeds_of_their_demise->occur();
-        seeds_triggered = true;
       }
 
-      if ( destruction() && p()->hero.seeds_of_their_demise.ok() && p()->cooldowns.seeds_of_their_demise->up() && p()->flat_rng.seeds_of_their_demise->trigger() )
+      if ( destruction() && p()->hero.seeds_of_their_demise.ok() && p()->progress_rng.seeds_of_their_demise->trigger( s ) )
       {
         p()->buffs.flashpoint->trigger( as<int>( p()->hero.seeds_of_their_demise->effectN( 3 ).base_value() ) );
         p()->procs.seeds_of_their_demise->occur();
-        seeds_triggered = true;
       }
-
-      if ( seeds_triggered )
-        p()->cooldowns.seeds_of_their_demise->start();
     }
   };
 

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -631,7 +631,6 @@ namespace warlock
     hero.malevolence_dmg = conditional_spell_lookup( hero.malevolence.ok(), 446285 );
 
     cooldowns.blackened_soul->duration = hero.blackened_soul->internal_cooldown();
-    cooldowns.seeds_of_their_demise->duration = 15_s;
   }
 
   void warlock_t::init_spells_soul_harvester()
@@ -1413,7 +1412,26 @@ namespace warlock
       prd_rng.bleakheart_tactics = get_accumulated_rng( "bleakheart_tactics", c_bt );
     }
 
-    flat_rng.seeds_of_their_demise = get_simple_proc_rng( "seeds_of_their_demise", rng_settings.seeds_of_their_demise.setting_value );
+    // Seeds of their Demise proc
+    if ( hero.seeds_of_their_demise.ok() )
+    {
+      double base_inc_max = rng_settings.seeds_of_their_demise.setting_value;
+
+      progress_rng.seeds_of_their_demise = get_threshold_rng( "seeds_of_their_demise", base_inc_max,
+        [ this ]( double increment_max, action_state_t* s ) {
+          assert( hero.wither.ok() );
+          assert( s );
+          auto tdata = get_target_data( s->target );
+          assert( tdata );
+          dot_t* wither_dot = tdata->dots.wither;
+          assert( wither_dot && wither_dot->is_ticking() );
+          const double stacks_before = wither_dot->current_stack() + 1.0;
+          unsigned active_withers = get_active_dots( wither_dot );
+          assert( active_withers > 0 );
+          const double weight = std::pow( stacks_before, -2.0 / 3.0 ) * std::pow( active_withers, -3.0 / 4.0 );
+          return rng().range( increment_max * weight );
+        }, true, true );
+    }
 
     // Modeling Mark of Perotharn as a shared pseudo-random distribution (PRD) with a nominal
     // rate of 15%, which corresponds to PRD constant C = 0.032220914373087675.
@@ -1422,7 +1440,6 @@ namespace warlock
       double c_mop = prd::find_constant( rng_settings.mark_of_perotharn.setting_value );
       prd_rng.mark_of_perotharn = get_accumulated_rng( "mark_of_perotharn", c_mop );
     }
-    
 
     rppm_rng.devil_fruit = get_rppm( "devil_fruit", hero.devil_fruit );
   }

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1180,8 +1180,9 @@ namespace warlock
           auto tdata = get_target_data( s->target );
           assert( tdata );
           dot_t* agony_dot = tdata->dots.agony;
+          assert( agony_dot && agony_dot->is_ticking() );
           unsigned active_agonies = get_active_dots( agony_dot );
-          assert( agony_dot && agony_dot->is_ticking() && active_agonies > 0 );
+          assert( active_agonies > 0 );
           increment_max *= std::pow( active_agonies, -2.0 / 3.0 );
           return rng().range( 0.0, increment_max );
         }, true, true );
@@ -1217,8 +1218,9 @@ namespace warlock
           auto tdata = get_target_data( s->target );
           assert( tdata );
           dot_t* corruption_dot = hero.wither.ok() ? tdata->dots.wither : tdata->dots.corruption;
+          assert( corruption_dot && corruption_dot->is_ticking() );
           unsigned active_corruptions = get_active_dots( corruption_dot );
-          assert( corruption_dot && corruption_dot->is_ticking() && active_corruptions > 0 );
+          assert( active_corruptions > 0 );
           increment_max *= std::pow( active_corruptions, -2.0 / 3.0 );
           return rng().range( 0.0, increment_max );
         }, true, true );
@@ -1260,7 +1262,7 @@ namespace warlock
     {
       // Modeling Demoniac (Wild Imp fade) as a pseudo-random distribution (PRD) with a nominal rate of 10% and a hard cap of 21 attempts.
       // The corresponding PRD constant, calculated with that cap included, is C = 0.014559015812945588.
-      int demoniac_imp_fade_hardcap = static_cast<int>( rng_settings.demoniac_imp_fade_hard_cap.setting_value );
+      unsigned demoniac_imp_fade_hardcap = static_cast<unsigned>( rng_settings.demoniac_imp_fade_hard_cap.setting_value );
       double c_dwif = prd::find_constant( talents.demonic_core_spell->effectN( 1 ).percent(), demoniac_imp_fade_hardcap );
       prd_rng.demoniac_imp_fade = get_accumulated_rng( "demoniac_imp_fade", c_dwif, demoniac_imp_fade_hardcap );
 
@@ -1287,7 +1289,7 @@ namespace warlock
     if ( talents.spiteful_reconstitution.ok() )
     {
       double c_sr = prd::find_constant( rng_settings.spiteful_reconstitution.setting_value );
-      int spiteful_reconstitution_hardcap = static_cast<int>( rng_settings.spiteful_reconstitution_hard_cap.setting_value );
+      unsigned spiteful_reconstitution_hardcap = static_cast<unsigned>( rng_settings.spiteful_reconstitution_hard_cap.setting_value );
       prd_rng.spiteful_reconstitution = get_accumulated_rng( "spiteful_reconstitution", c_sr, spiteful_reconstitution_hardcap );
     }
 
@@ -1402,9 +1404,25 @@ namespace warlock
   {
     flat_rng.wither_crit_energize = get_simple_proc_rng( "wither_crit_energize", hero.wither_direct->effectN( 2 ).percent() );
     flat_rng.blackened_soul = get_simple_proc_rng( "blackened_soul", rng_settings.blackened_soul.setting_value );
-    flat_rng.bleakheart_tactics = get_simple_proc_rng( "bleakheart_tactics", rng_settings.bleakheart_tactics.setting_value );
+
+    // Modeling Bleakheart Tactics as a shared pseudo-random distribution (PRD) with a nominal
+    // rate of 15%, which corresponds to PRD constant C = 0.032220914373087675.
+    if ( hero.bleakheart_tactics.ok() )
+    {
+      double c_bt = prd::find_constant( rng_settings.bleakheart_tactics.setting_value );
+      prd_rng.bleakheart_tactics = get_accumulated_rng( "bleakheart_tactics", c_bt );
+    }
+
     flat_rng.seeds_of_their_demise = get_simple_proc_rng( "seeds_of_their_demise", rng_settings.seeds_of_their_demise.setting_value );
-    flat_rng.mark_of_perotharn = get_simple_proc_rng( "mark_of_perotharn", rng_settings.mark_of_perotharn.setting_value );
+
+    // Modeling Mark of Perotharn as a shared pseudo-random distribution (PRD) with a nominal
+    // rate of 15%, which corresponds to PRD constant C = 0.032220914373087675.
+    if ( hero.mark_of_perotharn.ok() )
+    {
+      double c_mop = prd::find_constant( rng_settings.mark_of_perotharn.setting_value );
+      prd_rng.mark_of_perotharn = get_accumulated_rng( "mark_of_perotharn", c_mop );
+    }
+    
 
     rppm_rng.devil_fruit = get_rppm( "devil_fruit", hero.devil_fruit );
   }
@@ -1433,26 +1451,34 @@ namespace warlock
       prd_rng.manifested_avarice = get_accumulated_rng( "manifested_avarice", c_ma );
     }
 
-    // Modeling Feast of Souls as a pseudo-random distribution (PRD) with an uncapped nominal rate of 4% (aff) / 10% (demo). Those
-    // nominal rates correspond to PRD constants C = 0.002448555471647706 (aff) / C = 0.014745844781072676 (demo). A separate hard
+    // Modeling Feast of Souls (Kill) as a pseudo-random distribution (PRD) with an uncapped nominal rate of 12% (aff) / 10% (demo), which
+    // corresponds to PRD constants C = 0.020983228162532177 (aff) / C = 0.014745844781072676 (demo). Due to a possible bug, Affliction FoS
+    // from Quietus shares the same PRD, but with a lower activation chance.
+    // Modeling Feast of Souls (Quietus) as a pseudo-random distribution (PRD) with an uncapped nominal rate of 4% (aff) / 10% (demo).
+    // Those nominal rates correspond to PRD constants C = 0.002448555471647706 (aff) / C = 0.014745844781072676 (demo). A separate hard
     // cap of 26 attempts is then applied on top of the PRD, raising the effective average proc chance to ~4.94% (aff) / ~10.01% (demo).
     if ( hero.feast_of_souls.ok() )
     {
       assert( affliction() || demonology() );
-      double c_fs = 0.0;
-      int feast_of_souls_hardcap = 0;
       if ( affliction() )
       {
-        c_fs = prd::find_constant( rng_settings.feast_of_souls_aff.setting_value );
-        feast_of_souls_hardcap = static_cast<int>( rng_settings.feast_of_souls_hard_cap_aff.setting_value );
+        double c_fs = prd::find_constant( rng_settings.feast_of_souls_aff.setting_value );
+        double c_fsq = prd::find_constant( rng_settings.feast_of_souls_aff_quietus.setting_value );
+        unsigned feast_of_souls_hardcap = static_cast<unsigned>( rng_settings.feast_of_souls_hard_cap_aff.setting_value );
+        prd_rng.feast_of_souls = get_accumulated_rng( "feast_of_souls", c_fs, feast_of_souls_hardcap,
+          !bugs ? accumulated_rng_fn{} :
+          [ c_fsq, cap = feast_of_souls_hardcap ]( double c_fs, unsigned trigger_count, action_state_t* s ) -> double
+          {
+            return ( cap > 0 && trigger_count >= cap ) ? 1.0 : ( s ? c_fsq : c_fs ) * trigger_count;
+          }
+        );
       }
       else if ( demonology() )
       {
-        c_fs = prd::find_constant( rng_settings.feast_of_souls_demo.setting_value );
-        feast_of_souls_hardcap = static_cast<int>( rng_settings.feast_of_souls_hard_cap_demo.setting_value );
+        double c_fs = prd::find_constant( rng_settings.feast_of_souls_demo.setting_value );
+        unsigned feast_of_souls_hardcap = static_cast<unsigned>( rng_settings.feast_of_souls_hard_cap_demo.setting_value );
+        prd_rng.feast_of_souls = get_accumulated_rng( "feast_of_souls", c_fs, feast_of_souls_hardcap );
       }
-
-      prd_rng.feast_of_souls = get_accumulated_rng( "feast_of_souls", c_fs, feast_of_souls_hardcap );
     }
   }
 
@@ -1608,7 +1634,11 @@ namespace warlock
 
   void warlock_t::add_rng_option( warlock_t::rng_settings_t::rng_setting_t& setting )
   {
-    add_option( opt_float( "warlock.rng_" + setting.option_name, setting.setting_value ) );
+    if ( setting.min != std::numeric_limits<double>::lowest() || setting.max != std::numeric_limits<double>::max() )
+      add_option( opt_float( "warlock.rng_" + setting.option_name, setting.setting_value, setting.min, setting.max ) );
+    else
+      add_option( opt_float( "warlock.rng_" + setting.option_name, setting.setting_value ) );
+
     add_option( opt_deprecated( "rng_" + setting.option_name,  "warlock.rng_" + setting.option_name ) );
   }
 


### PR DESCRIPTION
This PR updates the Warlock module to adjust the values and behavior of several RNG systems, mainly **Feast of Souls (on kills)** for Affliction and the different **Hellcaller procs** for both Affliction and Destruction. These are described below, but here is a *ZIP* file containing all the analyses, sample files (parsed logs), figures, and summary:
[HC_and_FoSAffKill_procs.zip](https://github.com/user-attachments/files/29175943/HC_and_FoSAffKill_procs.zip)

In addition to the RNG updates, we also checked how **collapse** works, as well as the different interactions between talents, stack gains, stack consumes (**Blackened Soul** damage events), **Malevolence**, and so on. The code has been updated with comments documenting most of these details.

One relevant finding about **Hellcaller** is that the number of pending **collapse** stacks does not necessarily have to match the number of **Wither stacks**. When a collapse starts on a target, it snapshots the number of **Wither stacks** on that target, and that becomes the number of stacks consumed by the collapse. However, any **Wither stack** gains that happen afterward while **collapse** is active do not refresh the number of pending collapse stacks. In practice, this means many collapses can end before all **Wither stacks** have been consumed.

However, if collapse conditions are met again while a collapse is already active, the number of stacks to be consumed by the active collapse is updated to the current number of **Wither stacks**.

In simc, this behavior has been replicated by giving stacks to the **Blackened Soul** dummy debuff used for collapse. These dummy stacks represent the active collapse snapshot/budget for that target. When collapse starts or is refreshed by collapse conditions being met again, the dummy stack count is synchronized to the current **Wither** stack count. Each **Blackened Soul** damage event then decrements both **Wither** and this dummy collapse counter until either **Wither** reaches 1 stack or the collapse counter is exhausted.

# Feast of Souls (Affliction) (on kill)

**Feast of Souls** RNG proc with **Quietus** has not been retested here, but the previously analyzed average chance was `~4%-~5%`, much lower than expected, possibly due to a bug.

It appears that the chance for **Feast of Souls** in Affliction is much higher when the proc comes from killing a target rather than from **Quietus**. Samples were collected to analyze the proc rate of **Feast of Souls** across ~3200 kills, resulting in a `~11.8%` average chance. Therefore, in the absence of more samples to get higher precision, we assume an average chance of `12%`.

The RNG type was also analyzed, and, as expected, it is accumulator PRD, the same as **Feast of Souls** with **Quietus** and the Demonology version.

We also confirmed that the accumulator PRD appears to be shared between **kills** and **Quietus** procs, so this is how it has been implemented in simc.

- Histogram for the distance between procs:
<img width="630" height="372" alt="fos_kills_unitdied_sample_gap_histogram" src="https://github.com/user-attachments/assets/883f0644-cfd2-4168-b0dd-5181641ffe7a" />

# Bleakheart Tactics (Hellcaller)

Chance to gain an additional stack when **Wither** gains a stack from **Blackened Soul**. **Malevolence** stack gains do not benefit from **Bleakheart Tactics**. **Wither stack** gains from **Mark of Perotharn** do not benefit from **Bleakheart Tactics**.

After analyzing several samples, we obtained an average chance of `14.90%` for Affliction and `14.95%` for Destruction. The most likely real value used in-game is `15%`, which is the value we set in simc.

The RNG type used is clearly accumulator PRD, and only a single global PRD accumulator is used, shared across all **Wither** targets.

- Histogram for the distance between procs:

`    · Affliction:`
<img width="720" height="360" alt="aff_marchitar_bs_global_gap_hist_v2" src="https://github.com/user-attachments/assets/ed91b857-322e-4ffe-a247-e331fec1883b" />

`    · Destruction:`
 <img width="680" height="408" alt="dest_BTBS_hist_global_corrected" src="https://github.com/user-attachments/assets/cb8f0338-86b3-48ab-a5f0-666283eb5530" />

- ECDF distance between procs:

`    · Destruction:`
<img width="680" height="408" alt="dest_BTBS_ecdf_global_corrected" src="https://github.com/user-attachments/assets/beab46da-919a-45eb-bbf0-b27b5f21f141" />

- Hazard per attempt (probability of success on attempt n since the last attempt):

`    · Destruction:`
<img width="680" height="408" alt="dest_BTBS_hazard_global_corrected" src="https://github.com/user-attachments/assets/fbb5a0e3-64d7-4077-ae38-ff7e976def93" />

- Tail / survival of the distance between procs (log scale):
`    · Destruction:`
<img width="680" height="408" alt="dest_BTBS_survival_global_corrected" src="https://github.com/user-attachments/assets/10d06556-bfc3-46d7-847f-abde0a9ec417" />

# Blackened Soul (Hellcaller)

Chance for a **Wither** to start **collapse** each time it gains a stack (on eligible **Wither stack** gain events). This proc cannot occur on a target while it already has an active **collapse**; it is only attempted when no **collapse** is active. **Malevolence** stack gains do not trigger the **Blackened Soul** collapse proc.

After analyzing several samples, we obtained an average chance of `23.18%` for Affliction and `22.47%` for Destruction. In the absence of higher precision, the most likely real value used in-game is `23%`, which is the value we set in simc.

The RNG type used is Flat %, so there does not appear to be any BLP mechanism associated with this proc.

- Histogram for the distance between procs:

`    · Affliction:`
<img width="700" height="420" alt="CPS_Aff_hist_global" src="https://github.com/user-attachments/assets/eaa724c7-e472-44c5-9327-0f10b9ec31c4" />

`    · Destruction:`
<img width="700" height="420" alt="CPS_Destr_hist_global" src="https://github.com/user-attachments/assets/639d381c-9998-43df-90b8-07d585a33ecd" />

- ECDF distance between procs:

`    · Affliction:`
<img width="700" height="420" alt="CPS_Aff_ecdf_global" src="https://github.com/user-attachments/assets/31046134-013a-4094-bc7f-eb1676e99ad1" />

`    · Destruction:`
<img width="700" height="420" alt="CPS_Destr_ecdf_global" src="https://github.com/user-attachments/assets/502db59e-6601-4716-ba00-487334f797b4" />

- Hazard per attempt (probability of success on attempt n since the last attempt):

`    · Affliction:`
<img width="700" height="420" alt="CPS_Aff_hazard_global" src="https://github.com/user-attachments/assets/fc4bacbd-d313-47fa-a240-1473dd6bf6e8" />

`    · Destruction:`
<img width="700" height="420" alt="CPS_Destr_hazard_global" src="https://github.com/user-attachments/assets/4b73c639-ceca-408d-b9bf-ed991944ab89" />

- Tail / survival of the distance between procs (log scale):

`    · Affliction:`
<img width="700" height="420" alt="CPS_Aff_survival_global" src="https://github.com/user-attachments/assets/fb913485-3fec-4203-9ff4-504693a4131d" />

`    · Destruction:`
<img width="700" height="420" alt="CPS_Destr_survival_global" src="https://github.com/user-attachments/assets/c2a44d42-292a-40df-bb16-f6d9e26dcdf1" />

# Mark of Perotharn (Hellcaller)

Chance to gain a **Wither stack** on a **Wither crit**. **Wither stack** gains from **Mark of Perotharn** do not directly trigger **collapse** on that tick (although the **collapse** can be triggered on the next **Wither** tick if collapse conditions are met). **Wither stack** gains from **Mark of Perotharn** do not benefit from **Bleakheart Tactics**.

After analyzing several samples, we obtained an average chance of `15.23%` for Affliction and `15.12%` for Destruction. The most likely real value used in-game is `15%`, which is the value we set in simc.

The RNG type used is clearly accumulator PRD, and only a single global PRD accumulator is used, shared across all **Wither** targets.

- Histogram for the distance between procs:

`    · Affliction:`
<img width="720" height="360" alt="aff_MP_law2_mp_global_comparison_figures-1" src="https://github.com/user-attachments/assets/d358dc57-2f2e-40d4-b403-6afcc903e44c" />

`    · Destruction:`
<img width="680" height="408" alt="dest_MP_hist_global" src="https://github.com/user-attachments/assets/cadb17e7-7b75-4142-82fa-5efee70c878a" />

- ECDF distance between procs:

`    · Affliction:`
<img width="720" height="360" alt="aff_MP_law2_mp_global_comparison_figures-2" src="https://github.com/user-attachments/assets/ba0a9c75-6441-4806-98d4-22bd9de1b762" />

`    · Destruction:`
<img width="680" height="408" alt="dest_MP_ecdf_global" src="https://github.com/user-attachments/assets/eaebf958-d6c7-4332-8a48-9b6d2a6b6623" />

- Hazard per attempt (probability of success on attempt n since the last attempt):

`    · Affliction:`
<img width="720" height="360" alt="aff_MP_law2_mp_global_comparison_figures-3" src="https://github.com/user-attachments/assets/0d61d4c6-e9f0-4c00-9651-32de5cb190a0" />

`    · Destruction:`
<img width="680" height="408" alt="dest_MP_hazard_global" src="https://github.com/user-attachments/assets/15024481-ee9b-4777-a8aa-8c4be6f46424" />

- Tail / survival of the distance between procs (log scale):

`    · Affliction:`
<img width="720" height="360" alt="aff_MP_law2_mp_global_comparison_figures-4" src="https://github.com/user-attachments/assets/eb0c5a38-d66e-4bbb-ba4c-a7d6920e3328" />

`    · Destruction:`
<img width="680" height="408" alt="dest_MP_survival_global" src="https://github.com/user-attachments/assets/d5513bf5-ddd6-4649-b363-4e81e058f7a1" />

# Seeds of Their Demise (Hellcaller)

Chance to gain **Shard Instability** (Affliction) / **Flashpoint** (Destruction) when **Blackened Soul** deals damage.

After analyzing multiple logs, both in Affliction and Destruction, using a variable number of targets (1T, 3T, 5T, and 9T), and varying the cadence of **Wither stack** gains and consumes, we confirmed that this RNG uses a Threshold accumulator, similar to the system used by **Agony energize** or **Nightfall proc**. This proc is somewhat more complex than those other procs because, in addition to scaling with the number of targets, it also scales with the number of **Wither stacks**. The accumulator increment appears to follow this formula: `rng().range( inc_max * ( std::pow( wither_stacks_before, -2.0 / 3.0 ) * std::pow( active_withers, -3.0 / 4.0 ) ) )` with an initial base `inc_max` value of `0.240`.

- `stacks_before` is used because, based on the result analysis, the data strongly favors using the number of stacks **Wither** had before the **Blackened Soul** damage event consumes a stack.
- `roll_over=true`: Although this parameter is difficult to distinguish in the samples, the result analysis favors `roll_over=true` over `roll_over=false`, and this also tends to match how Blizzard uses it in other similar threshold RNG procs.
- Although this proc was previously believed to have an ICD of ~10s or ~15s, this is simply a result of how this threshold accumulator currently behaves and how it scales with targets. There is currently nothing that seems to indicate that it has a real ICD.
- An attempt was made to analyze whether collapse windows have anything to do with this proc, whether the number of simultaneous collapses or the number of internal collapse stacks has any effect. The results seem to strongly favor that neither of them affects this proc, which appears to use the number of active **Withers** and the number of **Wither stacks**.
- Only a single global Threshold accumulator is used, shared across all **Wither** targets.
- Implemented as:
```cpp
double base_inc_max = rng_settings.seeds_of_their_demise.setting_value; // = 0.240
progress_rng.seeds_of_their_demise = get_threshold_rng( "seeds_of_their_demise", base_inc_max,
	[ this ]( double increment_max, action_state_t* s ) {
		assert( hero.wither.ok() );
		assert( s );
		auto tdata = get_target_data( s->target );
		assert( tdata );
		dot_t* wither_dot = tdata->dots.wither;
		assert( wither_dot && wither_dot->is_ticking() );
		const double stacks_before = wither_dot->current_stack() + 1.0;
		unsigned active_withers = get_active_dots( wither_dot );
		assert( active_withers > 0 );
		const double weight = std::pow( stacks_before, -2.0 / 3.0 ) * std::pow( active_withers, -3.0 / 4.0 );
		return rng().range( increment_max * weight );
	}, true, true );
```

- Histogram for the distance between procs across the different samples:
  - Affliction:

`      · 1T-v1 (aff):`
<img width="720" height="330" alt="aff-1t-vFast_event_gap_hist" src="https://github.com/user-attachments/assets/938c091c-9853-4235-877c-974da5005d4f" />

 `     · 1T-v2 (aff):`
<img width="720" height="330" alt="aff-1t-vSlow_event_gap_hist" src="https://github.com/user-attachments/assets/bc24d274-db9a-45c4-9730-fac0f781e5b6" />

`      · 3T-v1 (aff):`
<img width="720" height="330" alt="aff-3t-vFast_event_gap_hist" src="https://github.com/user-attachments/assets/1a873818-166a-4a20-8753-3b5f2d17d039" />

`      · 3T-v2 (aff):`
<img width="720" height="330" alt="aff-3t-vSlow_event_gap_hist" src="https://github.com/user-attachments/assets/f75998e5-de5b-46c9-83ed-7682def945a1" />

 `     · 5T-v1 (aff):`
<img width="720" height="336" alt="aff-5t-vFast_event_gap_hist_bw10" src="https://github.com/user-attachments/assets/739a73e2-8ba0-4cca-8eb9-76fce8325cc8" />

`      · 5T-v2 (aff):`
<img width="720" height="330" alt="aff-5t-vSlow_event_gap_hist" src="https://github.com/user-attachments/assets/a14f7e61-3b43-459f-9ae3-a618f1d8aea4" />

`      · 9T-v1 (aff):`
<img width="720" height="336" alt="aff-9t-vFast_event_gap_hist_bw20" src="https://github.com/user-attachments/assets/a9c68ff3-9092-4392-980c-7301eab7b23b" />

 `     · 9T-v2 (aff):`
<img width="720" height="336" alt="aff-9t-vSlow_event_gap_hist_bw5" src="https://github.com/user-attachments/assets/2c7640db-c0f0-4852-85ea-60f2ab94edad" />

  - Destruction:

 `     · 1T-v1 (dest):`
<img width="720" height="330" alt="destr-1t-vFast_event_gap_hist" src="https://github.com/user-attachments/assets/0257dc6f-4078-47ca-98c1-94729e90edef" />

 `     · 1T-v2 (dest):`
<img width="720" height="330" alt="destr-1t-vSlow_event_gap_hist" src="https://github.com/user-attachments/assets/5d5916fa-d392-4f22-87b1-428e605a62fd" />

`      · 3T-v1 (dest):`
<img width="720" height="330" alt="destr-3t-vFast_event_gap_hist" src="https://github.com/user-attachments/assets/bf7fe48f-09ad-424a-914c-c3517ec702f5" />

`      · 3T-v2 (dest):`
<img width="720" height="330" alt="destr-3t-vSlow_event_gap_hist" src="https://github.com/user-attachments/assets/1b619269-fb58-4d45-9d01-1280e3f9fd57" />

 `     · 5T-v1 (dest):`
<img width="720" height="330" alt="destr-5t-vFast_event_gap_hist" src="https://github.com/user-attachments/assets/364e7d81-1045-4d3e-90b0-aed24afcc68c" />

`      · 5T-v2 (dest):`
<img width="720" height="330" alt="destr-5t-vSlow_event_gap_hist" src="https://github.com/user-attachments/assets/4601d49a-ba8d-4305-b001-e90211e51345" />
