### PR TITLE
[DH] Swap thrill of the fight haste and damage buff application times

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -2804,10 +2804,10 @@ struct art_of_the_glaive_trigger_t : public BASE
     {
       if ( BASE::dh()->talent.aldrachi_reaver.thrill_of_the_fight->ok() )
       {
-        BASE::dh()->buff.thrill_of_the_fight_haste->trigger();
+        BASE::dh()->buff.thrill_of_the_fight_damage->trigger();
 
         make_event( *BASE::dh()->sim, thrill_delay,
-                    [ this ] { BASE::dh()->buff.thrill_of_the_fight_damage->trigger(); } );
+                    [ this ] { BASE::dh()->buff.thrill_of_the_fight_haste->trigger(); } );
       }
       if ( BASE::dh()->talent.aldrachi_reaver.aldrachi_tactics->ok() )
       {


### PR DESCRIPTION
https://www.warcraftlogs.com/reports/3cAw8Tr9ZHhRvbdQ?fight=1&source=4&type=auras&pins=0%24Separate%24%23244F4B%24damage%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24-188499%5E0%24Separate%24%23909049%24damage%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24-162794%5E0%24Separate%24%23a04D8A%24damage%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24442294%5E0%24Separate%24%23DF5353%24damage%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24-210152%5E0%24Separate%24rgb%2878%25%2C+61%25%2C+43%25%29%24damage%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24-201427%5E0%24Separate%24%23a0a0a0%24casts%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24210152%5E0%24Separate%24%23F43F5B%24casts%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24442294%5E0%24Separate%24%23FFFF89%24casts%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24201427%5E0%24Separate%24%23FF9D2A%24casts%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24188499%5E0%24Separate%24%23FF7373%24casts%240%240.0.0.Any%24252184069.0.0.DemonHunter%24true%240.0.0.Any%24false%24162794%5E0%24Separate%24rgb%2892%25%2C+76%25%2C+58%25%29%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24442688%5E0%24Separate%24%23c0c0c0%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24442695%5E0%24Separate%24%23244F4B%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24442435%5E0%24Separate%24%23909049%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24442442%5E0%24Separate%24%23a04D8A%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24188499%5E0%24Separate%24%23DF5353%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24442695%5E0%24Separate%24rgb%2878%25%2C+61%25%2C+43%25%29%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%24252184069.0.0.DemonHunter%24false%24442695&ability=442695&view=events&modal=fight-selection

Thrill of the fight damage applies on the execution of the second ability, while the haste buff is the delayed one