### PR TITLE
[buff] Short circuit if buff is fallback

### DIFF
--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -4233,6 +4233,15 @@ damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, const s
   return this;
 }
 
+damage_buff_t* damage_buff_t::set_is_stacking_mod( bool value )
+{
+  if ( is_fallback )
+    return this;
+
+  is_stacking = value;
+  return this;
+}
+
 damage_buff_t* damage_buff_t::set_direct_mod( double multiplier )
 {
   if ( is_fallback )

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -779,6 +779,9 @@ buff_t::~buff_t() = default;
 
 const spell_data_t& buff_t::data_reporting() const
 {
+  if ( is_fallback )
+    return spell_data_t::nil();
+
   if (s_data_reporting == spell_data_t::nil())
     return *s_data;
   else
@@ -828,17 +831,19 @@ void buff_t::update_trigger_calculations()
 
 buff_t* buff_t::set_chance( double chance )
 {
-  if ( !is_fallback )
-  {
-    manual_chance = chance;
-    update_trigger_calculations();
-  }
+  if ( is_fallback )
+    return this;
 
+  manual_chance = chance;
+  update_trigger_calculations();
   return this;
 }
 
 buff_t* buff_t::set_duration( timespan_t duration )
 {
+  if ( is_fallback )
+    return this;
+
   // Set Buff duration
   if ( duration == timespan_t::min() )
   {
@@ -869,12 +874,18 @@ buff_t* buff_t::set_duration( timespan_t duration )
 
 buff_t* buff_t::modify_duration( timespan_t duration )
 {
+  if ( is_fallback )
+    return this;
+
   set_duration( base_buff_duration + duration );
   return this;
 }
 
 buff_t* buff_t::set_duration_multiplier( double multiplier )
 {
+  if ( is_fallback )
+  return this;
+
   assert( multiplier >= 0.0 );
   buff_duration_multiplier = multiplier;
 
@@ -888,6 +899,9 @@ buff_t* buff_t::set_duration_multiplier( double multiplier )
 
 buff_t* buff_t::set_dynamic_time_duration_multiplier( double new_multiplier )
 {
+  if ( is_fallback )
+    return this;
+
   assert( new_multiplier > 0.0 );
   if ( new_multiplier == dynamic_time_duration_multiplier )
     return this;
@@ -940,10 +954,7 @@ buff_t* buff_t::set_dynamic_time_duration_multiplier( double new_multiplier )
 buff_t* buff_t::set_max_stack( int max_stack )
 {
   if ( is_fallback )
-  {
-    _max_stack = 1;
     return this;
-  }
 
   // _max_stack is initialized at -1, then set_max_stack is called in the buff_t base constructor
   if ( max_stack == -1 )
@@ -996,6 +1007,9 @@ buff_t* buff_t::set_max_stack( int max_stack )
 
 buff_t* buff_t::modify_max_stack( int max_stack )
 {
+  if ( is_fallback )
+    return this;
+
   set_max_stack( _max_stack + max_stack );
   return this;
 }
@@ -1003,12 +1017,18 @@ buff_t* buff_t::modify_max_stack( int max_stack )
 // TODO: find less blunt & hacky way to handle this
 buff_t* buff_t::increase_max_stack_uptime( int max_stack_uptime )
 {
+  if ( is_fallback )
+    return this;
+
   stack_uptime.resize( stack_uptime.size() + max_stack_uptime );
   return this;
 }
 
 buff_t* buff_t::set_initial_stack( int initial_stack )
 {
+  if ( is_fallback )
+    return this;
+
   // _initial_stack is initialized at -1, then set_initial_stack is called in the buff_t base constructor
   if ( initial_stack == -1 )
   {
@@ -1053,6 +1073,9 @@ buff_t* buff_t::set_initial_stack( int initial_stack )
 
 buff_t* buff_t::modify_initial_stack( int initial_stack )
 {
+  if ( is_fallback )
+    return this;
+
   assert( _initial_stack > 0 && "Cannot modify invalid initial stack. Use set_initial_stack() with a postive value.");
   set_initial_stack( _initial_stack + initial_stack );
   return this;
@@ -1060,6 +1083,9 @@ buff_t* buff_t::modify_initial_stack( int initial_stack )
 
 buff_t* buff_t::set_initial_stack_to_max_stack()
 {
+  if ( is_fallback )
+    return this;
+
   set_initial_stack( max_stack() );
   return this;
 }
@@ -1094,6 +1120,9 @@ buff_t* buff_t::set_consume_all_stacks( bool consume_all )
 
 buff_t* buff_t::set_cooldown( timespan_t duration )
 {
+  if ( is_fallback )
+    return this;
+
   if ( duration == timespan_t::min() )  // min() called in buff_t constructor
   {
     if ( data().ok() && data().cooldown() != 0_ms )
@@ -1116,6 +1145,9 @@ buff_t* buff_t::set_cooldown( timespan_t duration )
 
 buff_t* buff_t::set_internal_cooldown( timespan_t duration )
 {
+  if ( is_fallback )
+    return this;
+
   timespan_t _dur = timespan_t::min();
 
   if ( duration == timespan_t::min() )  // min() called in buff_t constructor
@@ -1151,12 +1183,18 @@ buff_t* buff_t::set_internal_cooldown( timespan_t duration )
 
 buff_t* buff_t::modify_cooldown( timespan_t duration )
 {
+  if ( is_fallback )
+    return this;
+
   set_cooldown( cooldown->duration + duration );
   return this;
 }
 
 buff_t* buff_t::set_period( timespan_t period )
 {
+  if ( is_fallback )
+    return this;
+
   if ( period == timespan_t::min() )
   {
     for ( size_t i = 1; i <= s_data->effect_count(); i++ )
@@ -1206,18 +1244,27 @@ buff_t* buff_t::set_period( timespan_t period )
 
 buff_t* buff_t::modify_period( timespan_t duration )
 {
+  if ( is_fallback )
+    return this;
+
   set_period( buff_period + duration );
   return this;
 }
 
 buff_t* buff_t::disable_ticking( bool v )
 {
+  if ( is_fallback )
+    return this;
+
   disable_tick_effects = v;
   return this;
 }
 
 buff_t* buff_t::add_invalidate( cache_e c )
 {
+  if ( is_fallback )
+    return this;
+
   if ( c == CACHE_NONE || is_fallback )
   {
     return this;
@@ -1238,13 +1285,16 @@ buff_t* buff_t::add_invalidate( cache_e c )
 
 buff_t* buff_t::set_schools( unsigned schools_ )
 {
+  if ( is_fallback )
+    return this;
+
   schools = schools_;
   return this;
 }
 
 buff_t* buff_t::set_schools_from_effect( size_t effect_idx )
 {
-  if ( !s_data->ok() )
+  if ( is_fallback || !s_data->ok() )
     return this;
 
   assert( effect_idx > 0 && effect_idx <= s_data->effect_count() );
@@ -1254,13 +1304,16 @@ buff_t* buff_t::set_schools_from_effect( size_t effect_idx )
 
 buff_t* buff_t::add_school( school_e school )
 {
+  if ( is_fallback )
+    return this;
+
   schools |= dbc::get_school_mask( school );
   return this;
 }
 
 buff_t* buff_t::set_pct_buff_type( stat_pct_buff_type type )
 {
-  if ( !player || type == STAT_PCT_BUFF_MAX )
+  if ( is_fallback || !player || type == STAT_PCT_BUFF_MAX )
     return this;
 
   auto& buffs = player->buffs.stat_pct_buffs[ type ];
@@ -1273,7 +1326,7 @@ buff_t* buff_t::set_pct_buff_type( stat_pct_buff_type type )
 
 buff_t* buff_t::set_pct_buff_type_from_effect( size_t effect_idx, bool set_default )
 {
-  if ( !data().ok() )
+  if ( is_fallback || !data().ok() )
     return this;
 
   if ( set_default )
@@ -1305,6 +1358,9 @@ buff_t* buff_t::set_pct_buff_type_from_effect( size_t effect_idx, bool set_defau
 
 buff_t* buff_t::set_pct_buff_type_from_data( bool set_default )
 {
+  if ( is_fallback )
+    return this;
+
   std::vector<double> validation;
 
   for ( const auto& _eff : data().effects() )
@@ -1370,7 +1426,7 @@ buff_t* buff_t::set_movement_speed_buff( bool stacking, double percent )
 
 buff_t* buff_t::set_movement_speed_buff_from_effect( size_t effect_idx, double percent )
 {
-  if ( !data().ok() )
+  if ( is_fallback || !data().ok() )
     return this;
 
   const auto& _eff = data().effectN( effect_idx );
@@ -1388,6 +1444,9 @@ buff_t* buff_t::set_movement_speed_buff_from_effect( size_t effect_idx, double p
 
 buff_t* buff_t::set_movement_speed_buff_from_data( double percent )
 {
+  if ( is_fallback )
+    return this;
+
   for ( const auto& _eff : data().effects() )
     if ( _eff.subtype() == A_MOD_INCREASE_SPEED || _eff.subtype() == A_MOD_SPEED_ALWAYS )
       return set_movement_speed_buff_from_effect( _eff.index() + 1, percent );
@@ -1397,6 +1456,9 @@ buff_t* buff_t::set_movement_speed_buff_from_data( double percent )
 
 buff_t* buff_t::set_default_value( double value, size_t effect_idx )
 {
+  if ( is_fallback )
+    return this;
+
   // Ensure we are not errantly overwriting a value that is already set to a given effect
   assert( default_value_effect_idx == 0 || default_value_effect_idx == effect_idx );
 
@@ -1407,7 +1469,7 @@ buff_t* buff_t::set_default_value( double value, size_t effect_idx )
 
 buff_t* buff_t::set_default_value_from_effect( size_t effect_idx, double multiplier )
 {
-  if ( !s_data->ok() )
+  if ( is_fallback || !s_data->ok() )
     return this;
 
   assert( effect_idx > 0 && effect_idx <= s_data->effect_count() );
@@ -1426,7 +1488,7 @@ buff_t* buff_t::set_default_value_from_effect( size_t effect_idx, double multipl
 buff_t* buff_t::set_default_value_from_effect_type( effect_subtype_t a_type, property_type_t p_type, double multiplier,
                                                     effect_type_t e_type )
 {
-  if ( !s_data->ok() )
+  if ( is_fallback || !s_data->ok() )
     return this;
 
   for ( size_t idx = 1; idx <= s_data->effect_count(); idx++ )
@@ -1459,36 +1521,54 @@ buff_t* buff_t::set_default_value_from_effect_type( effect_subtype_t a_type, pro
 
 buff_t* buff_t::modify_default_value( double value )
 {
+  if ( is_fallback )
+    return this;
+
   set_default_value( default_value + value, default_value_effect_idx );
   return this;
 }
 
 buff_t* buff_t::set_reverse( bool r )
 {
+  if ( is_fallback )
+    return this;
+
   reverse = r;
   return this;
 }
 
 buff_t* buff_t::set_quiet( bool q )
 {
+  if ( is_fallback )
+    return this;
+
   quiet = q;
   return this;
 }
 
 buff_t* buff_t::set_activated( bool a )
 {
+  if ( is_fallback )
+    return this;
+
   activated = a;
   return this;
 }
 
 buff_t* buff_t::set_can_cancel( bool cc )
 {
+  if ( is_fallback )
+    return this;
+
   can_cancel = cc;
   return this;
 }
 
 buff_t* buff_t::set_tick_behavior( buff_tick_behavior behavior )
 {
+  if ( is_fallback )
+    return this;
+
   tick_behavior = behavior;
 
   // If period is set, but no buff tick behavior, set the behavior automatically to clipped ticks
@@ -1502,17 +1582,21 @@ buff_t* buff_t::set_tick_behavior( buff_tick_behavior behavior )
 
 buff_t* buff_t::set_tick_callback( buff_tick_callback_t fn )
 {
-  if ( fn && !is_fallback )
-  {
+  if ( is_fallback )
+    return this;
+
+  if ( fn )
     tick_callback = std::move( fn );
-  }
 
   return this;
 }
 
 buff_t* buff_t::set_tick_time_callback( buff_tick_time_callback_t cb )
 {
-  if ( cb && !is_fallback )
+  if ( is_fallback )
+    return this;
+
+  if ( cb )
   {
     set_tick_time_behavior( buff_tick_time_behavior::CUSTOM );
     tick_time_callback = std::move( cb );
@@ -1523,12 +1607,18 @@ buff_t* buff_t::set_tick_time_callback( buff_tick_time_callback_t cb )
 
 buff_t* buff_t::set_affects_regen( bool state )
 {
+  if ( is_fallback )
+    return this;
+
   change_regen_rate = state;
   return this;
 }
 
 buff_t* buff_t::set_constant_behavior( buff_constant_behavior b )
 {
+  if ( is_fallback )
+    return this;
+
   constant_behavior = b;
   if ( b == buff_constant_behavior::ALWAYS_CONSTANT )
     constant = true;
@@ -1539,6 +1629,9 @@ buff_t* buff_t::set_constant_behavior( buff_constant_behavior b )
 
 buff_t* buff_t::set_refresh_behavior( buff_refresh_behavior b )
 {
+  if ( is_fallback )
+    return this;
+
   if ( b == buff_refresh_behavior::NONE )
   {
     // In wod, default behavior for ticking buffs is to pandemic-extend the duration
@@ -1563,7 +1656,10 @@ buff_t* buff_t::set_refresh_behavior( buff_refresh_behavior b )
 
 buff_t* buff_t::set_refresh_duration_callback( buff_refresh_duration_callback_t cb )
 {
-  if ( cb && !is_fallback )
+  if ( is_fallback )
+    return this;
+
+  if ( cb )
   {
     refresh_behavior          = buff_refresh_behavior::CUSTOM;
     refresh_duration_callback = std::move( cb );
@@ -1573,6 +1669,9 @@ buff_t* buff_t::set_refresh_duration_callback( buff_refresh_duration_callback_t 
 
 buff_t* buff_t::set_rppm( rppm_scale_e scale, double freq, double mod )
 {
+  if ( is_fallback )
+    return this;
+
   if ( scale == RPPM_DISABLE )
   {
     rppm = nullptr;
@@ -1601,6 +1700,9 @@ buff_t* buff_t::set_rppm( rppm_scale_e scale, double freq, double mod )
 
 buff_t* buff_t::set_trigger_spell( const spell_data_t* s )
 {
+  if ( is_fallback )
+    return this;
+
   // If the params specifies a trigger spell (even if it's not found), use it instead of the actual
   // spell data of the buff.
   if ( s != spell_data_t::nil() )
@@ -1616,61 +1718,73 @@ buff_t* buff_t::set_trigger_spell( const spell_data_t* s )
 
 buff_t* buff_t::set_stack_change_callback( const buff_stack_change_callback_t& cb )
 {
-  if ( !is_fallback )
-  {
-    stack_change_callback.clear();
-    stack_change_callback.push_back( cb );
-  }
+  if ( is_fallback )
+    return this;
 
+  stack_change_callback.clear();
+  stack_change_callback.push_back( cb );
   return this;
 }
 
 buff_t* buff_t::add_stack_change_callback( const buff_stack_change_callback_t& cb )
 {
-  if ( !is_fallback )
-  {
-    stack_change_callback.push_back( cb );
-  }
+  if ( is_fallback )
+    return this;
 
+  stack_change_callback.push_back( cb );
   return this;
 }
 
 buff_t* buff_t::set_expire_callback( const buff_expire_callback_t& cb )
 {
-  if (!is_fallback)
-  {
-    expire_callback = cb;
-  }
+  if ( is_fallback )
+    return this;
 
+  expire_callback = cb;
   return this;
 }
 
 buff_t* buff_t::set_reverse_stack_count( int count )
 {
+  if ( is_fallback )
+    return this;
+
   reverse_stack_reduction = count;
   return this;
 }
 
 buff_t* buff_t::set_stack_behavior( buff_stack_behavior b )
 {
+  if ( is_fallback )
+    return this;
+
   stack_behavior = b;
   return this;
 }
 
 buff_t* buff_t::set_allow_precombat( bool b )
 {
+  if ( is_fallback )
+    return this;
+
   allow_precombat = b;
   return this;
 }
 
 buff_t* buff_t::set_name_reporting( std::string_view n )
 {
+  if ( is_fallback )
+    return this;
+
   name_str_reporting = n;
   return this;
 }
 
 buff_t* buff_t::set_disable_async_expire_events_removal( bool b )
 {
+  if ( is_fallback )
+    return this;
+
   disable_async_expire_events_removal = b;
   return this;
 }
@@ -1687,7 +1801,7 @@ buff_t* buff_t::set_disable_async_expire_events_removal( bool b )
 // aware there may be more work required to support your usecase.
 buff_t* buff_t::apply_time_rate_modifier( const spell_data_t* spell )
 {
-  if ( !spell->ok() || !s_data->ok() )
+  if ( is_fallback || !spell->ok() || !s_data->ok() )
     return this;
 
   assert( ( spell->flags( SX_PASSIVE ) || spell->duration() < 0_ms ) && "only passive spells should be affecting buffs." );
@@ -3354,6 +3468,9 @@ stat_buff_t::stat_buff_t( actor_pair_t q, util::string_view name, const spell_da
 
 stat_buff_t* stat_buff_t::add_stat( stat_e s, double a, const stat_check_fn& c )
 {
+  if ( is_fallback )
+    return this;
+
   if ( !manual_stats_added )
   {
     // If we are the first to add manual stats, clear the spell_data parsed ones.
@@ -3379,6 +3496,9 @@ stat_buff_t* stat_buff_t::add_stat( stat_e s, double a, const stat_check_fn& c )
 
 stat_buff_t* stat_buff_t::set_stat( stat_e s, double a, const stat_check_fn& c )
 {
+  if ( is_fallback )
+    return this;
+
   manual_stats_added = false;
 
   return add_stat( s, a, c );
@@ -3386,6 +3506,9 @@ stat_buff_t* stat_buff_t::set_stat( stat_e s, double a, const stat_check_fn& c )
 
 stat_buff_t* stat_buff_t::add_stat_from_effect( size_t i, double a, const stat_check_fn& c )
 {
+  if ( is_fallback )
+    return this;
+
   auto do_error = [ this, i ]( std::string_view msg ) -> stat_buff_t* {
     sim->error( "{} cannot add stat from effect#{}: {}", name(), i, msg );
     return this;
@@ -3443,6 +3566,9 @@ stat_buff_t* stat_buff_t::add_stat_from_effect( size_t i, double a, const stat_c
 
 stat_buff_t* stat_buff_t::set_stat_from_effect( size_t i, double a, const stat_check_fn& c )
 {
+  if ( is_fallback )
+    return this;
+
   manual_stats_added = false;
 
   return add_stat_from_effect( i, a, c );
@@ -3450,6 +3576,9 @@ stat_buff_t* stat_buff_t::set_stat_from_effect( size_t i, double a, const stat_c
 
 stat_buff_t* stat_buff_t::add_stat_from_effect_type( effect_subtype_t type, double a, const stat_check_fn& c )
 {
+  if ( is_fallback )
+    return this;
+
   const auto& eff = spell_data_t::find_spelleffect( data(), E_APPLY_AURA, type );
   assert( eff.ok() && "Effect type not found in stat buff" );
 
@@ -3458,6 +3587,9 @@ stat_buff_t* stat_buff_t::add_stat_from_effect_type( effect_subtype_t type, doub
 
 stat_buff_t* stat_buff_t::set_stat_from_effect_type( effect_subtype_t type, double a, const stat_check_fn& c )
 {
+  if ( is_fallback )
+    return this;
+
   manual_stats_added = false;
 
   return add_stat_from_effect_type( type, a, c );
@@ -3641,6 +3773,9 @@ void cost_reduction_buff_t::expire_override( int expiration_stacks, timespan_t r
 
 cost_reduction_buff_t* cost_reduction_buff_t::set_reduction( school_e s, double a )
 {
+  if ( is_fallback )
+    return this;
+
   amount = a;
   school = s;
   return this;
@@ -3730,12 +3865,18 @@ double absorb_buff_t::consume( double amount, action_state_t* state )
 
 absorb_buff_t* absorb_buff_t::set_absorb_gain( gain_t* g )
 {
+  if ( is_fallback )
+    return this;
+
   absorb_gain = g;
   return this;
 }
 
 absorb_buff_t* absorb_buff_t::set_absorb_source( stats_t* s )
 {
+  if ( is_fallback )
+    return this;
+
   if ( s )
     s->type = STATS_ABSORB;
   absorb_source = s;
@@ -3744,6 +3885,9 @@ absorb_buff_t* absorb_buff_t::set_absorb_source( stats_t* s )
 
 absorb_buff_t* absorb_buff_t::set_absorb_school( school_e s )
 {
+  if ( is_fallback )
+    return this;
+
   absorb_school = s;
   if ( s == SCHOOL_CHAOS )
   {
@@ -3769,6 +3913,9 @@ absorb_buff_t* absorb_buff_t::set_absorb_school( school_e s )
 
 absorb_buff_t* absorb_buff_t::set_absorb_high_priority( bool hp )
 {
+  if ( is_fallback )
+    return this;
+
   high_priority = hp;
   // TODO: check if player absorb_priority and instant_absorb_list could be automatically
   // populated from here somehow.
@@ -3777,6 +3924,9 @@ absorb_buff_t* absorb_buff_t::set_absorb_high_priority( bool hp )
 
 absorb_buff_t* absorb_buff_t::set_absorb_eligibility( absorb_eligibility e )
 {
+  if ( is_fallback )
+    return this;
+
   eligibility = std::move(e);
   // TODO: check if player absorb_priority and instant_absorb_list could be automatically
   // populated from here somehow.
@@ -3785,6 +3935,9 @@ absorb_buff_t* absorb_buff_t::set_absorb_eligibility( absorb_eligibility e )
 
 absorb_buff_t* absorb_buff_t::set_cumulative( bool c )
 {
+  if ( is_fallback )
+    return this;
+
   cumulative = c;
   return this;
 }
@@ -3844,7 +3997,7 @@ damage_buff_t::damage_buff_t( actor_pair_t q, util::string_view name, const spel
 
 damage_buff_t* damage_buff_t::parse_spell_data( const spell_data_t* spell, double conduit_value, double talent_value )
 {
-  if ( !spell->ok() )
+  if ( is_fallback || !spell->ok() )
     return this;
 
   for ( size_t idx = 1; idx <= spell->effect_count(); idx++ )
@@ -4022,7 +4175,7 @@ damage_buff_t* damage_buff_t::apply_dynamic_buff_multiplier( buff_t* buff )
 
 damage_buff_t* damage_buff_t::apply_mod_affecting_effect( damage_buff_modifier_t& mod, const spelleffect_data_t& effect )
 {
-  if ( !mod.s_data || !mod.s_data->ok() )
+  if ( is_fallback || !mod.s_data || !mod.s_data->ok() )
     return this;
 
   if ( ( effect.subtype() == A_ADD_FLAT_MODIFIER && mod.s_data->affected_by( effect ) ) ||
@@ -4053,11 +4206,17 @@ damage_buff_t* damage_buff_t::apply_mod_affecting_effect( damage_buff_modifier_t
 
 damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, double multiplier )
 {
+  if ( is_fallback )
+    return this;
+
   return set_buff_mod( mod, spell_data_t::nil(), 0, multiplier, 1.0 );
 }
 
 damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
 {
+  if ( is_fallback )
+    return this;
+
   assert( mod.s_data == nullptr && mod.effect_idx == 0 );
   mod.initial_multiplier = initial_multiplier;
 
@@ -4077,28 +4236,68 @@ damage_buff_t* damage_buff_t::set_buff_mod( damage_buff_modifier_t& mod, const s
 }
 
 damage_buff_t* damage_buff_t::set_direct_mod( double multiplier )
-{ return set_direct_mod( spell_data_t::nil(), 0, multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_direct_mod( spell_data_t::nil(), 0, multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_direct_mod( const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
-{ return set_buff_mod( direct_mod, s, effect_idx, multiplier, initial_multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_buff_mod( direct_mod, s, effect_idx, multiplier, initial_multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_periodic_mod( double multiplier )
-{ return set_periodic_mod( spell_data_t::nil(), 0, multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_periodic_mod( spell_data_t::nil(), 0, multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_periodic_mod( const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
-{ return set_buff_mod( periodic_mod, s, effect_idx, multiplier, initial_multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_buff_mod( periodic_mod, s, effect_idx, multiplier, initial_multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_auto_attack_mod( double multiplier )
-{ return set_auto_attack_mod( spell_data_t::nil(), 0, multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_auto_attack_mod( spell_data_t::nil(), 0, multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_auto_attack_mod( const spell_data_t* s, size_t effect_idx, double multiplier, double initial_multiplier )
-{ return set_buff_mod( auto_attack_mod, s, effect_idx, multiplier, initial_multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_buff_mod( auto_attack_mod, s, effect_idx, multiplier, initial_multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_crit_chance_mod( double multiplier )
-{ return set_crit_chance_mod( spell_data_t::nil(), 0, multiplier ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_crit_chance_mod( spell_data_t::nil(), 0, multiplier );
+}
 
 damage_buff_t* damage_buff_t::set_crit_chance_mod( const spell_data_t* s, size_t effect_idx, double multiplier )
-{ return set_buff_mod( crit_chance_mod, s, effect_idx, multiplier, 1.0 ); }
+{
+  if ( is_fallback )
+    return this;
+
+  return set_buff_mod( crit_chance_mod, s, effect_idx, multiplier, 1.0 );
+}
 
 bool damage_buff_t::is_affecting( const spell_data_t* s )
 {

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -780,7 +780,7 @@ buff_t::~buff_t() = default;
 const spell_data_t& buff_t::data_reporting() const
 {
   if ( is_fallback )
-    return spell_data_t::nil();
+    return *spell_data_t::nil();
 
   if (s_data_reporting == spell_data_t::nil())
     return *s_data;
@@ -884,7 +884,7 @@ buff_t* buff_t::modify_duration( timespan_t duration )
 buff_t* buff_t::set_duration_multiplier( double multiplier )
 {
   if ( is_fallback )
-  return this;
+    return this;
 
   assert( multiplier >= 0.0 );
   buff_duration_multiplier = multiplier;

--- a/engine/buff/buff.cpp
+++ b/engine/buff/buff.cpp
@@ -1262,13 +1262,8 @@ buff_t* buff_t::disable_ticking( bool v )
 
 buff_t* buff_t::add_invalidate( cache_e c )
 {
-  if ( is_fallback )
+  if ( is_fallback || c == CACHE_NONE )
     return this;
-
-  if ( c == CACHE_NONE || is_fallback )
-  {
-    return this;
-  }
 
   if ( range::find( invalidate_list, c ) == invalidate_list.end() )  // avoid duplication
   {
@@ -1393,7 +1388,7 @@ buff_t* buff_t::set_pct_buff_type_from_data( bool set_default )
 
 buff_t* buff_t::set_movement_speed_buff( bool stacking, double percent )
 {
-  if ( !player || is_fallback )
+  if ( is_fallback || !player )
     return this;
 
   if ( stacking )
@@ -4126,6 +4121,9 @@ damage_buff_t* damage_buff_t::parse_spell_data( const spell_data_t* spell, doubl
 
 damage_buff_t* damage_buff_t::apply_dynamic_buff_multiplier( buff_t* buff )
 {
+  if ( is_fallback )
+    return this;
+
   auto parse_dynamic_buff_multiplier_for_mod = [ this, buff ]( damage_buff_modifier_t& mod ) {
 
     if ( !mod.s_data || !mod.s_data->ok() )

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -26,23 +26,15 @@
 #include <vector>
 
 struct buff_t;
-struct stat_buff_t;
-struct spelleffect_data_t;
-struct absorb_buff_t;
-struct cost_reduction_buff_t;
-struct actor_pair_t;
-struct sim_t;
-struct action_t;
-struct item_t;
-struct gain_t;
-struct action_state_t;
-struct stats_t;
-struct event_t;
 struct cooldown_t;
-struct real_ppm_t;
+struct event_t;
 struct expr_t;
-struct spell_data_t;
-namespace rng{
+struct gain_t;
+struct item_t;
+struct real_ppm_t;
+struct spelleffect_data_t;
+struct stats_t;
+namespace rng {
 struct rng_t;
 }
 

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -584,12 +584,7 @@ struct damage_buff_t : public buff_t
   damage_buff_t* apply_dynamic_buff_multiplier( buff_t* buff );
   damage_buff_t* apply_mod_affecting_effect( damage_buff_modifier_t&, const spelleffect_data_t& );
 
-  damage_buff_t* set_is_stacking_mod( bool value )
-  {
-    is_stacking = value;
-    return this;
-  };
-
+  damage_buff_t* set_is_stacking_mod( bool value );
   damage_buff_t* set_direct_mod( double );
   damage_buff_t* set_direct_mod( const spell_data_t*, size_t, double = 0.0, double = 1.0 );
   damage_buff_t* set_periodic_mod( double );

--- a/engine/buff/buff.hpp
+++ b/engine/buff/buff.hpp
@@ -34,10 +34,10 @@ struct item_t;
 struct real_ppm_t;
 struct spelleffect_data_t;
 struct stats_t;
-namespace rng {
+namespace rng
+{
 struct rng_t;
 }
-
 
 using buff_tick_callback_t = std::function<void(buff_t* buff, int remaining_ticks, timespan_t tick_time)>;
 using buff_tick_time_callback_t = std::function<timespan_t(const buff_t*, unsigned)>;


### PR DESCRIPTION
Check if `buff_t::is_fallback` is true and short circuit for all `buff_t` (and derived type) member functions that are setters or immediately check for buff data validity.

Non-setters were avoided as they tend to be called more frequently.