### PR TITLE
[Hunter] Remove 3T condition from BM PL AoE APL

### DIFF
--- a/engine/class_modules/apl/apl_hunter.cpp
+++ b/engine/class_modules/apl/apl_hunter.cpp
@@ -102,7 +102,7 @@ void beast_mastery( player_t* p )
   cleave->add_action( "wild_thrash,if=talent.beast_cleave" );
   cleave->add_action( "bestial_wrath,if=!prev.wild_thrash" );
   cleave->add_action( "wild_thrash,if=!talent.beast_cleave" );
-  cleave->add_action( "kill_command,if=cooldown.bestial_wrath.remains>gcd&(buff.natures_ally.react|talent.master_handler&(active_enemies>3|howl_summon.ready))" );
+  cleave->add_action( "kill_command,if=cooldown.bestial_wrath.remains>gcd&(buff.natures_ally.react|talent.master_handler)" );
   cleave->add_action( "cobra_shot,if=cooldown.wild_thrash.remains>gcd&buff.hogstrider.up&active_enemies<4" );
   cleave->add_action( "barbed_shot,target_if=min:dot.barbed_shot.remains|max_prio_damage" );
   cleave->add_action( "cobra_shot,if=talent.beast_cleave&cooldown.wild_thrash.remains>gcd|!talent.beast_cleave" );

--- a/engine/class_modules/apl/hunter/bm.txt
+++ b/engine/class_modules/apl/hunter/bm.txt
@@ -23,7 +23,7 @@ actions.cleave=barbed_shot,target_if=min:dot.barbed_shot.remains|max_prio_damage
 actions.cleave+=/wild_thrash,if=talent.beast_cleave
 actions.cleave+=/bestial_wrath,if=!prev.wild_thrash
 actions.cleave+=/wild_thrash,if=!talent.beast_cleave
-actions.cleave+=/kill_command,if=cooldown.bestial_wrath.remains>gcd&(buff.natures_ally.react|talent.master_handler&(active_enemies>3|howl_summon.ready))
+actions.cleave+=/kill_command,if=cooldown.bestial_wrath.remains>gcd&(buff.natures_ally.react|talent.master_handler)
 actions.cleave+=/cobra_shot,if=cooldown.wild_thrash.remains>gcd&buff.hogstrider.up&active_enemies<4
 actions.cleave+=/barbed_shot,target_if=min:dot.barbed_shot.remains|max_prio_damage
 actions.cleave+=/cobra_shot,if=talent.beast_cleave&cooldown.wild_thrash.remains>gcd|!talent.beast_cleave


### PR DESCRIPTION
Seems like 3t condition is dps loss for both aoe and prio dmg now. Also it makes rotation more complicated. Not sure what changed since we added this condition initially.
2t https://www.raidbots.com/simbot/report/jwAHxc37ZXw1vCZTWh9NLm
3t https://www.raidbots.com/simbot/report/oFXBLXy7MyNfPwRpczgm8J
Now it's simple "ignore NA for both aoe and prio"