### PR TITLE
[Devourer] Allow Pick Up Fragment during Consume and Devour casts

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -5101,6 +5101,8 @@ struct pick_up_fragment_t : public demon_hunter_spell_t
     // use_off_gcd = true;
     may_miss = callbacks = harmful = false;
     range                          = 5.0;  // Disallow use outside of melee.
+    // Consume and Devour are castable while moving; fragments can be collected during those casts.
+    usable_while_casting = use_while_casting = true;
   }
 
   void parse_mode( util::string_view value )
@@ -5268,6 +5270,13 @@ struct pick_up_fragment_t : public demon_hunter_spell_t
   bool ready() override
   {
     if ( dh()->soul_fragment_pick_up )
+    {
+      return false;
+    }
+
+    // Only Consume and Devour can be cast while moving; any other cast or channel blocks the pick up.
+    action_t* casting = dh()->executing ? dh()->executing : dh()->channeling;
+    if ( casting && casting->id != dh()->spec.consume->id() && casting->id != dh()->spec.devour->id() )
     {
       return false;
     }


### PR DESCRIPTION
Consume and Devour are castable while moving, and picking up fragments during those casts is standard play. The off-GCD scheduler refuses to poll while the actor is executing, so the sim can only start a pickup in a rotation gap.

`pick_up_fragment` now sets `use_while_casting` and gates `ready()` on the executing or channeling spell id, permitting Consume (473662) and Devour (1217610) only. Everything else that casts or channels roots the actor, so the block stays. Same `executing->id` pattern as the meta expiry handling. No change when not casting.

Testing shows pickups initiating inside Consume and Devour casts and never inside a Void Ray channel.