### PR TITLE
[ele] Fix profiles for cantrip changes, APL: simplify SK/Asc syncs

### DIFF
--- a/engine/class_modules/apl/shaman/elemental.simc
+++ b/engine/class_modules/apl/shaman/elemental.simc
@@ -92,7 +92,7 @@ actions.single_target=stormkeeper,if=!buff.stormkeeper.up&!buff.tempest.up&set_b
 actions.single_target+=/ancestral_swiftness
 
 # Prespend SK charges before going into Ascendance - Farseer only in 1t, SB in both 1t and 2t
-actions.single_target+=/lightning_bolt,if=set_bonus.mid2_4pc&buff.stormkeeper.up&cooldown.ascendance.remains<2*gcd&&(spell_targets.chain_lightning=1|talent.tempest)
+actions.single_target+=/lightning_bolt,if=set_bonus.mid2_4pc&buff.stormkeeper.up&cooldown.ascendance.remains<2*gcd&(spell_targets.chain_lightning=1|talent.tempest)
 
 # Maintain Flame shock, minor gain to refresh it when FE is about to fade on up to 2 targets.
 actions.single_target+=/flame_shock,if=!buff.master_of_the_elements.up&dot.flame_shock.refreshable&cooldown.ascendance.remains>5

--- a/engine/class_modules/apl/shaman/elemental.simc
+++ b/engine/class_modules/apl/shaman/elemental.simc
@@ -5,8 +5,8 @@ actions.precombat+=/lightning_shield
 actions.precombat+=/thunderstrike_ward
 actions.precombat+=/variable,name=trinket_1_buffs,value=(trinket.1.has_use_buff|trinket.1.is.funhouse_lens)
 actions.precombat+=/variable,name=trinket_2_buffs,value=(trinket.2.has_use_buff|trinket.2.is.funhouse_lens)
-actions.precombat+=/variable,name=trinket_1_special,value=(trinket.1.is.stormbound_emblem_of_dazar|trinket.1.is.hex_lords_dooming_idol)
-actions.precombat+=/variable,name=trinket_2_special,value=(trinket.2.is.stormbound_emblem_of_dazar|trinket.2.is.hex_lords_dooming_idol)
+actions.precombat+=/variable,name=trinket_1_special,value=(trinket.1.is.stormbound_emblem_of_dazar|trinket.1.is.hex_lords_dooming_idol|trinket.1.is.font_of_venomous_rage)
+actions.precombat+=/variable,name=trinket_2_special,value=(trinket.2.is.stormbound_emblem_of_dazar|trinket.2.is.hex_lords_dooming_idol|trinket.2.is.font_of_venomous_rage)
 actions.precombat+=/stormkeeper
 
 # Executed every time the actor is available.
@@ -19,14 +19,17 @@ actions+=/berserking
 actions+=/fireblood
 actions+=/ancestral_call
 
-# Special trinkets
+# Special buff trinkets
 actions+=/use_item,name=stormbound_emblem_of_dazar,if=cooldown.ascendance.ready&(cooldown.stormkeeper.remains>15|cooldown.stormkeeper.remains<2)|fight_remains<23
-actions+=/use_item,name=hex_lords_dooming_idol,if=cooldown.ascendance.ready&cooldown.stormkeeper.remains>15|fight_remains<23
+actions+=/use_item,name=hex_lords_dooming_idol,use_off_gcd=1,if=cooldown.ascendance.ready&cooldown.stormkeeper.remains>15|fight_remains<23
 # Normal buff trinkets, mimic Ascendance activation conditions
-actions+=/use_item,slot=trinket1,use_off_gcd=1,if=!variable.trinket_1_special&variable.trinket_1_buffs&(cooldown.ascendance.remains>trinket.1.cooldown.duration-5|cooldown.ascendance.ready&cooldown.stormkeeper.remains>15|fight_remains<21)
-actions+=/use_item,slot=trinket2,use_off_gcd=1,if=!variable.trinket_2_special&variable.trinket_2_buffs&(cooldown.ascendance.remains>trinket.2.cooldown.duration-5|cooldown.ascendance.ready&cooldown.stormkeeper.remains>15|fight_remains<21)
+actions+=/use_item,slot=trinket1,use_off_gcd=1,if=!variable.trinket_1_special&variable.trinket_1_buffs&(cooldown.ascendance.remains>trinket.1.cooldown.duration-5|cooldown.ascendance.ready&(!buff.stormkeeper.up|spell_targets.chain_lightning>=2)|fight_remains<21)
+actions+=/use_item,slot=trinket2,use_off_gcd=1,if=!variable.trinket_2_special&variable.trinket_2_buffs&(cooldown.ascendance.remains>trinket.2.cooldown.duration-5|cooldown.ascendance.ready&(!buff.stormkeeper.up|spell_targets.chain_lightning>=2)|fight_remains<21)
 # Normal weapons
 actions+=/use_item,slot=main_hand,use_off_gcd=1
+
+#Special dmg trinkets
+actions+=/use_item,name=font_of_venomous_rage,if=!variable.trinket_1_buffs&!variable.trinket_2_buffs&!buff.ascendance.up|!buff.ascendance.up&!cooldown.ascendance.ready|fight_remains<23
 # Dmg trinkets
 actions+=/use_item,slot=trinket1,use_off_gcd=1,if=!variable.trinket_1_special&!variable.trinket_1_buffs&(cooldown.ascendance.remains>20|trinket.2.cooldown.remains>20)
 actions+=/use_item,slot=trinket2,use_off_gcd=1,if=!variable.trinket_2_special&!variable.trinket_2_buffs&(cooldown.ascendance.remains>20|trinket.1.cooldown.remains>20)
@@ -35,13 +38,14 @@ actions+=/lightning_shield,if=buff.lightning_shield.down
 actions+=/natures_swiftness
 # Use Power Infusion on Cooldown.
 actions+=/invoke_external_buff,name=power_infusion
-actions+=/potion,if=buff.bloodlust.up|cooldown.ascendance.ready&cooldown.stormkeeper.remains>15|fight_remains<31
+actions+=/potion,if=buff.bloodlust.up|cooldown.ascendance.ready|fight_remains<31
 actions+=/run_action_list,name=aoe,if=spell_targets.chain_lightning>=3
 actions+=/run_action_list,name=single_target
 
 # --- 3+ TARGET ROTATION ---
-# Stormkeeper on CD, unless sub 10s hold for Asc or the fight is about to end.
-actions.aoe=stormkeeper,if=cooldown.ascendance.remains>10|cooldown.ascendance.remains<gcd|fight_remains<20
+
+# Stormkeeper on CD (always with MID2 set), unless sub 10s hold for Asc or the fight is about to end.
+actions.aoe=stormkeeper,if=set_bonus.mid2_4pc|cooldown.ascendance.remains>10|cooldown.ascendance.remains<gcd|fight_remains<20
 actions.aoe+=/ancestral_swiftness
 
 # [3t] Apply Flame shock on 3t for MotE and Inferno arc.
@@ -49,19 +53,18 @@ actions.aoe+=/flame_shock,if=!buff.master_of_the_elements.up&((dot.flame_shock.r
 # Apply Voltaic blaze for Inferno arc or Purging flames.
 actions.aoe+=/voltaic_blaze,if=!buff.master_of_the_elements.up&((dot.flame_shock.refreshable&cooldown.ascendance.remains>5)|(buff.fire_elemental.up&buff.fire_elemental.remains<2)|talent.purging_flames)
 
-# Ascendance on CD, unless SK can be sync'd with it.
-actions.aoe+=/ascendance,if=cooldown.stormkeeper.remains>15|fight_remains<20
+# Ascendance on CD (always with MID2 set), unless SK can be sync'd with it.
+actions.aoe+=/ascendance,if=set_bonus.mid2_4pc|cooldown.stormkeeper.remains>15|fight_remains<20
 
 # [SB] Elemental Blast if no buffs or at 3t, Earthquake to spread Lightning Rod otherwise
-# [FS] EQ with ancestors, EB - without
 actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=buff.tempest.stack<2&(buff.elemental_blast_critical_strike.up+buff.elemental_blast_haste.up+buff.elemental_blast_mastery.up=0)&talent.tempest
 actions.aoe+=/earthquake,if=buff.tempest.stack<2&lightning_rod<active_enemies&(spell_targets.chain_lightning>=3+talent.elemental_blast)&(buff.elemental_blast_critical_strike.up+buff.elemental_blast_haste.up+buff.elemental_blast_mastery.up>0|!talent.elemental_blast)&talent.tempest
-actions.aoe+=/earthquake,if=buff.call_of_the_ancestors.up|(spell_targets.chain_lightning>=3+3*talent.elemental_blast)&talent.call_of_the_ancestors
-actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=buff.tempest.stack<2&(spell_targets.chain_lightning<=3+2*talent.call_of_the_ancestors)&!buff.call_of_the_ancestors.up
+# [FS] EQ with ancestors, EB (3 and 4t) - without
+actions.aoe+=/earthquake,if=buff.call_of_the_ancestors.up|(spell_targets.chain_lightning>=3+2*talent.elemental_blast)&talent.call_of_the_ancestors
+actions.aoe+=/elemental_blast,target_if=min:debuff.lightning_rod.remains,if=buff.tempest.stack<2&(spell_targets.chain_lightning<=3+talent.call_of_the_ancestors)&!buff.call_of_the_ancestors.up
 
 # Spend Purging flames.
-# !!! Remove tier requirement once fixed ingame
-actions.aoe+=/lava_burst,if=buff.purging_flames.up&(buff.lava_surge.up&buff.flowing_elements.stack<2|cooldown.voltaic_blaze.remains<2)
+actions.aoe+=/lava_burst,if=buff.purging_flames.up&(buff.lava_surge.up|cooldown.voltaic_blaze.remains<2)
 # [3t] Spend Lava Surge procs to buff Tempest with MotE OR anything with Farseer (without PF specced).
 actions.aoe+=/lava_burst,if=(buff.tempest.up|!talent.purging_flames&talent.call_of_the_ancestors)&buff.lava_surge.up&talent.master_of_the_elements&spell_targets.chain_lightning=3
 # [3t] Tempest if you have MotE.
@@ -83,9 +86,13 @@ actions.aoe+=/voltaic_blaze,moving=1
 actions.aoe+=/frost_shock,moving=1
 
 # --- 1 and 2 TARGET ROTATION ---
-# Stormkeeper on CD, unless sub 10s hold for Asc or the fight is about to end.
-actions.single_target=stormkeeper,if=cooldown.ascendance.remains>10|cooldown.ascendance.remains<gcd|fight_remains<20
+
+# Stormkeeper on CD (proc all 4p first if using MID2 4pc), unless sub 10s hold for Asc or the fight is about to end.
+actions.single_target=stormkeeper,if=!buff.stormkeeper.up&!buff.tempest.up&set_bonus.mid2_4pc|!set_bonus.mid2_4pc&(cooldown.ascendance.remains>10|cooldown.ascendance.remains<gcd|fight_remains<20)
 actions.single_target+=/ancestral_swiftness
+
+# Prespend SK charges before going into Ascendance - Farseer only in 1t, SB in both 1t and 2t
+actions.single_target+=/lightning_bolt,if=set_bonus.mid2_4pc&buff.stormkeeper.up&cooldown.ascendance.remains<2*gcd&&(spell_targets.chain_lightning=1|talent.tempest)
 
 # Maintain Flame shock, minor gain to refresh it when FE is about to fade on up to 2 targets.
 actions.single_target+=/flame_shock,if=!buff.master_of_the_elements.up&dot.flame_shock.refreshable&cooldown.ascendance.remains>5
@@ -93,8 +100,8 @@ actions.single_target+=/flame_shock,target_if=min:dot.flame_shock.remains,if=!bu
 # Voltaic Blaze to maintain Flame shock and on cooldown to proc Purging Flames.
 actions.single_target+=/voltaic_blaze,if=!buff.master_of_the_elements.up&(dot.flame_shock.refreshable&cooldown.ascendance.remains>5|talent.purging_flames&spell_targets.chain_lightning=2)
 
-# Ascendance on CD, unless SK can be sync'd with it.
-actions.single_target+=/ascendance,if=cooldown.stormkeeper.remains>15|fight_remains<20
+# Ascendance on CD (always with MID2 set), unless SK can be sync'd with it.
+actions.single_target+=/ascendance,if=set_bonus.mid2_4pc|cooldown.stormkeeper.remains>15|fight_remains<20
 
 # Consume tier procs if you gona proc new one with next builder.
 actions.single_target+=/earthquake,if=buff.flowing_elements.up&buff.overcharge_tier.up&buff.call_of_the_ancestors.stack>=3&spell_targets.chain_lightning=2
@@ -111,7 +118,6 @@ actions.single_target+=/lava_burst,if=talent.master_of_the_elements&!buff.master
 actions.single_target+=/lava_burst,if=!talent.master_of_the_elements&maelstrom.deficit>15&(!buff.storm_elemental.up|buff.wind_gust.stack=4)&((cooldown.lava_burst.charges_fractional>1.8|!buff.call_of_the_ancestors.up)&(talent.molten_wrath|talent.purging_flames)|buff.lava_surge.up)
 
 actions.single_target+=/lava_burst,if=!buff.master_of_the_elements.up&maelstrom.deficit>15&buff.flowing_elements.up
-actions.single_target+=/lava_burst,if=!buff.master_of_the_elements.up&maelstrom.deficit>15&buff.power_of_the_maelstrom.stack=2
 actions.single_target+=/lava_burst,if=!buff.master_of_the_elements.up&maelstrom.deficit>15&buff.purging_flames.up&cooldown.voltaic_blaze.remains<2&active_dot.flame_shock=2
 
 # [SB] Tempest and Lightning Bolt with SK if you have MotE.

--- a/profiles/generators/MID2/MID2_Generate_Shaman.simc
+++ b/profiles/generators/MID2/MID2_Generate_Shaman.simc
@@ -8,21 +8,23 @@ position=ranged_back
 talents=CYQAAAAAAAAAAAAAAAAAAAAAAAAAAAzMbbzMmZmZZbZMMjBAAAAsYmNYADY2YCZWAgZbmZGjtFTYmxYxMzMmZWsMjFzMMzyAAGGAzMGGGA
 omnium_talents=136822:1/136819:1/136817:1/136815:1/136814:1
 
-head=,id=271483,enchant_id=8017,gem_id=240967,bonus_id=13692/13698/13750/12854,redirected_base_stats=251220
-neck=,id=268265,gem_id=240918/240908,bonus_id=13708/13668/13848/13662
+flask=flask_of_the_shattered_sun_2
+
+head=,id=271483,enchant_id=8017,gem_id=240983,bonus_id=12854/13692/13698/13750,redirected_base_stats=251220
+neck=,id=268265,gem_id=240906/240906,bonus_id=13987/13668/13848/13662
 shoulder=,id=271481,enchant_id=8001,bonus_id=13694/13697/13848,redirected_base_stats=268231
-back=,id=268253,bonus_id=13848/13662
+back=,id=268253,bonus_id=13662/13848
 chest=,id=271486,enchant_id=7987,bonus_id=13690/13698/13846/13848,redirected_base_stats=271876
-wrist=,id=244584,gem_id=240900,bonus_id=12214/13836/13751/9627/8960/12384/13750,crafted_stats=36/49,crafting_quality=5
-hands=,id=271484,bonus_id=13691/13697/12854,redirected_base_stats=160213
-waist=,id=268254,gem_id=240892,bonus_id=12854/13662/13750
+wrist=,id=244584,gem_id=240906,bonus_id=8960/12214/12384/13750/13751/13836/9627/8790,crafted_stats=36/49,crafting_quality=5
+hands=,id=271484,bonus_id=13691/13697/12854,redirected_base_stats=268238
+waist=,id=268254,gem_id=240906,bonus_id=12854/13662/13750
 legs=,id=271482,enchant_id=7935,bonus_id=13693/13698/13848,redirected_base_stats=268237
-feet=,id=244577,enchant_id=8019,bonus_id=12214/13836/13751/9627/8960/12384/8790,crafted_stats=36/49,crafting_quality=5
-finger1=,id=268252,enchant_id=7967,gem_id=240892,bonus_id=13668/12854/13662
-finger2=,id=273792,enchant_id=7967,gem_id=240892,bonus_id=13668/12854/13662
+feet=,id=244577,enchant_id=8019,bonus_id=8790/8960/12214/12384/13751/13836/9627,crafted_stats=36/49,crafting_quality=5
+finger1=,id=251136,enchant_id=7967,gem_id=240906,bonus_id=13668/12854/13662
+finger2=,id=268252,enchant_id=7967,gem_id=240906,bonus_id=12854/13662/13668
 trinket1=,id=270164,bonus_id=12854/13662
 trinket2=,id=273796,bonus_id=12854/13662
-main_hand=,id=271092,enchant_id=7983,bonus_id=13848/13662
+main_hand=,id=271092,enchant_id=8689,bonus_id=13662/13848
 off_hand=,id=268262,bonus_id=12854/13662
 
 save=MID2_Shaman_Elemental.simc
@@ -37,21 +39,21 @@ position=ranged_back
 talents=CYQAAAAAAAAAAAAAAAAAAAAAAAAAAAzMbbzMmZmZZbZgxMDAAAAAWMjhNYBmRDN2AgZbmZGjtFTYmxYxMzMmZWsMjFzMjZWAAGGYmBGGGA
 omnium_talents=136822:1/136819:1/136817:1/136815:1/136814:1
 
-head=,id=271483,enchant_id=8017,gem_id=240967,bonus_id=13692/13698/13750/12854,redirected_base_stats=251220
-neck=,id=268265,gem_id=240918/240908,bonus_id=13708/13668/13848/13662
+head=,id=271483,enchant_id=8017,gem_id=240983,bonus_id=12854/13692/13698/13750,redirected_base_stats=251220
+neck=,id=268265,gem_id=240906/240906,bonus_id=13987/13668/13848/13662
 shoulder=,id=271481,enchant_id=8001,bonus_id=13694/13697/13848,redirected_base_stats=268231
-back=,id=268253,bonus_id=13848/13662
-chest=,id=271486,enchant_id=7987,bonus_id=13690/13698/13708/13848,redirected_base_stats=271876
-wrist=,id=244584,gem_id=240900,bonus_id=12214/13836/13751/9627/8960/12384/13750,crafted_stats=36/49,crafting_quality=5
-hands=,id=271484,bonus_id=13691/13697/12854,redirected_base_stats=160213
-waist=,id=268254,gem_id=240892,bonus_id=12854/13662/13750
+back=,id=268253,bonus_id=13662/13848
+chest=,id=271486,enchant_id=7987,bonus_id=13690/13698/13846/13848,redirected_base_stats=271876
+wrist=,id=244584,gem_id=240906,bonus_id=8960/12214/12384/13750/13751/13836/9627/8790,crafted_stats=36/49,crafting_quality=5
+hands=,id=271484,bonus_id=13691/13697/12854,redirected_base_stats=268238
+waist=,id=268254,gem_id=240906,bonus_id=12854/13662/13750
 legs=,id=271482,enchant_id=7935,bonus_id=13693/13698/13848,redirected_base_stats=268237
-feet=,id=244577,enchant_id=8019,bonus_id=12214/13836/13751/9627/8960/12384,crafted_stats=36/49,crafting_quality=5
-finger1=,id=268249,enchant_id=7967,gem_id=240892,bonus_id=13668/12854/13662
-finger2=,id=252258,enchant_id=7967,gem_id=240892,bonus_id=13668/12854/13662
+feet=,id=244577,enchant_id=8019,bonus_id=8790/8960/12214/12384/13751/13836/9627,crafted_stats=36/49,crafting_quality=5
+finger1=,id=251136,enchant_id=7967,gem_id=240906,bonus_id=13668/12854/13662
+finger2=,id=268252,enchant_id=7967,gem_id=240906,bonus_id=12854/13662/13668
 trinket1=,id=270164,bonus_id=12854/13662
 trinket2=,id=273796,bonus_id=12854/13662
-main_hand=,id=271092,enchant_id=7983,bonus_id=13848/13662
+main_hand=,id=271092,enchant_id=8689,bonus_id=13662/13848
 off_hand=,id=268262,bonus_id=12854/13662
 
 save=MID2_Shaman_Elemental_Stormbringer.simc


### PR DESCRIPTION
Both SB and Farseer profiles updates with fixed cantrip items and adjusted other gear to compensate

Removed practically all syncing between SK and Asc coz tier doesnt favor it. Added procing tier before going into Asc if Sk and Asc are lined up
