### PR TITLE
[Warlock] Apply Nightfall Seed of Corruption detonation hotfix

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1864,10 +1864,18 @@ using namespace helpers;
 
       const auto& tl = target_list();
       player_t* main_seed_target = !tl.empty() ? tl.front() : target;
+      warlock_td_t* mstdata = td( main_seed_target );
 
       // Patient Zero target is updated on SoC cast success, not on impact or debuff application
       if ( p()->talents.patient_zero.ok() )
         p()->patient_zero_target = main_seed_target;
+
+      // 2026-06-30 Hotfix: Nightfall SoC detonates existing SoC when smart targeting leaves the primary seed on an already seeded target
+      if ( p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() && mstdata->dots.seed_of_corruption->is_ticking() && mstdata->soc_threshold > 0 )
+      {
+        mstdata->soc_threshold = 0;
+        mstdata->dots.seed_of_corruption->cancel();
+      }
 
       warlock_spell_t::execute();
 


### PR DESCRIPTION
Blizzard implemented the following hotfix on 2026-06-30:

> Consuming Nightfall with Seed of Corruption on a target already afflicted with Seed of Corruption will cause the preexisting Seed of Corruption to detonate

Although it is listed under PvP fixes, it seems to apply in PvE environments as well. This PR implements this hotfix.

Based on testing, this hotfix is not just triggered by casting **Seed of Corruption** on a target that already has **Seed of Corruption** while **Nightfall** is active. It is also a requirement that the main seed of **Seed of Corruption** be directed at a target that already has a seed (so the rules of how smart-targeting works matter here).

The hotfix appears to work as follows:
- It applies when **Seed of Corruption** is cast with **Nightfall** active and the primary seed ends up on a target that already has an active **Seed of Corruption** debuff.
- If smart-targeting redirects the primary seed to a nearby target without **Seed of Corruption**, the existing seed on the original target does not detonate.
- If no valid seed-free target exists and smart-targeting leaves the primary seed on a target that already has **Seed of Corruption**, the preexisting seed on that target detonates early.
- The detonation happens on **SoC** cast finish, before the newly cast seed reaches and applies to the target.
- This does not cover seeds that are in flight/travel and have not applied their debuff yet. So, sadly, this hotfix does not solve the case where you get the **Nightfall** buff while casting **SoC** and end up casting two **SoC** in a row, losing one of them.
- With **Sow the Seeds**, only the behavior of primary seed matters for this hotfix. Secondary seeds do not affect whether the hotfix detonation occurs.
- This detonation hotfix only applies to **Seed of Corruption** casts made with **Nightfall** active.
- The hotfix detonation behavior also happens if **Nightfall** is gained during the **Seed of Corruption** cast. In that case, the cast benefits from the **Nightfall** cost reduction but does not consume the **Nightfall** buff, while still triggering this detonation hotfix if the targeting conditions are met.