### PR TITLE
[monk] Use Profileset Controller to validate talents

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -7365,7 +7365,7 @@ const std::string valid_talents_t::name() const
 
 bool valid_talents_t::evaluate_post_init()
 {
-  if ( !player )
+  if ( !player || sim->enable_all_talents )
     return true;
 
   switch ( player->specialization() )
@@ -7388,8 +7388,8 @@ bool valid_talents_t::evaluate_post_init()
         count -= 1;
         if ( count == this->count )
           return true;
-        return false;
       }
+      return false;
     default:
       break;
   }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -2224,7 +2224,7 @@ struct auto_attack_t : public monk_melee_attack_t
     action_t *damage;
 
     template <typename... Args>
-    thunderfist_t( monk_t *player, Args &&...args ) : TBase( player, std::forward<Args>( args )... )
+    thunderfist_t( monk_t *player, Args &&...args ) : TBase( player, std::forward<Args>( args )... ), damage( nullptr )
     {
       if ( !player->talent.windwalker.thunderfist->ok() )
         return;

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -5527,7 +5527,7 @@ bool monk_t::validate_actor()
 
       // Report without counting the hidden talent that activates the subtree
       count -= 1;
-      if ( count < expected )
+      if ( count < expected && count != 0 )
       {
         sim->error( SEVERE, "Invalid Hero Talent tree, possibly low level. Found {} talents, expected {}.", count,
                     expected );
@@ -7365,6 +7365,27 @@ const std::string valid_talents_t::name() const
   return "valid_talents";
 }
 
+std::function<bool( std::tuple<talent_tree, unsigned, unsigned> )> matching_talent( player_t *player,
+                                                                                    unsigned hero_tree )
+{
+  return [ = ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
+    if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
+      return false;
+    const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), player->is_ptr() );
+    if ( !trait )
+      return false;
+    return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
+  };
+}
+
+std::function<unsigned( unsigned )> has_expected_count( player_t *player, unsigned expected_count )
+{
+  return [ = ]( unsigned hero_tree ) {
+    unsigned count = range::count_if( player->player_traits, matching_talent( player, hero_tree ) );
+    return count > expected_count;
+  };
+}
+
 bool valid_talents_t::evaluate_post_init()
 {
   if ( !player || sim->enable_all_talents )
@@ -7374,24 +7395,7 @@ bool valid_talents_t::evaluate_post_init()
   {
     case MONK_BREWMASTER:
     case MONK_WINDWALKER:
-      for ( const auto &hero_tree : player->player_sub_trees )
-      {
-        auto count = as<unsigned int>( range::count_if(
-            player->player_traits,
-            [ is_ptr = player->is_ptr(), hero_tree ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
-              if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
-                return false;
-              const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), is_ptr );
-              if ( !trait )
-                return false;
-              return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
-            } ) );
-        // Report without counting the hidden talent that activates the subtree
-        count -= 1;
-        if ( count == this->count )
-          return true;
-      }
-      return false;
+      return range::all_of( player->player_sub_trees, has_expected_count( player, count ) );
     default:
       break;
   }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -7024,7 +7024,7 @@ void monk_t::init_finished()
   parse_player_effects();
 
   profileset_controller_t::register_controller(
-      "valid_talents", profileset_controller::create_fn_pair<profileset_control::valid_talents_t>() );
+      sim, "valid_talents", profileset_controller::create_fn_pair<profileset_control::valid_talents_t>() );
   std::vector<std::string> rhs = { fmt::format( "player={},count=13", name() ) };
   sim->profileset_controller_options.emplace( "valid_talents", rhs );
 }

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -41,6 +41,7 @@ WINDWALKER:
 #include "report/charts.hpp"
 #include "report/highchart.hpp"
 #include "sc_enums.hpp"
+#include "sim/profileset_control.hpp"
 
 #include <deque>
 
@@ -5509,28 +5510,28 @@ bool monk_t::validate_actor()
     return false;
   }
 
-  int expected = 13;
-  for ( const auto &hero_tree : player_sub_trees )
-  {
-    int count = as<int>( range::count_if(
-        player_traits, [ is_ptr = is_ptr(), hero_tree ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
-          if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
-            return false;
-          const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), is_ptr );
-          if ( !trait )
-            return false;
-          return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
-        } ) );
+  // int expected = 13;
+  // for ( const auto &hero_tree : player_sub_trees )
+  // {
+  //   int count = as<int>( range::count_if(
+  //       player_traits, [ is_ptr = is_ptr(), hero_tree ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
+  //         if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
+  //           return false;
+  //         const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), is_ptr );
+  //         if ( !trait )
+  //           return false;
+  //         return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
+  //       } ) );
 
-    // Report without counting the hidden talent that activates the subtree
-    count -= 1;
-    if ( count < expected )
-    {
-      sim->error( SEVERE, "Invalid Hero Talent tree, possibly low level. Found {} talents, expected {}.", count,
-                  expected );
-      return false;
-    }
-  }
+  //   // Report without counting the hidden talent that activates the subtree
+  //   count -= 1;
+  //   if ( count < expected )
+  //   {
+  //     sim->error( SEVERE, "Invalid Hero Talent tree, possibly low level. Found {} talents, expected {}.", count,
+  //                 expected );
+  //     return false;
+  //   }
+  // }
 
   switch ( specialization() )
   {
@@ -7018,6 +7019,12 @@ void monk_t::init_finished()
 {
   base_t::init_finished();
   parse_player_effects();
+
+  profileset_controller_t::register_controller(
+      "valid_talents", profileset_controller::create_fn_pair<profileset_control::valid_talents_t>() );
+  std::vector<std::string> rhs;
+  rhs.push_back( fmt::format( "player={},count=13", name() ) );
+  sim->profileset_controller_options.emplace( "valid_talents", rhs );
 }
 
 void monk_t::reset()
@@ -7344,6 +7351,76 @@ void monk_t::create_actions()
   base_t::create_actions();
   buff.aspect_of_harmony.construct_actions( this );
 }
+
+namespace profileset_control
+{
+valid_talents_t::valid_talents_t( sim_t *sim, unsigned int id ) : profileset_controller_t( sim, id )
+{
+}
+
+const std::string valid_talents_t::name() const
+{
+  return "valid_talents";
+}
+
+bool valid_talents_t::evaluate_post_init()
+{
+  if ( !player )
+    return true;
+
+  switch ( player->specialization() )
+  {
+    case MONK_BREWMASTER:
+    case MONK_WINDWALKER:
+      for ( const auto &hero_tree : player->player_sub_trees )
+      {
+        auto count = as<unsigned int>( range::count_if(
+            player->player_traits,
+            [ is_ptr = player->is_ptr(), hero_tree ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
+              if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
+                return false;
+              const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), is_ptr );
+              if ( !trait )
+                return false;
+              return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
+            } ) );
+        // Report without counting the hidden talent that activates the subtree
+        count -= 1;
+        if ( count == this->count )
+          return true;
+        return false;
+      }
+    default:
+      break;
+  }
+
+  return true;
+}
+
+const std::string valid_talents_t::reason() const
+{
+  return fmt::format( "player {} does not have {} talents selected in hero tree", player->name(), count );
+}
+
+void valid_talents_t::create_options()
+{
+  add_option( opt_func( "count", [ this ]( sim_t *, util::string_view, util::string_view value ) {
+    this->count = util::to_unsigned( value );
+    return true;
+  } ) );
+  add_option( opt_func( "player", [ this ]( sim_t *sim, util::string_view, util::string_view value ) {
+    for ( auto &player : sim->player_list )
+    {
+      if ( util::str_compare_ci( player->name(), value ) )
+      {
+        this->player = player;
+        return true;
+      }
+    }
+    return false;
+  } ) );
+}
+}  // namespace profileset_control
 
 std::unique_ptr<expr_t> monk_t::create_expression( std::string_view name_str )
 {

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -5510,28 +5510,31 @@ bool monk_t::validate_actor()
     return false;
   }
 
-  // int expected = 13;
-  // for ( const auto &hero_tree : player_sub_trees )
-  // {
-  //   int count = as<int>( range::count_if(
-  //       player_traits, [ is_ptr = is_ptr(), hero_tree ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
-  //         if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
-  //           return false;
-  //         const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), is_ptr );
-  //         if ( !trait )
-  //           return false;
-  //         return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
-  //       } ) );
+  if ( !sim->parent && !sim->profileset_enabled )
+  {
+    int expected = 13;
+    for ( const auto &hero_tree : player_sub_trees )
+    {
+      int count = as<int>( range::count_if(
+          player_traits, [ is_ptr = is_ptr(), hero_tree ]( std::tuple<talent_tree, unsigned, unsigned> entry ) {
+            if ( std::get<talent_tree>( entry ) != talent_tree::HERO )
+              return false;
+            const trait_data_t *trait = trait_data_t::find( std::get<1>( entry ), is_ptr );
+            if ( !trait )
+              return false;
+            return static_cast<hero_tree_e>( trait->id_sub_tree ) == hero_tree;
+          } ) );
 
-  //   // Report without counting the hidden talent that activates the subtree
-  //   count -= 1;
-  //   if ( count < expected )
-  //   {
-  //     sim->error( SEVERE, "Invalid Hero Talent tree, possibly low level. Found {} talents, expected {}.", count,
-  //                 expected );
-  //     return false;
-  //   }
-  // }
+      // Report without counting the hidden talent that activates the subtree
+      count -= 1;
+      if ( count < expected )
+      {
+        sim->error( SEVERE, "Invalid Hero Talent tree, possibly low level. Found {} talents, expected {}.", count,
+                    expected );
+        return false;
+      }
+    }
+  }
 
   switch ( specialization() )
   {
@@ -7022,8 +7025,7 @@ void monk_t::init_finished()
 
   profileset_controller_t::register_controller(
       "valid_talents", profileset_controller::create_fn_pair<profileset_control::valid_talents_t>() );
-  std::vector<std::string> rhs;
-  rhs.push_back( fmt::format( "player={},count=13", name() ) );
+  std::vector<std::string> rhs = { fmt::format( "player={},count=13", name() ) };
   sim->profileset_controller_options.emplace( "valid_talents", rhs );
 }
 

--- a/engine/class_modules/monk/sc_monk.hpp
+++ b/engine/class_modules/monk/sc_monk.hpp
@@ -16,6 +16,7 @@
 #include "sc_enums.hpp"
 #include "sc_stagger.hpp"
 #include "sim/proc.hpp"
+#include "sim/profileset_control.hpp"
 #include "util/timeline.hpp"
 
 #include <array>
@@ -1215,6 +1216,24 @@ public:
   // Actions
   void trigger_celestial_fortune( action_state_t * );
 };
+
+namespace profileset_control
+{
+struct valid_talents_t : profileset_controller_t
+{
+  using data_t = profileset_controller_data_t;
+
+  player_t *player;
+  unsigned int count;
+
+  valid_talents_t( sim_t *sim, unsigned int id );
+
+  const std::string name() const override;
+  bool evaluate_post_init() override;
+  const std::string reason() const override;
+  void create_options() override;
+};
+}  // namespace profileset_control
 
 namespace events
 {

--- a/engine/sim/profileset.cpp
+++ b/engine/sim/profileset.cpp
@@ -403,7 +403,7 @@ void worker_t::execute()
 {
   try
   {
-    m_sim = new sim_t( m_parent, 0, m_profileset->options() );
+    m_sim = new sim_t( m_parent, 0, m_profileset->options(), m_profileset->name() );
 
     simulate_profileset( m_parent, *m_profileset, m_sim );
   }
@@ -501,7 +501,7 @@ void profilesets_t::generate_work( sim_t* parent, std::unique_ptr<profile_set_t>
 
     try
     {
-      sim_t* profile_sim = new sim_t( parent );
+      sim_t* profile_sim = new sim_t( parent, 0, ptr_set->name() );
 
       parent->control = original_opts;
       simulate_profileset( parent, *ptr_set, profile_sim );

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -107,7 +107,7 @@ bool profileset_controller_t::register_controller( std::string key, profileset_c
 {
   if ( factory.find( key ) != factory.end() )
     return false;
-  factory.emplace( key, std::move( value ) );
+  factory.emplace( key, value );
   return true;
 }
 

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -105,10 +105,8 @@ void profileset_controller_data_wrapper_t::construct_controller( sim_t* sim )
 
 bool profileset_controller_t::register_controller( std::string key, profileset_controller_t::factory_fn_pair_t&& value )
 {
-  if ( factory.find( key ) == factory.end() )
-    return false;
-  factory.emplace( key, std::move( value ) );
-  return true;
+  const auto val = factory.try_emplace( key, std::move( value ) );
+  return val.second;
 }
 
 bool profileset_controller_t::controller_exists( std::string key )

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -8,9 +8,6 @@
 #include "sc_enums.hpp"
 #include "sim.hpp"
 
-std::unordered_map<std::string, profileset_controller_t::factory_fn_pair_t> profileset_controller_t::factory = {
-    { "set_bonus_enabled", profileset_controller::create_fn_pair<set_bonus_enabled_t>() } };
-
 std::atomic_uint profileset_controller_data_wrapper_t::id_generator;
 
 profileset_controller_data_t::profileset_controller_data_t( std::string_view key, std::string_view options )
@@ -70,18 +67,14 @@ void profileset_controller_data_t::report_json_profileset( js::JsonOutput& root 
 }
 
 profileset_controller_data_wrapper_t::profileset_controller_data_wrapper_t( std::string key, std::string_view options )
-  : mutex(), id( id_generator++ ), key( key ), options( options )
+  : mutex(), id( id_generator++ ), key( key ), options( options ), data()
 {
-  if ( const auto& value = profileset_controller_t::factory.find( key );
-       value != profileset_controller_t::factory.end() )
-    data = value->second.second( key, options );
-  assert( data );
 }
 
 void profileset_controller_data_wrapper_t::construct_controller( sim_t* sim )
 {
-  if ( const auto& value = profileset_controller_t::factory.find( key );
-       value != profileset_controller_t::factory.end() )
+  if ( const auto& value = sim->profileset_controller_factory.find( key );
+       value != sim->profileset_controller_factory.end() )
   {
     auto controller = value->second.first( sim, id );
     controller->create_options();
@@ -97,23 +90,27 @@ void profileset_controller_data_wrapper_t::construct_controller( sim_t* sim )
                          key, name, value );
                    return status;
                  } );
+
+    data = value->second.second( key, options );
+
     sim->profileset_controller.emplace_back( std::move( controller ) );
     return;
   }
   assert( false && "No factory fn for key found." );
 }
 
-bool profileset_controller_t::register_controller( std::string key, profileset_controller_t::factory_fn_pair_t&& value )
+bool profileset_controller_t::register_controller( sim_t* sim, std::string key,
+                                                   profileset_controller_t::factory_fn_pair_t&& value )
 {
-  if ( factory.find( key ) != factory.end() )
+  if ( sim->profileset_controller_factory.find( key ) != sim->profileset_controller_factory.end() )
     return false;
-  factory.emplace( key, value );
+  sim->profileset_controller_factory.emplace( key, value );
   return true;
 }
 
-bool profileset_controller_t::controller_exists( std::string key )
+bool profileset_controller_t::controller_exists( sim_t* sim, std::string key )
 {
-  return factory.find( key ) != factory.end();
+  return sim->profileset_controller_factory.find( key ) != sim->profileset_controller_factory.end();
 }
 
 void profileset_controller_t::evaluate( sim_t* sim, call_point_e call_point )
@@ -142,8 +139,7 @@ void profileset_controller_t::evaluate( sim_t* sim, call_point_e call_point )
   assert( controller->sim == sim );
   assert( controller->parent == sim->parent );
 
-  controller->set_exit_reason(
-      { sim->profileset_name, call_point, controller->reason() } );
+  controller->set_exit_reason( { sim->profileset_name, call_point, controller->reason() } );
 
   sim->canceled = true;
   sim->error( error_level_e::TRIVIAL, "{}", controller->message( call_point ) );
@@ -164,8 +160,7 @@ profileset_controller_t::profileset_controller_t( sim_t* sim, unsigned int id )
 const std::string profileset_controller_t::message( call_point_e call_point )
 {
   std::string msg = fmt::format( "Profileset {} was canceled by Profileset Controller {} after {}",
-                                 sim->profileset_name, name(),
-                                 profileset_controller::call_point_string( call_point ) );
+                                 sim->profileset_name, name(), profileset_controller::call_point_string( call_point ) );
   if ( call_point == POST_ITER )
     msg += std::to_string( sim->current_iteration );
 

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -105,7 +105,7 @@ void profileset_controller_data_wrapper_t::construct_controller( sim_t* sim )
 
 bool profileset_controller_t::register_controller( std::string key, profileset_controller_t::factory_fn_pair_t&& value )
 {
-  if ( factory.find( key ) == factory.end() )
+  if ( factory.find( key ) != factory.end() )
     return false;
   factory.emplace( key, std::move( value ) );
   return true;

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -105,8 +105,10 @@ void profileset_controller_data_wrapper_t::construct_controller( sim_t* sim )
 
 bool profileset_controller_t::register_controller( std::string key, profileset_controller_t::factory_fn_pair_t&& value )
 {
-  const auto val = factory.try_emplace( key, std::move( value ) );
-  return val.second;
+  if ( factory.find( key ) == factory.end() )
+    return false;
+  factory.emplace( key, std::move( value ) );
+  return true;
 }
 
 bool profileset_controller_t::controller_exists( std::string key )

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -140,7 +140,7 @@ void profileset_controller_t::evaluate( sim_t* sim, call_point_e call_point )
   assert( controller->parent == sim->parent );
 
   controller->set_exit_reason(
-      { sim->parent->profilesets->current_profileset_name(), call_point, controller->reason() } );
+      { sim->profileset_name, call_point, controller->reason() } );
 
   sim->canceled = true;
   sim->error( error_level_e::TRIVIAL, "{}", controller->message( call_point ) );
@@ -161,7 +161,7 @@ profileset_controller_t::profileset_controller_t( sim_t* sim, unsigned int id )
 const std::string profileset_controller_t::message( call_point_e call_point )
 {
   std::string msg = fmt::format( "Profileset {} was canceled by Profileset Controller {} after {}",
-                                 parent->profilesets->current_profileset_name(), name(),
+                                 sim->profileset_name, name(),
                                  profileset_controller::call_point_string( call_point ) );
   if ( call_point == POST_ITER )
     msg += std::to_string( sim->current_iteration );

--- a/engine/sim/profileset_control.cpp
+++ b/engine/sim/profileset_control.cpp
@@ -105,7 +105,10 @@ void profileset_controller_data_wrapper_t::construct_controller( sim_t* sim )
 
 bool profileset_controller_t::register_controller( std::string key, profileset_controller_t::factory_fn_pair_t&& value )
 {
-  return factory.try_emplace( key, std::move( value ) ).second;
+  if ( factory.find( key ) == factory.end() )
+    return false;
+  factory.emplace( key, std::move( value ) );
+  return true;
 }
 
 bool profileset_controller_t::controller_exists( std::string key )

--- a/engine/sim/profileset_control.hpp
+++ b/engine/sim/profileset_control.hpp
@@ -34,7 +34,7 @@ public:
 
 struct exit_reason_t
 {
-  const std::string profileset_name;
+  const std::string_view profileset_name;
   const call_point_e exit_point;
   const std::string exit_reason;
 };

--- a/engine/sim/profileset_control.hpp
+++ b/engine/sim/profileset_control.hpp
@@ -81,11 +81,10 @@ struct profileset_controller_t : private noncopyable
 
 protected:
   friend profileset_controller_data_wrapper_t;
-  static std::unordered_map<std::string, factory_fn_pair_t> factory;
 
 public:
-  static bool register_controller( std::string, factory_fn_pair_t&& );
-  static bool controller_exists( std::string );
+  static bool register_controller( sim_t* sim, std::string, factory_fn_pair_t&& );
+  static bool controller_exists( sim_t* sim, std::string );
 
   using data_t = profileset_controller_data_t;
   static void evaluate( sim_t* sim, call_point_e call_point );

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -1551,6 +1551,8 @@ sim_t::sim_t()
     count_overheal_as_heal( false ),
     scaling_normalized( 1.0 ),
     merge_enemy_priority_dmg( false ),
+    profileset_controller_factory(
+        { { "set_bonus_enabled", profileset_controller::create_fn_pair<set_bonus_enabled_t>() } } ),
     profileset_controller(),
     profileset_controller_data(),
     // Multi-Threading
@@ -2899,7 +2901,7 @@ void sim_t::init()
   {
     for ( const auto& [ key, values ] : profileset_controller_options )
     {
-      if ( profileset_controller_t::controller_exists( key ) )
+      if ( profileset_controller_t::controller_exists( this, key ) )
         for ( const auto& value : values )
           profileset_controller_data.emplace_back( key, value );
       else

--- a/engine/sim/sim.cpp
+++ b/engine/sim/sim.cpp
@@ -1579,7 +1579,8 @@ sim_t::sim_t()
     profileset_enabled( false ),
     profileset_work_threads( 0 ),
     profileset_init_threads( 1 ),
-    profilesets( std::make_unique<profileset::profilesets_t>() )
+    profilesets( std::make_unique<profileset::profilesets_t>() ),
+    profileset_name()
 {
   item_db_sources.assign( std::begin( default_item_db_sources ), std::end( default_item_db_sources ) );
 
@@ -1592,9 +1593,12 @@ sim_t::sim_t()
   profileset::create_options( this );
 }
 
-sim_t::sim_t( sim_t* p, int index ) : sim_t()
+sim_t::sim_t( sim_t* p, int index, std::string_view profileset_name )
+  : sim_t()
 {
   assert( p );
+
+  this->profileset_name = profileset_name;
 
   parent = p;
   thread_index = index;
@@ -1619,9 +1623,12 @@ sim_t::sim_t( sim_t* p, int index ) : sim_t()
   parent -> add_relative( this );
 }
 
-sim_t::sim_t( sim_t* p, int index, sim_control_t* control ) : sim_t()
+sim_t::sim_t( sim_t* p, int index, sim_control_t* control, std::string_view profileset_name )
+  : sim_t()
 {
   assert( p && control );
+
+  this->profileset_name = profileset_name;
 
   parent = p;
   thread_index = index;
@@ -3387,7 +3394,7 @@ void sim_t::partition()
 
   for ( int i = 0; i < num_children; i++ )
   {
-    auto  child = new sim_t( this, i + 1, child_control );
+    auto  child = new sim_t( this, i + 1, child_control, child_control->combat.name );
 
     assert( child );
     children.push_back( child );

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -585,6 +585,7 @@ struct sim_t : private sc_thread_t
   bool merge_enemy_priority_dmg;
 
   // sim control
+  std::unordered_map<std::string, profileset_controller_t::factory_fn_pair_t> profileset_controller_factory;
   std::vector<std::unique_ptr<profileset_controller_t>> profileset_controller;
   std::deque<profileset_controller_data_wrapper_t> profileset_controller_data;
   opts::map_list_t profileset_controller_options;

--- a/engine/sim/sim.hpp
+++ b/engine/sim/sim.hpp
@@ -651,10 +651,11 @@ struct sim_t : private sc_thread_t
   bool profileset_enabled;
   int profileset_work_threads, profileset_init_threads;
   std::unique_ptr<profileset::profilesets_t> profilesets;
+  std::string_view profileset_name;
 
   sim_t();
-  explicit sim_t( sim_t* parent, int thread_index = 0 );
-  sim_t( sim_t* parent, int thread_index, sim_control_t* control );
+  explicit sim_t( sim_t* parent, int thread_index = 0, std::string_view profileset_name = {} );
+  sim_t( sim_t* parent, int thread_index, sim_control_t* control, std::string_view profileset_name = {} );
   ~sim_t() override;
 
   void run() override;


### PR DESCRIPTION
- **[monk] Use a profileset controller to gracefully handle profilesets that include impermissible Monk hero talent configurations.**
- **[profileset_control] Fix a deadlock caused when `profileset_work_threads` is set to a value greater than 1 and cancellations occur at similar times.**
- **[monk] Allow `valid_talents` to permit sims using `enable_all_talents` option.**
- **[monk] Allow talent verification to occur for non-profileset sims.**
