### PR TITLE
[Warlock] Remove 12.1.0 version checks

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -294,122 +294,56 @@ void destruction( player_t* p )
   precombat->add_action( "immolate,if=active_enemies>=2&talent.roaring_blaze" );
   precombat->add_action( "incinerate" );
 
-  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-  {
-    default_->add_action( "call_action_list,name=variables" );
-    default_->add_action( "call_action_list,name=ogcd" );
-    default_->add_action( "call_action_list,name=items" );
-    default_->add_action( "call_action_list,name=aoe_hc,if=active_enemies>=2&talent.wither" );
-    default_->add_action( "call_action_list,name=aoe_dia,if=active_enemies>=2&talent.diabolic_ritual" );
-    default_->add_action( "soul_fire,if=soul_shard<=4" );
-    default_->add_action( "chaos_bolt,if=talent.diabolic_ritual&(demonic_art|(variable.ritual_length<action.chaos_bolt.execute_time))&target.health.pct>20" );
-    default_->add_action( "conflagrate,if=soul_shard<=4.2&buff.backdraft.stack<1" );
-    default_->add_action( "summon_infernal" );
-    default_->add_action( "malevolence" );
-    default_->add_action( "incinerate,if=buff.chaotic_inferno_buff.up&soul_shard<=4.6" );
-    default_->add_action( "shadowburn,if=((!demonic_art&(variable.ritual_length>2|talent.wither))|target.health.pct<=20)&(buff.fiendish_cruelty.up|talent.conflagration_of_chaos)&(!talent.wither|soul_shard>=4|buff.malevolence.up|pet.infernal.active|fight_remains<=15)" );
-    default_->add_action( "wither,if=(((dot.wither.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.wither.duration*0.3)|refreshable|(dot.wither.remains-action.chaos_bolt.execute_time)<5&talent.internal_combustion&action.chaos_bolt.usable)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.wither.remains-5*talent.internal_combustion))&(!talent.cataclysm|(cooldown.cataclysm.remains+action.cataclysm.cast_time)>dot.wither.remains)&target.time_to_die>8" );
-    default_->add_action( "immolate,if=(((dot.immolate.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.immolate.duration*0.3)|refreshable|(dot.immolate.remains-action.chaos_bolt.execute_time)<5&talent.internal_combustion&action.chaos_bolt.usable)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.immolate.remains-5*talent.internal_combustion))&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&target.time_to_die>8" );
-    default_->add_action( "ruination" );
-    default_->add_action( "cataclysm,if=talent.lake_of_fire" );
-    default_->add_action( "chaos_bolt,if=(talent.wither&(soul_shard>=4|buff.malevolence.up|pet.infernal.active|fight_remains<=15))|(talent.diabolic_ritual&variable.ritual_length>4)" );
-    default_->add_action( "infernal_bolt,if=soul_shard<=3" );
-    default_->add_action( "incinerate" );
-  }
-  else
-  {
-    default_->add_action( "call_action_list,name=variables" );
-    default_->add_action( "call_action_list,name=ogcd" );
-    default_->add_action( "call_action_list,name=items" );
-    default_->add_action( "call_action_list,name=aoe_hc,if=active_enemies>=2&talent.wither" );
-    default_->add_action( "call_action_list,name=aoe_dia,if=active_enemies>=2&talent.diabolic_ritual" );
-    default_->add_action( "soul_fire,if=soul_shard<=4" );
-    default_->add_action( "conflagrate,if=action.conflagrate.charges>=2" );
-    default_->add_action( "chaos_bolt,if=talent.diabolic_ritual&(demonic_art|(variable.ritual_length<action.chaos_bolt.execute_time))&target.health.pct>20" );
-    default_->add_action( "conflagrate,if=soul_shard<=4.2&buff.backdraft.stack<1" );
-    default_->add_action( "summon_infernal" );
-    default_->add_action( "malevolence" );
-    default_->add_action( "shadowburn,if=((!demonic_art&(variable.ritual_length>2|talent.wither))|target.health.pct<=20)&(buff.fiendish_cruelty.up|talent.conflagration_of_chaos)&(!talent.wither|soul_shard>=4|buff.malevolence.up|pet.infernal.active|fight_remains<=15)" );
-    default_->add_action( "wither,if=(((dot.wither.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.wither.duration*0.3)|refreshable|(dot.wither.remains-action.chaos_bolt.execute_time)<5&talent.internal_combustion&action.chaos_bolt.usable)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.wither.remains-5*talent.internal_combustion))&(!talent.cataclysm|(cooldown.cataclysm.remains+action.cataclysm.cast_time)>dot.wither.remains)&target.time_to_die>8" );
-    default_->add_action( "immolate,if=(((dot.immolate.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.immolate.duration*0.3)|refreshable|(dot.immolate.remains-action.chaos_bolt.execute_time)<5&talent.internal_combustion&action.chaos_bolt.usable)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.immolate.remains-5*talent.internal_combustion))&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&target.time_to_die>8" );
-    default_->add_action( "conflagrate,if=soul_shard<=4.4&buff.backdraft.stack<1" );
-    default_->add_action( "ruination" );
-    default_->add_action( "cataclysm,if=talent.lake_of_fire" );
-    default_->add_action( "chaos_bolt,if=(talent.wither&(soul_shard>=4|buff.malevolence.up|pet.infernal.active|fight_remains<=15))|(talent.diabolic_ritual&variable.ritual_length>4)" );
-    default_->add_action( "infernal_bolt,if=soul_shard<=3" );
-    default_->add_action( "incinerate" );
-  }
+  default_->add_action( "call_action_list,name=variables" );
+  default_->add_action( "call_action_list,name=ogcd" );
+  default_->add_action( "call_action_list,name=items" );
+  default_->add_action( "call_action_list,name=aoe_hc,if=active_enemies>=2&talent.wither" );
+  default_->add_action( "call_action_list,name=aoe_dia,if=active_enemies>=2&talent.diabolic_ritual" );
+  default_->add_action( "soul_fire,if=soul_shard<=4" );
+  default_->add_action( "conflagrate,if=action.conflagrate.charges>=2" );
+  default_->add_action( "chaos_bolt,if=talent.diabolic_ritual&(demonic_art|(variable.ritual_length<action.chaos_bolt.execute_time))&target.health.pct>20" );
+  default_->add_action( "conflagrate,if=soul_shard<=4.2&buff.backdraft.stack<1" );
+  default_->add_action( "summon_infernal" );
+  default_->add_action( "malevolence" );
+  default_->add_action( "shadowburn,if=((!demonic_art&(variable.ritual_length>2|talent.wither))|target.health.pct<=20)&(buff.fiendish_cruelty.up|talent.conflagration_of_chaos)&(!talent.wither|soul_shard>=4|buff.malevolence.up|pet.infernal.active|fight_remains<=15)" );
+  default_->add_action( "wither,if=(((dot.wither.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.wither.duration*0.3)|refreshable|(dot.wither.remains-action.chaos_bolt.execute_time)<5&talent.internal_combustion&action.chaos_bolt.usable)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.wither.remains-5*talent.internal_combustion))&(!talent.cataclysm|(cooldown.cataclysm.remains+action.cataclysm.cast_time)>dot.wither.remains)&target.time_to_die>8" );
+  default_->add_action( "immolate,if=(((dot.immolate.remains-5*(action.chaos_bolt.in_flight&talent.internal_combustion))<dot.immolate.duration*0.3)|refreshable|(dot.immolate.remains-action.chaos_bolt.execute_time)<5&talent.internal_combustion&action.chaos_bolt.usable)&(!talent.soul_fire|cooldown.soul_fire.remains+action.soul_fire.cast_time>(dot.immolate.remains-5*talent.internal_combustion))&(!talent.cataclysm|cooldown.cataclysm.remains>dot.immolate.remains)&target.time_to_die>8" );
+  default_->add_action( "conflagrate,if=soul_shard<=4.4&buff.backdraft.stack<1" );
+  default_->add_action( "ruination" );
+  default_->add_action( "cataclysm,if=talent.lake_of_fire" );
+  default_->add_action( "chaos_bolt,if=(talent.wither&(soul_shard>=4|buff.malevolence.up|pet.infernal.active|fight_remains<=15))|(talent.diabolic_ritual&variable.ritual_length>4)" );
+  default_->add_action( "infernal_bolt,if=soul_shard<=3" );
+  default_->add_action( "incinerate" );
 
-  
-  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-  {
-    aoe_hc->add_action( "summon_infernal" );
-    aoe_hc->add_action( "malevolence" );
-    aoe_hc->add_action( "rain_of_fire,if=(soul_shard>=(4.0-0.1*(active_dot.wither)))&active_enemies>=(5-talent.destructive_rapidity)" );
-    aoe_hc->add_action( "conflagrate,target_if=max:(dot.wither.remains-99*debuff.havoc.remains),if=dot_refreshable_count.wither>0&!dot.wither.refreshable" );
-    aoe_hc->add_action( "shadowburn,target_if=min:(time_to_die+999*debuff.havoc.remains),if=buff.fiendish_cruelty.up|(talent.conflagration_of_chaos&((active_enemies<=5&talent.destructive_rapidity)|(active_enemies<=6&!talent.destructive_rapidity)))" );
-    aoe_hc->add_action( "cataclysm,if=raid_event.adds.in>15" );
-    aoe_hc->add_action( "havoc,target_if=min:((-target.time_to_die)<?-15)+dot.wither.remains+99*(self.target=target),if=(!cooldown.summon_infernal.up|!talent.summon_infernal)&target.time_to_die>8&(cooldown.malevolence.remains>15|!talent.malevolence)|time<5" );
-    aoe_hc->add_action( "rain_of_fire,if=active_enemies>=(5-talent.destructive_rapidity)" );
-    aoe_hc->add_action( "chaos_bolt,if=active_enemies<=(4-talent.destructive_rapidity)" );
-    aoe_hc->add_action( "soul_fire,target_if=min:(dot.wither.remains+100*debuff.havoc.remains),if=soul_shard<4&(active_enemies<=8|talent.avatar_of_destruction)" );
-    aoe_hc->add_action( "wither,target_if=min:dot.wither.remains+99*debuff.havoc.remains,if=dot.wither.refreshable&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.wither.remains)&active_dot.wither<=active_enemies&target.time_to_die>8" );
-    aoe_hc->add_action( "incinerate,if=talent.fire_and_brimstone&buff.backdraft.up" );
-    aoe_hc->add_action( "conflagrate,target_if=max:(dot.wither.remains-99*debuff.havoc.remains),if=buff.backdraft.stack<2|!talent.backdraft" );
-    aoe_hc->add_action( "incinerate" );
-  }
-  else
-  {
-    aoe_hc->add_action( "summon_infernal" );
-    aoe_hc->add_action( "malevolence" );
-    aoe_hc->add_action( "rain_of_fire,if=(soul_shard>=(4.0-0.1*(active_dot.wither)))&active_enemies>=4" );
-    aoe_hc->add_action( "conflagrate,target_if=max:(dot.wither.remains-99*debuff.havoc.remains),if=dot_refreshable_count.wither>0&!dot.wither.refreshable" );
-    aoe_hc->add_action( "shadowburn,target_if=min:(time_to_die+999*debuff.havoc.remains),if=buff.fiendish_cruelty.up|(talent.conflagration_of_chaos&(active_enemies<=(5-talent.destructive_rapidity)))" );
-    aoe_hc->add_action( "cataclysm,if=raid_event.adds.in>15" );
-    aoe_hc->add_action( "havoc,target_if=min:((-target.time_to_die)<?-15)+dot.wither.remains+99*(self.target=target),if=(!cooldown.summon_infernal.up|!talent.summon_infernal)&target.time_to_die>8&(cooldown.malevolence.remains>15|!talent.malevolence)|time<5" );
-    aoe_hc->add_action( "rain_of_fire,if=active_enemies>=4" );
-    aoe_hc->add_action( "chaos_bolt,if=active_enemies<=3" );
-    aoe_hc->add_action( "soul_fire,target_if=min:(dot.wither.remains+100*debuff.havoc.remains),if=soul_shard<4&(active_enemies<=8|talent.avatar_of_destruction)" );
-    aoe_hc->add_action( "wither,target_if=min:dot.wither.remains+99*debuff.havoc.remains,if=dot.wither.refreshable&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.wither.remains)&active_dot.wither<=active_enemies&target.time_to_die>8" );
-    aoe_hc->add_action( "incinerate,if=talent.fire_and_brimstone&buff.backdraft.up" );
-    aoe_hc->add_action( "conflagrate,target_if=max:(dot.wither.remains-99*debuff.havoc.remains),if=buff.backdraft.stack<2|!talent.backdraft" );
-    aoe_hc->add_action( "incinerate" );
-  }
+  aoe_hc->add_action( "summon_infernal" );
+  aoe_hc->add_action( "malevolence" );
+  aoe_hc->add_action( "rain_of_fire,if=(soul_shard>=(4.0-0.1*(active_dot.wither)))&active_enemies>=4" );
+  aoe_hc->add_action( "conflagrate,target_if=max:(dot.wither.remains-99*debuff.havoc.remains),if=dot_refreshable_count.wither>0&!dot.wither.refreshable" );
+  aoe_hc->add_action( "shadowburn,target_if=min:(time_to_die+999*debuff.havoc.remains),if=buff.fiendish_cruelty.up|(talent.conflagration_of_chaos&(active_enemies<=(5-talent.destructive_rapidity)))" );
+  aoe_hc->add_action( "cataclysm,if=raid_event.adds.in>15" );
+  aoe_hc->add_action( "havoc,target_if=min:((-target.time_to_die)<?-15)+dot.wither.remains+99*(self.target=target),if=(!cooldown.summon_infernal.up|!talent.summon_infernal)&target.time_to_die>8&(cooldown.malevolence.remains>15|!talent.malevolence)|time<5" );
+  aoe_hc->add_action( "rain_of_fire,if=active_enemies>=4" );
+  aoe_hc->add_action( "chaos_bolt,if=active_enemies<=3" );
+  aoe_hc->add_action( "soul_fire,target_if=min:(dot.wither.remains+100*debuff.havoc.remains),if=soul_shard<4&(active_enemies<=8|talent.avatar_of_destruction)" );
+  aoe_hc->add_action( "wither,target_if=min:dot.wither.remains+99*debuff.havoc.remains,if=dot.wither.refreshable&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.wither.remains)&active_dot.wither<=active_enemies&target.time_to_die>8" );
+  aoe_hc->add_action( "incinerate,if=talent.fire_and_brimstone&buff.backdraft.up" );
+  aoe_hc->add_action( "conflagrate,target_if=max:(dot.wither.remains-99*debuff.havoc.remains),if=buff.backdraft.stack<2|!talent.backdraft" );
+  aoe_hc->add_action( "incinerate" );
 
-  if ( p->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-  {
-    aoe_dia->add_action( "summon_infernal" );
-    aoe_dia->add_action( "chaos_bolt,if=talent.diabolic_ritual&(demonic_art|(variable.ritual_length<action.chaos_bolt.execute_time))&target.health.pct>20&active_enemies<=4" );
-    aoe_dia->add_action( "rain_of_fire,if=((soul_shard>=(3.5-0.1*(active_dot.immolate)))|buff.alythesss_ire.up)&active_enemies>=4" );
-    aoe_dia->add_action( "conflagrate,target_if=max:(dot.immolate.remains-99*debuff.havoc.remains),if=dot_refreshable_count.immolate>0&!dot.immolate.refreshable" );
-    aoe_dia->add_action( "shadowburn,target_if=min:(time_to_die+999*debuff.havoc.remains),if=(active_enemies<=(3+buff.fiendish_cruelty.up))|(talent.conflagration_of_chaos&active_enemies<=(6-talent.destructive_rapidity+buff.fiendish_cruelty.up))" );
-    aoe_dia->add_action( "ruination" );
-    aoe_dia->add_action( "cataclysm,if=raid_event.adds.in>15|talent.lake_of_fire" );
-    aoe_dia->add_action( "havoc,target_if=min:((-target.time_to_die)<?-15)+dot.immolate.remains+99*(self.target=target),if=(!cooldown.summon_infernal.up|!talent.summon_infernal)&target.time_to_die>8|time<5" );
-    aoe_dia->add_action( "infernal_bolt,if=soul_shard<3" );
-    aoe_dia->add_action( "chaos_bolt,if=active_enemies<=3&variable.ritual_length>4" );
-    aoe_dia->add_action( "soul_fire,target_if=min:(dot.immolate.remains+100*debuff.havoc.remains),if=soul_shard<4&(talent.avatar_of_destruction&active_enemies<=10|active_enemies<=5)" );
-    aoe_dia->add_action( "immolate,target_if=min:dot.immolate.remains+99*debuff.havoc.remains,if=dot.immolate.refreshable&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.immolate.remains)&active_dot.immolate<=5&!talent.cataclysm&target.time_to_die>18" );
-    aoe_dia->add_action( "conflagrate,target_if=max:(dot.immolate.remains-99*debuff.havoc.remains),if=buff.backdraft.stack<2|!talent.backdraft" );
-    aoe_dia->add_action( "incinerate" );
-  }
-  else
-  {
-    aoe_dia->add_action( "summon_infernal" );
-    aoe_dia->add_action( "chaos_bolt,if=talent.diabolic_ritual&(demonic_art|(variable.ritual_length<action.chaos_bolt.execute_time))&(active_enemies<=(10-2*talent.destructive_rapidity))" );
-    aoe_dia->add_action( "rain_of_fire,if=((soul_shard>=(3.5-0.1*(active_dot.immolate)))|buff.alythesss_ire.up)&active_enemies>=3" );
-    aoe_dia->add_action( "conflagrate,target_if=max:(dot.immolate.remains-99*debuff.havoc.remains),if=dot_refreshable_count.immolate>0&!dot.immolate.refreshable" );
-    aoe_dia->add_action( "shadowburn,target_if=min:(time_to_die+999*debuff.havoc.remains),if=(active_enemies<=(4-talent.destructive_rapidity+2*buff.fiendish_cruelty.up))|(talent.conflagration_of_chaos&active_enemies<=(6+2*buff.fiendish_cruelty.up))" );
-    aoe_dia->add_action( "ruination" );
-    aoe_dia->add_action( "cataclysm,if=raid_event.adds.in>15|talent.lake_of_fire" );
-    aoe_dia->add_action( "havoc,target_if=min:((-target.time_to_die)<?-15)+dot.immolate.remains+99*(self.target=target),if=(!cooldown.summon_infernal.up|!talent.summon_infernal)&target.time_to_die>8|time<5" );
-    aoe_dia->add_action( "infernal_bolt,if=soul_shard<3" );
-    aoe_dia->add_action( "chaos_bolt,if=active_enemies<=2&variable.ritual_length>4" );
-    aoe_dia->add_action( "soul_fire,target_if=min:(dot.immolate.remains+100*debuff.havoc.remains),if=soul_shard<4&(talent.avatar_of_destruction&active_enemies<=10|active_enemies<=5)" );
-    aoe_dia->add_action( "immolate,target_if=min:dot.immolate.remains+99*debuff.havoc.remains,if=dot.immolate.refreshable&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.immolate.remains)&active_dot.immolate<=5&!talent.cataclysm&target.time_to_die>18" );
-    aoe_dia->add_action( "conflagrate,target_if=max:(dot.immolate.remains-99*debuff.havoc.remains),if=buff.backdraft.stack<2|!talent.backdraft" );
-    aoe_dia->add_action( "incinerate" );
-  }
+  aoe_dia->add_action( "summon_infernal" );
+  aoe_dia->add_action( "chaos_bolt,if=talent.diabolic_ritual&(demonic_art|(variable.ritual_length<action.chaos_bolt.execute_time))&(active_enemies<=(10-2*talent.destructive_rapidity))" );
+  aoe_dia->add_action( "rain_of_fire,if=((soul_shard>=(3.5-0.1*(active_dot.immolate)))|buff.alythesss_ire.up)&active_enemies>=3" );
+  aoe_dia->add_action( "conflagrate,target_if=max:(dot.immolate.remains-99*debuff.havoc.remains),if=dot_refreshable_count.immolate>0&!dot.immolate.refreshable" );
+  aoe_dia->add_action( "shadowburn,target_if=min:(time_to_die+999*debuff.havoc.remains),if=(active_enemies<=(4-talent.destructive_rapidity+2*buff.fiendish_cruelty.up))|(talent.conflagration_of_chaos&active_enemies<=(6+2*buff.fiendish_cruelty.up))" );
+  aoe_dia->add_action( "ruination" );
+  aoe_dia->add_action( "cataclysm,if=raid_event.adds.in>15|talent.lake_of_fire" );
+  aoe_dia->add_action( "havoc,target_if=min:((-target.time_to_die)<?-15)+dot.immolate.remains+99*(self.target=target),if=(!cooldown.summon_infernal.up|!talent.summon_infernal)&target.time_to_die>8|time<5" );
+  aoe_dia->add_action( "infernal_bolt,if=soul_shard<3" );
+  aoe_dia->add_action( "chaos_bolt,if=active_enemies<=2&variable.ritual_length>4" );
+  aoe_dia->add_action( "soul_fire,target_if=min:(dot.immolate.remains+100*debuff.havoc.remains),if=soul_shard<4&(talent.avatar_of_destruction&active_enemies<=10|active_enemies<=5)" );
+  aoe_dia->add_action( "immolate,target_if=min:dot.immolate.remains+99*debuff.havoc.remains,if=dot.immolate.refreshable&(!talent.cataclysm.enabled|cooldown.cataclysm.remains>dot.immolate.remains)&active_dot.immolate<=5&!talent.cataclysm&target.time_to_die>18" );
+  aoe_dia->add_action( "conflagrate,target_if=max:(dot.immolate.remains-99*debuff.havoc.remains),if=buff.backdraft.stack<2|!talent.backdraft" );
+  aoe_dia->add_action( "incinerate" );
 
   items->add_action( "use_item,slot=trinket1,if=(variable.infernal_active|!talent.summon_infernal|variable.trinket_1_will_lose_cast)&(variable.trinket_priority=1|!trinket.2.has_cooldown|(trinket.2.cooldown.remains|variable.trinket_priority=2&cooldown.summon_infernal.remains>20&!variable.infernal_active&trinket.2.cooldown.remains<cooldown.summon_infernal.remains))&variable.trinket_1_buffs|(variable.trinket_1_buff_duration+1>=fight_remains)" );
   items->add_action( "use_item,slot=trinket2,if=(variable.infernal_active|!talent.summon_infernal|variable.trinket_2_will_lose_cast)&(variable.trinket_priority=2|!trinket.1.has_cooldown|(trinket.1.cooldown.remains|variable.trinket_priority=1&cooldown.summon_infernal.remains>20&!variable.infernal_active&trinket.1.cooldown.remains<cooldown.summon_infernal.remains))&variable.trinket_2_buffs|(variable.trinket_2_buff_duration+1>=fight_remains)" );
@@ -423,7 +357,6 @@ void destruction( player_t* p )
   ogcd->add_action( "blood_fury,if=variable.infernal_active|!talent.summon_infernal|(fight_remains<cooldown.summon_infernal.remains_expected+10+cooldown.blood_fury.duration&fight_remains>cooldown.blood_fury.duration)|fight_remains<cooldown.summon_infernal.remains" );
   ogcd->add_action( "fireblood,if=variable.infernal_active|!talent.summon_infernal|(fight_remains<cooldown.summon_infernal.remains_expected+10+cooldown.fireblood.duration&fight_remains>cooldown.fireblood.duration)|fight_remains<cooldown.summon_infernal.remains_expected" );
   ogcd->add_action( "ancestral_call,if=variable.infernal_active|!talent.summon_infernal|(fight_remains<(cooldown.summon_infernal.remains_expected+cooldown.berserking.duration)&(fight_remains>cooldown.berserking.duration))|fight_remains<cooldown.summon_infernal.remains_expected" );
-
 
   variables->add_action( "variable,name=infernal_active,op=set,value=pet.infernal.active|(cooldown.summon_infernal.duration-cooldown.summon_infernal.remains)<20" );
   variables->add_action( "variable,name=ritual_length,value=buff.diabolic_ritual_mother_of_chaos.remains+buff.diabolic_ritual_overlord.remains+buff.diabolic_ritual_pit_lord.remains,default=0,op=set" );

--- a/engine/class_modules/warlock/sc_warlock.cpp
+++ b/engine/class_modules/warlock/sc_warlock.cpp
@@ -67,14 +67,11 @@ warlock_td_t::warlock_td_t( player_t* target, warlock_t& p )
                              ->set_max_stack( 1 )
                              ->set_proc_callbacks( false );
 
-  debuffs.shadowburn = make_buff( *this, "shadowburn", ( p.sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) ) ? p.talents.shadowburn_debuff : p.talents.shadowburn )
+  debuffs.shadowburn = make_buff( *this, "shadowburn", p.talents.shadowburn_debuff )
                            ->set_default_value( p.talents.shadowburn_2->effectN( 1 ).base_value() / 10 );
 
-  if ( p.sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-  {
-    debuffs.dark_titans_mark = make_buff( *this, "dark_titans_mark", p.tier.dark_titans_mark_debuff )
-                                   ->set_default_value_from_effect( 1 );
-  }
+  debuffs.dark_titans_mark = make_buff( *this, "dark_titans_mark", p.tier.dark_titans_mark_debuff )
+                                 ->set_default_value_from_effect( 1 );
 
   // Use havoc_debuff where we need the data but don't have the active talent
   // Mayhem proc chance follows a Flat % RNG model, but has ICD
@@ -593,7 +590,7 @@ std::pair<timespan_t, timespan_t> warlock_t::dreadstalkers_delay_duration_adjust
     // There is no delay on the first melee attack when summoned from melee
     delay = 0_ms;
     // In this case the extra duration of the dreadstalkers can be assumed random between the minumum (0ms) and the maximum (820ms) (last tested 2025-04-06)
-    dur_adjust = timespan_t::from_millis( rng().range( 0.0, 820.0 ) );
+    dur_adjust = timespan_t::from_millis( rng().range( 820.0 ) );
   }
   return ret;
 }
@@ -1158,8 +1155,7 @@ void warlock_t::parse_player_effects()
     parse_effects( warlock_base.potent_afflictions ); // 77215
 
     // Affliction Buffs
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      parse_effects( buffs.unstable_empowerment ); // 1305774
+    parse_effects( buffs.unstable_empowerment ); // 1305774
 
     // Affliction Debuffs/DoTs
     // NOTE: Shadow of Nathreza II (rank 2) only increases by 2% (as if it were rank 1) the
@@ -1180,8 +1176,7 @@ void warlock_t::parse_player_effects()
   // Destruction
   if ( destruction() )
   {
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      parse_target_effects( d_fn( &warlock_td_t::debuffs_t::dark_titans_mark ), tier.dark_titans_mark_debuff ); // 1305711
+    parse_target_effects( d_fn( &warlock_td_t::debuffs_t::dark_titans_mark ), tier.dark_titans_mark_debuff ); // 1305711
   }
 
   // Diabolist

--- a/engine/class_modules/warlock/sc_warlock.hpp
+++ b/engine/class_modules/warlock/sc_warlock.hpp
@@ -271,7 +271,6 @@ public:
   player_t* havoc_target;
   std::vector<action_t*> havoc_spells; // Used for smarter target cache invalidation.
   player_t* haunt_target; // Used for tracking the current haunt target
-  player_t* patient_zero_target; // Used to track which target benefits from the Patient Zero talent damage increase
   std::vector<event_t*> wild_imp_spawns; // Used for tracking incoming imps from HoG TODO: Is this still needed with faster spawns?
   int diabolic_ritual; // Used to cycle between the three different Diabolic Ritual buffs
   bool demonic_art_buff_replaced; // Used to not spawn the Demonic Art demon if the buff is replaced by another
@@ -386,7 +385,6 @@ public:
 
     player_talent_t nightfall;
     const spell_data_t* nightfall_buff;
-    const spell_data_t* nightfall_buff_2;
     player_talent_t haunt;
     player_talent_t shared_agony;
 
@@ -430,7 +428,6 @@ public:
     const spell_data_t* shard_instability_buff;
     player_talent_t niskaran_methods;
     player_talent_t potent_soul_shards;
-    player_talent_t nocturnal_yield;
     player_talent_t impetuous_wrath;
 
     player_talent_t xavius_gambit; // Unstable Affliction Damage Multiplier
@@ -441,7 +438,6 @@ public:
     player_talent_t cascading_calamity;
     const spell_data_t* cascading_calamity_buff;
     player_talent_t deaths_embrace; // Volatile Agony and Perpetual Unstability are unaffected by this
-    player_talent_t patient_zero;
     player_talent_t hedonic_gorging;
     player_talent_t sow_the_seeds;
 
@@ -622,8 +618,7 @@ public:
     player_talent_t soul_fire;
     const spell_data_t* soul_fire_2; // Contains Soul Shard energize data
     player_talent_t chaos_incarnate; // Greater mastery value for some spells
-    player_talent_t conflagration_of_chaos; // Conflagrate/Shadowburn has chance to make next cast of it a guaranteed crit
-    const spell_data_t* conflagration_of_chaos_buff; // Player buff which affects next Conflagrate/Shadowburn
+    player_talent_t conflagration_of_chaos;
     player_talent_t diabolic_embers; // Incinerate generates more Soul Shards
     player_talent_t demonfire_infusion;
     player_talent_t channel_demonfire;
@@ -884,7 +879,6 @@ public:
     propagate_const<buff_t*> fiendish_cruelty;
     propagate_const<buff_t*> chaotic_inferno;
     propagate_const<buff_t*> rain_of_chaos;
-    propagate_const<buff_t*> conflagration_of_chaos;
     propagate_const<buff_t*> flashpoint;
     propagate_const<buff_t*> crashing_chaos;
     propagate_const<buff_t*> alythesss_ire;
@@ -976,7 +970,6 @@ public:
     proc_t* chaotic_inferno;
     proc_t* dimensional_rift;
     proc_t* avatar_of_destruction;
-    proc_t* conflagration_of_chaos;
     proc_t* demonfire_infusion_inc;
     proc_t* demonfire_infusion_dot;
     proc_t* alythesss_ire;
@@ -991,7 +984,6 @@ public:
     proc_t* blackened_soul;
     proc_t* bleakheart_tactics;
     proc_t* seeds_of_their_demise;
-    proc_t* mark_of_perotharn;
     proc_t* devil_fruit;
 
     // Soul Harvester
@@ -1043,7 +1035,6 @@ public:
     accumulated_rng_t* demoniac_imp_fade;
     accumulated_rng_t* spiteful_reconstitution;
     accumulated_rng_t* bleakheart_tactics;
-    accumulated_rng_t* mark_of_perotharn;
     accumulated_rng_t* isolated_implosion;
     double infernal_rapidity_prd_c_value;
   } prd_rng;
@@ -1087,7 +1078,6 @@ public:
     rng_setting_t rain_of_chaos_cards = { 3.0, 3.0, "rain_of_chaos_cards", 0.0 };
     rng_setting_t rain_of_chaos_deck_size = { 20.0, 20.0, "rain_of_chaos_deck_size", 0.0 };
     rng_setting_t alythesss_ire_shift = { 0.01, 0.01, "alythesss_ire_shift", 0.0 };
-    rng_setting_t echo_of_sargeras = { 0.10, 0.10, "echo_of_sargeras", 0.0 };
 
     // Diabolist
 
@@ -1095,7 +1085,6 @@ public:
     rng_setting_t blackened_soul = { 0.23, 0.23, "blackened_soul", 0.0 };
     rng_setting_t bleakheart_tactics = { 0.15, 0.15, "bleakheart_tactics", 0.0 };
     rng_setting_t seeds_of_their_demise = { 0.240, 0.240, "seeds_of_their_demise", 0.0 };
-    rng_setting_t mark_of_perotharn = { 0.15, 0.15, "mark_of_perotharn", 0.0 };
 
     // Soul Harvester
     rng_setting_t succulent_soul_aff = { 0.225, 0.225, "succulent_soul_aff", 0.0 };
@@ -1123,11 +1112,9 @@ public:
       f( rain_of_chaos_cards );
       f( rain_of_chaos_deck_size );
       f( alythesss_ire_shift );
-      f( echo_of_sargeras );
       f( blackened_soul );
       f( bleakheart_tactics );
       f( seeds_of_their_demise );
-      f( mark_of_perotharn );
       f( succulent_soul_aff );
       f( succulent_soul_demo );
       f( feast_of_souls_aff );

--- a/engine/class_modules/warlock/sc_warlock_actions.cpp
+++ b/engine/class_modules/warlock/sc_warlock_actions.cpp
@@ -196,11 +196,10 @@ using namespace helpers;
       if ( affliction() )
       {
         parse_effects( p()->warlock_base.potent_afflictions ); // 77215
-        parse_effects( p()->buffs.nightfall, effect_mask_t( true ).disable( 3 ) ); // 264571/1260279 // Effect #3 is handled in a custom action_state
+        parse_effects( p()->buffs.nightfall, effect_mask_t( true ).disable( 3 ) ); // 264571 // Effect #3 is handled in a custom action_state
         parse_effects( p()->buffs.darkglare_presence ); // 1280663
         parse_effects( p()->buffs.shard_instability ); // 1260269
-        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-          parse_effects( p()->buffs.unstable_empowerment ); // 1305774
+        parse_effects( p()->buffs.unstable_empowerment ); // 1305774
       }
 
       // Demonology
@@ -218,9 +217,6 @@ using namespace helpers;
         parse_effects( p()->buffs.fiendish_cruelty ); // 1245664
         parse_effects( p()->buffs.chaotic_inferno ); // 1244860
         parse_effects( p()->buffs.crashing_chaos ); // 417282 // RoF is dummy
-        if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-          parse_effects( p()->buffs.conflagration_of_chaos ); // 387109
-
         parse_effects( p()->buffs.alythesss_ire ); // 1244947
       }
 
@@ -266,8 +262,7 @@ using namespace helpers;
       {
         parse_target_effects( d_fn( &warlock_td_t::dots_t::immolate ), p()->warlock_base.immolate_dot ); // 157736
         parse_target_effects( d_fn( &warlock_td_t::debuffs_t::lake_of_fire ), p()->talents.lake_of_fire_debuff ); // 1244918
-        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-          parse_target_effects( d_fn( &warlock_td_t::debuffs_t::dark_titans_mark ), p()->tier.dark_titans_mark_debuff ); // 1305711
+        parse_target_effects( d_fn( &warlock_td_t::debuffs_t::dark_titans_mark ), p()->tier.dark_titans_mark_debuff ); // 1305711
       }
 
       // Diabolist
@@ -289,7 +284,6 @@ using namespace helpers;
       if ( resource_current == RESOURCE_SOUL_SHARD && p()->in_combat )
       {
         int shards_used = as<int>( last_resource_cost );
-        int base_shards = as<int>( base_cost() );
 
         // Only effective shards consumed count towards the Rain of Chaos proc
         if ( p()->buffs.rain_of_chaos->check() && shards_used > 0 )
@@ -360,14 +354,6 @@ using namespace helpers;
               break;
             default:
               break;
-          }
-        }
-
-        if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-        {
-          if ( hellcaller() && base_shards > 0 && harmful && p()->hero.blackened_soul.ok() )
-          {
-            helpers::trigger_blackened_soul( p(), false );
           }
         }
       }
@@ -929,11 +915,8 @@ using namespace helpers;
       if ( p()->talents.withering_bolt.ok() )
         m *= 1.0 + p()->talents.withering_bolt->effectN( 1 ).percent() * std::min( ( int )( p()->talents.withering_bolt->effectN( 2 ).base_value() ), p()->get_target_data( t )->count_affliction_dots() );
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( p()->talents.impetuous_wrath.ok() )
-          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
-      }
+      if ( p()->talents.impetuous_wrath.ok() )
+        m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
 
       return m;
     }
@@ -1168,19 +1151,6 @@ using namespace helpers;
           }
         }
 
-        if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-        {
-          if ( d->state->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
-          {
-            // Wither stack gain by Mark of Perotharn does not directly trigger collapse in that tick (it will be trigged on the next tick)
-            // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
-            d->increment( 1 );
-            td( d->target )->debuffs.wither->bump( 1 );
-            assert( d->current_stack() == td( d->target )->debuffs.wither->check() && d->remains() == td( d->target )->debuffs.wither->remains() );
-            p()->procs.mark_of_perotharn->occur();
-          }
-        }
-
         if ( p()->hero.devil_fruit.ok() )
         {
           if ( p()->rppm_rng.devil_fruit->trigger() )
@@ -1233,26 +1203,6 @@ using namespace helpers;
 
     dot_t* get_dot( player_t* t ) override
     { return impact_action->get_dot( t ); }
-
-    void impact( action_state_t* s ) override
-    {
-      warlock_spell_t::impact( s );
-
-      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      {
-        if ( s->result == RESULT_CRIT && p()->hero.mark_of_perotharn.ok() && p()->prd_rng.mark_of_perotharn->trigger() )
-        {
-          auto& wither_dot = td( s->target )->dots.wither;
-          auto& wither_debuff = td( s->target )->debuffs.wither;
-          // Wither stack gain by Mark of Perotharn does not directly trigger collapse (it will be trigged on the next Wither tick)
-          // Wither stack gain by Mark of Perotharn does not benefit from Bleakheart Tactics
-          wither_dot->increment( 1 );
-          wither_debuff->bump( 1 );
-          assert( wither_dot->current_stack() == wither_debuff->check() && wither_dot->remains() == wither_debuff->remains() );
-          p()->procs.mark_of_perotharn->occur();
-        }
-      }
-    }
   };
 
   struct blackened_soul_t : public warlock_spell_t
@@ -1570,12 +1520,9 @@ using namespace helpers;
 
       warlock_spell_t::execute();
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        // NOTE: 2026-07-06 12.1 4pc seed-applied UA does not increment Wither stacks
-        if ( hellcaller() && p()->hero.blackened_soul.ok() && !is_seed_applied )
-          helpers::trigger_blackened_soul( p(), false, ua_target );
-      }
+      // NOTE: 2026-07-06 12.1 4pc seed-applied UA does not increment Wither stacks
+      if ( hellcaller() && p()->hero.blackened_soul.ok() && !is_seed_applied )
+        helpers::trigger_blackened_soul( p(), false, ua_target );
 
       // NOTE: 2026-07-06 12.1 4pc seed-applied UA does not reduce the cooldown of Dark Harvest (Cull the Weak talent)
       if ( p()->talents.cull_the_weak.ok() && !is_seed_applied )
@@ -1616,11 +1563,8 @@ using namespace helpers;
       {
         tdata->ua_stack_applied( is_seed_applied );
 
-        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-        {
-          if ( active_4pc<MID2>() )
-            helpers::update_unstable_empowerment_buff( p() );
-        }
+        if ( active_4pc<MID2>() )
+          helpers::update_unstable_empowerment_buff( p() );
 
         // NOTE: The spell data is using DOT_REFRESH_DURATION, which should add the time-until-the-next-full-tick to the total duration
         // However, ingame, the duration does not add the last tick and only refresh the dot to the total duration (always 8 seconds)
@@ -1664,15 +1608,12 @@ using namespace helpers;
         }
       }
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+      if ( active_4pc<MID2>() )
       {
-        if ( active_4pc<MID2>() )
-        {
-          // Delay to allow the dot to reset()
-          make_event( sim, 0_ms, [ this ] {
-            helpers::update_unstable_empowerment_buff( p() );
-          } );
-        }
+        // Delay to allow the dot to reset()
+        make_event( sim, 0_ms, [ this ] {
+          helpers::update_unstable_empowerment_buff( p() );
+        } );
       }
     }
 
@@ -1711,7 +1652,7 @@ using namespace helpers;
       // 12.1 4pc seed-applied UAs are displayed as full UA stacks, but only contribute
       // partial UA damage. The core applies the visible stack count through dot_multiplier,
       // so rescale it to the effective damage stack count on each tick.
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
+      if ( active_4pc<MID2>() )
       {
         auto tdata = td( state->target );
         const int current_stacks = tdata->dots.unstable_affliction->current_stack();
@@ -1808,30 +1749,8 @@ using namespace helpers;
       {
         double m = warlock_spell_t::composite_target_da_multiplier( t );
 
-        if ( ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ) && p()->talents.patient_zero.ok() )
-        {
-          // NOTE (2026-04-24): Patient Zero does not track seeds individually (bug?). Instead, it
-          // uses a single per-caster target reference updated on cast success to the target of the
-          // primary Seed of Corruption. Any seed explosion hitting that target gets the Patient Zero
-          // bonus. If the target is out of range, dead, or otherwise invalid (e.g., immune) at the
-          // time of explosion, the bonus is not reassigned and is simply not applied.
-          if ( p()->bugs )
-          {
-            assert( p()->patient_zero_target && "SoC does not have a valid Patient Zero target" );
-            if ( t == p()->patient_zero_target )
-              m *= 1.0 + p()->talents.patient_zero->effectN( 1 ).percent();
-          }
-          else
-          {
-            if ( t == target )
-              m *= 1.0 + p()->talents.patient_zero->effectN( 1 ).percent();
-          }
-        }
-
         if ( p()->talents.sow_the_seeds.ok() )
-        {
           m *= effectiveness;
-        }
 
         return m;
       }
@@ -1875,7 +1794,7 @@ using namespace helpers;
 
       add_child( explosion );
 
-      if ( p->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && p->active_4pc<MID2>() && p->talents.unstable_affliction.ok() )
+      if ( p->active_4pc<MID2>() && p->talents.unstable_affliction.ok() )
       {
         ua_seed_tier = new unstable_affliction_t( p );
         ua_seed_tier->background = ua_seed_tier->dual = true;
@@ -1970,59 +1889,13 @@ using namespace helpers;
 
       const auto& tl = target_list();
       player_t* main_seed_target = !tl.empty() ? tl.front() : target;
-      warlock_td_t* mstdata = td( main_seed_target );
-
-      // Patient Zero target is updated on SoC cast success, not on impact or debuff application
-      if ( ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ) && p()->talents.patient_zero.ok() )
-        p()->patient_zero_target = main_seed_target;
-
-      if ( p()->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      {
-        // 2026-06-30 Hotfix: Nightfall SoC detonates existing SoC when smart targeting leaves the primary seed on an already seeded target
-        if ( p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() && mstdata->dots.seed_of_corruption->is_ticking() && mstdata->soc_threshold > 0 )
-        {
-          mstdata->soc_threshold = 0;
-          mstdata->dots.seed_of_corruption->cancel();
-        }
-      }
 
       warlock_spell_t::execute();
 
       p()->buffs.seed_of_corruption_is_out_dnt->trigger();
 
-      const bool soc_had_prev_succulent_soul = p()->buffs.succulent_soul->check();
-
-      if ( p()->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      {
-        if ( time_to_execute == 0_ms && soul_harvester() && p()->talents.nocturnal_yield.ok() && p()->buffs.nightfall->check() )
-        {
-          if ( p()->hero.wicked_reaping.ok() )
-            p()->proc_actions.wicked_reaping->execute_on_target( main_seed_target );
-
-          if ( p()->hero.quietus.ok() && p()->hero.shared_fate.ok() )
-            p()->proc_actions.shared_fate->execute_on_target( main_seed_target );
-
-          // Feast of Souls is processed after SoC captures its previous Succulent Soul state but before the delayed stack removal
-          if ( p()->hero.quietus.ok() && p()->hero.feast_of_souls.ok() && p()->prd_rng.feast_of_souls->trigger( execute_state ) )
-            p()->feast_of_souls_gain();
-        }
-      }
-
       if ( soul_harvester() )
-      {
-        // NOTE: 2026-07-07 If Nightfall SoC gains Succulent Soul through Feast of Souls with no pre-existing stack,
-        // SoC removes one stack after a short delay without triggering Succulent Soul effects (bug)
-        if ( !p()->bugs || soc_had_prev_succulent_soul )
-        {
-          helpers::consume_succulent_soul( p(), main_seed_target );
-        }
-        else if ( p()->buffs.succulent_soul->check() )
-        {
-          make_event( sim, 10_ms, [ p = p() ] {
-            p->buffs.succulent_soul->decrement();
-          } );
-        }
-      }
+        helpers::consume_succulent_soul( p(), main_seed_target );
 
       if ( ua_seed_tier )
       {
@@ -2032,20 +1905,9 @@ using namespace helpers;
         ua_seed_tier->execute();
       }
 
-      // NOTE: 2026-02-26 If Nightfall is obtained during the casting of Seed of Corruption, that SoC cast
-      // benefits from the cost reduction but does not consume the effect. (bug?)
-      if ( p()->sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      {
-        if ( p()->talents.nocturnal_yield.ok() && time_to_execute == 0_ms )
-          p()->buffs.nightfall->decrement();
-      }
-
       // NOTE: 2026-07-26 Seed of Corruption is not consuming Shard Instability buff (bug)
-      if ( p()->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( !p()->bugs && time_to_execute == 0_ms )
-          p()->buffs.shard_instability->decrement();
-      }
+      if ( !p()->bugs && time_to_execute == 0_ms )
+        p()->buffs.shard_instability->decrement();
 
       if ( p()->talents.cull_the_weak.ok() )
         p()->cooldowns.dark_harvest->adjust( -p()->talents.cull_the_weak->effectN( 1 ).time_value() );
@@ -2272,11 +2134,8 @@ using namespace helpers;
 
     void snapshot_state( action_state_t* s, result_amount_type rt ) override
     {
-      // NOTE: 2026-07-26 12.0.7: Malefic Grasp does not benefit from the Nightfall damage bonus under any circumstances (bug)
-      // NOTE: 2026-07-26 12.1.0: PTR Nightfall does not buff Malefic Grasp damage unless the Necrolyte Teachings hero talent (Soul Harvester) is used (bug)
-      double dmg_mul = ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-                ? ( p()->bugs ? 0.0 : p()->talents.nightfall_buff->effectN( 2 ).percent() )
-                : ( ( p()->bugs && !p()->hero.necrolyte_teachings.ok() ) ? 0.0 : p()->talents.nightfall_buff->effectN( 2 ).percent() );
+      // NOTE: 2026-07-26: Nightfall does not buff Malefic Grasp damage unless the Necrolyte Teachings hero talent (Soul Harvester) is used (bug)
+      double dmg_mul = ( p()->bugs && !p()->hero.necrolyte_teachings.ok() ) ? 0.0 : p()->talents.nightfall_buff->effectN( 2 ).percent();
 
       debug_cast<malefic_grasp_state_t*>( s )->td_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? dmg_mul : 0.0 );
       debug_cast<malefic_grasp_state_t*>( s )->tick_time_multiplier = 1.0 + ( p()->buffs.nightfall->check() ? p()->talents.nightfall_buff->effectN( 3 ).percent() : 0.0 );
@@ -2349,11 +2208,8 @@ using namespace helpers;
     {
       double m = warlock_spell_t::composite_target_multiplier( t );
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( p()->talents.impetuous_wrath.ok() )
-          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
-      }
+      if ( p()->talents.impetuous_wrath.ok() )
+        m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
 
       return m;
     }
@@ -2497,11 +2353,8 @@ using namespace helpers;
       if ( p()->talents.withering_bolt.ok() )
         m *= 1.0 + p()->talents.withering_bolt->effectN( 1 ).percent() * std::min( ( int )( p()->talents.withering_bolt->effectN( 2 ).base_value() ), td( t )->count_affliction_dots() );
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( p()->talents.impetuous_wrath.ok() )
-          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
-      }
+      if ( p()->talents.impetuous_wrath.ok() )
+        m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 2 ).percent() : p()->talents.impetuous_wrath->effectN( 1 ).percent() );
 
       return m;
     }
@@ -2580,11 +2433,8 @@ using namespace helpers;
       {
         double m = warlock_spell_t::composite_target_multiplier( t );
 
-        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-        {
-          if ( p()->talents.impetuous_wrath.ok() )
-            m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 4 ).percent() : p()->talents.impetuous_wrath->effectN( 3 ).percent() );
-        }
+        if ( p()->talents.impetuous_wrath.ok() )
+          m *= 1.0 + ( td( t )->debuffs.haunt->check() ? p()->talents.impetuous_wrath->effectN( 4 ).percent() : p()->talents.impetuous_wrath->effectN( 3 ).percent() );
 
         return m;
       }
@@ -3191,8 +3041,8 @@ using namespace helpers;
       } );
 
       unsigned max_imps = as<unsigned>( data().effectN( 1 ).base_value() );
-      // NOTE: 2026-07-18: PTR 12.1.0 Without the To Hell and Back talent, when trying to implode 6 Wild Imps, only 5 are sent to implode (bug)
-      if ( p()->bugs && sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && !p()->talents.to_hell_and_back.ok() )
+      // NOTE: 2026-07-18: Without the To Hell and Back talent, when trying to implode 6 Wild Imps, only 5 are sent to implode (bug)
+      if ( p()->bugs && !p()->talents.to_hell_and_back.ok() )
         max_imps--;
 
       unsigned launch_counter = 0;
@@ -3230,8 +3080,8 @@ using namespace helpers;
         const unsigned imps_per_group = as<unsigned>( p()->talents.to_hell_and_back->effectN( 1 ).base_value() );
         const unsigned group_size = as<unsigned>( p()->talents.to_hell_and_back->effectN( 2 ).base_value() );
         unsigned groups;
-        // NOTE: 2026-07-11: PTR 12.1.0 Implosion rounds up To Hell and Back summons (bug?)
-        if ( p()->bugs && sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
+        // NOTE: 2026-07-11: Implosion rounds up To Hell and Back summons (bug?)
+        if ( p()->bugs )
           groups = ( launch_counter + group_size - 1 ) / group_size;
         else
           groups = launch_counter / group_size;
@@ -4455,11 +4305,8 @@ using namespace helpers;
 
       warlock_spell_t::execute();
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( hellcaller() && p()->hero.blackened_soul.ok() )
-          helpers::trigger_blackened_soul( p(), false, cb_target );
-      }
+      if ( hellcaller() && p()->hero.blackened_soul.ok() )
+        helpers::trigger_blackened_soul( p(), false, cb_target );
 
       base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
 
@@ -4582,19 +4429,6 @@ using namespace helpers;
     {
       warlock_spell_t::execute();
 
-      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      {
-        p()->buffs.conflagration_of_chaos->expire();
-
-        if ( p()->talents.conflagration_of_chaos.ok() )
-        {
-          bool success = p()->buffs.conflagration_of_chaos->trigger();
-
-          if ( success )
-            p()->procs.conflagration_of_chaos->occur();
-        }
-      }
-
       if ( p()->talents.backdraft.ok() )
         p()->buffs.backdraft->trigger();
     }
@@ -4603,7 +4437,7 @@ using namespace helpers;
     {
       double m = warlock_spell_t::composite_da_multiplier( s );
 
-      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ? p()->buffs.conflagration_of_chaos->check() : p()->talents.conflagration_of_chaos.ok() )
+      if ( p()->talents.conflagration_of_chaos.ok() )
         m *= 1.0 + player->cache.spell_crit_chance();
 
       return m;
@@ -4920,26 +4754,10 @@ using namespace helpers;
 
       warlock_spell_t::execute();
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( hellcaller() && p()->hero.blackened_soul.ok() )
-          helpers::trigger_blackened_soul( p(), false, sb_target );
-      }
+      if ( hellcaller() && p()->hero.blackened_soul.ok() )
+        helpers::trigger_blackened_soul( p(), false, sb_target );
 
       base_aoe_multiplier = prev_base_aoe_multiplier; // Restore original previous havoc aoe multiplier
-
-      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      {
-        p()->buffs.conflagration_of_chaos->expire();
-
-        if ( p()->talents.conflagration_of_chaos.ok() )
-        {
-          bool success = p()->buffs.conflagration_of_chaos->trigger();
-
-          if ( success )
-            p()->procs.conflagration_of_chaos->occur();
-        }
-      }
 
       p()->buffs.fiendish_cruelty->decrement();
     }
@@ -4948,7 +4766,7 @@ using namespace helpers;
     {
       double m = warlock_spell_t::composite_da_multiplier( s );
 
-      if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ? p()->buffs.conflagration_of_chaos->check() : p()->talents.conflagration_of_chaos.ok() )
+      if ( p()->talents.conflagration_of_chaos.ok() )
         m *= 1.0 + player->cache.spell_crit_chance();
 
       return m;
@@ -5107,7 +4925,7 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       // Random extra duration time between 0_ms and 820_ms following a uniform distribution
-      const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 0.0, 820.0 ) );
+      const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 820.0 ) );
       p()->warlock_pet_list.infernals.spawn( data().duration() + dur_adjust );
     }
   };
@@ -5126,7 +4944,7 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       // Random extra duration time between 0_ms and 820_ms following a uniform distribution
-      const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 0.0, 820.0 ) );
+      const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 820.0 ) );
       auto spawned = p()->warlock_pet_list.rocs.spawn( data().duration() + dur_adjust );
       for ( pets::destruction::infernal_t* s : spawned )
         s->type = pets::destruction::infernal_t::infernal_type_e::RAIN;
@@ -5147,7 +4965,7 @@ using namespace helpers;
       warlock_spell_t::execute();
 
       // Random extra duration time between 0_ms and 820_ms following a uniform distribution
-      const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 0.0, 820.0 ) );
+      const timespan_t dur_adjust = timespan_t::from_millis( rng().range( 820.0 ) );
       p()->warlock_pet_list.fragments.spawn( data().duration() + dur_adjust );
     }
   };
@@ -5277,13 +5095,8 @@ using namespace helpers;
     {
       warlock_spell_t::impact( s );
 
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( result_is_hit( s->result ) && active_4pc<MID2>() )
-        {
-          td( s->target )->debuffs.dark_titans_mark->trigger();
-        }
-      }
+      if ( result_is_hit( s->result ) && active_4pc<MID2>() )
+        td( s->target )->debuffs.dark_titans_mark->trigger();
     }
   };
 
@@ -5649,17 +5462,10 @@ using namespace helpers;
   void helpers::trigger_blackened_soul( warlock_t* p, bool malevolence, player_t* bs_target )
   {
     std::vector<player_t*> target_list;
-    if ( p->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-    {
-      if ( malevolence )
-        target_list = p->sim->target_non_sleeping_list.data();
-      else if ( bs_target != nullptr )
-        target_list.push_back( bs_target );
-    }
-    else
-    {
+    if ( malevolence )
       target_list = p->sim->target_non_sleeping_list.data();
-    }
+    else if ( bs_target != nullptr )
+      target_list.push_back( bs_target );
 
     for ( const auto target : target_list )
     {
@@ -5898,11 +5704,8 @@ using namespace helpers;
         ua_action->is_fatal_echoes_execute = false;
       }
 
-      if ( p->sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( p->active_4pc<MID2>() )
-          helpers::update_unstable_empowerment_buff( p );
-      }
+      if ( p->active_4pc<MID2>() )
+        helpers::update_unstable_empowerment_buff( p );
     }
   }
 
@@ -6129,7 +5932,7 @@ using namespace helpers;
   {
     proc_actions.doom_proc     = new doom_t( this );
     proc_actions.blighted_maw  = new blighted_maw_t( this );
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
+    if ( active_4pc<MID2>() )
       proc_actions.isolated_implosion = new isolated_implosion_t( this );
 
     summons.wild_imp           = new summon_wild_imp_t( this );

--- a/engine/class_modules/warlock/sc_warlock_init.cpp
+++ b/engine/class_modules/warlock/sc_warlock_init.cpp
@@ -121,14 +121,6 @@ namespace warlock
     parse_all_passive_talents();
     parse_all_passive_sets();
     parse_raid_buffs();
-
-    // NOTE: 2026-07-05 The redesigned 12.1.0 Mark of Peroth'arn no longer double dips
-    if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-    {
-      // NOTE: 2026-02-17 Mark of Perotharn is being applied twice in what appears to be a bug
-      if ( bugs )
-        parse_passive_effects( hero.mark_of_perotharn, true );
-    }
   }
 
   void warlock_t::init_spells_affliction()
@@ -146,7 +138,6 @@ namespace warlock
 
     talents.nightfall = find_talent_spell( talent_tree::SPECIALIZATION, "Nightfall" ); // Should be ID 108558
     talents.nightfall_buff = conditional_spell_lookup( warlock_base.affliction_warlock->ok(), 264571 );
-    talents.nightfall_buff_2 = conditional_spell_lookup( warlock_base.affliction_warlock->ok() && ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) ), 1260279 );
 
     talents.haunt = find_talent_spell( talent_tree::SPECIALIZATION, "Haunt" ); // Should be ID 48181
 
@@ -208,10 +199,7 @@ namespace warlock
 
     talents.potent_soul_shards = find_talent_spell( talent_tree::SPECIALIZATION, "Potent Soul Shards" ); // Should be ID 1259815
 
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      talents.impetuous_wrath = find_talent_spell( talent_tree::SPECIALIZATION, "Impetuous Wrath" ); // Should be ID 1312998
-    else
-      talents.nocturnal_yield = find_talent_spell( talent_tree::SPECIALIZATION, "Nocturnal Yield" ); // Should be ID 1260271
+    talents.impetuous_wrath = find_talent_spell( talent_tree::SPECIALIZATION, "Impetuous Wrath" ); // Should be ID 1312998
 
     talents.xavius_gambit = find_talent_spell( talent_tree::SPECIALIZATION, "Xavius' Gambit" ); // Should be ID 416615
 
@@ -226,10 +214,7 @@ namespace warlock
 
     talents.deaths_embrace = find_talent_spell( talent_tree::SPECIALIZATION, "Death's Embrace" ); // Should be ID 234876
 
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      talents.hedonic_gorging = find_talent_spell( talent_tree::SPECIALIZATION, "Hedonic Gorging" ); // Should be ID 1311969
-    else
-      talents.patient_zero = find_talent_spell( talent_tree::SPECIALIZATION, "Patient Zero" ); // Should be ID 1260285
+    talents.hedonic_gorging = find_talent_spell( talent_tree::SPECIALIZATION, "Hedonic Gorging" ); // Should be ID 1311969
 
     talents.sow_the_seeds = find_talent_spell( talent_tree::SPECIALIZATION, "Sow the Seeds" ); // Should be ID 196226
 
@@ -245,12 +230,9 @@ namespace warlock
     // Additional Tier Set spell data
     tier.wl_affliction_12_0_class_set_2pc = sets->set( WARLOCK_AFFLICTION, MID1, B2 ); // Should be ID 1264869
     tier.wl_affliction_12_0_class_set_4pc = sets->set( WARLOCK_AFFLICTION, MID1, B4 ); // Should be ID 1264870
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-    {
-      tier.wl_affliction_12_1_class_set_2pc = sets->set( WARLOCK_AFFLICTION, MID2, B2 ); // Should be ID 1296568
-      tier.wl_affliction_12_1_class_set_4pc = sets->set( WARLOCK_AFFLICTION, MID2, B4 ); // Should be ID 1296569
-      tier.unstable_empowerment_buff = conditional_spell_lookup( tier.wl_affliction_12_1_class_set_4pc->ok(), 1305774 );
-    }
+    tier.wl_affliction_12_1_class_set_2pc = sets->set( WARLOCK_AFFLICTION, MID2, B2 ); // Should be ID 1296568
+    tier.wl_affliction_12_1_class_set_4pc = sets->set( WARLOCK_AFFLICTION, MID2, B4 ); // Should be ID 1296569
+    tier.unstable_empowerment_buff = conditional_spell_lookup( tier.wl_affliction_12_1_class_set_4pc->ok(), 1305774 );
 
     // Initialize some default values for pet spawners
     warlock_pet_list.darkglares.set_default_duration( talents.summon_darkglare->duration() );
@@ -385,13 +367,10 @@ namespace warlock
     // Additional Tier Set spell data
     tier.wl_demonology_12_0_class_set_2pc = sets->set( WARLOCK_DEMONOLOGY, MID1, B2 ); // Should be ID 1264871
     tier.wl_demonology_12_0_class_set_4pc = sets->set( WARLOCK_DEMONOLOGY, MID1, B4 ); // Should be ID 1264872
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-    {
-      tier.wl_demonology_12_1_class_set_2pc = sets->set( WARLOCK_DEMONOLOGY, MID2, B2 ); // Should be ID 1296573
-      tier.wl_demonology_12_1_class_set_4pc = sets->set( WARLOCK_DEMONOLOGY, MID2, B4 ); // Should be ID 1296574
-      tier.isolated_implosion = conditional_spell_lookup( tier.wl_demonology_12_1_class_set_4pc->ok(), 1309535 );
-      tier.isolated_implosion_aoe = conditional_spell_lookup( tier.wl_demonology_12_1_class_set_4pc->ok(), 1306077 );
-    }
+    tier.wl_demonology_12_1_class_set_2pc = sets->set( WARLOCK_DEMONOLOGY, MID2, B2 ); // Should be ID 1296573
+    tier.wl_demonology_12_1_class_set_4pc = sets->set( WARLOCK_DEMONOLOGY, MID2, B4 ); // Should be ID 1296574
+    tier.isolated_implosion = conditional_spell_lookup( tier.wl_demonology_12_1_class_set_4pc->ok(), 1309535 );
+    tier.isolated_implosion_aoe = conditional_spell_lookup( tier.wl_demonology_12_1_class_set_4pc->ok(), 1306077 );
 
     // Initialize some default values for pet spawners
     warlock_pet_list.wild_imps.set_default_duration( warlock_base.wild_imp->duration() );
@@ -436,9 +415,7 @@ namespace warlock
 
     talents.shadowburn = find_talent_spell( talent_tree::SPECIALIZATION, "Shadowburn" ); // Should be ID 17877
     talents.shadowburn_2 = conditional_spell_lookup( talents.shadowburn.ok(), 245731 );
-
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      talents.shadowburn_debuff = conditional_spell_lookup( talents.shadowburn.ok(), 1311913 );
+    talents.shadowburn_debuff = conditional_spell_lookup( talents.shadowburn.ok(), 1311913 );
 
     talents.backlash = find_talent_spell( talent_tree::SPECIALIZATION, "Backlash" ); // Should be ID 387384
 
@@ -511,8 +488,6 @@ namespace warlock
     talents.chaos_incarnate = find_talent_spell( talent_tree::SPECIALIZATION, "Chaos Incarnate" ); // Should be ID 387275
 
     talents.conflagration_of_chaos = find_talent_spell( talent_tree::SPECIALIZATION, "Conflagration of Chaos" ); // Should be ID 387108
-    if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      talents.conflagration_of_chaos_buff = conditional_spell_lookup( talents.conflagration_of_chaos.ok(), 387109 );
 
     talents.diabolic_embers = find_talent_spell( talent_tree::SPECIALIZATION, "Diabolic Embers" ); // Should be ID 387173
 
@@ -545,12 +520,9 @@ namespace warlock
     // Additional Tier Set spell data
     tier.wl_destruction_12_0_class_set_2pc = sets->set( WARLOCK_DESTRUCTION, MID1, B2 ); // Should be ID 1264873
     tier.wl_destruction_12_0_class_set_4pc = sets->set( WARLOCK_DESTRUCTION, MID1, B4 ); // Should be ID 1264874
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-    {
-      tier.wl_destruction_12_1_class_set_2pc = sets->set( WARLOCK_DESTRUCTION, MID2, B2 ); // Should be ID 1296571
-      tier.wl_destruction_12_1_class_set_4pc = sets->set( WARLOCK_DESTRUCTION, MID2, B4 ); // Should be ID 1296572
-      tier.dark_titans_mark_debuff = conditional_spell_lookup( tier.wl_destruction_12_1_class_set_4pc->ok(), 1305711 );
-    }
+    tier.wl_destruction_12_1_class_set_2pc = sets->set( WARLOCK_DESTRUCTION, MID2, B2 ); // Should be ID 1296571
+    tier.wl_destruction_12_1_class_set_4pc = sets->set( WARLOCK_DESTRUCTION, MID2, B4 ); // Should be ID 1296572
+    tier.dark_titans_mark_debuff = conditional_spell_lookup( tier.wl_destruction_12_1_class_set_4pc->ok(), 1305711 );
 
     // Initialize some default values for pet spawners
     warlock_pet_list.infernals.set_default_duration( talents.summon_infernal_main->duration() );
@@ -768,7 +740,7 @@ namespace warlock
 
   void warlock_t::create_buffs_affliction()
   {
-    buffs.nightfall = make_buff( this, "nightfall", ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) && talents.nocturnal_yield.ok() ) ? talents.nightfall_buff_2 : talents.nightfall_buff );
+    buffs.nightfall = make_buff( this, "nightfall", talents.nightfall_buff );
 
     buffs.darkglare_presence = make_buff( this, "darkglare_presence", talents.darkglare_presence_buff );
 
@@ -781,9 +753,8 @@ namespace warlock
     buffs.seed_of_corruption_is_out_dnt = make_buff( this, "seed_of_corruption_is_out_dnt", talents.seed_of_corruption_is_out_dnt )
                                               ->set_quiet( true );
 
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      buffs.unstable_empowerment = make_buff( this, "unstable_empowerment", tier.unstable_empowerment_buff )
-                                       ->set_default_value_from_effect( 1 );
+    buffs.unstable_empowerment = make_buff( this, "unstable_empowerment", tier.unstable_empowerment_buff )
+                                     ->set_default_value_from_effect( 1 );
   }
 
   void warlock_t::create_buffs_demonology()
@@ -863,10 +834,6 @@ namespace warlock
                                 ->set_default_value_from_effect( 1 );
 
     buffs.rain_of_chaos = make_buff( this, "rain_of_chaos", talents.rain_of_chaos_buff );
-
-    if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-      buffs.conflagration_of_chaos = make_buff( this, "conflagration_of_chaos", talents.conflagration_of_chaos_buff )
-                                         ->set_chance( talents.conflagration_of_chaos->effectN( 1 ).percent() );
 
     buffs.flashpoint = make_buff( this, "flashpoint", talents.flashpoint_buff )
                            ->set_pct_buff_type( STAT_PCT_BUFF_HASTE )
@@ -1128,8 +1095,7 @@ namespace warlock
     procs.infernal_rapidity = get_proc( "infernal_rapidity" );
     procs.spiteful_reconstitution = get_proc( "spiteful_reconstitution" );
     procs.demonic_knowledge = get_proc( "demonic_knowledge" );
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      procs.isolated_implosion = get_proc( "isolated_implosion" );
+    procs.isolated_implosion = get_proc( "isolated_implosion" );
   }
 
   void warlock_t::init_procs_destruction()
@@ -1139,7 +1105,6 @@ namespace warlock
     procs.chaotic_inferno = get_proc( "chaotic_inferno" );
     procs.dimensional_rift = get_proc( "dimensional_rift" );
     procs.avatar_of_destruction = get_proc( "avatar_of_destruction" );
-    procs.conflagration_of_chaos = get_proc( "conflagration_of_chaos" );
     procs.alythesss_ire = get_proc( "alythesss_ire" );
     procs.reverse_entropy = get_proc( "reverse_entropy" );
     procs.rain_of_chaos = get_proc( "rain_of_chaos" );
@@ -1160,7 +1125,6 @@ namespace warlock
     procs.blackened_soul = get_proc( "blackened_soul" );
     procs.bleakheart_tactics = get_proc( "bleakheart_tactics" );
     procs.seeds_of_their_demise = get_proc( "seeds_of_their_demise" );
-    procs.mark_of_perotharn = get_proc( "mark_of_perotharn" );
     procs.devil_fruit = get_proc( "devil_fruit" );
   }
 
@@ -1221,7 +1185,7 @@ namespace warlock
           unsigned active_agonies = get_active_dots( agony_dot );
           assert( active_agonies > 0 );
           increment_max *= std::pow( active_agonies, -2.0 / 3.0 );
-          return rng().range( 0.0, increment_max );
+          return rng().range( increment_max );
         }, true, true );
     }
 
@@ -1259,7 +1223,7 @@ namespace warlock
           unsigned active_corruptions = get_active_dots( corruption_dot );
           assert( active_corruptions > 0 );
           increment_max *= std::pow( active_corruptions, -2.0 / 3.0 );
-          return rng().range( 0.0, increment_max );
+          return rng().range( increment_max );
         }, true, true );
     }
 
@@ -1346,7 +1310,7 @@ namespace warlock
 
     // Modeling Isolated Implosion as a pseudo-random distribution (PRD) with a nominal
     // rate of 20%, which corresponds to PRD constant C = 0.055704042949781852.
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) && active_4pc<MID2>() )
+    if ( active_4pc<MID2>() )
     {
       double c_ii = prd::find_constant( tier.wl_demonology_12_1_class_set_4pc->effectN( 3 ).percent() );
       prd_rng.isolated_implosion = get_accumulated_rng( "isolated_implosion", c_ii );
@@ -1444,7 +1408,7 @@ namespace warlock
             // Immolate and Wither use the default increment_max initialized from inc_max_demonfire_infusion_dot
             assert( s->action->id == warlock_base.immolate_dot->id() || s->action->id == hero.wither_dot->id() );
           }
-          return rng().range( 0.0, increment_max );
+          return rng().range( increment_max );
         }, true, true );
     }
 
@@ -1464,12 +1428,11 @@ namespace warlock
       } );
     }
 
-    // Modeling Echo of Sargeras as a pseudo-random distribution (PRD) with a nominal rate of 10% (20% with 12.1.0 2p tier),
-    // which corresponds to PRD constant C = 0.014745844781072676 (0.055704042949781852 with 12.1.0 2p tier).
+    // Modeling Echo of Sargeras as a pseudo-random distribution (PRD) with a nominal rate of 10% (20% with 12.1 2pc tier),
+    // which corresponds to PRD constant C = 0.014745844781072676 (0.055704042949781852 with 12.1 2pc tier).
     if ( talents.embers_of_nihilam_1.ok() )
     {
-      double c_es = prd::find_constant( ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) ) ? talents.embers_of_nihilam_1->effectN( 1 ).percent()
-                                        : rng_settings.echo_of_sargeras.setting_value );
+      double c_es = prd::find_constant( talents.embers_of_nihilam_1->effectN( 1 ).percent() );
       prd_rng.echo_of_sargeras = get_accumulated_rng( "echo_of_sargeras", c_es );
     }
   }
@@ -1510,14 +1473,6 @@ namespace warlock
           const double weight = std::pow( stacks_before, -2.0 / 3.0 ) * std::pow( active_withers, -3.0 / 4.0 );
           return rng().range( increment_max * weight );
         }, true, true );
-    }
-
-    // Modeling Mark of Perotharn as a shared pseudo-random distribution (PRD) with a nominal
-    // rate of 15%, which corresponds to PRD constant C = 0.032220914373087675.
-    if ( hero.mark_of_perotharn.ok() )
-    {
-      double c_mop = prd::find_constant( rng_settings.mark_of_perotharn.setting_value );
-      prd_rng.mark_of_perotharn = get_accumulated_rng( "mark_of_perotharn", c_mop );
     }
 
     rppm_rng.devil_fruit = get_rppm( "devil_fruit", hero.devil_fruit );
@@ -1796,7 +1751,6 @@ namespace warlock
     warlock_pet_list.active = nullptr;
     havoc_target = nullptr;
     haunt_target = nullptr;
-    patient_zero_target = nullptr;
     wild_imp_spawns.clear();
     diabolic_ritual = rng().range( 0, 3 );
     demonic_art_buff_replaced = false;

--- a/engine/class_modules/warlock/sc_warlock_pets.cpp
+++ b/engine/class_modules/warlock/sc_warlock_pets.cpp
@@ -818,7 +818,7 @@ struct fel_firebolt_t : public warlock_pet_spell_t
 
     warlock_pet_spell_t::execute();
 
-    // NOTE: 2026-07-18 PTR 12.1.0 Infernal Rapidity cannot proc from the last Fel Firebolt cast of a Wild Imp if that Wild Imp also triggers Isolated Implosion (bug)
+    // NOTE: 2026-07-18 Infernal Rapidity cannot proc from the last Fel Firebolt cast of a Wild Imp if that Wild Imp also triggers Isolated Implosion (bug)
     if ( !p()->bugs || !triggers_isolated_implosion )
     {
       // Extra Fel Firebolts from Infernal Rapidity cannot proc Infernal Rapidity again
@@ -840,24 +840,14 @@ struct fel_firebolt_t : public warlock_pet_spell_t
     if ( player->resources.current[ RESOURCE_ENERGY ] < cost() )
     {
       auto imp = debug_cast<warlock::pets::demonology::wild_imp_pet_t*>( player );
-      if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-      {
-        if ( p()->o()->active_4pc<MID2>() && imp->o()->prd_rng.isolated_implosion->trigger() )
-          triggers_isolated_implosion = true;
-      }
+      if ( p()->o()->active_4pc<MID2>() && imp->o()->prd_rng.isolated_implosion->trigger() )
+        triggers_isolated_implosion = true;
 
-      make_event( sim, 0_ms, [ this, imp = imp, imp_target = ffb_target, isolated_implosion_proc = triggers_isolated_implosion ] {
-        if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-        {
-          if ( isolated_implosion_proc )
-            helpers::trigger_isolated_implosion( imp->o(), imp, imp_target );
-          else
-            imp->cast_pet()->dismiss();
-        }
+      make_event( sim, 0_ms, [ imp = imp, imp_target = ffb_target, isolated_implosion_proc = triggers_isolated_implosion ] {
+        if ( isolated_implosion_proc )
+          helpers::trigger_isolated_implosion( imp->o(), imp, imp_target );
         else
-        {
           imp->cast_pet()->dismiss();
-        }
       } );
     }
   }
@@ -967,7 +957,7 @@ void wild_imp_pet_t::demise()
     {
       if ( !power_siphon )
       {
-        // NOTE: 2026-07-11: PTR 12.1.0 Isolated Imploded imps cannot trigger Demoniac (bug)
+        // NOTE: 2026-07-11: Isolated Imploded imps cannot trigger Demoniac (bug)
         if ( imploded )
         {
           if ( o()->flat_rng.demoniac_imp_implosion->trigger() )
@@ -1317,16 +1307,9 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
     npc_id = owner->talents.gloomhound->effectN( 1 ).misc_value1();
     npc_suffix = "vilefiend";
     // 2026-08-01: Validated coefficients
-    if ( sim->dbc->wowv() >= wowv_t( 12, 1, 0 ) )
-    {
-      owner_coeff.ap_from_sp = 0.6075;
-      owner_coeff.sp_from_sp = 2.6325;
-    }
-    else
-    {
-      owner_coeff.ap_from_sp = 0.45;
-      owner_coeff.sp_from_sp = 1.95;
-    }
+    // Gloomhound does 35% more damage than the other variants
+    owner_coeff.ap_from_sp = 0.6075;
+    owner_coeff.sp_from_sp = 2.6325;
   }
   else if ( owner->talents.mark_of_fharg.ok() )
   {
@@ -1352,10 +1335,6 @@ vilefiend_t::vilefiend_t( warlock_t* owner )
   action_list_str = "bile_spit";
   action_list_str += "/travel";
   action_list_str += "/headbutt";
-
-  // Currently bugged in 12.0.7 and not being affected by the crit bonus
-  if ( sim->dbc->wowv() < wowv_t( 12, 1, 0 ) )
-    affected_by.demonic_brutality = false;
 
   owner_coeff.health = 0.75;
 


### PR DESCRIPTION
This PR removes the Warlock version checks and pre-12.1.0 code paths now that 12.1.0 is live.

The existing `>=12.1.0` behavior is now used unconditionally. This also removes obsolete talents, spell data, buffs, procs, RNG settings, APL branches, and related code that were only used for versions `<12.1.0`.

No Warlock behavior for the current live version is intended to change with this PR.