### PR TITLE
[Gear] Rotmire's Sporeheart is not split aoe damage

### DIFF
--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -3715,10 +3715,10 @@ void rotmires_sporeheart( special_effect_t& effect )
     protective_toadstool_buff_t( const special_effect_t& e )
       : absorb_buff_t( e.player, "protective_toadstools", e.player->find_spell( 1285161 ) )
     {
-      damage = create_proc_action<generic_aoe_proc_t>( "bursting_toadstools", e, 1285163 );
+      damage = create_proc_action<generic_proc_t>( "bursting_toadstools", e, 1285163 );
       damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 3 ).average( e );
       damage->base_multiplier *= role_mult( e );
-      damage->split_aoe_damage = false;
+      damage->aoe = -1;
 
       set_default_value( e.driver()->effectN( 2 ).average( e ) );
     }

--- a/engine/player/unique_gear_midnight.cpp
+++ b/engine/player/unique_gear_midnight.cpp
@@ -3705,7 +3705,6 @@ void sporecallers_blooming_loop( special_effect_t& effect )
 void rotmires_sporeheart( special_effect_t& effect )
 {
   effect.player->sim->error( UNVERIFIED_IMPLEMENTATION,
-    "Rotmire's Sporeheart: Damage is assumed to split and increase by 15% per target hit. "
     "Shield is assumed to apply immediately and will only burst when depleted by incoming damage. "
     "What types of triggers can proc the shield has not been verified." );
 
@@ -3719,6 +3718,7 @@ void rotmires_sporeheart( special_effect_t& effect )
       damage = create_proc_action<generic_aoe_proc_t>( "bursting_toadstools", e, 1285163 );
       damage->base_dd_min = damage->base_dd_max = e.driver()->effectN( 3 ).average( e );
       damage->base_multiplier *= role_mult( e );
+      damage->split_aoe_damage = false;
 
       set_default_value( e.driver()->effectN( 2 ).average( e ) );
     }


### PR DESCRIPTION
https://www.warcraftlogs.com/reports/XpkLYjKr13m9TF4C?fight=1&type=damage-done&source=5&pins=2%24Separate%24%23244F4B%24damage%240%240.0.0.Any%24207714534.0.0.Paladin%24true%240.0.0.Any%24false%24-1285139&view=events

see single target hits (11:45.447, 11:47.449, 11:49.440) dealing the same damage as huge aoe hits (00:37.61, 22 targets)