### PR TITLE
[Shaman] Fix Flametongue Weapon buff never applying

### DIFF
--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12590,7 +12590,7 @@ void shaman_t::create_buffs()
   buff.surging_totem = make_buff( this, "surging_totem", find_spell( 1221347 ) )
     ->set_trigger_spell( talent.surging_totem );
 
-  buff.flametongue_weapon = make_buff( this, "flametongue_weapon", find_class_spell( "Flametongue Weapon") );
+  buff.flametongue_weapon = make_buff( this, "flametongue_weapon", find_spell( 319778 ) );
 
   //
   // Elemental

--- a/engine/class_modules/sc_shaman.cpp
+++ b/engine/class_modules/sc_shaman.cpp
@@ -12590,7 +12590,8 @@ void shaman_t::create_buffs()
   buff.surging_totem = make_buff( this, "surging_totem", find_spell( 1221347 ) )
     ->set_trigger_spell( talent.surging_totem );
 
-  buff.flametongue_weapon = make_buff( this, "flametongue_weapon", find_spell( 319778 ) );
+  buff.flametongue_weapon = make_buff( this, "flametongue_weapon", find_spell( 319778 ) )
+    ->set_trigger_spell( talent.flametongue_weapon );
 
   //
   // Elemental


### PR DESCRIPTION
Trying to sim my elemental shaman Traxxen with `use_blizzard_action_list=1` on raidbots after I picked _Flametongue Weapon_ produced some really low numbers (7k DPS), see the report at https://www.raidbots.com/simbot/report/2GQFRwTqKp2aQzCMbQog1s. All it did was cast that buff over and over the whole fight.

This patch fixes the issue. I tested a local build and it now correctly simulates the fight, and DPS went up to around 60k. I suspect this might also solve the really low numbers for enhancement at https://www.noxxic.com/wow/sims/enhancement-shaman/one-button-alt. Their build takes this talent (but not the elemental one, for some reason).