### PR TITLE
[Havoc] don't apply Blade Dance Rank 2 cooldown reduction twice

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -7009,10 +7009,6 @@ struct blade_dance_base_t
     }
 
     ability_cooldown = data().cooldown();
-    if ( data().affected_by( p->spec.blade_dance_2->effectN( 1 ) ) )
-    {
-      ability_cooldown += p->spec.blade_dance_2->effectN( 1 ).time_value();
-    }
 
     if ( p->talent.havoc.trail_of_ruin->ok() )
     {


### PR DESCRIPTION
Fixes #11657
Since #10659 passive effects are parsed onto the player-specific DBC, so data().cooldown() already includes blade_dance_2's -5s. Adding it again left Blade Dance on a 5s cooldown instead of 10s.