### PR TITLE
[Hunter] Simplify Rapid Fire logic for Precise Shots and No Scope with Unload

### DIFF
--- a/engine/class_modules/sc_hunter.cpp
+++ b/engine/class_modules/sc_hunter.cpp
@@ -5925,26 +5925,11 @@ struct rapid_fire_t: public hunter_ranged_attack_t
     hydra_target = p()->get_hydra_target( target );
     marked_targets.clear();
 
-    // 2026-07-22: Unload is a weird spell with No Scope talented. If Precise Shots is active before casting Rapid Fire, Precise Shots
-    //             will be refreshed by No Scope and then consumed by Unload's first shot. If Precise Shots is not active, No Scope will
-    //             apply it but Unload's first shot will not consume it, leaving it for the second shot.
-    //
-    //             I am choosing to trigger Precise Shots after Unload's first shot in the second case for simplicity of modeling.
-    if ( p()->buffs.precise_shots->check() )
+    // 2026-08-20 HotFix: No Scope applies Precise Shots after Unload's first shot, allowing the second shot to benefit from and consume it.
+    execute_unload( 1 );
+    if ( p()->talents.no_scope.ok() )
     {
-      if ( p()->talents.no_scope.ok() )
-      {
-        p()->buffs.precise_shots->trigger();
-      }
-      execute_unload( 1 );
-    }
-    else
-    {
-      execute_unload( 1 );
-      if ( p()->talents.no_scope.ok() )
-      {
-        p()->buffs.precise_shots->trigger();
-      }
+      p()->buffs.precise_shots->trigger();
     }
 
     hunter_ranged_attack_t::execute();


### PR DESCRIPTION
Hotfixes applied on **08/20/2026** changed the interaction between **Rapid Fire**, **No Scope**, and **Unload**.

Previously, the **Precise Shots** buff was applied at the same time as the **Arcane Shot** triggered by Rapid Fire. As a result, the triggered Arcane Shot could consume an existing Precise Shots buff if one was active before Rapid Fire was cast.

The hotfix that addressed Arcane Shot clipping at the end of Rapid Fire also changed the order of these events. The triggered **Arcane Shot now fires before the new Precise Shots buff is applied**.

This means that with **Unload**, both Arcane Shots triggered during Rapid Fire can now benefit from **Precise Shots**, rather than the first Arcane Shot consuming the previously active buff before the second is fired.

This PR updates the relevant logic to account for the new post-hotfix behavior.
