### PR TITLE
[Warlock] Add Unstable Affliction stack remains expression

### DIFF
--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -16,6 +16,7 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
     soc_threshold( 0.0 ),
     ua_regular_stacks( 0 ),
     ua_seed_stacks( 0 ),
+    ua_stack_drop_events(),
     warlock( p )
 {
   // Shared
@@ -165,11 +166,29 @@ void warlock_td_t::reset_ua_stack_tracking()
 {
   ua_regular_stacks = 0;
   ua_seed_stacks = 0;
+  ua_stack_drop_events.clear();
 }
 
 double warlock_td_t::ua_calculate_damage_stacks() const
 {
   return as<double>( ua_regular_stacks ) + as<double>( ua_seed_stacks ) * warlock.tier.wl_affliction_12_1_class_set_4pc->effectN( 1 ).percent();
+}
+
+timespan_t warlock_td_t::ua_stack_remains( int min_stacks ) const
+{
+  assert( min_stacks > 0 );
+
+  const int current_stacks = dots.unstable_affliction->current_stack();
+  assert( current_stacks >= 0 );
+
+  if ( current_stacks < min_stacks || dots.unstable_affliction->remains() == 0_ms )
+    return 0_ms;
+
+  const size_t expiration_index = as<size_t>( current_stacks - min_stacks );
+  assert( expiration_index < ua_stack_drop_events.size() && "UA stack count exceeds tracked stack expiration events" );
+
+  // UA stack events are stored in application order and all stacks have the same duration, so application order is also expiration order
+  return ua_stack_drop_events[ expiration_index ]->remains();
 }
 
 void warlock_td_t::target_demise()
@@ -1050,6 +1069,50 @@ std::unique_ptr<expr_t> warlock_t::create_expression( util::string_view name_str
   }
 
   return player_t::create_expression( name_str );
+}
+
+std::unique_ptr<expr_t> warlock_t::create_action_expression( action_t& action, util::string_view name_str )
+{
+  auto splits = util::string_split<util::string_view>( name_str, ".", false );
+
+  if ( splits.size() >= 3 && util::str_compare_ci( splits[ 0 ], "dot" ) && util::str_compare_ci( splits[ 1 ], "unstable_affliction" ) && util::str_compare_ci( splits[ 2 ], "stack_remains" ) )
+  {
+    const bool use_current_stacks = splits.size() == 4 && util::str_compare_ci( splits[ 3 ], "current" );
+
+    if ( splits.size() != 4 || util::ends_with( name_str, '.' ) || splits[ 3 ].empty() || ( !use_current_stacks && !util::is_number( splits[ 3 ] ) ) )
+      throw sc_invalid_apl_argument( fmt::format( "Invalid expression '{}'. Expected 'dot.unstable_affliction.{}.N', where N is a positive integer or 'current'.", name_str, splits[ 2 ] ) );
+
+    int min_stacks = 0;
+    if ( !use_current_stacks )
+    {
+      try
+      {
+        min_stacks = util::to_int( splits[ 3 ] );
+      }
+      catch ( const std::exception& )
+      {
+        throw sc_invalid_apl_argument( fmt::format( "Invalid expression '{}'. Expected 'dot.unstable_affliction.{}.N', where N is a positive integer or 'current'.", name_str, splits[ 2 ] ) );
+      }
+
+      if ( min_stacks <= 0 )
+        throw sc_invalid_apl_argument( fmt::format( "Invalid expression '{}'. Expected 'dot.unstable_affliction.{}.N', where N is a positive integer or 'current'.", name_str, splits[ 2 ] ) );
+
+      const int max_stacks = as<int>( talents.unstable_affliction->max_stacks() );
+      if ( max_stacks > 0 && min_stacks > max_stacks )
+        throw sc_invalid_apl_argument( fmt::format( "Invalid stack amount in '{}'. N must be between 1 and {}.", name_str, max_stacks ) );
+    }
+
+    return make_fn_expr( name_str, [ this, &action, min_stacks, use_current_stacks ] {
+      auto tdata = get_target_data( action.get_expression_target() );
+      const int threshold = use_current_stacks ? tdata->dots.unstable_affliction->current_stack() : min_stacks;
+      if ( threshold == 0 )
+        return 0_ms;
+
+      return tdata->ua_stack_remains( threshold );
+    } );
+  }
+
+  return player_t::create_action_expression( action, name_str );
 }
 
 /* ----------------------------------------------------------

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -94,9 +94,11 @@ struct warlock_td_t : public actor_target_data_t
 
   double soc_threshold; // Aff - Seed of Corruption counts damage from cross-spec spells such as Drain Life
 
-  // 12.1 Affliction 4pc
+  // 12.1 Affliction 4pc UA
   int ua_regular_stacks;
   int ua_seed_stacks;
+  // Track the independent expiration of each UA stack
+  std::vector<event_t*> ua_stack_drop_events;
 
   warlock_t& warlock;
   warlock_td_t( player_t* target, warlock_t& p );
@@ -114,6 +116,7 @@ struct warlock_td_t : public actor_target_data_t
   void ua_stack_expired( bool is_seed_ua );
   void reset_ua_stack_tracking();
   double ua_calculate_damage_stacks() const;
+  timespan_t ua_stack_remains( int min_stacks ) const; // Time until the target has fewer than min_stacks UA stacks
 };
 
 // Shuffled Bag RNG (sampling without replacement)
@@ -1193,6 +1196,7 @@ public:
   void invalidate_cache( cache_e c ) override;
   double composite_mastery() const override;
   std::unique_ptr<expr_t> create_expression( util::string_view name_str ) override;
+  std::unique_ptr<expr_t> create_action_expression( action_t& action, util::string_view name_str ) override;
   std::string default_potion() const override { return warlock_apl::potion( this ); }
   std::string default_flask() const override { return warlock_apl::flask( this ); }
   std::string default_food() const override { return warlock_apl::food( this ); }

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -1618,7 +1618,8 @@ using namespace helpers;
         if ( dot->duration() > dot_new_last_duration )
           dot->adjust_duration( dot_new_last_duration - dot->duration() );
 
-        make_event<ua_stack_drop_event_t>( *sim, p(), dot, dot_new_last_duration, is_seed_applied );
+        auto ev = make_event<ua_stack_drop_event_t>( *sim, p(), dot, dot_new_last_duration, is_seed_applied );
+        tdata->ua_stack_drop_events.push_back( ev );
       }
     }
 
@@ -5773,12 +5774,18 @@ using namespace helpers;
   void ua_stack_drop_event_t::execute()
   {
     warlock_t* p = static_cast<warlock_t*>( player() );
+    player_t* target = dot->target;
+    warlock_td_t* tdata = p->get_target_data( target );
+
+    // A previous UA expiration or cancellation invalidates its remaining stack events
+    auto ua_stack_drop_events_it = std::find( tdata->ua_stack_drop_events.begin(), tdata->ua_stack_drop_events.end(), this );
+    if ( ua_stack_drop_events_it == tdata->ua_stack_drop_events.end() )
+      return;
+
+    tdata->ua_stack_drop_events.erase( ua_stack_drop_events_it );
 
     if ( dot->is_ticking() && dot->tick_event && dot->current_action && dot->remains() > 0_ms )
     {
-      player_t* target = dot->target;
-      warlock_td_t* tdata = p->get_target_data( target );
-
       dot->decrement( 1 );
       tdata->ua_stack_expired( is_seed_applied );
       assert( ( dot->is_ticking() && dot->current_stack() > 0 ) && "UA stack decrement event should not cancel the DoT" );


### PR DESCRIPTION
**Unstable Affliction** (**UA**) applications have independent 8-second-duration application stacks, and the module has special handling to manage the correct decrement of those stacks. While the existing `dot.unstable_affliction.stack` expression returns the current number of stacks and `dot.unstable_affliction.remains` returns the time until the complete DoT expires, there was no way for the APL to determine when individual stacks would expire or when the target would fall below a specific number of stacks.

This PR adds the following target-specific expressions:
- `dot.unstable_affliction.stack_remains.N`: Returns the time remaining before the target falls below `N` **Unstable Affliction** stacks, or `0` if the target already has fewer than `N` stacks.
- `dot.unstable_affliction.stack_remains.current`: Returns the time remaining before the target loses its next **UA** stack, or `0` if **UA** is not active.

For example, with **5** active **UA** stacks:
- `dot.unstable_affliction.stack_remains.5` returns the time until the first stack expires and the target drops to 4 stacks.
- `dot.unstable_affliction.stack_remains.3` returns the time until the third stack expires and the target drops below 3 stacks.
- `dot.unstable_affliction.stack_remains.1` returns the time until the final stack expires.
- `dot.unstable_affliction.stack_remains.current` is equivalent to `dot.unstable_affliction.stack_remains.5` in this case and always returns the time until the next stack expires.

The numeric argument must be a positive integer no greater than `99`, the current maximum number of **Unstable Affliction** stacks.

To support these expressions, the independent stack expiration events are now tracked per target. These events are stored in application order, which is also their expiration order because every **Unstable Affliction** application has the same duration. Each event is removed from the tracking list when it executes, and the list is cleared when the **Unstable Affliction** DoT expires, is canceled, or the target data is reset.

Stack expiration events invalidated by a previous **Unstable Affliction** expiration or cancellation are ignored. This prevents an old event from decrementing the stacks of a later **Unstable Affliction** application on the same target.

The expressions use the action's current expression target, allowing them to work correctly with target-specific APL behavior such as `target_if` and `cycle_targets`.