### PR TITLE
[Havoc]  Cycle of Hatred behavior with 12.1 tier

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -1029,6 +1029,7 @@ public:
     cooldown_t* relentless_onslaught_icd;
     cooldown_t* fel_rush_vengeful_retreat_movement_shared;
     cooldown_t* felblade_vengeful_retreat_movement_shared;
+    cooldown_t* essence_break;
     target_specific_cooldown_t* essence_break_proc_icd;
 
     // Vengeance
@@ -4032,9 +4033,19 @@ struct eye_beam_base_t : public student_of_suffering_trigger_t<final_breath_trig
 
     if ( dh()->talent.havoc.cycle_of_hatred->ok() )
     {
+      this->cooldown->adjust(
+          -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) ) );
+
+      // Essence Break and Eyebeam currently reduce the value of the other by 2.5 seconds when stacks 2 - 4 are each applied. 
+      if ( dh()->buff.cycle_of_hatred->check() && dh()->buff.cycle_of_hatred->stack() < 4 )
+      {
+        dh()->cooldown.essence_break->adjust(
+            -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_value() ) ) );
+      }
+
       dh()->buff.cycle_of_hatred->trigger();
     }
-
+    
     timespan_t duration = composite_dot_duration( execute_state );
 
     // Since Demonic triggers Meta with 5s + hasted duration, need to extend by the hasted duration after have an
@@ -4060,12 +4071,6 @@ struct eye_beam_base_t : public student_of_suffering_trigger_t<final_breath_trig
   result_amount_type amount_type( const action_state_t*, bool ) const override
   {
     return result_amount_type::DMG_DIRECT;
-  }
-
-  timespan_t cooldown_base_duration( const cooldown_t& cd ) const override
-  {
-    return base_t::cooldown_base_duration( cd ) -
-           timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) );
   }
 };
 
@@ -7656,6 +7661,7 @@ struct essence_break_t : public demon_hunter_attack_t
   {
     aoe                 = -1;
     reduced_aoe_targets = p->talent.havoc.essence_break->effectN( 2 ).base_value();
+    cooldown            = p->cooldown.essence_break;
 
     add_child( p->active.essence_break_proc );
   }
@@ -7666,6 +7672,17 @@ struct essence_break_t : public demon_hunter_attack_t
 
     if ( dh()->set_bonuses.mid2_havoc_4pc->ok() && dh()->talent.havoc.cycle_of_hatred->ok() )
     {
+      dh()->cooldown.essence_break->adjust(
+          -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) ) );
+
+      // Essence Break and Eyebeam currently reduce the value of the other by 2.5 seconds when stacks 2 - 4 are each
+      // applied. 
+      if ( dh()->buff.cycle_of_hatred->check() && dh()->buff.cycle_of_hatred->stack() < 4 )
+      {
+        dh()->cooldown.eye_beam->adjust(
+            -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_value() ) ) );
+      }
+
       dh()->buff.cycle_of_hatred->trigger();
     }
   }
@@ -7680,16 +7697,6 @@ struct essence_break_t : public demon_hunter_attack_t
       buff_t* debuff = td( s->target )->debuffs.essence_break;
       make_event( *dh()->sim, 250_ms, [ debuff ] { debuff->trigger(); } );
     }
-  }
-
-  timespan_t cooldown_base_duration( const cooldown_t& cd ) const override
-  {
-    if ( dh()->set_bonuses.mid2_havoc_4pc->ok() )
-    {
-      return demon_hunter_attack_t::cooldown_base_duration( cd ) -
-             timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) );
-    }
-    return demon_hunter_attack_t::cooldown_base_duration( cd );
   }
 };
 
@@ -9425,9 +9432,9 @@ demon_hunter_td_t::demon_hunter_td_t( player_t* target, demon_hunter_t& p )
     case DEMON_HUNTER_VENGEANCE:
       dots.fiery_brand = target->get_dot( "fiery_brand", &p );
       debuffs.frailty  = make_buff( *this, "frailty", p.spec.frailty_debuff )
-                            ->set_default_value_from_effect( 1 )
-                            ->set_refresh_behavior( buff_refresh_behavior::DURATION )
-                            ->disable_ticking( true );
+                             ->set_default_value_from_effect( 1 )
+                             ->set_refresh_behavior( buff_refresh_behavior::DURATION )
+                             ->disable_ticking( true );
       break;
     default:
       break;
@@ -9771,7 +9778,7 @@ void demon_hunter_t::create_buffs()
   buff.immolation_aura      = make_buff<buffs::immolation_aura_buff_t>( this );
   buff.metamorphosis        = make_buff<buffs::metamorphosis_buff_t>( this );
   buff.soul_fragments       = make_buff( this, "soul_fragments", spec.soul_fragments_buff )
-                            ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
+                                  ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
 
   // Devourer ===============================================================
 
@@ -11777,6 +11784,7 @@ void demon_hunter_t::create_cooldowns()
   cooldown.relentless_onslaught_icd                  = get_cooldown( "relentless_onslaught_icd" );
   cooldown.fel_rush_vengeful_retreat_movement_shared = get_cooldown( "fel_rush_vengeful_retreat_movement_shared" );
   cooldown.felblade_vengeful_retreat_movement_shared = get_cooldown( "felblade_vengeful_retreat_movement_shared" );
+  cooldown.essence_break                             = get_cooldown( "essence_break" );
   cooldown.essence_break_proc_icd                    = get_target_specific_cooldown( "essence_break_proc_icd" );
 
   // Vengeance

--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -4033,10 +4033,10 @@ struct eye_beam_base_t : public student_of_suffering_trigger_t<final_breath_trig
 
     if ( dh()->talent.havoc.cycle_of_hatred->ok() )
     {
-      this->cooldown->adjust(
-          -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) ) );
+      this->cooldown->adjust( -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) ) );
 
-      // Essence Break and Eyebeam currently reduce the value of the other by 2.5 seconds when stacks 2 - 4 are each applied. 
+      // 08/01/2026 - Essence Break and Eyebeam currently reduce the value of the other by 2.5 seconds when stacks 2 - 4 are each
+      // applied.
       if ( dh()->buff.cycle_of_hatred->check() && dh()->buff.cycle_of_hatred->stack() < 4 )
       {
         dh()->cooldown.essence_break->adjust(
@@ -4045,7 +4045,7 @@ struct eye_beam_base_t : public student_of_suffering_trigger_t<final_breath_trig
 
       dh()->buff.cycle_of_hatred->trigger();
     }
-    
+
     timespan_t duration = composite_dot_duration( execute_state );
 
     // Since Demonic triggers Meta with 5s + hasted duration, need to extend by the hasted duration after have an
@@ -7675,8 +7675,8 @@ struct essence_break_t : public demon_hunter_attack_t
       dh()->cooldown.essence_break->adjust(
           -timespan_t::from_millis( as<int>( dh()->buff.cycle_of_hatred->check_stack_value() ) ) );
 
-      // Essence Break and Eyebeam currently reduce the value of the other by 2.5 seconds when stacks 2 - 4 are each
-      // applied. 
+      // 08/01/2026 - Essence Break and Eyebeam currently reduce the value of the other by 2.5 seconds when stacks 2 - 4 are each
+      // applied.
       if ( dh()->buff.cycle_of_hatred->check() && dh()->buff.cycle_of_hatred->stack() < 4 )
       {
         dh()->cooldown.eye_beam->adjust(
@@ -9432,9 +9432,9 @@ demon_hunter_td_t::demon_hunter_td_t( player_t* target, demon_hunter_t& p )
     case DEMON_HUNTER_VENGEANCE:
       dots.fiery_brand = target->get_dot( "fiery_brand", &p );
       debuffs.frailty  = make_buff( *this, "frailty", p.spec.frailty_debuff )
-                             ->set_default_value_from_effect( 1 )
-                             ->set_refresh_behavior( buff_refresh_behavior::DURATION )
-                             ->disable_ticking( true );
+                            ->set_default_value_from_effect( 1 )
+                            ->set_refresh_behavior( buff_refresh_behavior::DURATION )
+                            ->disable_ticking( true );
       break;
     default:
       break;
@@ -9778,7 +9778,7 @@ void demon_hunter_t::create_buffs()
   buff.immolation_aura      = make_buff<buffs::immolation_aura_buff_t>( this );
   buff.metamorphosis        = make_buff<buffs::metamorphosis_buff_t>( this );
   buff.soul_fragments       = make_buff( this, "soul_fragments", spec.soul_fragments_buff )
-                                  ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
+                            ->set_constant_behavior( buff_constant_behavior::NEVER_CONSTANT );
 
   // Devourer ===============================================================
 


### PR DESCRIPTION
Changes the Cycle of Hatred buff itself does not modify the actual cooldown of Eye Beam (and Essence Break with 12.1 tier) but apply a cooldown reduction on each cast.
Ingame, incrementing the 2nd 3rd and 4th cycle stacks applies a reduction on the other ability as well.