### PR TITLE
[Devourer] Fix Eradicate AoE soft cap reading the wrong effect

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5958,7 +5958,7 @@ struct eradicate_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
 
     damage_action      = p->get_background_action<eradicate_damage_t>( "eradicate_reap", p->spec.eradicate_damage );
     damage_action->aoe = -1;
-    damage_action->reduced_aoe_targets = p->spec.eradicate->effectN( 1 ).base_value();
+    damage_action->reduced_aoe_targets = p->talent.devourer.eradicate->effectN( 1 ).base_value();
     add_child( damage_action );
 
     if ( p->talent.devourer.void_metamorphosis->ok() )
@@ -5966,7 +5966,7 @@ struct eradicate_t : public voidfall_spending_trigger_t<meteoric_fall_trigger_t<
       damage_action_meta =
           p->get_background_action<eradicate_damage_t>( "eradicate_cull", p->spec.eradicate_damage_meta );
       damage_action_meta->aoe                 = -1;
-      damage_action_meta->reduced_aoe_targets = p->spec.eradicate->effectN( 1 ).base_value();
+      damage_action_meta->reduced_aoe_targets = p->talent.devourer.eradicate->effectN( 1 ).base_value();
       add_child( damage_action_meta );
     }
 


### PR DESCRIPTION
Eradicate's `reduced_aoe_targets` was set from effect #1 of the active spell (1225826), which is the secondary damage percent (100), so the soft cap never applied and per-target damage stayed flat at any target count. The tooltip caps damage beyond $1226033s1 = 5 targets, i.e. effect #1 of the talent spell.

With the fix, per-target hit damage at 10 targets drops to ~0.72x of the 5-target value (expected sqrt(5/10) ≈ 0.71), for both `eradicate_reap` and `eradicate_cull`.