### PR TITLE
[Devourer] Tune Void Metamorphosis fury drain constants

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -12226,14 +12226,14 @@ double demon_hunter_t::fury_state_t::fury_drain_per_second( int stacks ) const
 
   if ( has_reduced_drain )
   {
-    // Guess
-    drain *= 0.15;
+    // Reduced while casting Collapsing Star / channeling Void Ray. Measured ~0.127 from logs.
+    drain *= 0.127;
   }
 
   if ( drain_stacks < 1 )
   {
-    // Slow after meta cast
-    drain = 15;
+    // Slow first second after meta cast. Measured ~10/s from logs.
+    drain = 10;
   }
 
   return drain;

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1415,9 +1415,11 @@ public:
     int drain_stacks;
     demon_hunter_t* actor;
     double meta_drain_multiplier = 1.0;
+    // Fit against per-tick drain event schedules from logs (matches cumulative drain
+    // timing through end of meta, not just instantaneous rates); see PR #11549.
     double initial_drain         = 15.0;
-    double exp_factor            = 1.455;
-    double exp_power             = 0.075;
+    double exp_factor            = 1.40;
+    double exp_power             = 0.0775;
 
     fury_state_t( demon_hunter_t* a )
       : start_time( timespan_t::min() ), next_drain_event( nullptr ), drain_stacks( 0 ), actor( a )


### PR DESCRIPTION
Measured the in-meta fury drain constants in `fury_state_t::fury_drain_per_second` against WCL. The drain logs each 2 fury as a resource-change event under spell 473671, so both the instantaneous rate (2 divided by the time between ticks) and the full cumulative drain-event schedule are directly observable. Pulled ~100 current Devourer raid logs, 210 metas (Soul Glutton excluded).

Three values were off:

- First second after entering Void Metamorphosis drains 10/s, not 15 (the `drain_stacks < 1` floor).
- Reduced drain while casting Collapsing Star or channeling Void Ray is 0.127x, not 0.15x.
- The curve tail is slightly steeper than `15 + 1.455 * exp(0.075 * s)`. With only the two changes above, replaying SimC's drain scheduler through each logged meta (against that meta's actual Collapsing Star / Void Ray windows) tracks in-game cumulative drain counts mid-meta but falls ~9 drain events (~18 fury) behind by meta end, so sim metas would run ~0.3s long. Refit against the cumulative schedules: `15 + 1.40 * exp(0.0775 * s)` matches in-game cumulative drain events within +-2 at every checkpoint including meta end.

For reference, the old constants (15/s first second, 0.15x reduced, 1.455/0.075 curve) do not match the in-game timeline either: they run 4-9 drain events ahead through mid-meta and only land near the correct end time because the too-shallow tail cancels the too-hot early drain.

Structure checks from the same logs: the acceleration steps once per second exactly like `drain_stacks` (the within-second rate pattern is flat, not continuous-time), the quantum is exactly -2 per event, and Soul Glutton's 1.333x multiplier matches. Coverage past ~52s in meta is thin (few logged metas survive that long), so the tail beyond that is the fit's extrapolation.