### PR TITLE
[Warlock] Update Hellcaller Affliction's profile and APL

### DIFF
--- a/engine/class_modules/apl/warlock.cpp
+++ b/engine/class_modules/apl/warlock.cpp
@@ -154,13 +154,13 @@ void affliction( player_t* p )
   HC_st->add_action( "haunt" );
   HC_st->add_action( "agony,if=refreshable" );
   HC_st->add_action( "wither,if=refreshable" );
+  HC_st->add_action( "dark_harvest,if=execute_time<(dot.agony.remains<?dot.corruption.remains)" );
   HC_st->add_action( "malevolence" );
   HC_st->add_action( "malefic_grasp,if=buff.nightfall.react>1|pet.darkglare.remains<gcd" );
   HC_st->add_action( "drain_soul,if=buff.nightfall.react>1" );
   HC_st->add_action( "shadow_bolt,if=buff.nightfall.react>1" );
   HC_st->add_action( "unstable_affliction,if=pet.darkglare.remains|buff.malevolence.remains|soul_shard>4|buff.shard_instability.react|buff.cascading_calamity.remains<gcd.max" );
   HC_st->add_action( "summon_darkglare" );
-  HC_st->add_action( "dark_harvest,if=execute_time<(dot.agony.remains<?dot.corruption.remains)&(!talent.cascading_calamity|buff.cascading_calamity.remains)" );
 
   HC_aoe->add_action( "haunt" );
   HC_aoe->add_action( "seed_of_corruption,if=(!dot.wither.ticking|dot.wither.refreshable)&!dot.seed_of_corruption.ticking&!prev.seed_of_corruption&!action.seed_of_corruption.in_flight" );

--- a/profiles/MID2_Raid.simc
+++ b/profiles/MID2_Raid.simc
@@ -60,7 +60,7 @@ MID2_Shaman_Enhancement.simc
 MID2_Shaman_Enhancement_Totemic.simc
 
 MID2_Warlock_Affliction.simc
-MID2_Warlock_Affliction_Hellcaller.simc
+MID2_Warlock_Affliction_Soul_Harvester.simc
 MID2_Warlock_Demonology_Soul_Harvester.simc
 MID2_Warlock_Demonology.simc
 MID2_Warlock_Destruction.simc

--- a/profiles/generators/MID2/MID2_Generate_Warlock.simc
+++ b/profiles/generators/MID2/MID2_Generate_Warlock.simc
@@ -27,7 +27,7 @@ trinket2=,id=273649,bonus_id=12854/13662
 main_hand=,id=271092,enchant_id=8689,bonus_id=40/13335/13848,content_tuning=883
 off_hand=,id=245769,bonus_id=13836/13751/9627/13771/8960,crafted_stats=32/36,crafting_quality=5
 
-save=MID2_Warlock_Affliction.simc
+save=MID2_Warlock_Affliction_Soul_Harvester.simc
 
 warlock=MID2_Warlock_Affliction_Hellcaller
 spec=affliction
@@ -35,7 +35,7 @@ level=90
 race=troll
 role=spell
 position=ranged_back
-talents=CkQAAAAAAAAAAAAAAAAAAAAAAwMzMzoZhhZmZmlBAAYmZZWmZmlxAAWgBmFjGzAysBWGAAAmBAAmZAzMjxYGmZMzMGMzMzAAmBG
+talents=CkQAAAAAAAAAAAAAAAAAAAAAAwMzMzoZhhZmZmlBAAYmZZWmZml5BGAwCMwsY0YGQmNwyAAAwMAAwMDYmZMYGmZMzMGMzMzAAmBG
 omnium_talents=136822:1/136819:1/136817:1/136815:1/136814:1
 warlock.default_pet=sayaad
 flask=flask_of_the_shattered_sun_2
@@ -46,19 +46,19 @@ neck=,id=268265,gem_id=240902/240894,bonus_id=13987/13668/13848/13662
 shoulder=,id=271544,enchant_id=8001,bonus_id=13694/13697,redirected_base_stats=239031,ilevel=334
 back=,id=268253,ilevel=344
 chest=,id=271549,enchant_id=7987,bonus_id=13690/13698/12854,redirected_base_stats=251139
-wrist=,id=239648,gem_id=240914,bonus_id=12214/12384/8960/13750/8790,ilevel=331
+wrist=,id=239648,gem_id=240910,bonus_id=12214/12384/8960/13750/8790,ilevel=331
 hands=,id=271547,bonus_id=13691/13697/13848,redirected_base_stats=268243
-waist=,id=251222,gem_id=240914,bonus_id=12854/13662/13750
+waist=,id=251222,gem_id=240910,bonus_id=12854/13662/13750
 legs=,id=271545,enchant_id=7935,bonus_id=13693/13698/12854,redirected_base_stats=251160
 feet=,id=268255,enchant_id=7993,ilevel=344
-finger1=,id=273792,enchant_id=7967,gem_id=240914,bonus_id=13668/12854/13662
-finger2=,id=268252,enchant_id=7967,gem_id=240910,bonus_id=13668/12854/13662
-trinket1=,id=270167,bonus_id=12854/13662
-trinket2=,id=270169,bonus_id=13848/13662
+finger1=,id=273792,enchant_id=7967,gem_id=240910,bonus_id=13668/12854/13662
+finger2=,id=268252,enchant_id=7967,gem_id=240914,bonus_id=13668/12854/13662
+trinket1=,id=273649,bonus_id=12854/13662
+trinket2=,id=270168,bonus_id=13848/13662
 main_hand=,id=271092,enchant_id=8689,bonus_id=40/13335/13848,content_tuning=883
 off_hand=,id=245769,bonus_id=13836/13751/9627/13771/8960,crafted_stats=32/36,crafting_quality=5
 
-save=MID2_Warlock_Affliction_Hellcaller.simc
+save=MID2_Warlock_Affliction.simc
 
 
 warlock=MID2_Warlock_Demonology_Soul_Harvester


### PR DESCRIPTION
# Hellcaller Affliction's APL and profile updated
## APL
- The APL wasn't accounting for cast time trinkets correctly, this has been corrected.
- Dark Harvest cast moved to be before Malevolence
## Profile
- Default ST talents updated
- BiS trinkets updated
- Hellcaller has now been set as default profile for Affliction