### PR TITLE
[Warlock] Update Demonology pet interactions

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -299,7 +299,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
   regen_caches[ CACHE_SPELL_HASTE ] = true;
 
   sim->register_heartbeat_event_callback( [ this ]( sim_t* ) {
-    // NOTE (2026-04-24): Some pets are currently bugged when updating Hellbent Commander stacks on arise/demise.
+    // NOTE (2026-07-11): Some pets are currently bugged when updating Hellbent Commander stacks on arise/demise.
     // Hellbent Commander's stacks are refreshed on each heartbeat update, but not all pets are correctly accounted for.
     if ( bugs && talents.hellbent_commander.ok() )
     {
@@ -331,7 +331,7 @@ warlock_t::warlock_t( sim_t* sim, util::string_view name, race_e r )
         this->sim->print_debug( "{} heartbeat event update {} buff stack number from stacks_before={} to stacks_after={}",
                         this->name(), buffs.hellbent_commander->name(), current_stacks, expected_stacks );
       }
-      assert( ( buffs.hellbent_commander->check() == expected_stacks ) && "Incorrent Demon Count for Hellbent Commander" );
+      assert( ( buffs.hellbent_commander->check() == expected_stacks ) && "Incorrect Demon Count for Hellbent Commander" );
     }
 
     for ( auto pet : active_pets )
@@ -551,7 +551,7 @@ int warlock_t::active_demon_count( bool include_diabolist ) const
     if ( lock_pet->is_sleeping() )
       continue;
 
-    // NOTE: 2026-02-17 Dibolist guardians seems to not count for some effects/talents (Sacrificed Souls)
+    // NOTE: 2026-07-11 Diabolist guardians seem to not count for some effects/talents (Sacrificed Souls)
     if ( !include_diabolist && lock_pet->is_diabolist_guardian )
       continue;
 

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -961,6 +961,7 @@ public:
     proc_t* infernal_rapidity;
     proc_t* spiteful_reconstitution;
     proc_t* demonic_knowledge;
+    proc_t* isolated_implosion;
 
     // Destruction
     proc_t* reverse_entropy;
@@ -1037,6 +1038,7 @@ public:
     accumulated_rng_t* spiteful_reconstitution;
     accumulated_rng_t* bleakheart_tactics;
     accumulated_rng_t* mark_of_perotharn;
+    accumulated_rng_t* isolated_implosion;
     double infernal_rapidity_prd_c_value;
   } prd_rng;
 

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -531,7 +531,7 @@ using namespace helpers;
       if ( affliction() && affected_by.deaths_embrace && s->target->health_percentage() < deaths_embrace_health )
         m *= 1.0 + p()->talents.deaths_embrace->effectN( 1 ).percent() * ( 1 - s->target->health_percentage() / deaths_embrace_health );
 
-      // NOTE: 2026-02-17 Diabolist guardians do not count towards Sacrificed Souls talent (bug?)
+      // NOTE: 2026-07-11 Diabolist guardians do not count towards Sacrificed Souls talent (bug?)
       if ( demonology() && affected_by.sacrificed_souls )
         m *= 1.0 + p()->talents.sacrificed_souls->effectN( 1 ).percent() * p()->active_demon_count( !p()->bugs );
 
@@ -3112,7 +3112,7 @@ using namespace helpers;
       // - The distance of the wild imps from the player can affect their selection.
       // - When there are many imps (more than 9), the selection of some of them seems to become somewhat random
       //   (maybe not random; in any case, their actual behavior in this situation has not been fully determined).
-      range::sort( imps, [ &bugs = p()->bugs ]( const pets::demonology::wild_imp_pet_t* imp1, const pets::demonology::wild_imp_pet_t* imp2 ) {
+      range::sort( imps, []( const pets::demonology::wild_imp_pet_t* imp1, const pets::demonology::wild_imp_pet_t* imp2 ) {
         double lv = imp1->resources.current[ RESOURCE_ENERGY ];
         double rv = imp2->resources.current[ RESOURCE_ENERGY ];
         if ( lv == rv )
@@ -3153,7 +3153,16 @@ using namespace helpers;
       }
       if ( p()->talents.to_hell_and_back.ok() )
       {
-        unsigned new_imps = ( launch_counter / as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() ) ) * as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
+        const unsigned imps_per_group = as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
+        const unsigned group_size = as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() );
+        unsigned groups;
+        // NOTE: 2026-07-11: PTR 12.1.0 Implosion rounds up To Hell and Back summons (bug?)
+        if ( p()->bugs && sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+          groups = ( launch_counter + group_size - 1 ) / group_size;
+        else
+          groups = launch_counter / group_size;
+
+        unsigned new_imps = groups * imps_per_group;
         if ( new_imps > 0 )
         {
           auto imps = debug_cast<summon_wild_imp_2_t*>( p()->summons.wild_imp_2 )->execute_spawn( new_imps );
@@ -3268,7 +3277,7 @@ using namespace helpers;
 
       imp->trigger_movement( dist, movement_direction_type::TOWARDS );
       imp->interrupt();
-      imp->imploded = true;
+      imp->isolated_imploded = true;
 
       make_event( sim, imp_travel_time, [ ex, tar, imp = imp ] {
         if ( imp && !imp->is_sleeping() )
@@ -3542,7 +3551,9 @@ using namespace helpers;
 
       if ( p()->talents.to_hell_and_back.ok() )
       {
-        unsigned new_imps = ( sac_counter / as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() ) ) * as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
+        const unsigned imps_per_group = as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
+        const unsigned group_size = as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() );
+        unsigned new_imps = ( sac_counter / group_size ) * imps_per_group;
         if ( new_imps > 0 )
         {
           auto imps = debug_cast<summon_wild_imp_2_t*>( p()->summons.wild_imp_2 )->execute_spawn( new_imps );
@@ -5619,6 +5630,7 @@ using namespace helpers;
     isolated_implosion->set_target( target );
     isolated_implosion->imp = imp;
     isolated_implosion->execute();
+    p->procs.isolated_implosion->occur();
   }
 
   void helpers::update_unstable_empowerment_buff( warlock_t* p )

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -1119,6 +1119,8 @@ namespace warlock
     procs.infernal_rapidity = get_proc( "infernal_rapidity" );
     procs.spiteful_reconstitution = get_proc( "spiteful_reconstitution" );
     procs.demonic_knowledge = get_proc( "demonic_knowledge" );
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      procs.isolated_implosion = get_proc( "isolated_implosion" );
   }
 
   void warlock_t::init_procs_destruction()
@@ -1331,6 +1333,14 @@ namespace warlock
         cards = static_cast<int>( rng_settings.demonic_knowledge_rank1_cards.setting_value );
 
       deck_rng.demonic_knowledge = get_shuffled_rng( "demonic_knowledge", cards, deck_size );
+    }
+
+    // Modeling Isolated Implosion as a pseudo-random distribution (PRD) with a nominal
+    // rate of 20%, which corresponds to PRD constant C = 0.055704042949781852.
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
+    {
+      double c_ii = prd::find_constant( tier.wl_demonology_12_1_class_set_4pc->effectN( 3 ).percent() );
+      prd_rng.isolated_implosion = get_accumulated_rng( "isolated_implosion", c_ii );
     }
   }
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -211,7 +211,7 @@ void warlock_pet_t::arise()
   if ( triggers.hellbent_commander_arise )
   {
     o()->buffs.hellbent_commander->trigger();
-    assert( ( bugs || o()->buffs.hellbent_commander->check() == o()->active_demon_count() ) && "Incorrent Demon Count for Hellbent Commander" );
+    assert( ( bugs || o()->buffs.hellbent_commander->check() == o()->active_demon_count() ) && "Incorrect Demon Count for Hellbent Commander" );
   }
 }
 
@@ -230,7 +230,7 @@ void warlock_pet_t::demise()
   if ( melee_attack )
     melee_attack->reset();
 
-  assert( ( bugs || !o()->talents.hellbent_commander.ok() || o()->buffs.hellbent_commander->check() == o()->active_demon_count() ) && "Incorrent Demon Count for Hellbent Commander" );
+  assert( ( bugs || !o()->talents.hellbent_commander.ok() || o()->buffs.hellbent_commander->check() == o()->active_demon_count() ) && "Incorrect Demon Count for Hellbent Commander" );
 }
 
  // TODO: Add all pet spells to base warlock data
@@ -310,7 +310,8 @@ felhunter_pet_t::felhunter_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 691 )->effectN( 1 ).misc_value1();
 
-  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Main pets do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel/shadow_bite";
@@ -360,7 +361,8 @@ imp_pet_t::imp_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 688 )->effectN( 1 ).misc_value1();
 
-  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Main pets do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "firebolt";
@@ -405,7 +407,8 @@ sayaad_pet_t::sayaad_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 366222 )->effectN( 1 ).misc_value1();
 
-  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Main pets do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel/whiplash/lash_of_pain";
@@ -466,7 +469,8 @@ voidwalker_pet_t::voidwalker_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->find_spell( 697 )->effectN( 1 ).misc_value1();
 
-  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Main pets do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel/consuming_shadows";
@@ -519,7 +523,8 @@ felguard_pet_t::felguard_pet_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->talents.summon_felguard->effectN( 1 ).misc_value1();
 
-  // NOTE: 2026-04-24 Main pets do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Main pets do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel";
@@ -681,10 +686,12 @@ action_t* felguard_pet_t::create_action( util::string_view name, util::string_vi
 /// Wild Imp Begin
 
 wild_imp_pet_t::wild_imp_pet_t( warlock_t* owner )
-  : warlock_pet_t( owner, "wild_imp", PET_WILD_IMP, true ), firebolt( nullptr ), is_hog_imp( true ), power_siphon( false ), imploded( false )
+  : warlock_pet_t( owner, "wild_imp", PET_WILD_IMP, true ), firebolt( nullptr ), is_hog_imp( true ), power_siphon( false ), imploded( false ), isolated_imploded( false )
 {
   npc_id = owner->warlock_base.wild_imp->effectN( 1 ).misc_value1();
 
+  // NOTE: 2026-07-11 Wild Imps do not trigger Hellbent Commander on arise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   // Manually handle the Wild Imps contribution to Hellbent Commander on demise to replicate its bugged behavior
   triggers.hellbent_commander_demise &= !bugs;
 
@@ -827,7 +834,7 @@ struct fel_firebolt_t : public warlock_pet_spell_t
       make_event( sim, 0_ms, [ this, imp = debug_cast<warlock::pets::demonology::wild_imp_pet_t*>( player ), imp_target = ffb_target ]() {
         if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
         {
-          if ( imp->o()->active_4pc<MID2>() && rng().roll( imp->o()->tier.wl_demonology_12_1_class_set_4pc->effectN( 3 ).percent() ) )
+          if ( imp->o()->active_4pc<MID2>() && imp->o()->prd_rng.isolated_implosion->trigger() )
             helpers::trigger_isolated_implosion( imp->o(), imp, imp_target );
           else
             imp->cast_pet()->dismiss();
@@ -892,6 +899,7 @@ void wild_imp_pet_t::arise()
   is_hog_imp = ( duration == o()->warlock_base.wild_imp->duration() ); // TODO: Only valid because duration diff, look for a safer way
   power_siphon = false;
   imploded = false;
+  isolated_imploded = false;
 
   // Each Wild Imp uses its own independent accumulator PRD, reset to 0 on arise
   if ( o()->talents.infernal_rapidity.ok() )
@@ -933,7 +941,7 @@ void wild_imp_pet_t::demise()
     {
       for ( auto t : o()->warlock_pet_list.demonic_tyrants )
       {
-        // NOTE: 2026-04-24: Imploded Wild Imps does not substract stacks from Demonic Power buff (bug?)
+        // NOTE: 2026-07-11: Imploded Wild Imps do not subtract stacks from Demonic Power buff (bug?)
         if ( t->is_active() && ( !bugs || !imploded ) )
           t->buffs.demonic_power->decrement();
       }
@@ -943,6 +951,7 @@ void wild_imp_pet_t::demise()
     {
       if ( !power_siphon )
       {
+        // NOTE: 2026-07-11: PTR 12.1.0 Isolated Imploded imps cannot trigger Demoniac (bug)
         if ( imploded )
         {
           if ( o()->flat_rng.demoniac_imp_implosion->trigger() )
@@ -951,7 +960,7 @@ void wild_imp_pet_t::demise()
             o()->procs.demonic_core_imps_implosion->occur();
           }
         }
-        else
+        else if ( !bugs || !isolated_imploded )
         {
           if ( o()->prd_rng.demoniac_imp_fade->trigger() )
           {
@@ -963,7 +972,7 @@ void wild_imp_pet_t::demise()
     }
 
     // Manual handling of Hellbent Commander buff for Wild Imps
-    // NOTE (2026-04-24): Wild Imps are currently bugged when updating Hellbent Commander stacks on demise:
+    // NOTE (2026-07-11): Wild Imps are currently bugged when updating Hellbent Commander stacks on demise:
     // If imploded, imps summoned via HoG decrease one stack each, while those summoned via Inner Demons,
     // Spiteful Reconstitution, or To Hell and Back do not decrease any stacks.
     // If the imps demise normally or are sacrificed with Power Siphon, HoG imps decrease two stacks each,
@@ -1014,6 +1023,9 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner ) : warlock_pet_t( owner, "drea
   action_list_str = "leap/travel/dreadbite";
   resource_regeneration  = regen_type::DISABLED;
 
+  // NOTE: 2026-07-11 Dreadstalkers do not trigger Hellbent Commander on arise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
+
   // 2026-02-17: Validated coefficient
   owner_coeff.ap_from_sp = 0.825;
 
@@ -1030,6 +1042,9 @@ dreadstalker_t::dreadstalker_t( warlock_t* owner, util::string_view pet_name, pe
 
   action_list_str = "leap/travel/dreadbite";
   resource_regeneration  = regen_type::DISABLED;
+
+  // NOTE: 2026-07-11 Dreadstalkers do not trigger Hellbent Commander on arise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
 
   // 2026-02-17: Validated coefficient
   owner_coeff.ap_from_sp = 0.825;
@@ -1294,11 +1309,11 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   else
   {
     npc_id = owner->talents.vilefiend->effectN( 1 ).misc_value1();
-    // NOTE: 2026-04-24 Regular Vilefiend do not trigger Hellbent Commander on heartbeat (bug?)
+    // NOTE: 2026-07-11 Regular Vilefiend do not trigger Hellbent Commander on heartbeat (bug?)
     triggers.hellbent_commander_heartbeat &= !bugs;
   }
 
-  // NOTE: 2026-04-24 Vilefiend do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Vilefiend do not trigger Hellbent Commander on demise (must wait to player heartbeat) (bug?)
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "bile_spit";
@@ -1480,7 +1495,8 @@ demonic_tyrant_t::demonic_tyrant_t( warlock_t* owner, util::string_view name )
 {
   npc_id = owner->talents.summon_demonic_tyrant->effectN( owner->talents.antoran_armaments.ok() ? 4 : 1 ).misc_value1();
 
-  // NOTE: 2026-04-24 Demonic Tyrant do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Demonic Tyrant do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   resource_regeneration = regen_type::DISABLED;
@@ -1607,6 +1623,9 @@ doomguard_t::doomguard_t( warlock_t* owner )
 {
   npc_id = owner->talents.summon_doomguard->effectN( 1 ).misc_value1();
 
+  // NOTE: 2026-07-11 Doomguard do not trigger Hellbent Commander on arise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
+
   action_list_str = "doom_bolt_volley";
 
   // 2026-02-17: Validated coefficients
@@ -1662,7 +1681,8 @@ grimoire_imp_lord_t::grimoire_imp_lord_t( warlock_t* owner )
   npc_id = owner->talents.grimoire_imp_lord->effectN( 2 ).misc_value1();
   npc_suffix = "grimoire";
 
-  // NOTE: 2026-04-24 Grimoire: Imp Lord do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Grimoire: Imp Lord do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "greater_felbolt,if=energy>=" + util::to_string( max_energy_threshold );
@@ -1738,7 +1758,8 @@ grimoire_fel_ravager_t::grimoire_fel_ravager_t( warlock_t* owner )
   npc_id = owner->talents.grimoire_fel_ravager->effectN( 2 ).misc_value1();
   npc_suffix = "grimoire";
 
-  // NOTE: 2026-04-24 Grimoire: Fel Ravager do not trigger Hellbent Commander on demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 Grimoire: Fel Ravager do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
+  triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 
   action_list_str = "travel/abyssal_bite,if=energy>=" + util::to_string( max_energy_threshold );
@@ -1815,7 +1836,7 @@ dominion_of_argus_pet_t::dominion_of_argus_pet_t( warlock_t* owner, std::string_
 {
   resource_regeneration = regen_type::DISABLED;
   affected_by.demonic_brutality = false;
-  // NOTE: 2026-04-24 DoA guardians do not trigger Hellbent Commander on arise/demise (must wait to player heatbeat) (bug?)
+  // NOTE: 2026-07-11 DoA guardians do not trigger Hellbent Commander on arise/demise (must wait to player heartbeat) (bug?)
   triggers.hellbent_commander_arise &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;
 }
@@ -2560,7 +2581,7 @@ namespace diabolist
 
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
-    // NOTE: 2026-04-24 Diabolist guardians do not trigger Hellbent Commander (bug?)
+    // NOTE: 2026-07-11 Diabolist guardians do not trigger Hellbent Commander (bug?)
     triggers.hellbent_commander_heartbeat &= !bugs;
     triggers.hellbent_commander_arise &= !bugs;
     triggers.hellbent_commander_demise &= !bugs;
@@ -2683,7 +2704,7 @@ namespace diabolist
 
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
-    // NOTE: 2026-04-24 Diabolist guardians do not trigger Hellbent Commander (bug?)
+    // NOTE: 2026-07-11 Diabolist guardians do not trigger Hellbent Commander (bug?)
     triggers.hellbent_commander_heartbeat &= !bugs;
     triggers.hellbent_commander_arise &= !bugs;
     triggers.hellbent_commander_demise &= !bugs;
@@ -2777,7 +2798,7 @@ namespace diabolist
 
     is_diabolist_guardian = true;
     affected_by.demonic_brutality = false;
-    // NOTE: 2026-04-24 Diabolist guardians do not trigger Hellbent Commander (bug?)
+    // NOTE: 2026-07-11 Diabolist guardians do not trigger Hellbent Commander (bug?)
     triggers.hellbent_commander_heartbeat &= !bugs;
     triggers.hellbent_commander_arise &= !bugs;
     triggers.hellbent_commander_demise &= !bugs;
@@ -2994,7 +3015,7 @@ rampaging_demonic_soul_t::rampaging_demonic_soul_t( warlock_t* owner, std::strin
   affected_by.demonic_brutality = false;
   action_list_str               = "soul_swipe";
   owner_coeff.sp_from_sp        = 1.0;
-  // NOTE: 2026-04-24 Demonic Soul do not trigger Hellbent Commander (bug?)
+  // NOTE: 2026-07-11 Demonic Soul does not trigger Hellbent Commander (bug?)
   triggers.hellbent_commander_heartbeat &= !bugs;
   triggers.hellbent_commander_arise  &= !bugs;
   triggers.hellbent_commander_demise &= !bugs;

--- a/engine/class_modules/warlock/sc_warlock_pets.hpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.hpp
@@ -435,6 +435,7 @@ struct wild_imp_pet_t : public warlock_pet_t
   bool is_hog_imp;
   bool power_siphon;
   bool imploded;
+  bool isolated_imploded;
   timespan_t infernal_command_ev_ts;
   timespan_t infernal_command_ev_offset;
   accumulated_rng_t* prd_rng_infernal_rapidity;


### PR DESCRIPTION
# Isolated Implosion (12.1.0 WL Demo 4pc)

Several adjustments have been made to **Isolated Implosion**:

- It has been tested in-game that the chance is indeed 20%, as indicated by spell data. It has also been confirmed that the RNG model used is a PRD accumulator, not Flat %. In SimC it was implemented as Flat %, therefore it is changed to PRD.

  - Log: https://www.warcraftlogs.com/reports/p6qXM2Zk71FcxnH4?fight=last&type=damage-done&source=1
  - Figure:
    <img width="1290" height="689" alt="isolated_implosion_proc_distance_histogram_overlapped_colored" src="https://github.com/user-attachments/assets/981b38c0-2292-40d6-9702-37c580c7606d" />

- The spell behavior and its triggers have been updated to match in-game behavior:
  - It does not trigger **Demoniac**: In more than 22h of testing (the log cited above), no **Demonic Core** gains were observed when a **Wild Imp** died from **Isolated Implosion**. This is likely a bug.
  - For **Hellbent Commander**, it counts as a normal **Wild Imp** death due to lack of energy / **Power Siphon**, and the same applies to **Demonic Power** buff stacking.
  - It does not interact with **To Hell and Back**: **Wild Imps** killed by **Isolated Implosion** do not summon new empowered imps through this talent. This was already implemented this way, but it has been tested again.

- A `proc_t` has been added for **Isolated Implosion** to track the total number of procs.

# To Hell and Back

It has been observed that, on the 12.1.0 PTR, the behavior of **To Hell and Back** has changed slightly when using **Implosion**. Now, when an odd number of imps is imploded, the number of new empowered imps summoned is rounded up. This only affects Implosion; Power Siphon keeps the previous floor-based behavior. The behavior on the current live version, 12.0.7, remains the same as before:

| Imps Imploded | Empowered Imps Summoned 12.0.7 | Empowered Imps Summoned 12.1.0 |
| ------------- | ------------------------------ | ------------------------------ |
| 1             | 0                              | 1                              |
| 2             | 1                              | 1                              |
| 3             | 1                              | 2                              |
| 4             | 2                              | 2                              |
| 5             | 2                              | 3                              |
| 6             | 3                              | 3                              |

# Hellbent Commander

It appears that **Hellbent Commander** behavior has changed again since the last testing and adjustment in #11405. The new table is shown below, and the SimC code has been updated to match this new behavior. This was tested on live 12.0.7, and some quick tests on the 12.1.0 PTR seem to show the same behavior. The main changes mostly prevent demons from automatically updating the counter with `+1` on arise.

The table below shows how the **Hellbent Commander** buff is updated for each demon on arise/demise/heartbeat:

| pet                  | heartbeat | arise | demise | comment                                                            |
| --- | --- | --- | --- | --- |
| main_pets            | 1         | **-** | -      |                                                                    |
| wild_imps_1(hog)     | 1         | **-** | *      | -> `-2` stacks on `normal`/`PS`/`II` demise, `-1` stacks on `implosion` |
| wild_imps_2(talents) | 1         | **-** | *      | -> `-1` stacks on `normal`/`PS`/`II` demise, `±0` stacks on `implosion` |
| dreadstalker         | 1         | **-** | 1      |                                                                    |
| vilefiend            | -         | 1     | -      |                                                                    |
| vilefiend_shadow     | 1         | 1     | -      |                                                                    |
| vilefiend_fire       | 1         | 1     | -      |                                                                    |
| tyrant               | 1         | **-** | -      |                                                                    |
| grimoire_imp_lord    | 1         | **-** | -      |                                                                    |
| grimoire_fel_ravager | 1         | **-** | -      |                                                                    |
| doomguard            | 1         | **-** | 1      |                                                                    |
| doa_demons(apex)     | 1         | -     | -      |                                                                    |
| diabolist_mother     | -         | -     | -      |                                                                    |
| diabolist_pit_lord   | -         | -     | -      |                                                                    |
| diabolist_overlord   | -         | -     | -      |                                                                    |
| rampaging_demon_soul | -         | -     | -      |                                                                    |
