### PR TITLE
[Warlock] Implement Impetuous Wrath and 12.1.0 Affliction updates

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -92,7 +92,10 @@ void affliction( player_t* p )
   default_->add_action( "call_action_list,name=items" );
   default_->add_action( "call_action_list,name=soul_harvester,if=hero_tree.soul_harvester" );
   default_->add_action( "call_action_list,name=hellcaller,if=hero_tree.hellcaller" );
-  default_->add_action( "seed_of_corruption,if=talent.nocturnal_yield&active_enemies>1&buff.nightfall.react&(buff.nightfall.react=buff.nightfall.max_stack|buff.nightfall.remains<execute_time*buff.nightfall.max_stack)" );
+  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+  {
+    default_->add_action( "seed_of_corruption,if=talent.nocturnal_yield&active_enemies>1&buff.nightfall.react&(buff.nightfall.react=buff.nightfall.max_stack|buff.nightfall.remains<execute_time*buff.nightfall.max_stack)" );
+  }
   default_->add_action( "malefic_grasp,chain=1,early_chain_if=buff.nightfall.react,if=pet.darkglare.active" );
   default_->add_action( "drain_soul,chain=1,early_chain_if=buff.nightfall.react,interrupt_if=tick_time>0.5" );
   default_->add_action( "shadow_bolt" );

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -428,6 +428,7 @@ public:
     player_talent_t niskaran_methods;
     player_talent_t potent_soul_shards;
     player_talent_t nocturnal_yield;
+    player_talent_t impetuous_wrath;
 
     player_talent_t xavius_gambit; // Unstable Affliction Damage Multiplier
     player_talent_t ravenous_afflictions;

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -929,6 +929,12 @@ using namespace helpers;
       if ( p()->talents.withering_bolt.ok() )
         m *= 1.0 + p()->talents.withering_bolt->effectN( 1 ).percent() * std::min( ( int )( p()->talents.withering_bolt->effectN( 2 ).base_value() ), p()->get_target_data( t )->count_affliction_dots() );
 
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( p()->talents.impetuous_wrath.ok() )
+          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
+      }
+
       return m;
     }
   };
@@ -1960,11 +1966,14 @@ using namespace helpers;
       if ( ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ) && p()->talents.patient_zero.ok() )
         p()->patient_zero_target = main_seed_target;
 
-      // 2026-06-30 Hotfix: Nightfall SoC detonates existing SoC when smart targeting leaves the primary seed on an already seeded target
-      if ( p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() && mstdata->dots.seed_of_corruption->is_ticking() && mstdata->soc_threshold > 0 )
+      if ( p()->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
       {
-        mstdata->soc_threshold = 0;
-        mstdata->dots.seed_of_corruption->cancel();
+        // 2026-06-30 Hotfix: Nightfall SoC detonates existing SoC when smart targeting leaves the primary seed on an already seeded target
+        if ( p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() && mstdata->dots.seed_of_corruption->is_ticking() && mstdata->soc_threshold > 0 )
+        {
+          mstdata->soc_threshold = 0;
+          mstdata->dots.seed_of_corruption->cancel();
+        }
       }
 
       warlock_spell_t::execute();
@@ -1973,17 +1982,20 @@ using namespace helpers;
 
       const bool soc_had_prev_succulent_soul = p()->buffs.succulent_soul->check();
 
-      if ( time_to_execute == 0_ms && soul_harvester() && p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() )
+      if ( p()->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
       {
-        if ( p()->hero.wicked_reaping.ok() )
-          p()->proc_actions.wicked_reaping->execute_on_target( main_seed_target );
+        if ( time_to_execute == 0_ms && soul_harvester() && p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() )
+        {
+          if ( p()->hero.wicked_reaping.ok() )
+            p()->proc_actions.wicked_reaping->execute_on_target( main_seed_target );
 
-        if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-          p()->proc_actions.shared_fate->execute_on_target( main_seed_target );
+          if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
+            p()->proc_actions.shared_fate->execute_on_target( main_seed_target );
 
-        // Feast of Souls is processed after SoC captures its previous Succulent Soul state but before the delayed stack removal
-        if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
-          p()->feast_of_souls_gain();
+          // Feast of Souls is processed after SoC captures its previous Succulent Soul state but before the delayed stack removal
+          if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
+            p()->feast_of_souls_gain();
+        }
       }
 
       if ( soul_harvester() )
@@ -2012,8 +2024,18 @@ using namespace helpers;
 
       // NOTE: 2026-02-26 If Nightfall is obtained during the casting of Seed of Corruption, that SoC cast
       // benefits from the cost reduction but does not consume the effect. (bug?)
-      if ( p()->talents.nocturnal_yield.ok() && time_to_execute == 0_ms )
-        p()->buffs.nightfall->decrement();
+      if ( p()->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+      {
+        if ( p()->talents.nocturnal_yield.ok() && time_to_execute == 0_ms )
+          p()->buffs.nightfall->decrement();
+      }
+
+      // NOTE: 2026-07-26 Seed of Corruption is not consuming Shard Instability buff (bug)
+      if ( p()->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( !p()->bugs && time_to_execute == 0_ms )
+          p()->buffs.shard_instability->decrement();
+      }
 
       if ( p()->talents.cull_the_weak.ok() )
         p()->cooldowns.dark_harvest->adjust( -p()->talents.cull_the_weak->effectN( 1 ).time_value() );
@@ -2240,8 +2262,11 @@ using namespace helpers;
 
     void snapshot_state( action_state_t* s, result_amount_type rt ) override
     {
-      // NOTE: 2026-02-20 Malefic Grasp does not benefit from the Nightfall damage bonus under any circumstances (bug)
-      double dmg_mul = p()->bugs ? 0.0 : p()->talents.nightfall_buff->effectN( 2 ).percent();
+      // NOTE: 2026-07-26 12.0.7: Malefic Grasp does not benefit from the Nightfall damage bonus under any circumstances (bug)
+      // NOTE: 2026-07-26 12.1.0: PTR Nightfall does not buff Malefic Grasp damage unless the Necrolyte Teachings hero talent (Soul Harvester) is used (bug)
+      double dmg_mul = ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
+                ? ( p()->bugs ? 0.0 : p()->talents.nightfall_buff->effectN( 2 ).percent() )
+                : ( ( p()->bugs && !p()->hero.necrolyte_teachings.ok() ) ? 0.0 : p()->talents.nightfall_buff->effectN( 2 ).percent() );
 
       debug_cast<malefic_grasp_state_t*>( s )->td_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? dmg_mul : 0.0 );
       debug_cast<malefic_grasp_state_t*>( s )->tick_time_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? p()->talents.nightfall_buff->effectN( 3 ).percent() : 0.0 );
@@ -2308,6 +2333,19 @@ using namespace helpers;
         trigger_extra_tick( tdata->dots.wither, extra_tick_mul, wither_mg, false );
         trigger_extra_tick( tdata->dots.corruption, extra_tick_mul, corruption_mg );
       }
+    }
+
+    double composite_target_multiplier( player_t* t ) const override
+    {
+      double m = warlock_spell_t::composite_target_multiplier( t );
+
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( p()->talents.impetuous_wrath.ok() )
+          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
+      }
+
+      return m;
     }
 
     double composite_ta_multiplier( const action_state_t* s ) const override
@@ -2449,6 +2487,12 @@ using namespace helpers;
       if ( p()->talents.withering_bolt.ok() )
         m *= 1.0 + p()->talents.withering_bolt->effectN( 1 ).percent() * std::min( ( int )( p()->talents.withering_bolt->effectN( 2 ).base_value() ), td( t )->count_affliction_dots() );
 
+      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      {
+        if ( p()->talents.impetuous_wrath.ok() )
+          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
+      }
+
       return m;
     }
 
@@ -2520,6 +2564,19 @@ using namespace helpers;
         : warlock_spell_t( "Dark Harvest (tick)", p, p->talents.dark_harvest_dmg )
       {
         background = dual = true;
+      }
+
+      double composite_target_multiplier( player_t* t ) const override
+      {
+        double m = warlock_spell_t::composite_target_multiplier( t );
+
+        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+        {
+          if ( p()->talents.impetuous_wrath.ok() )
+            m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 4 ).percent() : p()->talents.impetuous_wrath->effectN( 3 ).percent() );
+        }
+
+        return m;
       }
     };
 

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -146,7 +146,7 @@ namespace warlock
 
     talents.nightfall = find_talent_spell( talent_tree::SPECIALIZATION, "Nightfall" ); // Should be ID 108558
     talents.nightfall_buff = conditional_spell_lookup( warlock_base.affliction_warlock->ok(), 264571 );
-    talents.nightfall_buff_2 = conditional_spell_lookup( warlock_base.affliction_warlock->ok(), 1260279 );
+    talents.nightfall_buff_2 = conditional_spell_lookup( warlock_base.affliction_warlock->ok() && ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ), 1260279 );
 
     talents.haunt = find_talent_spell( talent_tree::SPECIALIZATION, "Haunt" ); // Should be ID 48181
 
@@ -208,7 +208,10 @@ namespace warlock
 
     talents.potent_soul_shards = find_talent_spell( talent_tree::SPECIALIZATION, "Potent Soul Shards" ); // Should be ID 1259815
 
-    talents.nocturnal_yield = find_talent_spell( talent_tree::SPECIALIZATION, "Nocturnal Yield" ); // Should be ID 1260271
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      talents.impetuous_wrath = find_talent_spell( talent_tree::SPECIALIZATION, "Impetuous Wrath" ); // Should be ID 1312998
+    else
+      talents.nocturnal_yield = find_talent_spell( talent_tree::SPECIALIZATION, "Nocturnal Yield" ); // Should be ID 1260271
 
     talents.xavius_gambit = find_talent_spell( talent_tree::SPECIALIZATION, "Xavius' Gambit" ); // Should be ID 416615
 
@@ -765,7 +768,7 @@ namespace warlock
 
   void warlock_t::create_buffs_affliction()
   {
-    buffs.nightfall = make_buff( this, "nightfall", talents.nocturnal_yield.ok() ? talents.nightfall_buff_2 : talents.nightfall_buff );
+    buffs.nightfall = make_buff( this, "nightfall", ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) && talents.nocturnal_yield.ok() ) ? talents.nightfall_buff_2 : talents.nightfall_buff );
 
     buffs.darkglare_presence = make_buff( this, "darkglare_presence", talents.darkglare_presence_buff );
 

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -2670,13 +2670,13 @@ namespace diabolist
 
       if ( p()->o()->demonology() )
       {
-        // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
+        // Modify Diab Demons damage for Demonology
         m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
       }
 
       if ( p()->o()->destruction() )
       {
-        // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        // Modify Diab Demons damage for Destruction
         m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
       }
 
@@ -2746,13 +2746,13 @@ namespace diabolist
 
       if ( p()->o()->demonology() )
       {
-        // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
+        // Modify Diab Demons damage for Demonology
         m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
       }
 
       if ( p()->o()->destruction() )
       {
-        // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        // Modify Diab Demons damage for Destruction
         m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
       }
 
@@ -2841,13 +2841,13 @@ namespace diabolist
 
       if ( p()->o()->demonology() )
       {
-        // Added in build: 11.2.0.62253: reduces Diab Demons Damage by 20% for Demonology
+        // Modify Diab Demons damage for Demonology
         m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 3 ).percent();
       }
 
       if ( p()->o()->destruction() )
       {
-        // Added in build 11.2.0.62253: Increases Diab Demons damage by 15% for Destruction, missing from Patch Notes.
+        // Modify Diab Demons damage for Destruction
         m *= 1.0 + p()->o()->hero.diabolic_ritual->effectN( 4 ).percent();
       }
 


### PR DESCRIPTION
This PR implements the latest Affliction Warlock changes made by Blizzard on the 12.1.0 PTR (as of 2026-07-26). The latest Demonology tuning changes consist only of spell data modifications and do not require any code changes.

Changes intended for 12.1.0 are guarded behind version checks. The existing behavior for versions `<12.1.0` remains unchanged.

# Impetuous Wrath

The new **Impetuous Wrath** talent has been implemented for versions `>=12.1.0`, replacing **Nocturnal Yield**.

**Impetuous Wrath** increases **Shadow Bolt**, **Drain Soul**, **Malefic Grasp**, and **Dark Harvest** damage by 10%, or by 20% when the target is affected by **Haunt**.

Effects #­1 and #­2 apply to **Shadow Bolt**/**Drain Soul**/**Malefic Grasp**, while effects #­3 and #­4 apply to **Dark Harvest**. These are dummy effects (likely server-side scripted), so they need to be implemented manually.

The target's **Haunt** state is evaluated according to the behavior observed in-game:
- For **Shadow Bolt**, the multiplier is determined on execute, when the cast finishes, rather than when the missile impacts.
- For **Drain Soul** and **Malefic Grasp**, the multiplier is dynamic, and the target's **Haunt** state is checked again on every tick.
- For **Dark Harvest**, the target's **Haunt** state is checked independently for each damage event and target.
- The additional DoT ticks triggered by **Malefic Grasp** are not considered **Malefic Grasp** damage and therefore do not benefit from **Impetuous Wrath**.
- **Shadowbolt Volley** (**Cunning Cruelty** talent) is unaffected by this talent.

**Nocturnal Yield** and its associated **Seed of Corruption** interactions are now restricted to versions `<12.1.0`.

The default Affliction APL has also been updated to avoid referencing `talent.nocturnal_yield` in versions `>=12.1.0`, since that talent no longer exists and would otherwise cause errors.

# Shard Instability

**Shard Instability** has been redesigned on the 12.1.0 PTR. Its buff can now make either **Unstable Affliction** or **Seed of Corruption** free and instant.

The chance to trigger **Shard Instability** is unchanged:
- **Shadow Bolt** has a 20% chance.
- **Drain Soul** has a 10% chance.
- **Malefic Grasp** has a 10% chance, regardless of whether **Shadow Bolt** or **Drain Soul** is selected.

There is currently a bug on the PTR where **Seed of Corruption** benefits from **Shard Instability** but does not consume the buff. Without the Affliction 4pc tier bonus, this allows **Seed of Corruption** to be cast repeatedly for free and instantly while the buff remains active.

With the Affliction 4pc tier bonus, the additional **Unstable Affliction** applied by **Seed of Corruption** still consumes **Shard Instability**. This existing PTR bug remains unchanged.

As with **Unstable Affliction**, if **Shard Instability** is gained during the cast, that cast benefits from the Soul Shard cost reduction but does not consume the buff. This was already the behavior in previous versions and remains unchanged.

# Nightfall and Malefic Grasp

The interaction between **Nightfall** and **Malefic Grasp** has changed on the 12.1.0 PTR.

On live 12.0.7, **Malefic Grasp** does not benefit from the **Nightfall** damage increase under any circumstances. On the 12.1.0 PTR, it now benefits from the damage increase, but only when using the **Necrolyte Teachings** Soul Harvester hero talent (like **Drain Soul** does). This remains bugged (also like **Drain Soul** is), since **Malefic Grasp** should presumably benefit from **Nightfall** regardless of the selected hero talents.

# Additional automatically parsed changes

The latest spell data also includes several changes that do not require new manual implementations:
- **Hedonic Gorging** now correctly increases both the direct and periodic **Siphon Life** bonus to **Corruption**/**Wither** from 30% to 40%. This fixes the previous PTR bug where only the direct component received the increase.
- **Chaos Salvo**, **Felseeker**, and **Wicked Cleave** deal 20% less damage for Demonology through the existing demonology-specific **Diabolic Ritual** modifier.
- **Eye Explosion** deals 20% less damage for Demonology through a new specialization aura effect.
- **Flames of Xoroth** receives a new Demonology specialization modifier affecting its Fire, pet, and guardian damage effects.

The patch notes describe **Flames of Xoroth** as being reduced from `4%` to `3%`. However, spell data applies a `-1%` percent modifier to the existing `4%` effects, resulting in an actual value of `3.96%`. This `3.96%` value has been confirmed in-game and matches the spell data. This appears to be a clear bug and will likely be fixed in the future.