### PR TITLE
[Priest] implement Tentacle Slam line targeting shape

### DIFF
--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1707,6 +1707,33 @@ struct shadow_weaving_t final : public priest_spell_t
 // ==========================================================================
 // Tentacle Slam
 // ==========================================================================
+// Hits enemies on a line between the caster and the target plus a radius around the target.
+// Line width assumed to be around 8 yds
+static constexpr double tentacle_slam_line_half_width = 4.0;
+
+static bool in_tentacle_slam_area( const player_t* caster, const player_t* primary, const player_t* candidate,
+                                   double around_radius )
+{
+  if ( candidate == primary )
+    return true;
+  if ( candidate->get_position_distance( primary->x_position, primary->y_position ) <= around_radius )
+    return true;
+
+  double vx   = primary->x_position - caster->x_position;
+  double vy   = primary->y_position - caster->y_position;
+  double len2 = vx * vx + vy * vy;
+  double t    = 0.0;
+  if ( len2 > 0.0 )
+  {
+    t = ( ( candidate->x_position - caster->x_position ) * vx + ( candidate->y_position - caster->y_position ) * vy ) /
+        len2;
+    t = std::clamp( t, 0.0, 1.0 );
+  }
+  double dx = candidate->x_position - ( caster->x_position + t * vx );
+  double dy = candidate->y_position - ( caster->y_position + t * vy );
+  return std::sqrt( dx * dx + dy * dy ) <= tentacle_slam_line_half_width;
+}
+
 struct tentacle_slam_damage_t final : public priest_spell_t
 {
   tentacle_slam_damage_t( priest_t& p, const spell_data_t* s ) : priest_spell_t( "tentacle_slam_damage", p, s )
@@ -1714,6 +1741,17 @@ struct tentacle_slam_damage_t final : public priest_spell_t
     background                 = true;
     affected_by_shadow_weaving = true;
     aoe                        = -1;
+  }
+
+  std::vector<player_t*>& check_distance_targeting( std::vector<player_t*>& tl ) const override
+  {
+    double around = data().effectN( 1 ).radius();
+    tl.erase( std::remove_if( tl.begin(), tl.end(),
+                              [ this, around ]( player_t* t ) {
+                                return !in_tentacle_slam_area( player, target, t, around );
+                              } ),
+              tl.end() );
+    return tl;
   }
 };
 
@@ -1729,6 +1767,18 @@ struct tentacle_slam_dots_t final : public priest_spell_t
     background           = true;
     aoe                  = as<int>( s->effectN( 3 ).base_value() );
     child_vt->background = true;
+  }
+
+  std::vector<player_t*>& check_distance_targeting( std::vector<player_t*>& tl ) const override
+  {
+    // VT application uses the same slam area as the damage
+    double around = priest().talents.shadow.tentacle_slam_damage->effectN( 1 ).radius();
+    tl.erase( std::remove_if( tl.begin(), tl.end(),
+                              [ this, around ]( player_t* t ) {
+                                return !in_tentacle_slam_area( player, target, t, around );
+                              } ),
+              tl.end() );
+    return tl;
   }
 
   std::vector<player_t*>& target_list() const override

--- a/engine/class_modules/priest/sc_priest_shadow.cpp
+++ b/engine/class_modules/priest/sc_priest_shadow.cpp
@@ -1707,13 +1707,13 @@ struct shadow_weaving_t final : public priest_spell_t
 // ==========================================================================
 // Tentacle Slam
 // ==========================================================================
-// Hits enemies on a line between the caster and the target plus a radius around the target.
-// Line width assumed to be around 8 yds
-static constexpr double tentacle_slam_line_half_width = 4.0;
-
+// Hits enemies on a line between the caster and the target plus a radius around the target
 static bool in_tentacle_slam_area( const player_t* caster, const player_t* primary, const player_t* candidate,
-                                   double around_radius )
+                                   const spell_data_t* slam_data )
 {
+  double around_radius = slam_data->effectN( 1 ).radius();
+  double line_half_width = slam_data->line_width() / 2;
+
   if ( candidate == primary )
     return true;
   if ( candidate->get_position_distance( primary->x_position, primary->y_position ) <= around_radius )
@@ -1731,7 +1731,7 @@ static bool in_tentacle_slam_area( const player_t* caster, const player_t* prima
   }
   double dx = candidate->x_position - ( caster->x_position + t * vx );
   double dy = candidate->y_position - ( caster->y_position + t * vy );
-  return std::sqrt( dx * dx + dy * dy ) <= tentacle_slam_line_half_width;
+  return std::sqrt( dx * dx + dy * dy ) <= line_half_width;
 }
 
 struct tentacle_slam_damage_t final : public priest_spell_t
@@ -1745,10 +1745,9 @@ struct tentacle_slam_damage_t final : public priest_spell_t
 
   std::vector<player_t*>& check_distance_targeting( std::vector<player_t*>& tl ) const override
   {
-    double around = data().effectN( 1 ).radius();
     tl.erase( std::remove_if( tl.begin(), tl.end(),
-                              [ this, around ]( player_t* t ) {
-                                return !in_tentacle_slam_area( player, target, t, around );
+                              [ this ]( player_t* t ) {
+                                return !in_tentacle_slam_area( player, target, t, &data() );
                               } ),
               tl.end() );
     return tl;
@@ -1772,10 +1771,10 @@ struct tentacle_slam_dots_t final : public priest_spell_t
   std::vector<player_t*>& check_distance_targeting( std::vector<player_t*>& tl ) const override
   {
     // VT application uses the same slam area as the damage
-    double around = priest().talents.shadow.tentacle_slam_damage->effectN( 1 ).radius();
+    const spell_data_t* slam_data = priest().talents.shadow.tentacle_slam_damage;
     tl.erase( std::remove_if( tl.begin(), tl.end(),
-                              [ this, around ]( player_t* t ) {
-                                return !in_tentacle_slam_area( player, target, t, around );
+                              [ this, slam_data ]( player_t* t ) {
+                                return !in_tentacle_slam_area( player, target, t, slam_data );
                               } ),
               tl.end() );
     return tl;


### PR DESCRIPTION
Currently tentacle slam always hits everything even when we position bosses apart for spread cleave. This leads to slam oversimming on spread cleave as it does full dmg to everything.

This tries to simulate more how it works ingame. Splashing 8 yards around the target, and in a 8 yards wide rectangle from the caster to the target. The width is just assumed to be 8 yards, it feels a bit smaller ingame but I can't find any spelldata or confirmation of how wide it actually is, but the width is also not really that important for sims as long as it's roughly correct instead of hitting every target in a 40yard range.

Using this it seems to be worth dropping the tentacle slam talents on spread 2 target cleave like entombed sentinels:

Archon: drop Descending Darkness, Crushing Void. Take Spectral Horrors + Cthun. +1.42%
VW: drop Descending Darkness, Crushing Void. Take Maddening Touch + Mind Devourer. +1.27%

These were just some quick sims I did for testing there may be even more optimal talents for spread cleave. But just to give an idea that there is power to be gained. Without the change both of these changes would show as about -0.8% dps instead