### PR TITLE
[CI] update to use ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ubuntu-gcc-build:
     name: ubuntu-${{ matrix.compiler }}-cpp${{ matrix.cppVersion }}-build
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         compiler: [gcc-12, gcc-14]
@@ -18,12 +18,8 @@ jobs:
         include:
           - compiler: gcc-12
             cxx: g++-12
-            packages: gcc-12 g++-12
-            os: ubuntu-22.04
           - compiler: gcc-14
             cxx: g++-14
-            packages: gcc-14 g++-14
-            os: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -39,7 +35,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev ninja-build ccache ${{ matrix.packages }}
+          sudo apt-get install -y libcurl4-openssl-dev ninja-build ccache
 
       - name: Configure
         run:
@@ -70,19 +66,15 @@ jobs:
 
   ubuntu-clang-build:
     name: ubuntu-build-${{ matrix.compiler }}-C++${{ matrix.cppVersion }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-15, clang++-18]
+        compiler: [clang++-16, clang++-18]
         include:
-          - compiler: clang++-15
-            os: ubuntu-22.04
-            packages: clang-15 lld-15
+          - compiler: clang++-16
             enable_file_prefix_map: true
           - compiler: clang++-18
-            os: ubuntu-24.04
-            packages: clang-18 lld-18
             enable_file_prefix_map: true
 
     steps:
@@ -99,7 +91,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev ninja-build ccache ${{ matrix.packages }}
+          sudo apt-get install -y libcurl4-openssl-dev ninja-build ccache
 
       - name: Configure
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
           - compiler: gcc-12
             cxx: g++-12
             packages: gcc-12 g++-12
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - compiler: gcc-14
             cxx: g++-14
             packages: gcc-14 g++-14
-            os: ubuntu-latest
+            os: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -77,11 +77,11 @@ jobs:
         compiler: [clang++-15, clang++-18]
         include:
           - compiler: clang++-15
-            os: ubuntu-latest
+            os: ubuntu-22.04
             packages: clang-15 lld-15
             enable_file_prefix_map: true
           - compiler: clang++-18
-            os: ubuntu-latest
+            os: ubuntu-24.04
             packages: clang-18 lld-18
             enable_file_prefix_map: true
 

--- a/.github/workflows/generate_files.yml
+++ b/.github/workflows/generate_files.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   update-generated-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/cache@v5

--- a/.github/workflows/generate_files.yml
+++ b/.github/workflows/generate_files.yml
@@ -16,7 +16,7 @@ jobs:
             ActionPriorityLists
             profiles
             .git
-          key: ubuntu-clang++-15-for_run-${{ github.sha }}-cpp-17
+          key: ubuntu-clang++-16-for_run-${{ github.sha }}-cpp-17
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/generate_files.yml
+++ b/.github/workflows/generate_files.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   update-generated-files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/cache@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
     if: github.base_ref == github.event.repository.default_branch || github.ref_name == github.event.repository.default_branch
     uses: ./.github/workflows/spec_test.yml
     with:
-      cache-key: ubuntu-clang++-15-for_run-${{ github.sha }}-cpp-17
+      cache-key: ubuntu-clang++-16-for_run-${{ github.sha }}-cpp-17
       is-ptr: false
       spec-matrix: ${{ needs.spec-test-selection.outputs.spec-matrix }}
 
@@ -211,7 +211,7 @@ jobs:
     if: github.base_ref == github.event.repository.default_branch || github.ref_name == github.event.repository.default_branch
     uses: ./.github/workflows/spec_test.yml
     with:
-      cache-key: ubuntu-clang++-15-for_run-${{ github.sha }}-cpp-17
+      cache-key: ubuntu-clang++-16-for_run-${{ github.sha }}-cpp-17
       is-ptr: true
       spec-matrix: ${{ needs.spec-test-selection.outputs.spec-matrix }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       do-test: ${{ github.base_ref == github.event.repository.default_branch || github.ref_name == github.event.repository.default_branch }}
 
   spec-test-selection:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.base_ref == github.event.repository.default_branch || github.ref_name == github.event.repository.default_branch
     outputs:
       spec-matrix: ${{ steps.select.outputs.spec-matrix }}
@@ -191,7 +191,7 @@ jobs:
           echo "Selected spec matrix: $SPEC_JSON"
 
   environment-configuration-info:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Report Environment Configuration Information
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       do-test: ${{ github.base_ref == github.event.repository.default_branch || github.ref_name == github.event.repository.default_branch }}
 
   spec-test-selection:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.base_ref == github.event.repository.default_branch || github.ref_name == github.event.repository.default_branch
     outputs:
       spec-matrix: ${{ steps.select.outputs.spec-matrix }}
@@ -191,7 +191,7 @@ jobs:
           echo "Selected spec matrix: $SPEC_JSON"
 
   environment-configuration-info:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Report Environment Configuration Information
         run: |

--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   spec-test:
     name: spec-test-${{ matrix.spec }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ inputs.is-ptr }}
     timeout-minutes: 15
 

--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   spec-test:
     name: spec-test-${{ matrix.spec }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ inputs.is-ptr }}
     timeout-minutes: 15
 

--- a/.github/workflows/ubuntu_test.yml
+++ b/.github/workflows/ubuntu_test.yml
@@ -22,13 +22,13 @@ jobs:
         compiler: [clang++-15, clang++-18, gcc-12, gcc-14]
         include:
           - compiler: clang++-15
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - compiler: clang++-18
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - compiler: gcc-14
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - compiler: gcc-12
-            os: ubuntu-latest
+            os: ubuntu-22.04
 
     steps:
       - uses: actions/cache@v5

--- a/.github/workflows/ubuntu_test.yml
+++ b/.github/workflows/ubuntu_test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   ubuntu-test:
     name: ubuntu-${{ matrix.compiler }}-cpp-${{ matrix.cppVersion }}-${{ matrix.type }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       CACHE_KEY: ubuntu-${{ matrix.compiler }}-for_run-${{ github.sha }}-cpp-${{ matrix.cppVersion }}
       UBSAN_OPTIONS: print_stacktrace=1
@@ -19,16 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-15, clang++-18, gcc-12, gcc-14]
-        include:
-          - compiler: clang++-15
-            os: ubuntu-22.04
-          - compiler: clang++-18
-            os: ubuntu-24.04
-          - compiler: gcc-14
-            os: ubuntu-24.04
-          - compiler: gcc-12
-            os: ubuntu-22.04
+        compiler: [clang++-16, clang++-18, gcc-12, gcc-14]
 
     steps:
       - uses: actions/cache@v5
@@ -50,7 +41,7 @@ jobs:
         run: ${{ runner.workspace }}/b/ninja/simc $SIMC_ARGS $SIMC_PROFILE iterations=10 fight_style=DungeonSlice allow_experimental_specializations=1 cleanup_threads=1
 
       - name: Clear Cache
-        if: ( matrix.compiler != 'clang++-15' || matrix.cppVersion != '17' ) && github.event_name == 'push'
+        if: ( matrix.compiler != 'clang++-16' || matrix.cppVersion != '17' ) && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh cache delete ${{ env.CACHE_KEY }}


### PR DESCRIPTION
Ubuntu 22.x images are soon to be deprecated for github actions. Update all ubuntu jobs to use ubuntu-latest (Ubuntu 24.x), and update Clang++15 jobs to use Clang++16, which is pre-installed in ubuntu-latest.