### PR TITLE
[Devourer] Don't register a background The Hunt under the APL action's name

### DIFF
--- a/engine/class_modules/sc_demon_hunter.cpp
+++ b/engine/class_modules/sc_demon_hunter.cpp
@@ -11604,11 +11604,11 @@ void demon_hunter_t::init_spells()
     }
   }
 
-  if ( talent.scarred.demonic_intensity->ok() )
-  {
-    // Create a hunt to guarantee the cooldown object exists properly formed.
-    background_actions.push_back( new the_hunt_t( this, "" ) );
-  }
+  // No background the_hunt_t here: it registered under the name "the_hunt", which is the key
+  // the_hunt_base_t uses to look up its the_hunt_damage_t impact action, so the APL's hunt
+  // resolved a the_hunt_t and the dynamic_cast returned nullptr (The Hunt dealt no damage).
+  // cooldown.the_hunt is created in the constructor and initialised by whichever of The Hunt
+  // or Predator's Wake the APL creates; both carry the 90s data.
 
   if ( specialization() == DEMON_HUNTER_DEVOURER )
   {


### PR DESCRIPTION
b9880014fd added a background `the_hunt_t` for Demonic Intensity builds so the shared cooldown object exists. It registers under the name `the_hunt`, which is the key `the_hunt_base_t` uses to look up its impact action via `get_background_action<the_hunt_damage_t>( "the_hunt" )`. That lookup now finds the holder, the `dynamic_cast` returns nullptr, and The Hunt cast from an APL deals no damage on any Demonic Intensity build, on both Live and PTR data.

Receipt (Devourer, Void-Scarred, 1T 300s): before the fix `the_hunt` reports 2.1 casts, no `the_hunt_damage` child and 0 damage; after, 493k per cast with the child present.

The holder is not needed: `cooldown.the_hunt` is created in the constructor and initialised by whichever of The Hunt or Predator's Wake the APL creates, and both carry the 90s data. `collapsing_star_t`'s reset on an unused cooldown is a no-op.