### PR TITLE
[Devourer] Model Voidfall building procs as a pseudo-random distribution

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1159,6 +1159,13 @@ public:
   {
   } shuffled_rng;
 
+  // Accumulated proc objects
+  struct accumulated_rngs_t
+  {
+    // Annihilator
+    accumulated_rng_t* voidfall = nullptr;
+  } accumulated_rng;
+
   // Special
   struct actives_t
   {
@@ -2959,14 +2966,12 @@ struct voidfall_building_trigger_t : public BASE
     if ( !BASE::dh()->talent.annihilator.voidfall->ok() )
       return;
 
-    if ( !BASE::rng().roll( BASE::dh()->talent.annihilator.voidfall->effectN( 3 ).percent() ) )
+    // can't build (or roll) while spending is up
+    if ( BASE::dh()->buff.voidfall_spending->up() )
       return;
 
-    // can't gain building while spending is up
-    if ( BASE::dh()->buff.voidfall_spending->up() )
-    {
+    if ( !BASE::dh()->accumulated_rng.voidfall->trigger() )
       return;
-    }
 
     BASE::dh()->proc.voidfall_from_builder->occur();
     BASE::dh()->buff.voidfall_building->trigger(
@@ -10441,6 +10446,10 @@ void demon_hunter_t::init_rng()
     default:
       break;
   }
+
+  // Accumulated proc objects
+  accumulated_rng.voidfall = get_accumulated_rng(
+      "voidfall", prd::find_constant( talent.annihilator.voidfall->effectN( 3 ).percent() ) );
 
   player_t::init_rng();
 }

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1163,7 +1163,7 @@ public:
   struct accumulated_rngs_t
   {
     // Annihilator
-    accumulated_rng_t* voidfall = nullptr;
+    accumulated_rng_t* voidfall;
   } accumulated_rng;
 
   // Special


### PR DESCRIPTION
Voidfall's building proc is currently a flat 35% roll. In game it's a pseudo-random distribution: the per-cast chance starts near 16% after a proc and climbs with each miss, averaging 35% and guaranteed by the 7th cast. This was checked against ~24k builder casts from logs (a controlled dummy plus ranked raids), where the per-attempt rate matches `C*N` with `C = prd::find_constant(0.35)`.

- Replace the flat roll in `voidfall_building_trigger_t` with `accumulated_rng`, the existing PRD primitive (same pattern as DK/mage/hunter), with `C` from `prd::find_constant` on the talent chance.
- Check `voidfall_spending` before the roll so the accumulator only advances on real builder attempts. The counter resets on a builder proc and does not advance during spending; guaranteed sources (Meteoric Rise, Mass Acceleration) trigger the buff directly and stay off the PRD.

DPS-neutral, since `find_constant` preserves the mean. Only the proc cadence is smoothed.

This closes: https://github.com/simulationcraft/simc/pull/11154