### PR TITLE
[monk] Fix SCK channel cancelling, expire Zenith Stomp when Zenith fades

### DIFF
--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -1688,6 +1688,7 @@ struct spinning_crane_kick_t : public monk_melee_attack_t
 
   void execute() override
   {
+    set_target( player );
     auto *tick = spinning_crane_kick_tick;
     if ( !tick->execute_state )
       tick->execute_state = tick->get_state();

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -6476,7 +6476,8 @@ void monk_t::create_buffs()
   buff.whirling_dragon_punch = make_buff_fallback<buffs::whirling_dragon_punch_buff_t>(
       talent.windwalker.whirling_dragon_punch->ok(), this, "whirling_dragon_punch" );
 
-  buff.zenith = make_buff_fallback<buffs::zenith_t>( talent.windwalker.zenith->ok(), this, "zenith" );
+  buff.zenith = make_buff_fallback<buffs::zenith_t>( talent.windwalker.zenith->ok(), this, "zenith" )
+                    ->set_expire_callback( [ & ]( buff_t *, int, timespan_t ) { buff.zenith_stomp->expire(); } );
 
   buff.zenith_stomp = make_buff_fallback( talent.windwalker.tigereye_brew_3->ok(), this, "zenith_stomp",
                                           talent.monk.zenith_stomp_buff );


### PR DESCRIPTION
- **[monk] Zenith fades Zenith Stomp buffs on expiry.**
- **[monk] Set Spinning Crane Kick channel to execute on player. SCK needs no target to continue channeling, so instead place the driver dot on the casting player to avoid channels being cancelled if the target dies.**
