### PR TITLE
[Action] use explicit state flags instead of composite STATE_MUL_DA/TA

### DIFF
--- a/engine/action/action.cpp
+++ b/engine/action/action.cpp
@@ -2730,20 +2730,23 @@ void action_t::init()
 
   if ( does_periodic_damage() )
   {
-    snapshot_flags |= STATE_MUL_TA | STATE_MUL_VERSUS | STATE_TGT_MUL_TA | STATE_TGT_MITG_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
+    snapshot_flags |= STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM | STATE_MUL_VERSUS | STATE_TGT_MUL_TA |
+                      STATE_TGT_MITG_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
   }
 
   if ( does_direct_damage() )
   {
-    snapshot_flags |= STATE_MUL_DA | STATE_MUL_VERSUS | STATE_TGT_MUL_DA | STATE_TGT_MITG_DA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
+    snapshot_flags |= STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM | STATE_MUL_VERSUS | STATE_TGT_MUL_DA |
+                      STATE_TGT_MITG_DA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
 
     // Because schools can change during runtime, armor is flagged and not snapshot if determined to be non-physical
     if ( !ignores_armor )
       snapshot_flags |= STATE_TGT_ARMOR;
   }
 
-  if ( player->is_pet() && ( snapshot_flags & ( STATE_MUL_DA | STATE_MUL_TA | STATE_MUL_VERSUS | STATE_TGT_MUL_DA | STATE_TGT_MUL_TA |
-                                                STATE_MUL_PERSISTENT | STATE_VERSATILITY ) ) )
+  if ( player->is_pet() &&
+       ( snapshot_flags & ( STATE_MUL_SPELL_DA | STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM | STATE_MUL_VERSUS |
+                            STATE_TGT_MUL_DA | STATE_TGT_MUL_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY ) ) )
   {
     snapshot_flags |= STATE_MUL_PET | STATE_TGT_MUL_PET;
   }
@@ -2802,7 +2805,8 @@ void action_t::init()
   {
     if ( is_periodic_damage_effect( eff ) && eff.flags( spelleffect_attribute::EX_COMPUTE_ON_CAST ) )
     {
-      update_flags &= ~( STATE_AP | STATE_SP | STATE_MUL_TA | STATE_MUL_VERSUS | STATE_VERSATILITY );
+      update_flags &=
+        ~( STATE_AP | STATE_SP | STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM | STATE_MUL_VERSUS | STATE_VERSATILITY );
       break;
     }
   }

--- a/engine/action/residual_action.hpp
+++ b/engine/action/residual_action.hpp
@@ -61,7 +61,7 @@ public:
     // ab::hasted_ticks = false;
     // ab::rolling_periodic = false;
     // ab::dot_behavior = dot_behavior_e::DOT_REFRESH_DURATION;
-    // ab::snapshot_flags |= STATE_MUL_TA | STATE_TGT_MUL_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
+    // ab::snapshot_flags |= STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM | STATE_TGT_MUL_TA | STATE_MUL_PERSISTENT | STATE_VERSATILITY;
   }
 
   action_state_t* new_state() override

--- a/engine/class_modules/monk/sc_monk.cpp
+++ b/engine/class_modules/monk/sc_monk.cpp
@@ -4090,7 +4090,7 @@ struct celestial_fortune_t : public monk_heal_t
     // disable the snapshot_flags for all multipliers, but specifically allow
     // action_multiplier() to be called so we can override.
     snapshot_flags &= STATE_NO_MULTIPLIER;
-    snapshot_flags |= STATE_MUL_DA;
+    snapshot_flags |= STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM;
   }
 };
 

--- a/engine/class_modules/paladin/sc_paladin_retribution.cpp
+++ b/engine/class_modules/paladin/sc_paladin_retribution.cpp
@@ -206,9 +206,9 @@ struct execution_sentence_t : public paladin_melee_attack_t
     void init() override
     {
       paladin_melee_attack_t::init();
-      snapshot_flags |= STATE_TARGET_NO_PET | STATE_MUL_TA | STATE_MUL_DA;
+      snapshot_flags |= STATE_TARGET_NO_PET | STATE_MUL_SPELL_DA | STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM;
       update_flags &= ~STATE_TARGET;
-      update_flags |= STATE_MUL_TA | STATE_MUL_DA;
+      update_flags |= STATE_MUL_SPELL_DA | STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM;
     }
   };
 

--- a/engine/class_modules/priest/sc_priest.cpp
+++ b/engine/class_modules/priest/sc_priest.cpp
@@ -1140,7 +1140,7 @@ struct shadow_word_death_self_damage_t final : public priest_spell_t
     // We don't want this counted towards our dps
     stats->type = stats_e::STATS_NEUTRAL;
 
-    snapshot_flags |= STATE_MUL_DA;
+    snapshot_flags |= STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM;
   }
 
   proc_types proc_type() const override
@@ -2244,7 +2244,7 @@ struct atonement_t final : public priest_heal_t
   void init() override
   {
     priest_heal_t::init();
-    snapshot_flags |= STATE_TGT_MUL_DA | STATE_MUL_DA;
+    snapshot_flags |= STATE_TGT_MUL_DA | STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM;
     snapshot_flags &= ~( STATE_CRIT | STATE_VERSATILITY );
   }
 

--- a/engine/class_modules/sc_death_knight.cpp
+++ b/engine/class_modules/sc_death_knight.cpp
@@ -9994,7 +9994,7 @@ struct death_strike_heal_t final : public death_knight_heal_t
   {
     death_knight_heal_t::init();
 
-    snapshot_flags |= STATE_MUL_DA;
+    snapshot_flags |= STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM;
   }
 
   double base_da_min( const action_state_t* ) const override

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -4461,7 +4461,7 @@ struct stormblast_t : public shaman_attack_t
   {
     shaman_attack_t::init();
 
-    snapshot_flags = update_flags = ~STATE_MUL_PLAYER_DAM & ( STATE_MUL_DA | STATE_TGT_MUL_DA );
+    snapshot_flags = update_flags = STATE_MUL_SPELL_DA | STATE_TGT_MUL_DA;
 
     may_proc_hot_hand = false;
     may_proc_ability_procs = false;

--- a/engine/player/player.cpp
+++ b/engine/player/player.cpp
@@ -470,7 +470,8 @@ struct leech_t : public heal_t
   {
     heal_t::init();
 
-    snapshot_flags = update_flags = STATE_MUL_DA | STATE_TGT_MUL_DA | STATE_VERSATILITY | STATE_MUL_PERSISTENT;
+    snapshot_flags = update_flags =
+      STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM | STATE_TGT_MUL_DA | STATE_VERSATILITY | STATE_MUL_PERSISTENT;
 
     player->register_combat_begin( []( player_t* p ) {
       make_repeating_event( *p->sim,

--- a/engine/player/unique_gear.cpp
+++ b/engine/player/unique_gear.cpp
@@ -2554,7 +2554,7 @@ struct soul_capacitor_explosion_t : public spell_t
   {
     spell_t::init();
 
-    snapshot_flags = STATE_MUL_DA;
+    snapshot_flags = STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM;
     update_flags = 0;
   }
 

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -3946,7 +3946,7 @@ void item::figurehead_of_the_naglfar( special_effect_t& effect )
         proc_spell_t::init();
 
         // Allow DA multipliers so base_multiplier may take effect.
-        snapshot_flags = STATE_MUL_DA;
+        snapshot_flags = STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM;
         update_flags = 0;
       }
 
@@ -4197,7 +4197,7 @@ struct aw_nuts_t : public proc_spell_t
     proc_spell_t::init();
 
     // Don't benefit from player multipliers because, in game, the squirrel is dealing the damage, not you.
-    snapshot_flags &= ~( STATE_MUL_DA | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA );
+    snapshot_flags &= ~( STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA );
   }
 };
 
@@ -4711,7 +4711,8 @@ void item::wriggling_sinew( special_effect_t& effect )
   effect.trigger_spell_id = 222050;
   auto damage = effect.initialize_offensive_spell_action();
   damage->base_dd_min = damage->base_dd_max = effect.driver()->effectN( 1 ).average( effect.item );
-  damage->snapshot_flags |= STATE_MUL_DA | STATE_VERSATILITY | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA;
+  damage->snapshot_flags |=
+    STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM | STATE_VERSATILITY | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA;
   // Reset triggered spell; we don't want to trigger a spell on use.
   effect.trigger_spell_id = 0;
 

--- a/engine/sc_enums.hpp
+++ b/engine/sc_enums.hpp
@@ -1324,15 +1324,13 @@ enum snapshot_state_e
   STATE_TGT_USER_3     = 0x40000000,
   STATE_TGT_USER_4     = 0x80000000,
 
-  STATE_MUL_DA         = STATE_MUL_SPELL_DA | STATE_MUL_PLAYER_DAM,
-  STATE_MUL_TA         = STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM,
-
   /**
    * No multiplier helper, use in action_t::init() (after parent init) by issuing snapshot_flags &= STATE_NO_MULTIPLIER
    * (and/or update_flags &= STATE_NO_MULTIPLIER if a dot). This disables all multipliers, including versatility, and
    * any/all persistent multipliers the action would use. */
-  STATE_NO_MULTIPLIER  = ~( STATE_MUL_DA | STATE_MUL_TA | STATE_VERSATILITY | STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA |
-                            STATE_TGT_MUL_TA | STATE_TGT_ARMOR | STATE_MUL_PET | STATE_TGT_MUL_PET | STATE_MUL_VERSUS ),
+  STATE_NO_MULTIPLIER  = ~( STATE_MUL_SPELL_DA | STATE_MUL_SPELL_TA | STATE_MUL_PLAYER_DAM | STATE_VERSATILITY |
+                            STATE_MUL_PERSISTENT | STATE_TGT_MUL_DA | STATE_TGT_MUL_TA | STATE_TGT_ARMOR |
+                            STATE_MUL_PET | STATE_TGT_MUL_PET | STATE_MUL_VERSUS ),
 
   /// Target-specific state variables, excluding the pet damage multiplier
   STATE_TARGET_NO_PET  = ( STATE_TGT_CRIT | STATE_TGT_MUL_DA | STATE_TGT_MUL_TA | STATE_TGT_ARMOR | STATE_TGT_MITG_DA |


### PR DESCRIPTION
As various state flags exhibit different behavior, especially wrt to various SX_IGNORE spell attributes, they should be individually handled instead of using composite flags.