### PR TITLE
[Priest] Remove reduced AOE targets limit in tentacle slam damage

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1708,7 +1708,6 @@ struct tentacle_slam_damage_t final : public priest_spell_t
   {
     background                 = true;
     affected_by_shadow_weaving = true;
-    reduced_aoe_targets        = 5;
     aoe                        = -1;
   }
 };


### PR DESCRIPTION
Removed the limit on reduced AOE targets for tentacle slam damage.