### PR TITLE
[Gear] Venomcursed effects

### DIFF
--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -3675,6 +3675,32 @@ void rotmires_sporeheart( special_effect_t& effect )
 }
 }  // namespace armors
 
+namespace items
+{
+// Venomcursed <stat>, shared effect appearing on weapons, armor, and jewelry
+// Crit    : driver 1307906 / buff 1307910
+// Mastery : driver 1307923 / buff 1307922
+// Haste   : driver 1307928 / buff 1307927
+// <stat> increased, other 3 secondaries decreased
+custom_cb_t venomcursed( unsigned buff_id, stat_e primary )
+{
+  return [ = ]( special_effect_t& effect ) {
+    auto main_value    = effect.driver()->effectN( 1 ).average( effect );
+    auto penalty_value = effect.driver()->effectN( 2 ).average( effect );
+
+    auto buff = create_buff<stat_buff_t>( effect.player, effect.player->find_spell( buff_id ) )
+      ->add_stat( primary, main_value );
+
+    for ( auto s : secondary_ratings )
+      if ( s != primary )
+        buff->add_stat( s, -penalty_value );
+
+    effect.custom_buff = buff;
+    new dbc_proc_callback_t( effect.player, effect );
+  };
+}
+}  // namespace items
+
 namespace sets
 {
 // 1244005 driver

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -3693,7 +3693,7 @@ custom_cb_t venomcursed( unsigned buff_id, stat_e primary )
 
     for ( auto s : secondary_ratings )
       if ( s != primary )
-        buff->add_stat( s, -penalty_value );
+        buff->add_stat( s, penalty_value );
 
     effect.custom_buff = buff;
     new dbc_proc_callback_t( effect.player, effect );

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -4362,6 +4362,12 @@ void register_special_effects()
   register_special_effect( 1285138, armors::sporecallers_blooming_loop );
   register_special_effect( 1285139, armors::rotmires_sporeheart );
   reset_version_check();
+  // Items
+  set_min_version( wowv_t( 12, 1, 0 ) );
+  register_special_effect( 1307906, items::venomcursed( 1307910, STAT_CRIT_RATING ) );    // venomcursed critical strike
+  register_special_effect( 1307923, items::venomcursed( 1307922, STAT_MASTERY_RATING ) );  // venomcursed mastery
+  register_special_effect( 1307928, items::venomcursed( 1307927, STAT_HASTE_RATING ) );    // venomcursed haste
+  reset_version_check();
   // Sets
   register_special_effect( 1281574, sets::voidlight_bindings );
   register_special_effect( 1281581, DISABLED_EFFECT );  // voidlight bindings equip effect


### PR DESCRIPTION
The corresponding bonus id for each buffed stat seems to be necessary to be on the item when simming for the effects to be detected. The venomcursed items themselves, don't seem to inherently have the effects.

Made `namespace items` since it felt awkward to put in any existing category.