### PR TITLE
[Warlock] Update 12.1.0 Affliction and Destruction effects

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -146,8 +146,16 @@ void affliction( player_t* p )
   SH_cleave->add_action( "malefic_grasp,if=buff.nightfall.react>1|pet.darkglare.remains<gcd" );
   SH_cleave->add_action( "drain_soul,if=buff.nightfall.react>1" );
   SH_cleave->add_action( "shadow_bolt,if=buff.nightfall.react>1" );
-  SH_cleave->add_action( "unstable_affliction,if=!talent.patient_zero&!talent.sow_the_seeds&(soul_shard|buff.shard_instability.react)" );
-  SH_cleave->add_action( "seed_of_corruption,if=talent.patient_zero&talent.sow_the_seeds" );
+  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+  {
+    SH_cleave->add_action( "unstable_affliction,if=!talent.patient_zero&!talent.sow_the_seeds&(soul_shard|buff.shard_instability.react)" );
+    SH_cleave->add_action( "seed_of_corruption,if=talent.patient_zero&talent.sow_the_seeds" );
+  }
+  else
+  {
+    SH_cleave->add_action( "unstable_affliction,if=!talent.sow_the_seeds&(soul_shard|buff.shard_instability.react)" );
+    SH_cleave->add_action( "seed_of_corruption,if=talent.sow_the_seeds" );
+  }
 
   HC_st->add_action( "haunt", "Haunt on CD for apex" );
   HC_st->add_action( "agony,if=refreshable" );
@@ -180,11 +188,27 @@ void affliction( player_t* p )
   HC_cleave->add_action( "summon_darkglare" );
   HC_cleave->add_action( "malevolence" );
   HC_cleave->add_action( "malefic_grasp,if=pet.darkglare.remains<gcd" );
-  HC_cleave->add_action( "unstable_affliction,if=!talent.sow_the_seeds&!talent.patient_zero&(pet.darkglare.remains|buff.malevolence.remains|soul_shard>4|buff.shard_instability.react|(talent.cascading_calamity&buff.cascading_calamity.remains<gcd.max))" );
-  HC_cleave->add_action( "seed_of_corruption,if=talent.patient_zero&talent.sow_the_seeds" );
+  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+  {
+    HC_cleave->add_action( "unstable_affliction,if=!talent.sow_the_seeds&!talent.patient_zero&(pet.darkglare.remains|buff.malevolence.remains|soul_shard>4|buff.shard_instability.react|(talent.cascading_calamity&buff.cascading_calamity.remains<gcd.max))" );
+    HC_cleave->add_action( "seed_of_corruption,if=talent.patient_zero&talent.sow_the_seeds" );
+  }
+  else
+  {
+    HC_cleave->add_action( "unstable_affliction,if=!talent.sow_the_seeds&(pet.darkglare.remains|buff.malevolence.remains|soul_shard>4|buff.shard_instability.react|(talent.cascading_calamity&buff.cascading_calamity.remains<gcd.max))" );
+    HC_cleave->add_action( "seed_of_corruption,if=talent.sow_the_seeds" );
+  }
 
-  end_of_fight->add_action( "unstable_affliction,if=soul_shard&fight_remains<8&(!talent.patient_zero&!talent.sow_the_seeds)" );
-  end_of_fight->add_action( "seed_of_corruption,if=soul_shard&fight_remains<8&(talent.patient_zero&talent.sow_the_seeds)" );
+  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+  {
+    end_of_fight->add_action( "unstable_affliction,if=soul_shard&fight_remains<8&(!talent.patient_zero&!talent.sow_the_seeds)" );
+    end_of_fight->add_action( "seed_of_corruption,if=soul_shard&fight_remains<8&(talent.patient_zero&talent.sow_the_seeds)" );
+  }
+  else
+  {
+    end_of_fight->add_action( "unstable_affliction,if=soul_shard&fight_remains<8&(!talent.sow_the_seeds)" );
+    end_of_fight->add_action( "seed_of_corruption,if=soul_shard&fight_remains<8&(talent.sow_the_seeds)" );
+  }
   end_of_fight->add_action( "drain_soul,if=buff.nightfall.react&fight_remains<5" );
   end_of_fight->add_action( "shadow_bolt,if=buff.nightfall.react&fight_remains<5" );
 
@@ -244,7 +268,7 @@ void demonology( player_t* p )
   diabolist->add_action( "demonbolt,if=soul_shard<4&buff.demonic_core.react" );
   diabolist->add_action( "shadow_bolt" );
   diabolist->add_action( "infernal_bolt" );
-  
+
   soulharvest->add_action( "power_siphon,if=buff.demonic_core.stack<=1|fight_remains<10" );
   soulharvest->add_action( "hand_of_guldan,if=buff.dominion_of_argus.up" );
   soulharvest->add_action( "grimoire_imp_lord" );

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -16,7 +16,6 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
     soc_threshold( 0.0 ),
     ua_regular_stacks( 0 ),
     ua_seed_stacks( 0 ),
-    ua_seed_gap( false ),
     warlock( p )
 {
   // Shared
@@ -67,7 +66,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                              ->set_max_stack( 1 )
                              ->set_proc_callbacks( false );
 
-  debuffs.shadowburn = make_buff( *this, "shadowburn", p.talents.shadowburn )
+  debuffs.shadowburn = make_buff( *this, "shadowburn", ( p.sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) ) ? p.talents.shadowburn_debuff : p.talents.shadowburn )
                            ->set_default_value( p.talents.shadowburn_2->effectN( 1 ).base_value() / 10 );
 
   if ( p.sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
@@ -143,14 +142,9 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
 void warlock_td_t::ua_stack_applied( bool is_seed_ua )
 {
   if ( is_seed_ua )
-  {
     ua_seed_stacks++;
-    ua_seed_gap = true;
-  }
   else
-  {
     ua_regular_stacks++;
-  }
 }
 
 void warlock_td_t::ua_stack_expired( bool is_seed_ua )
@@ -159,7 +153,6 @@ void warlock_td_t::ua_stack_expired( bool is_seed_ua )
   {
     assert( ua_seed_stacks > 0 );
     ua_seed_stacks--;
-    ua_seed_gap = false;
   }
   else
   {
@@ -172,15 +165,11 @@ void warlock_td_t::reset_ua_stack_tracking()
 {
   ua_regular_stacks = 0;
   ua_seed_stacks = 0;
-  ua_seed_gap = false;
 }
 
-int warlock_td_t::ua_calculate_damage_stacks() const
+double warlock_td_t::ua_calculate_damage_stacks() const
 {
-  const int damage_effective_ua_seed_stacks = ua_seed_stacks - ( ua_seed_gap ? 1 : 0 );
-  assert( damage_effective_ua_seed_stacks >= 0 );
-
-  return ua_regular_stacks + damage_effective_ua_seed_stacks;
+  return as<double>( ua_regular_stacks ) + as<double>( ua_seed_stacks ) * warlock.tier.wl_affliction_12_1_class_set_4pc->effectN( 1 ).percent();
 }
 
 void warlock_td_t::target_demise()
@@ -1104,6 +1093,11 @@ void warlock_t::parse_player_effects()
   {
     // Affliction Mastery
     parse_effects( warlock_base.potent_afflictions ); // 77215
+
+    // Affliction Buffs
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      parse_effects( buffs.unstable_empowerment ); // 1305774
+
     // Affliction Debuffs/DoTs
     // NOTE: Shadow of Nathreza II (rank 2) only increases by 2% (as if it were rank 1) the
     // effect #2 and #3 (pet and guardian damage) of the Haunt debuff damage bonus (bug)
@@ -1115,6 +1109,7 @@ void warlock_t::parse_player_effects()
   {
     // Demonology Mastery
     parse_effects( warlock_base.master_demonologist ); // 77219
+
     // Demonology Buffs
     parse_effects( buffs.hellbent_commander ); // 1281559
   }

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -97,7 +97,6 @@ struct warlock_td_t : public actor_target_data_t
   // 12.1 Affliction 4pc
   int ua_regular_stacks;
   int ua_seed_stacks;
-  bool ua_seed_gap;
 
   warlock_t& warlock;
   warlock_td_t( player_t* target, warlock_t& p );
@@ -114,7 +113,7 @@ struct warlock_td_t : public actor_target_data_t
   void ua_stack_applied( bool is_seed_ua );
   void ua_stack_expired( bool is_seed_ua );
   void reset_ua_stack_tracking();
-  int ua_calculate_damage_stacks() const;
+  double ua_calculate_damage_stacks() const;
 };
 
 // Shuffled Bag RNG (sampling without replacement)
@@ -439,6 +438,7 @@ public:
     const spell_data_t* cascading_calamity_buff;
     player_talent_t deaths_embrace; // Volatile Agony and Perpetual Unstability are unaffected by this
     player_talent_t patient_zero;
+    player_talent_t hedonic_gorging;
     player_talent_t sow_the_seeds;
 
     // Affliction Apex
@@ -563,6 +563,7 @@ public:
 
     player_talent_t shadowburn;
     const spell_data_t* shadowburn_2; // Contains Soul Shard energize data
+    const spell_data_t* shadowburn_debuff; // Shadowburn Debuff
     player_talent_t backlash; // Crit chance increase. NOT IMPLEMENTED: Instant Incinerate proc when physically attacked
     player_talent_t improved_havoc;
     player_talent_t ashen_remains; // Increased Chaos Bolt and Incinerate damage to targets afflicted by Immolate

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -266,6 +266,8 @@ using namespace helpers;
       {
         parse_target_effects( d_fn( &warlock_td_t::dots_t::immolate ), p()->warlock_base.immolate_dot ); // 157736
         parse_target_effects( d_fn( &warlock_td_t::debuffs_t::lake_of_fire ), p()->talents.lake_of_fire_debuff ); // 1244918
+        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+          parse_target_effects( d_fn( &warlock_td_t::debuffs_t::dark_titans_mark ), p()->tier.dark_titans_mark_debuff ); // 1305711
       }
 
       // Diabolist
@@ -1690,16 +1692,16 @@ using namespace helpers;
 
     double calculate_tick_amount( action_state_t* state, double dot_multiplier ) const override
     {
-      // 12.1 4pc seed-applied UAs are visually full UA stacks, but one active seed-UA stack may not count
-      // toward UA periodic damage. Adjust the tick multiplier here because the core applies stack count through
-      // dot_multiplier after calculating the base tick, and the effective stack count can change between ticks.
+      // 12.1 4pc seed-applied UAs are displayed as full UA stacks, but only contribute
+      // partial UA damage. The core applies the visible stack count through dot_multiplier,
+      // so rescale it to the effective damage stack count on each tick.
       if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
       {
         auto tdata = td( state->target );
         const int current_stacks = tdata->dots.unstable_affliction->current_stack();
 
         if ( current_stacks > 0 )
-          dot_multiplier *= as<double>( tdata->ua_calculate_damage_stacks() ) / current_stacks;
+          dot_multiplier *= tdata->ua_calculate_damage_stacks() / current_stacks;
       }
 
       return warlock_spell_t::calculate_tick_amount( state, dot_multiplier );
@@ -1790,7 +1792,7 @@ using namespace helpers;
       {
         double m = warlock_spell_t::composite_target_da_multiplier( t );
 
-        if ( p()->talents.patient_zero.ok() )
+        if ( ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ) && p()->talents.patient_zero.ok() )
         {
           // NOTE (2026-04-24): Patient Zero does not track seeds individually (bug?). Instead, it
           // uses a single per-caster target reference updated on cast success to the target of the
@@ -1955,7 +1957,7 @@ using namespace helpers;
       warlock_td_t* mstdata = td( main_seed_target );
 
       // Patient Zero target is updated on SoC cast success, not on impact or debuff application
-      if ( p()->talents.patient_zero.ok() )
+      if ( ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ) && p()->talents.patient_zero.ok() )
         p()->patient_zero_target = main_seed_target;
 
       // 2026-06-30 Hotfix: Nightfall SoC detonates existing SoC when smart targeting leaves the primary seed on an already seeded target

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -223,7 +223,10 @@ namespace warlock
 
     talents.deaths_embrace = find_talent_spell( talent_tree::SPECIALIZATION, "Death's Embrace" ); // Should be ID 234876
 
-    talents.patient_zero = find_talent_spell( talent_tree::SPECIALIZATION, "Patient Zero" ); // Should be ID 1260285
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      talents.hedonic_gorging = find_talent_spell( talent_tree::SPECIALIZATION, "Hedonic Gorging" ); // Should be ID 1311969
+    else
+      talents.patient_zero = find_talent_spell( talent_tree::SPECIALIZATION, "Patient Zero" ); // Should be ID 1260285
 
     talents.sow_the_seeds = find_talent_spell( talent_tree::SPECIALIZATION, "Sow the Seeds" ); // Should be ID 196226
 
@@ -430,6 +433,9 @@ namespace warlock
 
     talents.shadowburn = find_talent_spell( talent_tree::SPECIALIZATION, "Shadowburn" ); // Should be ID 17877
     talents.shadowburn_2 = conditional_spell_lookup( talents.shadowburn.ok(), 245731 );
+
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      talents.shadowburn_debuff = conditional_spell_lookup( talents.shadowburn.ok(), 1311913 );
 
     talents.backlash = find_talent_spell( talent_tree::SPECIALIZATION, "Backlash" ); // Should be ID 387384
 


### PR DESCRIPTION
This PR includes changes made by Blizzard on the 12.1.0 PTR (as of 2026-07-14) for Affliction and Destruction Warlock:

- The damage of **Unstable Affliction (UA)** stacks applied by the Affliction 4pc tier set has been fixed. **UA** stacks applied by **Seed of Corruption** through the tier set now deal 20% of the regular damage (as expected), while regular stack applications deal 100% damage. There no longer appears to be any weird behavior or special cases.
- The remaining interactions between this tier-applied **Unstable Affliction** from **Seed of Corruption** and other talents/effects have been tested in-game, and there do not appear to be any changes.
- The **Patient Zero** talent has been removed for versions `>=12.1.0`.
- That talent has been replaced by a new talent called **Hedonic Gorging**, which is parsed automatically by the passive `parse_effects` system. A bugged effect has also been found in this new talent: it increases the **Siphon Life** damage bonus to **Corruption**/**Wither** from 30% to 40%, but only for direct damage (effect #­1), but not for periodic damage (effect #­3).
- **Unstable Empowerment** now also increases the damage of the warlock's pets and guardians.
- The **Shadowburn** debuff now has its own spell for versions `>=12.1.0`.
- The **Dark Titan's Mark** debuff effect from the Destruction tier set now increases the damage of all spells, in practice a long whitelist of spells, as well as the damage of the warlock's pets and guardians.
- The APL has been updated to remove any references to `patient_zero` in versions `>=12.1.0`, as they would otherwise cause an error.