### PR TITLE
[Warlock] Apply Gloomhound and Isolated Implosion hotfixes

### DIFF
--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -3288,8 +3288,7 @@ using namespace helpers;
         spell_power_mod.direct = p->talents.implosion_aoe->effectN( 1 ).sp_coeff();
         aoe = -1;
         target_filter_callback = secondary_targets_only();
-        // NOTE: 2026-07-06: The spell description lists 125% effectiveness, but in-game damage behaves as +125% increased effectiveness (bug?)
-        base_dd_multiplier *= ( p->bugs ? 1.0 : 0.0 ) + p->tier.wl_demonology_12_1_class_set_4pc->effectN( 2 ).percent();
+        base_dd_multiplier *= p->tier.wl_demonology_12_1_class_set_4pc->effectN( 2 ).percent();
       }
     };
 
@@ -3303,8 +3302,7 @@ using namespace helpers;
         spell_power_mod.direct = p->talents.implosion_aoe->effectN( 1 ).sp_coeff();
         aoe = 0;
         radius = 0;
-        // NOTE: 2026-07-06: The spell description lists 150% effectiveness, but in-game damage behaves as +150% increased effectiveness (bug?)
-        base_dd_multiplier *= ( p->bugs ? 1.0 : 0.0 ) + p->tier.wl_demonology_12_1_class_set_4pc->effectN( 1 ).percent();
+        base_dd_multiplier *= p->tier.wl_demonology_12_1_class_set_4pc->effectN( 1 ).percent();
 
         impact_action = new isolated_implosion_aoe_secondary_t( p );
         impact_action->stats = stats;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -1316,17 +1316,34 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   {
     npc_id = owner->talents.gloomhound->effectN( 1 ).misc_value1();
     npc_suffix = "vilefiend";
+    // 2026-08-01: Validated coefficients
+    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+    {
+      owner_coeff.ap_from_sp = 0.6075;
+      owner_coeff.sp_from_sp = 2.6325;
+    }
+    else
+    {
+      owner_coeff.ap_from_sp = 0.45;
+      owner_coeff.sp_from_sp = 1.95;
+    }
   }
   else if ( owner->talents.mark_of_fharg.ok() )
   {
     npc_id = owner->talents.charhound->effectN( 1 ).misc_value1();
     npc_suffix = "vilefiend";
+    // 2026-08-01: Validated coefficients
+    owner_coeff.ap_from_sp = 0.45;
+    owner_coeff.sp_from_sp = 1.95;
   }
   else
   {
     npc_id = owner->talents.vilefiend->effectN( 1 ).misc_value1();
     // NOTE: 2026-07-11 Regular Vilefiend do not trigger Hellbent Commander on heartbeat (bug?)
     triggers.hellbent_commander_heartbeat &= !bugs;
+    // 2026-08-01: Validated coefficients
+    owner_coeff.ap_from_sp = 0.45;
+    owner_coeff.sp_from_sp = 1.95;
   }
 
   // NOTE: 2026-07-11 Vilefiend do not trigger Hellbent Commander on demise (must wait to player heartbeat) (bug?)
@@ -1339,10 +1356,6 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   // Currently bugged in 12.0.7 and not being affected by the crit bonus
   if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
     affected_by.demonic_brutality = false;
-
-  // 2026-02-17: Validated coefficients
-  owner_coeff.ap_from_sp = 0.45;
-  owner_coeff.sp_from_sp = 1.95;
 
   owner_coeff.health = 0.75;
 


### PR DESCRIPTION
This PR implements the latest Demonology Warlock changes found in the 12.1.0 PTR spell data (as of 2026-08-01) that require manual code adjustments.

Changes intended for 12.1.0 are guarded behind version checks. The existing behavior for versions `<12.1.0` remains unchanged.

# Gloomhound

The **Summon Gloomhound** effect was hotfixed to increase all of its damage by 35%.

There is no visible damage modifier or coefficient change in the spells or spell data used by **Gloomhound**. However, in-game testing on the 12.1.0 PTR confirmed that all of its damage is increased by 35%, including melee attacks, physical attacks, and spell attacks.

This damage increase has been modeled in SimC by increasing **Gloomhound**'s owner-stat inheritance coefficients by 35% for versions `>=12.1.0`.

In spell data, the **Summon Gloomhound** spell changed its `misc_value2` from `4266` to `6852`. This value references a `SummonProperties` entry. **Vilefiend** and **Charhound** continue to use `4266`, while the new `6852` value is exclusive to **Gloomhound** among these variants. The new `SummonProperties` entry `6852` is not yet available in the currently exported DB2 data, so its exact internal differences from `4266` cannot be inspected. This can be revisited once the entry becomes available, in case it provides any additional information about how this damage increase is applied to **Gloomhound**.

# Isolated Implosion

The Demonology 12.1.0 4pc spell data effects used by **Isolated Implosion** were hotfixed:

```text
Main target:       150% → 250%
Secondary targets: 125% → 225%
```

In-game damage remains unchanged. Before this hotfix, the listed `150%`/`125%` values behaved as `+150%`/`+125%` increased effectiveness, resulting in total multipliers of `250%`/`225%`. The corrected spell data now directly contains the observed total effectiveness values of `250%`/`225%`. In SimC, the previous implementation `base_dd_multiplier *= 1.0 + modifier;` has therefore been changed to `base_dd_multiplier *= modifier;`