### PR TITLE
[Subtlety] Update 2t builders

### DIFF
--- a/engine/class_modules/apl/apl_rogue.cpp
+++ b/engine/class_modules/apl/apl_rogue.cpp
@@ -219,7 +219,8 @@ void subtlety( player_t* p )
   default_->add_action( "call_action_list,name=race" );
   default_->add_action( "call_action_list,name=item" );
   default_->add_action( "call_action_list,name=cds" );
-  default_->add_action( "shuriken_storm,if=variable.build_at_max_for_apex&(variable.targets>=3|!used_for_danse&talent.unseen_blade&talent.danse_macabre)&(buff.supercharge_1.up|cooldown.secret_technique.ready)" );
+  default_->add_action( "shuriken_storm,if=variable.build_at_max_for_apex&variable.targets>=3&(buff.supercharge_1.up|cooldown.secret_technique.ready)" );
+  default_->add_action( "gloomblade,if=variable.build_at_max_for_apex&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up)|cooldown.secret_technique.ready)&buff.lingering_shadow.stack>=35" );
   default_->add_action( "shadowstrike,if=variable.build_at_max_for_apex&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up)|cooldown.secret_technique.ready)" );
   default_->add_action( "call_action_list,name=finish,if=combo_points>=cp_max_spend-!buff.darkest_night.up" );
   default_->add_action( "call_action_list,name=build,if=variable.stealth|energy>60" );
@@ -245,14 +246,15 @@ void subtlety( player_t* p )
   item->add_action( "use_items,slots=trinket2,if=(variable.trinket_sync_slot=2&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=1&(!trinket.1.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)" );
 
   finish->add_action( "eviscerate,if=buff.darkest_night.up|!buff.slice_and_dice.up" );
-  finish->add_action( "secret_technique,if=buff.shadow_dance.up|(cooldown.secret_technique.duration<18|cooldown.shadow_dance.remains>=10)&!cooldown.shadow_dance.ready" );
-  finish->add_action( "coup_de_grace,if=cooldown.secret_technique.remains>=6|buff.shadow_dance.up" );
+  finish->add_action( "secret_technique,if=buff.shadow_dance.up" );
+  finish->add_action( "secret_technique,if=talent.unseen_blade&cooldown.secret_technique.duration<18&!cooldown.shadow_dance.ready", "Cast Secret Technique on cooldown as trickster if Shadow Dance is not ready" );
+  finish->add_action( "coup_de_grace,if=cooldown.secret_technique.remains>=3|buff.shadow_dance.up" );
   finish->add_action( "black_powder,if=talent.unseen_blade&variable.targets>=(3-talent.potent_powder)&(cooldown.secret_technique.remains>=3|buff.shadow_dance.up|buff.shadow_blades.up)", "Pool some Shadow Technique Stacks as Trickster before entering Shadow Dance by not finishing right before." );
   finish->add_action( "black_powder,if=talent.deathstalkers_mark&variable.targets>=2", "As Deathstalker just press BP" );
-  finish->add_action( "eviscerate,if=cooldown.secret_technique.remains>=6&talent.unseen_blade|buff.shadow_dance.up|buff.shadow_blades.up|debuff.deathstalkers_mark.stack>1|debuff.deathstalkers_mark.stack=1&buff.shadow_techniques.stack>=5", "Pool some Shadow Technique Stacks as Trickster before entering Shadow Dance by not finishing right before." );
+  finish->add_action( "eviscerate,if=cooldown.secret_technique.remains>=3&talent.unseen_blade|buff.shadow_dance.up|buff.shadow_blades.up|debuff.deathstalkers_mark.stack>1|debuff.deathstalkers_mark.stack=1&buff.shadow_techniques.stack>=5", "Pool some Shadow Technique Stacks as Trickster before entering Shadow Dance by not finishing right before." );
 
   build->add_action( "shuriken_storm,if=buff.shadow_dance.up&buff.premeditation.up&(debuff.deathstalkers_mark.up|buff.darkest_night.up|!talent.deathstalkers_mark)" );
-  build->add_action( "shadowstrike,if=!debuff.deathstalkers_mark.up&talent.deathstalkers_mark&!buff.darkest_night.up|variable.targets<=3|variable.priority_rotation" );
+  build->add_action( "shadowstrike,if=!debuff.deathstalkers_mark.up&talent.deathstalkers_mark&!buff.darkest_night.up|variable.targets<=2-set_bonus.midnight_season_2_2pc|variable.priority_rotation" );
   build->add_action( "shuriken_storm,if=variable.targets>1" );
   build->add_action( "gloomblade,if=variable.targets<2&!variable.stealth" );
   build->add_action( "backstab,if=variable.targets<2&!variable.stealth" );

--- a/engine/class_modules/apl/rogue/subtlety.simc
+++ b/engine/class_modules/apl/rogue/subtlety.simc
@@ -6,6 +6,7 @@ actions.precombat+=/variable,name=trinket_sync_slot,value=1,if=trinket.1.has_use
 actions.precombat+=/variable,name=trinket_sync_slot,value=2,if=trinket.2.has_use_buff&(!trinket.1.has_use_buff|trinket.2.cooldown.duration>trinket.1.cooldown.duration)
 actions.precombat+=/stealth
 
+# Executed every time the actor is available.
 actions=variable,name=stealth,value=buff.shadow_dance.up|buff.stealth.up|buff.vanish.up
 actions+=/variable,name=targets,value=spell_targets.shuriken_storm
 actions+=/variable,name=racial_sync,value=(buff.shadow_blades.up&buff.shadow_dance.up)|fight_remains<20
@@ -15,7 +16,8 @@ actions+=/stealth
 actions+=/call_action_list,name=race
 actions+=/call_action_list,name=item
 actions+=/call_action_list,name=cds
-actions+=/shuriken_storm,if=variable.build_at_max_for_apex&(variable.targets>=3|!used_for_danse&talent.unseen_blade&talent.danse_macabre)&(buff.supercharge_1.up|cooldown.secret_technique.ready)
+actions+=/shuriken_storm,if=variable.build_at_max_for_apex&variable.targets>=3&(buff.supercharge_1.up|cooldown.secret_technique.ready)
+actions+=/gloomblade,if=variable.build_at_max_for_apex&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up)|cooldown.secret_technique.ready)&buff.lingering_shadow.stack>=35
 actions+=/shadowstrike,if=variable.build_at_max_for_apex&variable.targets<=2&(buff.darkest_night.up|(talent.unseen_blade&buff.supercharge_1.up)|cooldown.secret_technique.ready)
 actions+=/call_action_list,name=finish,if=combo_points>=cp_max_spend-!buff.darkest_night.up
 actions+=/call_action_list,name=build,if=variable.stealth|energy>60
@@ -48,17 +50,19 @@ actions.item+=/use_items,slots=trinket1,if=(variable.trinket_sync_slot=1&(buff.s
 actions.item+=/use_items,slots=trinket2,if=(variable.trinket_sync_slot=2&(buff.shadow_blades.up|fight_remains<=20)|(variable.trinket_sync_slot=1&(!trinket.1.cooldown.ready&cooldown.shadow_blades.remains>20))|!variable.trinket_sync_slot)
 
 actions.finish=eviscerate,if=buff.darkest_night.up|!buff.slice_and_dice.up
-actions.finish+=/secret_technique,if=buff.shadow_dance.up|(cooldown.secret_technique.duration<18|cooldown.shadow_dance.remains>=10)&!cooldown.shadow_dance.ready
-actions.finish+=/coup_de_grace,if=cooldown.secret_technique.remains>=6|buff.shadow_dance.up
+actions.finish+=/secret_technique,if=buff.shadow_dance.up
+# Cast Secret Technique on cooldown as trickster if Shadow Dance is not ready
+actions.finish+=/secret_technique,if=talent.unseen_blade&cooldown.secret_technique.duration<18&!cooldown.shadow_dance.ready
+actions.finish+=/coup_de_grace,if=cooldown.secret_technique.remains>=3|buff.shadow_dance.up
 # Pool some Shadow Technique Stacks as Trickster before entering Shadow Dance by not finishing right before.
 actions.finish+=/black_powder,if=talent.unseen_blade&variable.targets>=(3-talent.potent_powder)&(cooldown.secret_technique.remains>=3|buff.shadow_dance.up|buff.shadow_blades.up)
 # As Deathstalker just press BP
 actions.finish+=/black_powder,if=talent.deathstalkers_mark&variable.targets>=2
 # Pool some Shadow Technique Stacks as Trickster before entering Shadow Dance by not finishing right before.
-actions.finish+=/eviscerate,if=cooldown.secret_technique.remains>=6&talent.unseen_blade|buff.shadow_dance.up|buff.shadow_blades.up|debuff.deathstalkers_mark.stack>1|debuff.deathstalkers_mark.stack=1&buff.shadow_techniques.stack>=5
+actions.finish+=/eviscerate,if=cooldown.secret_technique.remains>=3&talent.unseen_blade|buff.shadow_dance.up|buff.shadow_blades.up|debuff.deathstalkers_mark.stack>1|debuff.deathstalkers_mark.stack=1&buff.shadow_techniques.stack>=5
 
 actions.build=shuriken_storm,if=buff.shadow_dance.up&buff.premeditation.up&(debuff.deathstalkers_mark.up|buff.darkest_night.up|!talent.deathstalkers_mark)
-actions.build+=/shadowstrike,if=!debuff.deathstalkers_mark.up&talent.deathstalkers_mark&!buff.darkest_night.up|variable.targets<=3|variable.priority_rotation
+actions.build+=/shadowstrike,if=!debuff.deathstalkers_mark.up&talent.deathstalkers_mark&!buff.darkest_night.up|variable.targets<=2-set_bonus.midnight_season_2_2pc|variable.priority_rotation
 actions.build+=/shuriken_storm,if=variable.targets>1
 actions.build+=/gloomblade,if=variable.targets<2&!variable.stealth
 actions.build+=/backstab,if=variable.targets<2&!variable.stealth


### PR DESCRIPTION
- No longer strike at 3 targets, not even 2 with new tier set.
- Minor adjustment so sectech isnt used outside of dance for DS, was confusing too many people.
- Add gloomblade for apex "fishing".