### PR TITLE
[Warlock] Implement 12.1 updates and mechanic refinements

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -12,7 +12,12 @@ namespace warlock
 {
 
 warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
-  : actor_target_data_t( target, &p ), soc_threshold( 0.0 ), warlock( p )
+  : actor_target_data_t( target, &p ),
+    soc_threshold( 0.0 ),
+    ua_regular_stacks( 0 ),
+    ua_seed_stacks( 0 ),
+    ua_seed_gap( false ),
+    warlock( p )
 {
   // Shared
   dots.drain_life = target->get_dot( "drain_life", &p );
@@ -64,6 +69,12 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
 
   debuffs.shadowburn = make_buff( *this, "shadowburn", p.talents.shadowburn )
                            ->set_default_value( p.talents.shadowburn_2->effectN( 1 ).base_value() / 10 );
+
+  if ( p.sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+  {
+    debuffs.dark_titans_mark = make_buff( *this, "dark_titans_mark", p.tier.dark_titans_mark_debuff )
+                                   ->set_default_value_from_effect( 1 );
+  }
 
   // Use havoc_debuff where we need the data but don't have the active talent
   // Mayhem proc chance follows a Flat % RNG model, but has ICD
@@ -127,6 +138,49 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
   dots.shared_fate = target->get_dot( "shared_fate", &p );
 
   target->register_on_demise_callback( &p, [ this ]( player_t* ) { target_demise(); } );
+}
+
+void warlock_td_t::ua_stack_applied( bool is_seed_ua )
+{
+  if ( is_seed_ua )
+  {
+    ua_seed_stacks++;
+    ua_seed_gap = true;
+  }
+  else
+  {
+    ua_regular_stacks++;
+  }
+}
+
+void warlock_td_t::ua_stack_expired( bool is_seed_ua )
+{
+  if ( is_seed_ua )
+  {
+    assert( ua_seed_stacks > 0 );
+    ua_seed_stacks--;
+    ua_seed_gap = false;
+  }
+  else
+  {
+    assert( ua_regular_stacks > 0 );
+    ua_regular_stacks--;
+  }
+}
+
+void warlock_td_t::reset_ua_stack_tracking()
+{
+  ua_regular_stacks = 0;
+  ua_seed_stacks = 0;
+  ua_seed_gap = false;
+}
+
+int warlock_td_t::ua_calculate_damage_stacks() const
+{
+  const int damage_effective_ua_seed_stacks = ua_seed_stacks - ( ua_seed_gap ? 1 : 0 );
+  assert( damage_effective_ua_seed_stacks >= 0 );
+
+  return ua_regular_stacks + damage_effective_ua_seed_stacks;
 }
 
 void warlock_td_t::target_demise()
@@ -239,7 +293,6 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   cooldowns.summon_doomguard = get_cooldown( "summon_doomguard" );
   cooldowns.felstorm_icd = get_cooldown( "felstorm_icd" );
   cooldowns.echo_of_sargeras = get_cooldown( "echo_of_sargeras_icd" );
-  cooldowns.blackened_soul = get_cooldown( "blackened_soul_icd" );
 
   resource_regeneration = regen_type::DYNAMIC;
   regen_caches[ CACHE_HASTE ] = true;
@@ -1069,6 +1122,8 @@ void warlock_t::parse_player_effects()
   // Destruction
   if ( destruction() )
   {
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      parse_target_effects( d_fn( &warlock_td_t::debuffs_t::dark_titans_mark ), tier.dark_titans_mark_debuff ); // 1305711
   }
 
   // Diabolist
@@ -1113,7 +1168,7 @@ double warlock_t::resource_gain( resource_e resource_type, double amount, gain_t
   return actual_amount;
 }
 
-void warlock_t::feast_of_souls_gain( bool from_quietus_seed )
+void warlock_t::feast_of_souls_gain()
 {
   // NOTE: 2026-03-17 The shard gained from Feast of Souls can also proc another Succulent Soul (bug?)
   if ( bugs )
@@ -1124,12 +1179,6 @@ void warlock_t::feast_of_souls_gain( bool from_quietus_seed )
   buffs.succulent_soul->trigger();
   procs.succulent_soul->occur();
   procs.feast_of_souls->occur();
-
-  // NOTE: 2026-03-06 If Feast of Souls is gained by consuming Nightfall with SoC (Quietus hero talent) and after
-  // the gain you only have one stack of Succulent Soul, it will be spent without producing its effects (bug)
-  // This behavior is modeled here simply by decrementing a stack of Succulent Soul without triggering its effects
-  if ( bugs && from_quietus_seed && buffs.succulent_soul->check() == 1 )
-    buffs.succulent_soul->decrement();
 }
 
 // Setup to allow taking specific pets from Dominion of Argus, or a random one if the random enum is passed in.

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -58,6 +58,7 @@ struct warlock_td_t : public actor_target_data_t
     propagate_const<buff_t*> lake_of_fire;
     propagate_const<buff_t*> shadowburn;
     propagate_const<buff_t*> havoc;
+    propagate_const<buff_t*> dark_titans_mark;
 
     // Diabolist
     propagate_const<buff_t*> cloven_soul;
@@ -93,15 +94,27 @@ struct warlock_td_t : public actor_target_data_t
 
   double soc_threshold; // Aff - Seed of Corruption counts damage from cross-spec spells such as Drain Life
 
+  // 12.1 Affliction 4pc
+  int ua_regular_stacks;
+  int ua_seed_stacks;
+  bool ua_seed_gap;
+
   warlock_t& warlock;
   warlock_td_t( player_t* target, warlock_t& p );
 
   void reset()
-  { soc_threshold = 0; }
+  {
+    soc_threshold = 0;
+    reset_ua_stack_tracking();
+  }
 
   void target_demise();
 
   int count_affliction_dots() const;
+  void ua_stack_applied( bool is_seed_ua );
+  void ua_stack_expired( bool is_seed_ua );
+  void reset_ua_stack_tracking();
+  int ua_calculate_damage_stacks() const;
 };
 
 // Shuffled Bag RNG (sampling without replacement)
@@ -754,6 +767,7 @@ public:
     action_t* diabolic_gaze_3;
     action_t* diabolic_oculi;
     action_t* blighted_maw;
+    action_t* isolated_implosion;
     action_t* echo_of_sargeras;
     action_t* echo_of_sargeras_cb;
     action_t* echo_of_sargeras_sb;
@@ -805,6 +819,16 @@ public:
     const spell_data_t* wl_demonology_12_0_class_set_4pc;
     const spell_data_t* wl_destruction_12_0_class_set_2pc;
     const spell_data_t* wl_destruction_12_0_class_set_4pc;
+    const spell_data_t* wl_affliction_12_1_class_set_2pc;
+    const spell_data_t* wl_affliction_12_1_class_set_4pc;
+    const spell_data_t* unstable_empowerment_buff;
+    const spell_data_t* wl_demonology_12_1_class_set_2pc;
+    const spell_data_t* wl_demonology_12_1_class_set_4pc;
+    const spell_data_t* isolated_implosion;
+    const spell_data_t* isolated_implosion_aoe;
+    const spell_data_t* wl_destruction_12_1_class_set_2pc;
+    const spell_data_t* wl_destruction_12_1_class_set_4pc;
+    const spell_data_t* dark_titans_mark_debuff;
   } tier;
 
   // Cooldowns - Used for accessing cooldowns outside of their respective actions, such as reductions/resets
@@ -816,7 +840,6 @@ public:
     propagate_const<cooldown_t*> summon_doomguard;
     propagate_const<cooldown_t*> felstorm_icd;
     propagate_const<cooldown_t*> echo_of_sargeras; // ICD for Embers of Nihilam rank 4 procs
-    propagate_const<cooldown_t*> blackened_soul; // Internal cooldown on triggering stack increase to Wither
   } cooldowns;
 
   // Buffs
@@ -833,6 +856,7 @@ public:
     propagate_const<buff_t*> shard_instability;
     propagate_const<buff_t*> cascading_calamity;
     propagate_const<buff_t*> seed_of_corruption_is_out_dnt;
+    propagate_const<buff_t*> unstable_empowerment;
 
     // Demonology Buffs
     propagate_const<buff_t*> demonic_core;
@@ -1173,7 +1197,7 @@ public:
   std::vector<player_t*> get_smart_targets( const std::vector<player_t*>& tl, propagate_const<dot_t*> warlock_td_t::dots_t::* dot, int n_targets, player_t* exclude = nullptr, double range = 0.0, bool really_smart = false );
   player_t* get_smart_target( const std::vector<player_t*>& tl, propagate_const<dot_t*> warlock_td_t::dots_t::* dot, player_t* exclude = nullptr, double range = 0.0, bool really_smart = false );
   double resource_gain( resource_e resource_type, double amount, gain_t* source = nullptr, action_t* action = nullptr ) override;
-  void feast_of_souls_gain( bool from_quietus_seed = false );
+  void feast_of_souls_gain();
   void summon_dominion_of_argus_pet( dominion_of_argus_pet_e pet );
 
   bool affliction() const;
@@ -1291,16 +1315,23 @@ namespace helpers
 
   struct ua_stack_drop_event_t : public player_event_t
   {
-    ua_stack_drop_event_t( warlock_t*, dot_t*, timespan_t );
+    ua_stack_drop_event_t( warlock_t*, dot_t*, timespan_t, bool = false );
     dot_t* dot;
+    bool is_seed_applied;
     virtual const char* name() const override;
     virtual void execute() override;
   };
 
-  void trigger_blackened_soul( warlock_t* p, bool malevolence );
+  void consume_succulent_soul( warlock_t* p, player_t* target );
+
+  void trigger_blackened_soul( warlock_t* p, bool malevolence, player_t* bs_target = nullptr );
 
   void trigger_echo_of_sargeras( warlock_t* p, player_t* target, action_t* echo_action, proc_t* proc );
 
   void trigger_wrath_of_nathreza( warlock_t* p, player_t* target );
+
+  void trigger_isolated_implosion( warlock_t* p, pets::demonology::wild_imp_pet_t* imp, player_t* target );
+
+  void update_unstable_empowerment_buff( warlock_t* p );
 }
 }  // namespace warlock

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -199,6 +199,8 @@ using namespace helpers;
         parse_effects( p()->buffs.nightfall, effect_mask_t( true ).disable( 3 ) ); // 264571/1260279 // Effect #3 is handled in a custom action_state
         parse_effects( p()->buffs.darkglare_presence ); // 1280663
         parse_effects( p()->buffs.shard_instability ); // 1260269
+        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+          parse_effects( p()->buffs.unstable_empowerment ); // 1305774
       }
 
       // Demonology
@@ -215,8 +217,10 @@ using namespace helpers;
         parse_effects( p()->buffs.backdraft ); // 117828
         parse_effects( p()->buffs.fiendish_cruelty ); // 1245664
         parse_effects( p()->buffs.chaotic_inferno ); // 1244860
-        parse_effects( p()->buffs.conflagration_of_chaos ); // 387109
         parse_effects( p()->buffs.crashing_chaos ); // 417282 // RoF is dummy
+        if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+          parse_effects( p()->buffs.conflagration_of_chaos ); // 387109
+
         parse_effects( p()->buffs.alythesss_ire ); // 1244947
       }
 
@@ -357,15 +361,20 @@ using namespace helpers;
           }
         }
 
-        if ( hellcaller() && base_shards > 0 && harmful && p()->hero.blackened_soul.ok() )
+        if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
         {
-          helpers::trigger_blackened_soul( p(), false );
+          if ( hellcaller() && base_shards > 0 && harmful && p()->hero.blackened_soul.ok() )
+          {
+            helpers::trigger_blackened_soul( p(), false );
+          }
         }
       }
     }
 
     void execute() override
     {
+      player_t* execute_target = target;
+
       action_base_t::execute();
 
       // NOTE: Casted spells do not consume any Demonic Art buff if none were active at the start of the cast
@@ -373,7 +382,7 @@ using namespace helpers;
       {
         if ( p()->hero.diabolic_oculi.ok() )
         {
-          make_event( *sim, 0_ms, [ this ] {
+          make_event( *sim, 0_ms, [ this, execute_target ] {
             if ( p()->buffs.demonic_oculi->check() &&
                  ( p()->buffs.art_overlord->check() || p()->buffs.art_mother->check() ||
                    p()->buffs.art_pit_lord->check() ) )
@@ -394,7 +403,7 @@ using namespace helpers;
               }
               else
               {
-                p()->proc_actions.eye_explosion->execute_on_target( this->target );
+                p()->proc_actions.eye_explosion->execute_on_target( execute_target );
               }
             }
           } );
@@ -858,15 +867,17 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* sb_target = target;
+
       warlock_spell_t::execute();
 
       if ( time_to_execute == 0_ms && soul_harvester() && p()->buffs.nightfall->check() )
       {
         if ( p()->hero.wicked_reaping.ok() )
-          p()->proc_actions.wicked_reaping->execute_on_target( target );
+          p()->proc_actions.wicked_reaping->execute_on_target( sb_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          p()->proc_actions.shared_fate->execute_on_target( target );
+          p()->proc_actions.shared_fate->execute_on_target( sb_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain();
@@ -1143,14 +1154,17 @@ using namespace helpers;
           }
         }
 
-        if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
+        if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
         {
-          // Wither stack gain by Mark of Perotharn does not directly trigger collapse in that tick (it will be trigged on the next tick)
-          // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
-          d->increment( 1 );
-          td( d->target )->debuffs.wither->bump( 1 );
-          assert( d->current_stack() == td( d->target )->debuffs.wither->check() && d->remains() == td( d->target )->debuffs.wither->remains() );
-          p()->procs.mark_of_perotharn->occur();
+          if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
+          {
+            // Wither stack gain by Mark of Perotharn does not directly trigger collapse in that tick (it will be trigged on the next tick)
+            // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
+            d->increment( 1 );
+            td( d->target )->debuffs.wither->bump( 1 );
+            assert( d->current_stack() == td( d->target )->debuffs.wither->check() && d->remains() == td( d->target )->debuffs.wither->remains() );
+            p()->procs.mark_of_perotharn->occur();
+          }
         }
 
         if ( p()->hero.devil_fruit.ok() )
@@ -1210,16 +1224,19 @@ using namespace helpers;
     {
       warlock_spell_t::impact( s );
 
-      if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
+      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
       {
-        auto& wither_dot = td( s->target )->dots.wither;
-        auto& wither_debuff = td( s->target )->debuffs.wither;
-        // Wither stack gain by Mark of Perotharn does not directly trigger collapse (it will be trigged on the next Wither tick)
-        // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
-        wither_dot->increment( 1 );
-        wither_debuff->bump( 1 );
-        assert( wither_dot->current_stack() == wither_debuff->check() && wither_dot->remains() == wither_debuff->remains() );
-        p()->procs.mark_of_perotharn->occur();
+        if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
+        {
+          auto& wither_dot = td( s->target )->dots.wither;
+          auto& wither_debuff = td( s->target )->debuffs.wither;
+          // Wither stack gain by Mark of Perotharn does not directly trigger collapse (it will be trigged on the next Wither tick)
+          // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
+          wither_dot->increment( 1 );
+          wither_debuff->bump( 1 );
+          assert( wither_dot->current_stack() == wither_debuff->check() && wither_dot->remains() == wither_debuff->remains() );
+          p()->procs.mark_of_perotharn->occur();
+        }
       }
     }
   };
@@ -1462,25 +1479,33 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      if ( twin != nullptr )
+      if ( twin != nullptr && execute_state )
       {
         const auto& tl = target_list();
-        if ( auto twin_target = p()->get_smart_target( tl, &warlock_td_t::dots_t::agony, target, twin_range, true ) )
+        if ( auto twin_target = p()->get_smart_target( tl, &warlock_td_t::dots_t::agony, execute_state->target, twin_range, true ) )
           twin->execute_on_target( twin_target );
       }
+    }
 
-      int initial_stacks = 0;
+    void impact( action_state_t* s ) override
+    {
+      warlock_spell_t::impact( s );
 
-      if ( p()->talents.sudden_onset.ok() )
-        initial_stacks += ( int )( p()->talents.sudden_onset->effectN( 2 ).base_value() );
+      if ( result_is_hit( s->result ) )
+      {
+        int initial_stacks = 0;
 
-      if ( active_4pc<MID1>() )
-        initial_stacks += ( int )( p()->tier.wl_affliction_12_0_class_set_4pc->effectN( 1 ).base_value() );
+        if ( p()->talents.sudden_onset.ok() )
+          initial_stacks += ( int )( p()->talents.sudden_onset->effectN( 2 ).base_value() );
 
-      int delta_stacks = initial_stacks - td( execute_state->target )->dots.agony->current_stack();
+        if ( active_4pc<MID1>() )
+          initial_stacks += ( int )( p()->tier.wl_affliction_12_0_class_set_4pc->effectN( 1 ).base_value() );
 
-      if ( delta_stacks > 0 )
-          td( execute_state->target )->dots.agony->increment( delta_stacks );
+        int delta_stacks = initial_stacks - td( s->target )->dots.agony->current_stack();
+
+        if ( delta_stacks > 0 )
+            td( s->target )->dots.agony->increment( delta_stacks );
+      }
     }
 
     void tick( dot_t* d ) override
@@ -1502,17 +1527,24 @@ using namespace helpers;
   struct unstable_affliction_t : public warlock_spell_t
   {
     bool is_fatal_echoes_execute = false;
+    bool is_seed_applied = false;
 
-    unstable_affliction_t( warlock_t* p, util::string_view options_str )
-      : warlock_spell_t( "Unstable Affliction", p, p->talents.unstable_affliction, options_str )
+    unstable_affliction_t( warlock_t* p )
+      : warlock_spell_t( "Unstable Affliction", p, p->talents.unstable_affliction )
     {
       triggers.ravenous_afflictions = p->talents.ravenous_afflictions.ok();
 
       affected_by.deaths_embrace = p->talents.deaths_embrace.ok();
     }
 
+    unstable_affliction_t( warlock_t* p, util::string_view options_str )
+      : unstable_affliction_t( p )
+    { parse_options( options_str ); }
+
     void execute() override
     {
+      player_t* ua_target = target;
+
       // NOTE: 2026-04-29 Currently ingame a UA applied by Fatal Echoes also processes/consumes some UA 'execute' effects:
       // - Succulent Soul: consumes a stack and triggers its effects (Demonic Soul dmg and Manifested Avarice rng proc)
       // - Cull the Weak: reduces the cooldown of Dark Harvest
@@ -1521,33 +1553,37 @@ using namespace helpers;
 
       warlock_spell_t::execute();
 
-      if ( p()->talents.cull_the_weak.ok() )
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        // NOTE: 2026-07-06 12.1 4pc seed-applied UA does not increment Wither stacks
+        if ( hellcaller() && p()->hero.blackened_soul.ok() && !is_seed_applied )
+          helpers::trigger_blackened_soul( p(), false, ua_target );
+      }
+
+      // NOTE: 2026-07-06 12.1 4pc seed-applied UA does not reduce the cooldown of Dark Harvest (Cull the Weak talent)
+      if ( p()->talents.cull_the_weak.ok() && !is_seed_applied )
         p()->cooldowns.dark_harvest->adjust( -p()->talents.cull_the_weak->effectN( 1 ).time_value() );
 
       // NOTE: 2026-04-29 If Shard Instability buff is gained during the casting of Unstable Affliction, that UA cast benefits from the cost
       // reduction but does not consume the effect (bug?). As expected, a Fatal Echoes UA proc does not consume it either.
       if ( time_to_execute == 0_ms && !is_fatal_echoes_execute )
       {
-        p()->buffs.shard_instability->decrement();
+        // NOTE: 2026-07-06 12.1 4pc seed-applied UA consumes shard instability (bug?)
+        if ( p()->bugs || !is_seed_applied )
+          p()->buffs.shard_instability->decrement();
       }
 
-      if ( soul_harvester() && p()->buffs.succulent_soul->check() )
+      if ( soul_harvester() )
       {
-        p()->buffs.succulent_soul->decrement();
-
-        if ( p()->hero.manifested_avarice.ok() && p()->prd_rng.manifested_avarice->trigger() )
-        {
-          p()->summons.manifested_demonic_soul->execute();
-          p()->procs.manifested_avarice->occur();
-        }
-
-        p()->proc_actions.demonic_soul->execute_on_target( target );
+        // NOTE: 2026-07-06 12.1 4pc seed-applied UA consumes a Succulent Soul stack and triggers its effects
+        helpers::consume_succulent_soul( p(), ua_target );
       }
     }
 
     void impact( action_state_t* s ) override
     {
-      auto dot = td( s->target )->dots.unstable_affliction;
+      auto tdata = td( s->target );
+      auto dot = tdata->dots.unstable_affliction;
 
       if ( p()->talents.cascading_calamity.ok() && dot->is_ticking() )
         p()->buffs.cascading_calamity->trigger();
@@ -1561,13 +1597,20 @@ using namespace helpers;
       // We need to handle the UA stacks/duration manually
       if ( result_is_hit( s->result ) )
       {
+        tdata->ua_stack_applied( is_seed_applied );
+
+        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+        {
+          if ( active_4pc<MID2>() )
+            helpers::update_unstable_empowerment_buff( p() );
+        }
+
         // NOTE: The spell data is using DOT_REFRESH_DURATION, which should add the time-until-the-next-full-tick to the total duration
         // However, ingame, the duration does not add the last tick and only refresh the dot to the total duration (always 8 seconds)
-        dot_t* dot = td( s->target )->dots.unstable_affliction;
         if ( dot->duration() > dot_new_last_duration )
           dot->adjust_duration( dot_new_last_duration - dot->duration() );
 
-        make_event<ua_stack_drop_event_t>( *sim, p(), dot, dot_new_last_duration );
+        make_event<ua_stack_drop_event_t>( *sim, p(), dot, dot_new_last_duration, is_seed_applied );
       }
     }
 
@@ -1576,6 +1619,7 @@ using namespace helpers;
       int stacks = d->current_stack();
 
       warlock_spell_t::last_tick( d );
+      td( d->target )->reset_ua_stack_tracking();
 
       if ( p()->talents.fatal_echoes.ok() && !d->target->is_sleeping() )
       {
@@ -1586,16 +1630,30 @@ using namespace helpers;
             p()->procs.fatal_echoes->occur();
             make_event( sim, 1_ms, [ this, t = d->target ] {
               const bool prev_ua_ticking = td( t )->dots.unstable_affliction->is_ticking();
+              const bool prev_is_seed_applied = this->is_seed_applied;
               this->set_target( t );
               this->time_to_execute = 0_ms;
               this->is_fatal_echoes_execute = true;
+              this->is_seed_applied = false; // Fatal Echoes always applies a fully effective UA DoT stack
               this->execute();
+              this->is_seed_applied = prev_is_seed_applied;
               this->is_fatal_echoes_execute = false;
               // When UA is applied by Fatal Echoes, Cascading Calamity is also triggered
               if ( p()->talents.cascading_calamity.ok() && !prev_ua_ticking )
                 p()->buffs.cascading_calamity->trigger();
             } );
           }
+        }
+      }
+
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( active_4pc<MID2>() )
+        {
+          // Delay to allow the dot to reset()
+          make_event( sim, 0_ms, [ this ] {
+            helpers::update_unstable_empowerment_buff( p() );
+          } );
         }
       }
     }
@@ -1628,6 +1686,23 @@ using namespace helpers;
       }
 
       return m;
+    }
+
+    double calculate_tick_amount( action_state_t* state, double dot_multiplier ) const override
+    {
+      // 12.1 4pc seed-applied UAs are visually full UA stacks, but one active seed-UA stack may not count
+      // toward UA periodic damage. Adjust the tick multiplier here because the core applies stack count through
+      // dot_multiplier after calculating the base tick, and the effective stack count can change between ticks.
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
+      {
+        auto tdata = td( state->target );
+        const int current_stacks = tdata->dots.unstable_affliction->current_stack();
+
+        if ( current_stacks > 0 )
+          dot_multiplier *= as<double>( tdata->ua_calculate_damage_stacks() ) / current_stacks;
+      }
+
+      return warlock_spell_t::calculate_tick_amount( state, dot_multiplier );
     }
 
     double cost_pct_multiplier() const override
@@ -1763,10 +1838,12 @@ using namespace helpers;
     };
 
     seed_of_corruption_aoe_t* explosion;
+    unstable_affliction_t* ua_seed_tier;
 
     seed_of_corruption_t( warlock_t* p, util::string_view options_str )
       : warlock_spell_t( "Seed of Corruption", p, p->talents.seed_of_corruption, options_str ),
-      explosion( new seed_of_corruption_aoe_t( p ) )
+      explosion( new seed_of_corruption_aoe_t( p ) ),
+      ua_seed_tier( nullptr )
     {
       may_crit = false;
       tick_zero = false;
@@ -1779,6 +1856,17 @@ using namespace helpers;
       aoe = 1 + as<int>( p->talents.sow_the_seeds->effectN( 1 ).base_value() );
 
       add_child( explosion );
+
+      if ( p->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && p->active_4pc<MID2>() && p->talents.unstable_affliction.ok() )
+      {
+        ua_seed_tier = new unstable_affliction_t( p );
+        ua_seed_tier->background = ua_seed_tier->dual = true;
+        ua_seed_tier->base_costs[ RESOURCE_MANA ] = 0;
+        ua_seed_tier->base_costs[ RESOURCE_SOUL_SHARD ] = 0;
+        ua_seed_tier->trigger_gcd = 0_ms;
+        ua_seed_tier->time_to_execute = 0_ms;
+        ua_seed_tier->is_seed_applied = true;
+      }
     }
 
     action_state_t* new_state() override
@@ -1881,6 +1969,8 @@ using namespace helpers;
 
       p()->buffs.seed_of_corruption_is_out_dnt->trigger();
 
+      const bool soc_had_prev_succulent_soul = p()->buffs.succulent_soul->check();
+
       if ( time_to_execute == 0_ms && soul_harvester() && p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() )
       {
         if ( p()->hero.wicked_reaping.ok() )
@@ -1889,9 +1979,33 @@ using namespace helpers;
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
           p()->proc_actions.shared_fate->execute_on_target( main_seed_target );
 
-        // Feast of Souls is processed before the decrement of Succulent Soul, causing the same SoC cast that gains the Succulent Soul stack to consume it
+        // Feast of Souls is processed after SoC captures its previous Succulent Soul state but before the delayed stack removal
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
-          p()->feast_of_souls_gain( true );
+          p()->feast_of_souls_gain();
+      }
+
+      if ( soul_harvester() )
+      {
+        // NOTE: 2026-07-07 If Nightfall SoC gains Succulent Soul through Feast of Souls with no pre-existing stack,
+        // SoC removes one stack after a short delay without triggering Succulent Soul effects (bug)
+        if ( !p()->bugs || soc_had_prev_succulent_soul )
+        {
+          helpers::consume_succulent_soul( p(), main_seed_target );
+        }
+        else if ( p()->buffs.succulent_soul->check() )
+        {
+          make_event( sim, 10_ms, [ p = p() ] {
+            p->buffs.succulent_soul->decrement();
+          } );
+        }
+      }
+
+      if ( ua_seed_tier )
+      {
+        // 12.1 4pc seed UA is applied to the main_seed_target (could be redirected from the main SoC cast target)
+        ua_seed_tier->set_target( main_seed_target );
+        ua_seed_tier->time_to_execute = 0_ms;
+        ua_seed_tier->execute();
       }
 
       // NOTE: 2026-02-26 If Nightfall is obtained during the casting of Seed of Corruption, that SoC cast
@@ -1901,19 +2015,6 @@ using namespace helpers;
 
       if ( p()->talents.cull_the_weak.ok() )
         p()->cooldowns.dark_harvest->adjust( -p()->talents.cull_the_weak->effectN( 1 ).time_value() );
-
-      if ( soul_harvester() && p()->buffs.succulent_soul->check() )
-      {
-        p()->buffs.succulent_soul->decrement();
-
-        if ( p()->hero.manifested_avarice.ok() && p()->prd_rng.manifested_avarice->trigger() )
-        {
-          p()->summons.manifested_demonic_soul->execute();
-          p()->procs.manifested_avarice->occur();
-        }
-
-        p()->proc_actions.demonic_soul->execute_on_target( main_seed_target );
-      }
     }
 
     void impact( action_state_t* s ) override
@@ -2156,15 +2257,17 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* mg_target = target;
+
       warlock_spell_t::execute();
 
       if ( soul_harvester() && p()->buffs.nightfall->check() )
       {
         if ( p()->hero.wicked_reaping.ok() )
-          p()->proc_actions.wicked_reaping->execute_on_target( target );
+          p()->proc_actions.wicked_reaping->execute_on_target( mg_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          p()->proc_actions.shared_fate->execute_on_target( target );
+          p()->proc_actions.shared_fate->execute_on_target( mg_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain();
@@ -2198,6 +2301,7 @@ using namespace helpers;
 
         // Trigger extra DoT Ticks
         trigger_extra_tick( tdata->dots.agony, extra_tick_mul, agony_mg );
+        // UA extra ticks use the DoT stack count, regardless of 12.1 4pc seed-applied UA effectiveness
         trigger_extra_tick( tdata->dots.unstable_affliction, extra_tick_mul, unstable_affliction_mg );
         trigger_extra_tick( tdata->dots.wither, extra_tick_mul, wither_mg, false );
         trigger_extra_tick( tdata->dots.corruption, extra_tick_mul, corruption_mg );
@@ -2295,15 +2399,17 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* ds_target = target;
+
       warlock_spell_t::execute();
 
       if ( soul_harvester() && p()->buffs.nightfall->check() )
       {
         if ( p()->hero.wicked_reaping.ok() )
-          p()->proc_actions.wicked_reaping->execute_on_target( target );
+          p()->proc_actions.wicked_reaping->execute_on_target( ds_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          p()->proc_actions.shared_fate->execute_on_target( target );
+          p()->proc_actions.shared_fate->execute_on_target( ds_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
           p()->feast_of_souls_gain();
@@ -2799,6 +2905,8 @@ using namespace helpers;
       if ( p()->hero.diabolic_oculi.ok() )
         p()->buffs.demonic_oculi->trigger();
 
+      player_t* hog_target = target;
+
       warlock_spell_t::execute();
 
       if ( p()->talents.doom.ok() )
@@ -2816,18 +2924,8 @@ using namespace helpers;
         p()->procs.demonic_knowledge->occur();
       }
 
-      if ( soul_harvester() && p()->buffs.succulent_soul->check() )
-      {
-          p()->buffs.succulent_soul->decrement();
-
-          if ( p()->hero.manifested_avarice.ok() && p()->prd_rng.manifested_avarice->trigger() )
-          {
-            p()->summons.manifested_demonic_soul->execute();
-            p()->procs.manifested_avarice->occur();
-          }
-
-          p()->proc_actions.demonic_soul->execute_on_target( target );
-      }
+      if ( soul_harvester() )
+        helpers::consume_succulent_soul( p(), hog_target );
 
       // TODO: Are these execute, or impact? Check ingame timings to see when these effects are applied
       if ( p()->talents.dominion_of_argus_1.ok() && p()->buffs.dominion_of_argus->check() )
@@ -2897,6 +2995,8 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* db_target = target;
+
       warlock_spell_t::execute();
 
       p()->buffs.demonic_core->up(); // For benefit tracking
@@ -2913,10 +3013,10 @@ using namespace helpers;
       if ( soul_harvester() && p()->buffs.demonic_core->check() )
       {
         if ( p()->hero.wicked_reaping.ok() )
-          p()->proc_actions.wicked_reaping->execute_on_target( target );
+          p()->proc_actions.wicked_reaping->execute_on_target( db_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          p()->proc_actions.shared_fate->execute_on_target( target );
+          p()->proc_actions.shared_fate->execute_on_target( db_target );
 
         if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger() )
           p()->feast_of_souls_gain();
@@ -3094,6 +3194,120 @@ using namespace helpers;
     }
   };
 
+  struct isolated_implosion_t : public warlock_spell_t
+  {
+    struct isolated_implosion_aoe_base_t : public warlock_spell_t
+    {
+      isolated_implosion_aoe_base_t( std::string_view n, warlock_t* p, const spell_data_t* s )
+        : warlock_spell_t( n, p, s )
+      {
+        amount_delta = 0;
+        background = dual = true;
+      }
+    };
+
+    struct isolated_implosion_aoe_secondary_t : public isolated_implosion_aoe_base_t
+    {
+      isolated_implosion_aoe_secondary_t( warlock_t* p, std::string_view n = "Isolated Implosion (AoE) (Secondaries)" )
+        : isolated_implosion_aoe_base_t( n, p, p->tier.isolated_implosion_aoe )
+      {
+        spell_power_mod.direct = p->talents.implosion_aoe->effectN( 1 ).sp_coeff();
+        aoe = -1;
+        target_filter_callback = secondary_targets_only();
+        // NOTE: 2026-07-06: The spell description lists 125% effectiveness, but in-game damage behaves as +125% increased effectiveness (bug?)
+        base_dd_multiplier *= ( p->bugs ? 1.0 : 0.0 ) + p->tier.wl_demonology_12_1_class_set_4pc->effectN( 2 ).percent();
+      }
+    };
+
+    struct isolated_implosion_aoe_t : public isolated_implosion_aoe_base_t
+    {
+      warlock_pet_t* next_imp;
+
+      isolated_implosion_aoe_t( warlock_t* p, std::string_view n = "Isolated Implosion (AoE)" )
+        : isolated_implosion_aoe_base_t( n, p, p->tier.isolated_implosion_aoe )
+      {
+        spell_power_mod.direct = p->talents.implosion_aoe->effectN( 1 ).sp_coeff();
+        aoe = 0;
+        radius = 0;
+        // NOTE: 2026-07-06: The spell description lists 150% effectiveness, but in-game damage behaves as +150% increased effectiveness (bug?)
+        base_dd_multiplier *= ( p->bugs ? 1.0 : 0.0 ) + p->tier.wl_demonology_12_1_class_set_4pc->effectN( 1 ).percent();
+
+        impact_action = new isolated_implosion_aoe_secondary_t( p );
+        impact_action->stats = stats;
+        stats->action_list.push_back( impact_action );
+        add_child( impact_action );
+      }
+
+      void execute() override
+      {
+        warlock_spell_t::execute();
+        next_imp->dismiss();
+      }
+    };
+
+    warlock::pets::demonology::wild_imp_pet_t* imp = nullptr;
+    isolated_implosion_aoe_t* explosion;
+
+    isolated_implosion_t( warlock_t* p )
+      : warlock_spell_t( "Isolated Implosion", p, p->tier.isolated_implosion ),
+      explosion( new isolated_implosion_aoe_t( p ) )
+    {
+      background = true;
+
+      add_child( explosion );
+    }
+
+    void execute() override
+    {
+      // Travel speed is not in spell data, in game test appears to be 65 yds/sec
+      timespan_t imp_travel_time = calc_imp_travel_time( 65 );
+
+      isolated_implosion_aoe_t* ex = explosion;
+      player_t* tar = target;
+      double dist = p()->get_player_distance( *tar );
+
+      imp->trigger_movement( dist, movement_direction_type::TOWARDS );
+      imp->interrupt();
+      imp->imploded = true;
+
+      make_event( sim, imp_travel_time, [ ex, tar, imp = imp ] {
+        if ( imp && !imp->is_sleeping() )
+        {
+          ex->set_target( tar );
+          ex->next_imp = imp;
+          ex->execute();
+        }
+      } );
+
+      warlock_spell_t::execute();
+
+      // Isolated Implosion triggers procs through some hidden trigger
+      p()->trigger_aura_applied_callbacks( proc_data, p() );
+    }
+
+    timespan_t calc_imp_travel_time( double speed )
+    {
+      double t = 0;
+
+      if ( speed > 0 )
+      {
+        double distance = player->get_player_distance( *target );
+
+        if ( distance > 0 )
+          t += distance / speed;
+      }
+
+      double v = sim->travel_variance;
+
+      if ( v )
+        t = rng().gauss( t, v );
+
+      t = std::max( t, min_travel_time );
+
+      return timespan_t::from_seconds( t );
+    }
+  };
+
   struct summon_vilefiend_base_t : public warlock_spell_t
   {
     summon_vilefiend_base_t( util::string_view n, warlock_t* p, const spell_data_t* s = spell_data_t::nil() )
@@ -3193,11 +3407,13 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* cast_target = target;
+
       warlock_spell_t::execute();
 
       unsigned count = as<unsigned>( p()->talents.call_dreadstalkers->effectN( 1 ).base_value() );
 
-      const auto delay_dur_adjusts = p()->dreadstalkers_delay_duration_adjustment_helper( *target );
+      const auto delay_dur_adjusts = p()->dreadstalkers_delay_duration_adjustment_helper( *cast_target );
       const timespan_t& delay = delay_dur_adjusts.first;
       const timespan_t& dur_adjust = delay_dur_adjusts.second;
 
@@ -3210,7 +3426,7 @@ using namespace helpers;
       }
 
       if ( p()->talents.summon_vilefiend.ok() )
-        p()->summons.vilefiend->execute_on_target( target );
+        p()->summons.vilefiend->execute_on_target( cast_target );
     }
   };
 
@@ -3359,7 +3575,7 @@ using namespace helpers;
       // Last tested 2021-07-13
       // There is a chance for tyrant to get an extra cast off before reaching the required haste breakpoint.
       // In-game testing found this can be modelled fairly closely using a normal distribution.
-      timespan_t extraTyrantTime = rng().gauss<380,220>();
+      timespan_t extraTyrantTime = rng().gauss<380, 220>();
       auto tyrants = p()->warlock_pet_list.demonic_tyrants.spawn( data().duration() + extraTyrantTime );
 
       int demonic_power_counter = 0;
@@ -3691,14 +3907,16 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* cast_target = target;
+
       warlock_spell_t::execute();
 
       if ( p()->talents.fire_and_brimstone.ok() )
-        fnb_action->execute_on_target( target );
+        fnb_action->execute_on_target( cast_target );
 
       if ( p()->talents.demonfire_infusion.ok() && p()->flat_rng.demonfire_infusion_inc->trigger() )
       {
-        p()->proc_actions.demonfire_infusion->execute_on_target( target );
+        p()->proc_actions.demonfire_infusion->execute_on_target( cast_target );
         p()->procs.demonfire_infusion_inc->occur();
       }
 
@@ -3800,7 +4018,9 @@ using namespace helpers;
 
     void execute() override
     {
-      dot_t* dot = p()->hero.wither.ok() ? td( target )->dots.wither : td( target )->dots.immolate;
+      player_t* ic_target = target;
+
+      dot_t* dot = p()->hero.wither.ok() ? td( ic_target )->dots.wither : td( ic_target )->dots.immolate;
 
       assert( dot->current_action );
       action_state_t* state = dot->current_action->get_state( dot->state );
@@ -3821,7 +4041,7 @@ using namespace helpers;
       dot->adjust_duration( -remaining );
       if ( p()->hero.wither.ok() && remaining != 0_ms )
       {
-        auto& wither_debuff = td( target )->debuffs.wither;
+        auto& wither_debuff = td( ic_target )->debuffs.wither;
         if ( wither_debuff->remains() - remaining <= timespan_t::zero() )
           wither_debuff->expire();
         else
@@ -4070,7 +4290,15 @@ using namespace helpers;
       if ( p()->bugs && diabolist() && affected_by.touch_of_rancora && affected_by.havoc && rancora_empowered )
         base_aoe_multiplier *= havoc_rancora_mul_adjust;
 
+      player_t* cb_target = target;
+
       warlock_spell_t::execute();
+
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( hellcaller() && p()->hero.blackened_soul.ok() )
+          helpers::trigger_blackened_soul( p(), false, cb_target );
+      }
 
       base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
 
@@ -4193,14 +4421,17 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      p()->buffs.conflagration_of_chaos->expire();
-
-      if ( p()->talents.conflagration_of_chaos.ok() )
+      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
       {
-        bool success = p()->buffs.conflagration_of_chaos->trigger();
+        p()->buffs.conflagration_of_chaos->expire();
 
-        if ( success )
-          p()->procs.conflagration_of_chaos->occur();
+        if ( p()->talents.conflagration_of_chaos.ok() )
+        {
+          bool success = p()->buffs.conflagration_of_chaos->trigger();
+
+          if ( success )
+            p()->procs.conflagration_of_chaos->occur();
+        }
       }
 
       if ( p()->talents.backdraft.ok() )
@@ -4211,7 +4442,7 @@ using namespace helpers;
     {
       double m = warlock_spell_t::composite_da_multiplier( s );
 
-      if ( p()->buffs.conflagration_of_chaos->check() )
+      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ? p()->buffs.conflagration_of_chaos->check() : p()->talents.conflagration_of_chaos.ok() )
         m *= 1.0 + player->cache.spell_crit_chance();
 
       return m;
@@ -4274,6 +4505,8 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* rof_target = target;
+
       if ( p()->hero.diabolic_oculi.ok() )
       {
         // NOTE: 2026-03-17 Demonic Oculi stack buff is obtained after the explosion for RoF (bug?)
@@ -4288,9 +4521,9 @@ using namespace helpers;
       // Rain of Fire has no expiration pulse (none, neither partial nor full) (NO_EXPIRATION_PULSE is already the default for ground_aoe_params_t)
       make_event<ground_aoe_event_t>( *sim, p(),
                                       ground_aoe_params_t()
-                                        .target( execute_state->target )
-                                        .x( execute_state->target->x_position )
-                                        .y( execute_state->target->y_position )
+                                        .target( rof_target )
+                                        .x( rof_target->x_position )
+                                        .y( rof_target->y_position )
                                         .pulse_time( base_tick_time * player->cache.spell_haste() * ( 1.0 + p()->talents.destructive_rapidity->effectN( 1 ).percent() ) )
                                         .duration( p()->talents.rain_of_fire->duration() * player->cache.spell_haste() )
                                         .start_time( sim->current_time() )
@@ -4300,7 +4533,7 @@ using namespace helpers;
       p()->trigger_aura_applied_callbacks( proc_data, p() );
 
       if ( p()->talents.embers_of_nihilam_3.ok() )
-        helpers::trigger_echo_of_sargeras( p(), execute_state->target, p()->proc_actions.echo_of_sargeras_rof, p()->procs.echo_of_sargeras_rof );
+        helpers::trigger_echo_of_sargeras( p(), rof_target, p()->proc_actions.echo_of_sargeras_rof, p()->procs.echo_of_sargeras_rof );
 
       p()->buffs.crashing_chaos->decrement();
 
@@ -4382,6 +4615,8 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* lof_target = target;
+
       pulse_time = base_tick_time * player->cache.spell_haste();
       const timespan_t duration = p()->talents.lake_of_fire_aoe->duration() * player->cache.spell_haste();
       const timespan_t start_time = sim->current_time();
@@ -4394,9 +4629,9 @@ using namespace helpers;
 
       make_event<ground_aoe_event_t>( *sim, p(),
                                       ground_aoe_params_t()
-                                        .target( execute_state->target )
-                                        .x( execute_state->target->x_position )
-                                        .y( execute_state->target->y_position )
+                                        .target( lof_target )
+                                        .x( lof_target->x_position )
+                                        .y( lof_target->y_position )
                                         .pulse_time( pulse_time )
                                         .duration( duration )
                                         .start_time( start_time )
@@ -4442,11 +4677,13 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* cata_target = target;
+
       warlock_spell_t::execute();
 
       if ( p()->talents.lake_of_fire.ok() )
       {
-        lake_of_fire->set_target( target );
+        lake_of_fire->set_target( cata_target );
         lake_of_fire->execute();
       }
     }
@@ -4518,18 +4755,29 @@ using namespace helpers;
       if ( p()->bugs && diabolist() && affected_by.touch_of_rancora && affected_by.havoc && rancora_empowered )
         base_aoe_multiplier *= havoc_rancora_mul_adjust;
 
+      player_t* sb_target = target;
+
       warlock_spell_t::execute();
+
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( hellcaller() && p()->hero.blackened_soul.ok() )
+          helpers::trigger_blackened_soul( p(), false, sb_target );
+      }
 
       base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
 
-      p()->buffs.conflagration_of_chaos->expire();
-
-      if ( p()->talents.conflagration_of_chaos.ok() )
+      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
       {
-        bool success = p()->buffs.conflagration_of_chaos->trigger();
+        p()->buffs.conflagration_of_chaos->expire();
 
-        if ( success )
-          p()->procs.conflagration_of_chaos->occur();
+        if ( p()->talents.conflagration_of_chaos.ok() )
+        {
+          bool success = p()->buffs.conflagration_of_chaos->trigger();
+
+          if ( success )
+            p()->procs.conflagration_of_chaos->occur();
+        }
       }
 
       p()->buffs.fiendish_cruelty->decrement();
@@ -4539,7 +4787,7 @@ using namespace helpers;
     {
       double m = warlock_spell_t::composite_da_multiplier( s );
 
-      if ( p()->buffs.conflagration_of_chaos->check() )
+      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ? p()->buffs.conflagration_of_chaos->check() : p()->talents.conflagration_of_chaos.ok() )
         m *= 1.0 + player->cache.spell_crit_chance();
 
       return m;
@@ -4617,18 +4865,18 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* di_target = target;
+
       warlock_spell_t::execute();
 
-      auto t = execute_state->target;
-
-      demonfire_tick->execute_on_target( t );
+      demonfire_tick->execute_on_target( di_target );
 
       if ( p()->talents.raging_demonfire.ok() )
       {
         int extra_bolts = as<int>( p()->talents.raging_demonfire->effectN( 1 ).base_value() );
         for ( int i = 0; i < extra_bolts; i++ )
         {
-          demonfire_tick->execute_on_target( t );
+          demonfire_tick->execute_on_target( di_target );
         }
       }
     }
@@ -4822,9 +5070,11 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* sf_target = target;
+
       warlock_spell_t::execute();
 
-      applied_dot->execute_on_target( target );
+      applied_dot->execute_on_target( sf_target );
 
       p()->buffs.backdraft->decrement();
 
@@ -4860,6 +5110,19 @@ using namespace helpers;
         m *= p()->talents.echo_of_sargeras->effectN( 2 ).sp_coeff() / p()->talents.echo_of_sargeras->effectN( 1 ).sp_coeff();
 
       return m;
+    }
+
+    void impact( action_state_t* s ) override
+    {
+      warlock_spell_t::impact( s );
+
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( result_is_hit( s->result ) && active_4pc<MID2>() )
+        {
+          td( s->target )->debuffs.dark_titans_mark->trigger();
+        }
+      }
     }
   };
 
@@ -4923,12 +5186,14 @@ using namespace helpers;
 
     void execute() override
     {
+      player_t* ib_target = target;
+
       warlock_spell_t::execute();
 
       // 2026-02-18 Infernal Bolt can proc Demonfire Infusion
       if ( p()->talents.demonfire_infusion.ok() && p()->flat_rng.demonfire_infusion_inc->trigger() )
       {
-        p()->proc_actions.demonfire_infusion->execute_on_target( target );
+        p()->proc_actions.demonfire_infusion->execute_on_target( ib_target );
         p()->procs.demonfire_infusion_inc->occur();
       }
 
@@ -4978,7 +5243,7 @@ using namespace helpers;
           {
             // Ruination appears to trigger a HoG-like meteor after a certain delay, which summons the Wild Imps.
             // This delay can be modeled fairly closely using a normal distribution.
-            make_event( *sim, rng().gauss<395,35>(), [ this, t = target ] {
+            make_event( *sim, rng().gauss<395, 35>(), [ this, t = target ] {
               hog_impact_spell->execute_on_target( t );
             } );
           }
@@ -5191,14 +5456,42 @@ using namespace helpers;
   // Diabolist Actions End
   // Helper Functions Begin
 
-  void helpers::trigger_blackened_soul( warlock_t* p, bool malevolence )
+  void helpers::consume_succulent_soul( warlock_t* p, player_t* target )
   {
-    if ( !malevolence && p->cooldowns.blackened_soul->down() )
+    if ( !p->buffs.succulent_soul->check() )
       return;
 
-    bool stack_gained = false;
+    // Succulent Soul consume effects happen immediately, but the stack removal is delayed
+    make_event( p->sim, 10_ms, [ p ] {
+      p->buffs.succulent_soul->decrement();
+    } );
 
-    for ( const auto target : p->sim->target_non_sleeping_list )
+    if ( p->hero.manifested_avarice.ok() && p->prd_rng.manifested_avarice->trigger() )
+    {
+      p->summons.manifested_demonic_soul->execute();
+      p->procs.manifested_avarice->occur();
+    }
+
+    if ( target )
+      p->proc_actions.demonic_soul->execute_on_target( target );
+  }
+
+  void helpers::trigger_blackened_soul( warlock_t* p, bool malevolence, player_t* bs_target )
+  {
+    std::vector<player_t*> target_list;
+    if ( p->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+    {
+      if ( malevolence )
+        target_list = p->sim->target_non_sleeping_list.data();
+      else if ( bs_target != nullptr )
+        target_list.push_back( bs_target );
+    }
+    else
+    {
+      target_list = p->sim->target_non_sleeping_list.data();
+    }
+
+    for ( const auto target : target_list )
     {
       warlock_td_t* tdata = p->get_target_data( target );
       if ( !tdata )
@@ -5209,7 +5502,7 @@ using namespace helpers;
 
       int stacks = 1;
 
-      if( malevolence )
+      if ( malevolence )
       {
         stacks = as<int>( p->hero.malevolence->effectN( 1 ).base_value() );
       }
@@ -5232,7 +5525,6 @@ using namespace helpers;
       tdata->dots.wither->increment( stacks );
       tdata->debuffs.wither->bump( stacks );
       assert( tdata->dots.wither->current_stack() == tdata->debuffs.wither->check() && tdata->dots.wither->remains() == tdata->debuffs.wither->remains() );
-      stack_gained = true;
 
       const int prev_collapse_stacks = tdata->debuffs.blackened_soul->check();
       assert( prev_collapse_stacks >= 0 );
@@ -5269,9 +5561,6 @@ using namespace helpers;
       if ( malevolence )
         p->proc_actions.malevolence->execute_on_target( target );
     }
-
-    if ( stack_gained )
-      p->cooldowns.blackened_soul->start();
   }
 
   void helpers::trigger_echo_of_sargeras( warlock_t* p, player_t* target, action_t* echo_action, proc_t* proc )
@@ -5324,6 +5613,43 @@ using namespace helpers;
     p->procs.wrath_of_nathreza->occur();
   }
 
+  void helpers::trigger_isolated_implosion( warlock_t* p, pets::demonology::wild_imp_pet_t* imp, player_t* target )
+  {
+    isolated_implosion_t* isolated_implosion = debug_cast<isolated_implosion_t*>( p->proc_actions.isolated_implosion );
+    isolated_implosion->set_target( target );
+    isolated_implosion->imp = imp;
+    isolated_implosion->execute();
+  }
+
+  void helpers::update_unstable_empowerment_buff( warlock_t* p )
+  {
+    const unsigned ue_max_stacks = as<unsigned>( p->buffs.unstable_empowerment->max_stack() );
+    unsigned active_uas = 0;
+    for ( const auto t : p->sim->target_non_sleeping_list )
+    {
+      warlock_td_t* tdata = p->get_target_data( t );
+      if ( !tdata )
+        continue;
+
+      active_uas += tdata->dots.unstable_affliction->current_stack();
+      if ( active_uas >= ue_max_stacks )
+        break;
+    }
+
+    int ue_effective_stacks = as<int>( std::min( ue_max_stacks, active_uas ) );
+    assert( ue_effective_stacks >= 0 && ue_effective_stacks <= static_cast<int>( ue_max_stacks ) );
+
+    const int prev_ue_stacks = p->buffs.unstable_empowerment->check();
+    assert( prev_ue_stacks >= 0 );
+
+    const int diff_stacks = ue_effective_stacks - prev_ue_stacks;
+
+    if ( diff_stacks > 0 )
+      p->buffs.unstable_empowerment->trigger( diff_stacks );
+    else if ( diff_stacks < 0 )
+      p->buffs.unstable_empowerment->decrement( -diff_stacks );
+  }
+
   // Event for spawning Wild Imps for Demonology
   imp_delay_event_t::imp_delay_event_t( warlock_t* p, double delay, double exp, int _index ) : player_event_t( *p, timespan_t::from_millis( delay ) )
   {
@@ -5359,9 +5685,10 @@ using namespace helpers;
   { return std::max( 0_ms, this->remains() + diff ); }
 
   // Event to handle UA stacks decreases
-  ua_stack_drop_event_t::ua_stack_drop_event_t( warlock_t* p, dot_t* _dot , timespan_t event_time )
+  ua_stack_drop_event_t::ua_stack_drop_event_t( warlock_t* p, dot_t* _dot, timespan_t event_time, bool _is_seed_applied )
     : player_event_t( *p, event_time ),
-    dot( _dot )
+    dot( _dot ),
+    is_seed_applied( _is_seed_applied )
   { }
 
   const char* ua_stack_drop_event_t::name() const
@@ -5374,18 +5701,30 @@ using namespace helpers;
     if ( dot->is_ticking() && dot->tick_event && dot->current_action && dot->remains() > 0_ms )
     {
       player_t* target = dot->target;
+      warlock_td_t* tdata = p->get_target_data( target );
 
       dot->decrement( 1 );
+      tdata->ua_stack_expired( is_seed_applied );
       assert( ( dot->is_ticking() && dot->current_stack() > 0 ) && "UA stack decrement event should not cancel the DoT" );
 
       if ( p->talents.fatal_echoes.ok() && !target->is_sleeping() && p->prd_rng.fatal_echoes->trigger() )
       {
         p->procs.fatal_echoes->occur();
-        dot->current_action->set_target( target );
-        dot->current_action->time_to_execute = 0_ms;
-        debug_cast<unstable_affliction_t*>( dot->current_action )->is_fatal_echoes_execute = true;
-        dot->current_action->execute();
-        debug_cast<unstable_affliction_t*>( dot->current_action )->is_fatal_echoes_execute = false;
+        unstable_affliction_t* ua_action = debug_cast<unstable_affliction_t*>( dot->current_action );
+        const bool prev_is_seed_applied = ua_action->is_seed_applied;
+        ua_action->set_target( target );
+        ua_action->time_to_execute = 0_ms;
+        ua_action->is_fatal_echoes_execute = true;
+        ua_action->is_seed_applied = false; // Fatal Echoes always applies a fully effective UA DoT stack
+        ua_action->execute();
+        ua_action->is_seed_applied = prev_is_seed_applied;
+        ua_action->is_fatal_echoes_execute = false;
+      }
+
+      if ( p->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( p->active_4pc<MID2>() )
+          helpers::update_unstable_empowerment_buff( p );
       }
     }
   }
@@ -5613,6 +5952,9 @@ using namespace helpers;
   {
     proc_actions.doom_proc     = new doom_t( this );
     proc_actions.blighted_maw  = new blighted_maw_t( this );
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
+      proc_actions.isolated_implosion = new isolated_implosion_t( this );
+
     summons.wild_imp           = new summon_wild_imp_t( this );
     summons.wild_imp_2         = new summon_wild_imp_2_t( this );
     summons.dreadstalker_1     = new summon_dreadstalker_1_t( this );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -122,9 +122,13 @@ namespace warlock
     parse_all_passive_sets();
     parse_raid_buffs();
 
-    // NOTE: 2026-02-17 Mark of Perotharn is being applied twice in what appears to be a bug
-    if ( bugs )
-      parse_passive_effects( hero.mark_of_perotharn, true );
+    // NOTE: 2026-07-05 The redesigned 12.1.0 Mark of Peroth'arn no longer double dips
+    if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+    {
+      // NOTE: 2026-02-17 Mark of Perotharn is being applied twice in what appears to be a bug
+      if ( bugs )
+        parse_passive_effects( hero.mark_of_perotharn, true );
+    }
   }
 
   void warlock_t::init_spells_affliction()
@@ -235,6 +239,12 @@ namespace warlock
     // Additional Tier Set spell data
     tier.wl_affliction_12_0_class_set_2pc = sets->set( WARLOCK_AFFLICTION, MID1, B2 ); // Should be ID 1264869
     tier.wl_affliction_12_0_class_set_4pc = sets->set( WARLOCK_AFFLICTION, MID1, B4 ); // Should be ID 1264870
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+    {
+      tier.wl_affliction_12_1_class_set_2pc = sets->set( WARLOCK_AFFLICTION, MID2, B2 ); // Should be ID 1296568
+      tier.wl_affliction_12_1_class_set_4pc = sets->set( WARLOCK_AFFLICTION, MID2, B4 ); // Should be ID 1296569
+      tier.unstable_empowerment_buff = conditional_spell_lookup( tier.wl_affliction_12_1_class_set_4pc->ok(), 1305774 );
+    }
 
     // Initialize some default values for pet spawners
     warlock_pet_list.darkglares.set_default_duration( talents.summon_darkglare->duration() );
@@ -269,7 +279,7 @@ namespace warlock
     talents.imperator = find_talent_spell( talent_tree::SPECIALIZATION, "Imp-erator" ); // Should be ID 416230
 
     talents.implosion = find_talent_spell( talent_tree::SPECIALIZATION, "Implosion" ); // Should be ID 196277
-    talents.implosion_aoe = conditional_spell_lookup( talents.implosion.ok(), 196278 );
+    talents.implosion_aoe = conditional_spell_lookup( warlock_base.demonology_warlock->ok(), 196278 );
 
     talents.power_siphon = find_talent_spell( talent_tree::SPECIALIZATION, "Power Siphon" ); // Should be ID 264130
     talents.power_siphon_buff = conditional_spell_lookup( talents.power_siphon.ok(), 334581 );
@@ -369,6 +379,13 @@ namespace warlock
     // Additional Tier Set spell data
     tier.wl_demonology_12_0_class_set_2pc = sets->set( WARLOCK_DEMONOLOGY, MID1, B2 ); // Should be ID 1264871
     tier.wl_demonology_12_0_class_set_4pc = sets->set( WARLOCK_DEMONOLOGY, MID1, B4 ); // Should be ID 1264872
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+    {
+      tier.wl_demonology_12_1_class_set_2pc = sets->set( WARLOCK_DEMONOLOGY, MID2, B2 ); // Should be ID 1296573
+      tier.wl_demonology_12_1_class_set_4pc = sets->set( WARLOCK_DEMONOLOGY, MID2, B4 ); // Should be ID 1296574
+      tier.isolated_implosion = conditional_spell_lookup( tier.wl_demonology_12_1_class_set_4pc->ok(), 1309535 );
+      tier.isolated_implosion_aoe = conditional_spell_lookup( tier.wl_demonology_12_1_class_set_4pc->ok(), 1306077 );
+    }
 
     // Initialize some default values for pet spawners
     warlock_pet_list.wild_imps.set_default_duration( warlock_base.wild_imp->duration() );
@@ -485,7 +502,8 @@ namespace warlock
     talents.chaos_incarnate = find_talent_spell( talent_tree::SPECIALIZATION, "Chaos Incarnate" ); // Should be ID 387275
 
     talents.conflagration_of_chaos = find_talent_spell( talent_tree::SPECIALIZATION, "Conflagration of Chaos" ); // Should be ID 387108
-    talents.conflagration_of_chaos_buff = conditional_spell_lookup( talents.conflagration_of_chaos.ok(), 387109 );
+    if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+      talents.conflagration_of_chaos_buff = conditional_spell_lookup( talents.conflagration_of_chaos.ok(), 387109 );
 
     talents.diabolic_embers = find_talent_spell( talent_tree::SPECIALIZATION, "Diabolic Embers" ); // Should be ID 387173
 
@@ -518,6 +536,12 @@ namespace warlock
     // Additional Tier Set spell data
     tier.wl_destruction_12_0_class_set_2pc = sets->set( WARLOCK_DESTRUCTION, MID1, B2 ); // Should be ID 1264873
     tier.wl_destruction_12_0_class_set_4pc = sets->set( WARLOCK_DESTRUCTION, MID1, B4 ); // Should be ID 1264874
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+    {
+      tier.wl_destruction_12_1_class_set_2pc = sets->set( WARLOCK_DESTRUCTION, MID2, B2 ); // Should be ID 1296571
+      tier.wl_destruction_12_1_class_set_4pc = sets->set( WARLOCK_DESTRUCTION, MID2, B4 ); // Should be ID 1296572
+      tier.dark_titans_mark_debuff = conditional_spell_lookup( tier.wl_destruction_12_1_class_set_4pc->ok(), 1305711 );
+    }
 
     // Initialize some default values for pet spawners
     warlock_pet_list.infernals.set_default_duration( talents.summon_infernal_main->duration() );
@@ -629,8 +653,6 @@ namespace warlock
     hero.malevolence = find_talent_spell( talent_tree::HERO, "Malevolence" ); // Should be ID 430014
     hero.malevolence_buff = conditional_spell_lookup( hero.malevolence.ok(), 442726 );
     hero.malevolence_dmg = conditional_spell_lookup( hero.malevolence.ok(), 446285 );
-
-    cooldowns.blackened_soul->duration = hero.blackened_soul->internal_cooldown();
   }
 
   void warlock_t::init_spells_soul_harvester()
@@ -749,6 +771,10 @@ namespace warlock
 
     buffs.seed_of_corruption_is_out_dnt = make_buff( this, "seed_of_corruption_is_out_dnt", talents.seed_of_corruption_is_out_dnt )
                                               ->set_quiet( true );
+
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      buffs.unstable_empowerment = make_buff( this, "unstable_empowerment", tier.unstable_empowerment_buff )
+                                       ->set_default_value_from_effect( 1 );
   }
 
   void warlock_t::create_buffs_demonology()
@@ -829,8 +855,9 @@ namespace warlock
 
     buffs.rain_of_chaos = make_buff( this, "rain_of_chaos", talents.rain_of_chaos_buff );
 
-    buffs.conflagration_of_chaos = make_buff( this, "conflagration_of_chaos", talents.conflagration_of_chaos_buff )
-                                       ->set_chance( talents.conflagration_of_chaos->effectN( 1 ).percent() );
+    if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+      buffs.conflagration_of_chaos = make_buff( this, "conflagration_of_chaos", talents.conflagration_of_chaos_buff )
+                                         ->set_chance( talents.conflagration_of_chaos->effectN( 1 ).percent() );
 
     buffs.flashpoint = make_buff( this, "flashpoint", talents.flashpoint_buff )
                            ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
@@ -1328,7 +1355,8 @@ namespace warlock
     }
 
     // Rain of Chaos uses Deck of Cards RNG at 3 out of 20
-    if ( talents.rain_of_chaos.ok() ) {
+    if ( talents.rain_of_chaos.ok() )
+    {
       int deck_size = static_cast<int>( rng_settings.rain_of_chaos_deck_size.setting_value );
       int cards = static_cast<int>( rng_settings.rain_of_chaos_cards.setting_value );
       deck_rng.rain_of_chaos = get_shuffled_rng( "rain_of_chaos", cards, deck_size );
@@ -1386,11 +1414,12 @@ namespace warlock
       } );
     }
 
-    // Modeling Echo of Sargeras as a pseudo-random distribution (PRD) with a nominal
-    // rate of 10%, which corresponds to PRD constant C = 0.014745844781072676.
+    // Modeling Echo of Sargeras as a pseudo-random distribution (PRD) with a nominal rate of 10% (20% with 12.1.0 2p tier),
+    // which corresponds to PRD constant C = 0.014745844781072676 (0.055704042949781852 with 12.1.0 2p tier).
     if ( talents.embers_of_nihilam_1.ok() )
     {
-      double c_es = prd::find_constant( rng_settings.echo_of_sargeras.setting_value );
+      double c_es = prd::find_constant( ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) ) ? talents.embers_of_nihilam_1->effectN( 1 ).percent()
+                                        : rng_settings.echo_of_sargeras.setting_value );
       prd_rng.echo_of_sargeras = get_accumulated_rng( "echo_of_sargeras", c_es );
     }
   }

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -267,8 +267,7 @@ warlock_pet_spell_t::warlock_pet_spell_t( util::string_view token, warlock_pet_t
     affected_by()
 {
   affected_by.xalans_cruelty_effect_6 = p->o()->hero.xalans_cruelty.ok() && data().affected_by_label( p->o()->hero.xalans_cruelty->effectN( 6 ) );
-  if ( sim->dbc->wowv() < wowv_t{ 12, 0, 7 } ) // TODO: Effect is missing from 12.0.7 PTR; remove this check once added
-    affected_by.xalans_cruelty_effect_9 = p->o()->hero.xalans_cruelty.ok() && data().affected_by_label( p->o()->hero.xalans_cruelty->effectN( 9 ) );
+  affected_by.xalans_cruelty_effect_9 = p->o()->hero.xalans_cruelty.ok() && data().affected_by_label( p->o()->hero.xalans_cruelty->effectN( 9 ) );
 
   affected_by.xalans_ferocity_effect_6 = p->o()->hero.xalans_ferocity.ok() && data().affected_by_label( p->o()->hero.xalans_ferocity->effectN( 6 ) );
   affected_by.xalans_ferocity_effect_7 = p->o()->hero.xalans_ferocity.ok() && data().affected_by_label( p->o()->hero.xalans_ferocity->effectN( 7 ) );
@@ -805,23 +804,39 @@ struct fel_firebolt_t : public warlock_pet_spell_t
 
   void execute() override
   {
+    player_t* ffb_target = target;
+
     warlock_pet_spell_t::execute();
 
     // Extra Fel Firebolts from Infernal Rapidity cannot proc Infernal Rapidity again
     if ( ( twin != nullptr ) && ( p()->bugs ? debug_cast<wild_imp_pet_t*>( p() )->prd_rng_infernal_rapidity->trigger() : rng().roll( p()->o()->talents.infernal_rapidity->effectN( 1 ).percent() ) ) )
     {
       p()->o()->procs.infernal_rapidity->occur();
-      twin->execute_on_target( target );
+      twin->execute_on_target( ffb_target );
     }
   }
 
   void consume_resource() override
   {
+    player_t* ffb_target = target;
+
     warlock_pet_spell_t::consume_resource();
 
     // Imp dies if it cannot cast
     if ( player->resources.current[ RESOURCE_ENERGY ] < cost() )
-      make_event( sim, 0_ms, [ this ]() { player->cast_pet()->dismiss(); } );
+      make_event( sim, 0_ms, [ this, imp = debug_cast<warlock::pets::demonology::wild_imp_pet_t*>( player ), imp_target = ffb_target ]() {
+        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+        {
+          if ( imp->o()->active_4pc<MID2>() && rng().roll( imp->o()->tier.wl_demonology_12_1_class_set_4pc->effectN( 3 ).percent() ) )
+            helpers::trigger_isolated_implosion( imp->o(), imp, imp_target );
+          else
+            imp->cast_pet()->dismiss();
+        }
+        else
+        {
+          imp->cast_pet()->dismiss();
+        }
+      } );
   }
 };
 
@@ -1321,10 +1336,12 @@ struct vilefiend_melee_t : public warlock_pet_melee_t
 
   void execute() override
   {
+    player_t* vfm_target = target;
+
     warlock_pet_melee_t::execute();
 
     if ( debug_cast<vilefiend_t*>( p() )->mark_of_shatug->check() )
-      gloom->execute_on_target( target );
+      gloom->execute_on_target( vfm_target );
   }
 };
 
@@ -1369,10 +1386,12 @@ struct headbutt_t : public warlock_pet_melee_attack_t
 
   void execute() override
   {
+    player_t* hbtt_target = target;
+
     warlock_pet_melee_attack_t::execute();
 
     if ( debug_cast<vilefiend_t*>( p() )->mark_of_shatug->check() )
-      gloom->execute_on_target( target );
+      gloom->execute_on_target( hbtt_target );
   }
 };
 
@@ -2052,7 +2071,8 @@ void infernal_t::create_buffs()
 
   immolation = make_buff<buff_t>( this, "immolation", o()->talents.immolation_buff )
                    ->set_tick_callback( [ damage, this ]( buff_t*, int, timespan_t ) {
-                     damage->execute_on_target( target );
+                     if ( target )
+                       damage->execute_on_target( target );
                    } );
 }
 
@@ -2063,7 +2083,7 @@ void infernal_t::arise()
   // 2024-07-18 Testing indicates there is a delay after spawn before first melee
   // Embers looks to trigger at around the same time as first melee swing, but Immolation takes longer to apply (and has no zero-tick)
   // Additionally, there is some unknown amount of movement adjustment the pet can take, so we model this with a distribution
-  timespan_t delay = rng().gauss<1000,100>();
+  timespan_t delay = rng().gauss<1000, 100>();
 
   make_event( *sim, delay, [ this ] {
     buffs.embers->trigger();
@@ -2499,7 +2519,7 @@ struct wrath_of_nathreza_t : public warlock_pet_spell_t
   void execute() override
   {
     if ( p()->o()->haunt_target && !p()->o()->haunt_target->is_sleeping() )
-      target = p()->o()->haunt_target;
+      set_target( p()->o()->haunt_target );
 
     warlock_pet_spell_t::execute();
 

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -633,7 +633,7 @@ struct darkglare_t : public warlock_pet_t
   darkglare_t( warlock_t*, util::string_view = "darkglare" );
   void arise() override;
   void demise() override;
-  action_t* create_action( util::string_view , util::string_view ) override;
+  action_t* create_action( util::string_view, util::string_view ) override;
 };
 
 struct desperate_soul_t : public warlock_pet_t
@@ -642,7 +642,7 @@ struct desperate_soul_t : public warlock_pet_t
 
   desperate_soul_t( warlock_t*, util::string_view = "desperate_soul" );
   void arise() override;
-  action_t* create_action( util::string_view , util::string_view ) override;
+  action_t* create_action( util::string_view, util::string_view ) override;
 };
 }  // namespace affliction
 


### PR DESCRIPTION
This PR updates the Warlock module to implement the 12.1.0 class changes and the new 12.1.0 tier set bonuses. It also includes some general changes that affect the current live version covered by this PR (12.0.7). The changes intended for 12.1.0 are guarded behind version checks, and those guards can be revisited once 12.1.0 becomes the current live version.

# 12.1.0 class changes

> - Hero Talents
>   - Hellcaller
>     - Blackened Soul has been redesigned – If the target is afflicted with your Wither, your Chaos Bolt and Shadowburn increase its stack count by 1. Each time Wither gains a stack it has a chance to collapse, consuming a stack every 1 second to deal Shadowflame damage to its host until 1 stack remains.
>     - Mark of Peroth'arn has been redesigned – Damaging critical strikes dealt by Wither deal 215% damage instead of the usual 200%. Damaging critical strikes dealt by Blackened Soul deal 225% damage instead of the usual 200%.
> - Destruction
>   - Conflagration of Chaos has been redesigned – Conflagrate and Shadowburn have a 100% chance to critically strike, and their damage is increased by your critical strike chance.
>   - Apex Talent: Embers of Nihilam (Rank 1) tooltip has been updated to show players the percent chance of Incinerate evoking an Echo of Sargeras.

For Hellcaller, the 12.1.0 redesigned trigger behavior is guarded behind `>=12.1.0`, while pre-12.1.0 behavior is preserved where applicable. The obsolete **Blackened Soul** ICD handling is removed for all versions, since the spell no longer has an ICD in current spell data. It is worth noting that, for Affliction, instead of **Chaos Bolt** and **Shadowburn**, the spell that increments the target's stack count is **Unstable Affliction** (but not **Seed of Corruption**).

In its current behavior, due to a bug, **Mark of Peroth'arn** was being applied twice, effectively increasing its effect. Testing indicates that the redesigned **Mark of Peroth'arn** no longer has this bug and is now only applied once.

For Destruction, **Conflagration of Chaos** changed from being a buff to being a passive effect from the talent in 12.1.0. It is worth mentioning that, due to what appears to be a bug, the talent does not guarantee that **Conflagrate** / **Shadowburn** critically strike; instead, it simply doubles their critical strike chance. This is because it was implemented in the effect as `Add Percent Modifier (108): Spell Critical Chance (7)` instead of `Add Flat Modifier (107): Spell Critical Chance (7)`. Presumably, this will eventually be fixed by Blizzard, and when that happens, it should be handled by the `parse_effects` system automatically.

Regarding the apex talent **Embers of Nihilam**, the change means the **Echo of Sargeras** proc chance from **Incinerate** is now present directly in spell data, so we can use that value instead of relying on a custom `rng_setting_t`. In addition, effects that modify this chance, such as the new tier set 2-piece bonus, also appear to modify this value in spell data, making it straightforward to track the real proc chance.

# New 12.1.0 tier set

> - Affliction
>   - 2-Set Bonus: Wither damage increased by 25%. Agony damage increased by 15%.
>   - 4-Set Bonus: Each active Unstable Affliction increases your damage dealt by your spells and abilities by 2%, up to 6%. Seed of Corruption applies Unstable Affliction at ~~50%~~ 20% effectiveness to your target.
> - Demonology
>   - 2-Set Bonus: Wild Imp damage increased by 10%. Implosion damage increased by 20%.
>   - 4-Set Bonus: When their energy depletes, Wild Imps have a 20% chance to fling themselves at their target and Implode at 150% effectiveness to their main target and 125% effectiveness to other targets.
> - Destruction
>   - 2-Set Bonus: Incinerate damage increased by 25% and Incinerate has a 10% increased chance to evoke an Echo of Sargeras.
>   - 4-Set Bonus: Targets damaged by Echo of Sargeras take 6% increased damage from Echo of Sargeras for 6 seconds.

## Affliction 2pc

No manual changes are required; this is processed automatically by SimC's `parse_effects` system.

## Affliction 4pc

The **Unstable Empowerment** buff has been implemented to handle the 2%/4%/6% damage increase based on stacks. It should be noted that this buff counts the total number of **Unstable Affliction** stacks across all targets, and Seed-applied **Unstable Affliction** also counts as a normal application.

~~In addition, there is currently what appears to be a bug where this buff only increases the direct damage of certain whitelisted spells, but does not increase their periodic damage. In any case, if Blizzard fixes this in spell data, future code changes will most likely not be required, since it should be handled by the `parse_effects` system.~~ *(fixed in PTR 2026-07-08)*

The second effect of this bonus causes **Seed of Corruption** to apply the **Unstable Affliction** DoT to the target, supposedly at ~~50%~~ 20% effectiveness. Although the tooltip describes Seed-applied **Unstable Affliction** as "~~50%~~ 20% effectiveness", logs do not match a simple per-stack ~~50%~~ 20% multiplier. SimC models the observed periodic damage by tracking regular **Unstable Affliction** applications separately from Seed/tier **Unstable Affliction** applications, with Seed-UA applications creating a one-stack periodic damage deficit that is cleared when a Seed-UA stack expires.

*As of 2026-07-08, Blizzard announced a hotfix reducing Seed-UA effectiveness from 50% to 20%. However, this does not appear to affect how the UA actually behaves, as it still follows the same model as before and therefore deals the same damage as before.*

This is a model of observed combat log behavior, not a statement about Blizzard's internal implementation.

<details>
<summary>Detailed implemented UA stacking model</summary>

The model tracks:

```text
A = regular UA applications
S = Seed/tier UA applications
seed_gap = whether the most recent Seed-UA stack event was an application
```

The actual DoT stack count remains:

```text
A + S
```

Normal periodic UA damage is modeled as:

```text
A + S - (seed_gap ? 1 : 0)
```

With the following state transitions:

```text
apply_A:  A += 1
expire_A: A -= 1

apply_S:  S += 1, seed_gap = true
expire_S: S -= 1, seed_gap = false
```

This reproduces the observed behavior where a Seed-applied UA creates a one-stack periodic damage deficit, and that deficit is cleared when a Seed-applied UA stack expires.

Examples:

```text
S       -> 0 damage stacks
S S     -> 1 damage stack
S S S   -> 2 damage stacks

S S, then one S expires:
S       -> 1 damage stack

A S     -> 1 damage stack
A S S   -> 2 damage stacks
A A S S -> 3 damage stacks
```

Effects that use the actual UA DoT stack count continue to use `A + S`; only normal periodic UA damage uses the modeled effective stack count.

</details>

### Seed-applied UA related interaction notes

- **Fatal Echoes** applies a regular, full-effectiveness **Unstable Affliction** application. It does not inherit Seed-UA effectiveness and does not reset or convert the existing regular/Seed UA tracking.

- **Malefic Grasp** UA extra ticks use the actual DoT stack count, not the modeled periodic damage stack count. Every stack counts as a fully effective UA.

- **Unstable Empowerment** stacks use the total UA DoT stack count across all targets, not the modeled periodic damage stack count.

- Seed-applied UA can trigger **Cascading Calamity** when applied to a target that already had UA active.

- Seed-applied UA does not trigger **Cull the Weak**'s **Dark Harvest** cooldown reduction.

- Seed-applied UA does not increment **Wither** through **Blackened Soul**.

- On PTR, in what appears to be a bug, Seed-applied UA consumes **Shard Instability**.

- Seed-applied UA consumes **Succulent Soul** and triggers its consume effects.

- Casting **Seed of Corruption** with **Sow the Seeds** only applies UA to the main target (where the main seed goes).

## Demonology 2pc

No manual changes are required; this is processed automatically by SimC's `parse_effects` system.

## Demonology 4pc

It seems that, in earlier PTR iterations, there were several bugs with this bonus effect, causing it to be owned by pets (benefiting from pet-specific bonus effects) and interact with the **To Hell and Back** talent. This now appears to be fixed on PTR: the spell now belongs to the player and no longer interacts with **To Hell and Back**. The implosions triggered by this effect are considered individual implosions for each imp, even if they happen simultaneously, so they do not summon empowered imps from **To Hell and Back**.

The spell used for the implosion is **Isolated Implosion**. It does not have a spell power coefficient in spell data, and instead appears to inherit it directly from the original **Implosion**. In addition, unlike regular **Implosion**, the damage to the primary target and to secondary targets is split into two different effect components, and the final damage does not appear to be tied to the remaining energy of the **Wild Imp**, as expected for implosions from imps with no energy left.

This spell does have a custom multiplier, as described in the spell tooltip, although it may not be applied in the expected way: the spell description lists 150%/125% effectiveness, but in-game damage behaves as +150%/+125% increased effectiveness.

The RNG type used for the 20% chance of **Isolated Implosion** still needs to be checked. For now, it has been implemented as a simple flat chance.

## Destruction 2pc

The 25% damage bonus to **Incinerate** is processed automatically by SimC's `parse_effects` system and does not require manual implementation. The 10% increased chance to evoke an **Echo of Sargeras** is also processed by this system, and now that the **Echo of Sargeras** chance comes from spell data, it can be used directly from there. If this bonus is active, spell data will already return the modified value with this increase applied.

## Destruction 4pc

The new **Dark Titan's Mark** debuff has been implemented to handle the damage increase from this bonus.

# Other changes that also affect the current version, not only `>=12.1.0`

- **Xalan's Cruelty** effect #&#8203;9 was only active for `<12.0.7`, because for a while this effect was missing from later versions. However, it has now been added to spell data for the current version, as well as for 12.1.0, so that check has been removed.

- The ICD for **Blackened Soul** has been removed, since this spell has not had an ICD for a long time. It only had an ICD temporarily as part of a Blizzard fix attempt, which caused several issues; it was later removed, and it seems unlikely that it will be added again. If an ICD is added back in the future, it will need to be reimplemented in the module.

- The use of `target` in `execute()` has been redesigned for some actions. We found that using `target` after calling `<parent>::execute()` is not always safe, since it may be reset. In those cases, it is preferable to capture `target` before that call and use the captured value afterward. `execute_state->target` can also be used in some cases, although care is required because it may be stale in some situations or `nullptr`; for AoE spells, it may also not indicate the primary target.

- For **Agony**, it was considered more appropriate to move the handling of the DoT's initial stacks to `impact()`.

- Similar to what has been observed in-game, consuming a **Succulent Soul** stack/buff appears to be delayed by a few milliseconds. This causes simultaneous effects to be able to benefit from it even when there are fewer stacks available. In addition, to simplify its handling, its consume effects have been moved to a helper function.

- There was a partially modeled in-game bug with **Feast of Souls** (with **Quietus** procs), where proccing it by spending **Nightfall** with **Seed of Corruption** through the **Nocturnal Yield** talent causes one **Succulent Soul** stack to be consumed by that same **Seed of Corruption** without triggering its effects. With the new tier set, this still happens, but the UA applied by **Seed of Corruption** does trigger the **Succulent Soul** effects, so the impact of the bug is smaller. This bug has been modeled more accurately to match in-game behavior, both for the current version of the game and for 12.1.0 with the tier set.
