### PR TITLE
[Devourer] Soulburst procs have bad luck protection

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1172,6 +1172,8 @@ public:
   {
     // Annihilator
     accumulated_rng_t* voidfall;
+    // MID2 Devourer 2pc
+    accumulated_rng_t* soulburst;
   } accumulated_rng;
 
   // Special
@@ -1256,6 +1258,11 @@ public:
     double proc_from_killing_blow_chance          = 0.4;
     int entropy_starting_souls                    = -1;
     int channel_tick_cutoff_benefit               = 2;
+    // Soulburst chance grows by step with each harvest that fails to proc, up to cap.
+    // Fitted from PTR logs. Set base to 0 to use the flat roll from spell data.
+    double soulburst_blp_base = 0.0663;
+    double soulburst_blp_step = 0.0519;
+    double soulburst_blp_cap  = 0.3949;
   } options;
 
   demon_hunter_t( sim_t* sim, util::string_view name, race_e r );
@@ -3440,9 +3447,15 @@ struct soulburst_trigger_t : public BASE
   void trigger_soulburst( unsigned fragments_consumed )
   {
     // TOCHECK: Is this instant?
-    if ( BASE::dh()->set_bonuses.mid2_devourer_2pc->ok() &&
-         fragments_consumed >= BASE::dh()->set_bonuses.mid2_devourer_2pc->effectN( 1 ).base_value() &&
-         BASE::rng().roll( BASE::dh()->set_bonuses.mid2_devourer_2pc->effectN( 2 ).percent() ) )
+    if ( !BASE::dh()->set_bonuses.mid2_devourer_2pc->ok() ||
+         fragments_consumed < BASE::dh()->set_bonuses.mid2_devourer_2pc->effectN( 1 ).base_value() )
+      return;
+
+    // Harvests below the fragment threshold don't roll and don't advance the counter.
+    const bool proc = BASE::dh()->accumulated_rng.soulburst
+                          ? BASE::dh()->accumulated_rng.soulburst->trigger() > 0
+                          : BASE::rng().roll( BASE::dh()->set_bonuses.mid2_devourer_2pc->effectN( 2 ).percent() );
+    if ( proc )
     {
       BASE::dh()->buff.soulburst->trigger();
     }
@@ -10325,6 +10338,9 @@ void demon_hunter_t::create_options()
   add_option( opt_deprecated( "entropy_starting_souls", "demonhunter.entropy_starting_souls" ) );
   add_option( opt_int( "demonhunter.channel_tick_cutoff_benefit", options.channel_tick_cutoff_benefit, 0, 10 ) );
   add_option( opt_deprecated( "channel_tick_cutoff_benefit", "demonhunter.channel_tick_cutoff_benefit" ) );
+  add_option( opt_float( "demonhunter.soulburst_blp_base", options.soulburst_blp_base, 0.0, 1.0 ) );
+  add_option( opt_float( "demonhunter.soulburst_blp_step", options.soulburst_blp_step, 0.0, 1.0 ) );
+  add_option( opt_float( "demonhunter.soulburst_blp_cap", options.soulburst_blp_cap, 0.0, 1.0 ) );
 
   add_option( opt_float( "demonhunter.void_metamorphosis_initial_drain", devourer_fury_state.initial_drain, 0, 100 ) );
   add_option( opt_deprecated( "void_metamorphosis_initial_drain", "demonhunter.void_metamorphosis_initial_drain" ) );
@@ -10576,6 +10592,17 @@ void demon_hunter_t::init_rng()
   // Accumulated proc objects
   accumulated_rng.voidfall =
       get_accumulated_rng( "voidfall", prd::find_constant( talent.annihilator.voidfall->effectN( 3 ).percent() ) );
+
+  accumulated_rng.soulburst = nullptr;
+  if ( set_bonuses.mid2_devourer_2pc->ok() && options.soulburst_blp_base > 0 )
+  {
+    accumulated_rng.soulburst =
+        get_accumulated_rng( "soulburst", options.soulburst_blp_base, 0U,
+                             [ step = options.soulburst_blp_step, cap = options.soulburst_blp_cap ](
+                                 double base, unsigned count, action_state_t* ) {
+                               return std::min( base + step * ( as<double>( count ) - 1.0 ), cap );
+                             } );
+  }
 
   player_t::init_rng();
 }


### PR DESCRIPTION
The 2pc is not a flat 20% roll. PTR logs (386 player fights, about 20k harvests) show the chance climbing with the number of harvests since the last proc, then leveling off:

| harvests since last proc | n | observed | fitted |
|---|---|---|---|
| 1 | 4232 | 6.5% | 6.6% |
| 2 | 3907 | 12.3% | 11.8% |
| 3 | 3385 | 17.2% | 17.0% |
| 4 | 2778 | 21.7% | 22.2% |
| 5 | 2152 | 26.9% | 27.4% |
| 6 | 1557 | 31.9% | 32.6% |
| 7 | 1052 | 39.4% | 37.8% |
| 8 | 628 | 39.3% | 39.5% |
| 9 | 373 | 38.9% | 39.5% |
| 10 | 226 | 45.1% | 39.5% |

The fit is 6.6% on the first harvest, +5.2% per fail, capped at 39.5%.

- The counter is shared across Reap, Cull and Eradicate.
- Harvests under the 4 fragment threshold don't roll and don't advance the counter.
- The counter only moves on harvest casts. Waiting longer between casts doesn't help, and neither does harvesting more souls.
- The shape isn't the standard c*n PRD.
- Long run proc rate comes out at 19.9%.
- DPS impact is about -0.16% single target.
- Run to run DPS spread drops about 12% single target and 9% at 5 targets, fixed fight length.
